### PR TITLE
fix: person ch distinct id deletion less racy

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -42,7 +42,7 @@ from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.person.sql import GET_PERSON_PROPERTIES_COUNT
-from posthog.models.person.util import delete_ch_distinct_ids, delete_person
+from posthog.models.person.util import delete_person
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.queries.actor_base_query import ActorBaseQuery, get_people
 from posthog.queries.funnels import ClickhouseFunnelActors, ClickhouseFunnelTrendsActors
@@ -212,7 +212,6 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             person_id = person.id
 
             delete_person(person=person)
-            delete_ch_distinct_ids(person=person)
             if "delete_events" in request.GET:
                 AsyncDeletion.objects.create(
                     deletion_type=DeletionType.Person,

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from django.db import models, transaction
 
@@ -31,6 +31,14 @@ class Person(models.Model):
             .order_by("id")
             .values_list("distinct_id")
         ]
+
+    def get_distinct_ids_with_version(self) -> Dict[str, int]:
+        return {
+            obj[0]: int(obj[1] or 0)
+            for obj in PersonDistinctId.objects.filter(person=self, team_id=self.team_id)
+            .order_by("id")
+            .values_list("distinct_id", "version")
+        }
 
     # :DEPRECATED: This should happen through the plugin server
     def add_distinct_id(self, distinct_id: str) -> None:

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from django.db import models, transaction
 
@@ -31,14 +31,6 @@ class Person(models.Model):
             .order_by("id")
             .values_list("distinct_id")
         ]
-
-    def get_distinct_ids_with_version(self) -> Dict[str, int]:
-        return {
-            obj[0]: int(obj[1] or 0)
-            for obj in PersonDistinctId.objects.filter(person=self, team_id=self.team_id)
-            .order_by("id")
-            .values_list("distinct_id", "version")
-        }
 
     # :DEPRECATED: This should happen through the plugin server
     def add_distinct_id(self, distinct_id: str) -> None:

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -162,26 +162,8 @@ def get_persons_by_uuids(team: Team, uuids: List[str]) -> QuerySet:
 
 
 def delete_person(person: Person) -> None:
-    def _get_distinct_ids_with_version() -> Dict[str, int]:
-        return {
-            distinct_id: int(version or 0)
-            for distinct_id, version in PersonDistinctId.objects.filter(person=person, team_id=person.team_id)
-            .order_by("id")
-            .values_list("distinct_id", "version")
-        }
-
-    def _delete_ch_distinct_ids(distinct_ids_to_version: Dict[str, int]):
-        for distinct_id, version in distinct_ids_to_version.items():
-            create_person_distinct_id(
-                team_id=person.team_id,
-                distinct_id=distinct_id,
-                person_id=str(person.uuid),
-                version=version + 100,
-                is_deleted=True,
-            )
-
     # This is racy https://github.com/PostHog/posthog/issues/11590
-    distinct_ids_to_version = _get_distinct_ids_with_version()
+    distinct_ids_to_version = _get_distinct_ids_with_version(person)
     create_person(
         uuid=str(person.uuid),
         team_id=person.team.id,
@@ -191,7 +173,27 @@ def delete_person(person: Person) -> None:
         version=int(person.version or 0) + 100,  # keep in sync with deletePerson in plugin-server/src/utils/db/db.ts
         is_deleted=True,
     )
-    _delete_ch_distinct_ids(distinct_ids_to_version=distinct_ids_to_version)
+    _delete_ch_distinct_ids(person, distinct_ids_to_version=distinct_ids_to_version)
+
+
+def _get_distinct_ids_with_version(person: Person) -> Dict[str, int]:
+    return {
+        distinct_id: int(version or 0)
+        for distinct_id, version in PersonDistinctId.objects.filter(person=person, team_id=person.team_id)
+        .order_by("id")
+        .values_list("distinct_id", "version")
+    }
+
+
+def _delete_ch_distinct_ids(person: Person, distinct_ids_to_version: Dict[str, int]):
+    for distinct_id, version in distinct_ids_to_version.items():
+        create_person_distinct_id(
+            team_id=person.team_id,
+            distinct_id=distinct_id,
+            person_id=str(person.uuid),
+            version=version + 100,
+            is_deleted=True,
+        )
 
 
 class ClickhousePersonSerializer(serializers.Serializer):

--- a/posthog/models/test/test_person_model.py
+++ b/posthog/models/test/test_person_model.py
@@ -1,9 +1,9 @@
 from uuid import uuid4
 
 from posthog.client import sync_execute
-from posthog.models import Person
+from posthog.models import Person, PersonDistinctId
 from posthog.models.event.util import create_event
-from posthog.models.person.util import delete_ch_distinct_ids, delete_person
+from posthog.models.person.util import delete_person
 from posthog.test.base import BaseTest
 
 
@@ -21,26 +21,29 @@ class TestPerson(BaseTest):
         self.assertEqual(person_anonymous.is_identified, False)
 
     def test_delete_person(self):
-        person = Person.objects.create(team=self.team)
+        person = Person.objects.create(
+            team=self.team, version=15
+        )  # version be > 0 to check that we don't just assume 0 in deletes
         delete_person(person)
         ch_persons = sync_execute(
             "SELECT toString(id), version, is_deleted, properties FROM person FINAL WHERE team_id = %(team_id)s and id = %(uuid)s",
             {"team_id": self.team.pk, "uuid": person.uuid},
         )
-        self.assertEqual(ch_persons, [(str(person.uuid), 100, 1, "{}")])
+        self.assertEqual(ch_persons, [(str(person.uuid), 115, 1, "{}")])
 
     def test_delete_ch_distinct_ids(self):
-        person = Person.objects.create(team=self.team, distinct_ids=["distinct_id1"])
+        person = Person.objects.create(team=self.team)
+        PersonDistinctId.objects.create(team=self.team, person=person, distinct_id="distinct_id1", version=15)
 
         ch_distinct_ids = sync_execute(
-            "SELECT version, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
+            "SELECT is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
             {"team_id": self.team.pk, "distinct_id": "distinct_id1"},
         )
-        self.assertEqual(ch_distinct_ids, [(0, 0)])
+        self.assertEqual(ch_distinct_ids, [(0,)])
 
-        delete_ch_distinct_ids(person)
+        delete_person(person)
         ch_distinct_ids = sync_execute(
             "SELECT toString(person_id), version, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
             {"team_id": self.team.pk, "distinct_id": "distinct_id1"},
         )
-        self.assertEqual(ch_distinct_ids, [(str(person.uuid), 0, 1)])
+        self.assertEqual(ch_distinct_ids, [(str(person.uuid), 115, 1)])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This will solve bug 1 from https://github.com/PostHog/posthog/issues/11590 

Note that it's still a bit racy if there's updates happening to the person distinctIDs while being deleted, but to make it not racy at all is tricky as distinctId deletion in postgres happens through cascade and we can't look up the distinctIds and versions from CH either because they might not have been written yet.

Note 2: This doesn't solve bugs 2 and 3 (i.e. re-using the distinctID after deletion) from the issue above.


Release highlight:
Fixed person deletion (removing dangling distinctIDs). Important note (that was true before too): if you want to re-use the distinctID do NOT use delete person and instead use split distinctIDs. Re-using deleted person's distinctID's is not supported and will result in bad data state.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
