### PR TITLE
fix(apps): crash if loading image when app has repo with path

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1057,14 +1057,23 @@ export function identifierToHuman(identifier: string | number, caseType: 'senten
         words.map((word) => (caseType === 'sentence' ? word : capitalizeFirstLetter(word))).join(' ')
     )
 }
+// "https://github.com/PostHog/apps/tree/main/src/packages/currency-normalization-plugin"
 
 export function parseGithubRepoURL(url: string): Record<string, string> {
-    const match = url.match(/^https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/?$/)
-    if (!match) {
-        throw new Error('Must be in the format: https://github.com/user/repo')
+    // complex url with path
+    const match = url.match(
+        /^https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.\-]+)\/([A-Za-z0-9_.\-]+)(|\/tree\/([A-Za-z0-9_.\-]+)\/([A-Za-z0-9_.\-\/]*))$/
+    )
+    if (match) {
+        const [, user, repo, secondPart, branch, path] = match
+        if (secondPart) {
+            return { user, repo, branch, path }
+        } else {
+            return { user, repo, branch: 'main', path: '' }
+        }
     }
-    const [, user, repo] = match
-    return { user, repo }
+
+    throw new Error('Must be in the format: https://github.com/user/repo/tree/branch/path')
 }
 
 export function someParentMatchesSelector(element: HTMLElement, selector: string): boolean {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1057,7 +1057,6 @@ export function identifierToHuman(identifier: string | number, caseType: 'senten
         words.map((word) => (caseType === 'sentence' ? word : capitalizeFirstLetter(word))).join(' ')
     )
 }
-// "https://github.com/PostHog/apps/tree/main/src/packages/currency-normalization-plugin"
 
 export function parseGithubRepoURL(url: string): Record<string, string> {
     // complex url with path

--- a/frontend/src/scenes/plugins/plugin/PluginImage.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginImage.tsx
@@ -18,8 +18,16 @@ export function PluginImage({
 
     useEffect(() => {
         if (url?.includes('github.com')) {
-            const { user, repo } = parseGithubRepoURL(url)
-            setState({ ...state, image: `https://raw.githubusercontent.com/${user}/${repo}/main/logo.png` })
+            try {
+                const { user, repo, branch, path } = parseGithubRepoURL(url)
+                setState({
+                    ...state,
+                    image: `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${path}/logo.png`,
+                })
+            } catch (e) {
+                // parseGithubRepoURL throws if the github URL is in a bad format. We don't want the component to crash then.
+                console.log(e)
+            }
         }
     }, [url])
 


### PR DESCRIPTION
## Problem

When you have an app with a github repo url that contains a path, loading the image crashes:

<img width="919" alt="image" src="https://user-images.githubusercontent.com/53387/198313761-fa2ea555-bf15-4053-9513-7e2930a5aaa0.png">

## Changes

Fixes this

## How did you test this code?

It now loads `https://raw.githubusercontent.com/PostHog/apps/main/src/packages/currency-normalization-plugin/logo.png`

<img width="397" alt="image" src="https://user-images.githubusercontent.com/53387/198314260-248bd0c8-9b26-4424-8c2e-1e31e5b6f051.png">
