### PR TITLE
fix: Don't send groupidentify and alias events to buffer

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -108,6 +108,12 @@ export function shouldSendEventToBuffer(
     person: IngestionPersonData | undefined,
     teamId: TeamId
 ): boolean {
+    // Libraries by default create a unique id for this `type-name_value` for $groupidentify,
+    // we don't want to buffer these to make group properties available asap
+    // identify and alias are identical and could merge the person - the sooner we update the person_id the better
+    const isIdentifyingEvent =
+        event.event == '$groupidentify' || event.event == '$identify' || event.event == `$create_alias`
+
     const isAnonymousEvent =
         event.properties && event.properties['$device_id'] && event.distinct_id === event.properties['$device_id']
 
@@ -118,7 +124,8 @@ export function shouldSendEventToBuffer(
     const isMobileLibrary =
         !!event.properties &&
         ['posthog-ios', 'posthog-android', 'posthog-react-native', 'posthog-flutter'].includes(event.properties['$lib'])
-    const sendToBuffer = !isMobileLibrary && !person && !isAnonymousEvent && event.event !== '$identify'
+
+    const sendToBuffer = !isMobileLibrary && !person && !isAnonymousEvent && !isIdentifyingEvent
 
     if (sendToBuffer) {
         hub.statsd?.increment('conversion_events_buffer_size', { teamId: event.team_id.toString() })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -153,6 +153,16 @@ describe('shouldSendEventToBuffer()', () => {
         expect(result).toEqual(true)
     })
 
+    it('returns false for $groupidentify events', () => {
+        const event = {
+            ...pluginEvent,
+            event: '$groupidentify',
+        }
+
+        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+        expect(result).toEqual(false)
+    })
+
     it('returns false for $identify events for non-existing users', () => {
         const event = {
             ...pluginEvent,
@@ -174,6 +184,16 @@ describe('shouldSendEventToBuffer()', () => {
         }
 
         const result = shouldSendEventToBuffer(runner.hub, event, person, 2)
+        expect(result).toEqual(false)
+    })
+
+    it('returns false for $create_alias events', () => {
+        const event = {
+            ...pluginEvent,
+            event: '$create_alias',
+        }
+
+        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
         expect(result).toEqual(false)
     })
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Group identify events shouldn't be buffered - we by default create new distinct_ids for them and even if we didn't it would be better to get the properties updates sooner rather than later.

alias is a dupe of identify, so should be treated the same way.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
