### PR TITLE
Revert "feat(scheduler): allow spreading scheduled tasks load across the fleet"

### DIFF
--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -65,6 +65,15 @@ export class GraphileWorker {
         instrumentationContext?: InstrumentationContext,
         retryOnFailure = false
     ): Promise<void> {
+        const jobType = 'type' in job ? job.type : 'buffer'
+
+        let jobPayload: Record<string, any> = {}
+        if ('payload' in job) {
+            jobPayload = job.payload
+        } else if ('eventPayload' in job) {
+            jobPayload = job.eventPayload
+        }
+
         let enqueueFn = () => this._enqueue(jobName, job)
 
         // This branch will be removed once we implement a Kafka queue for all jobs
@@ -92,8 +101,8 @@ export class GraphileWorker {
                 metricName: 'job_queues_enqueue',
                 key: instrumentationContext?.key ?? '?',
                 tag: instrumentationContext?.tag ?? '?',
-                tags: { jobName, ...('type' in job ? { pluginJobName: job.type } : {}) },
-                data: { job },
+                tags: { jobName, type: jobType },
+                data: { timestamp: job.timestamp, type: jobType, payload: jobPayload },
             },
             enqueueFn
         )

--- a/plugin-server/src/main/graphile-worker/schedule.ts
+++ b/plugin-server/src/main/graphile-worker/schedule.ts
@@ -3,7 +3,6 @@ import Piscina from '@posthog/piscina'
 import { Hub, PluginConfigId } from '../../types'
 import { status } from '../../utils/status'
 import { delay } from '../../utils/utils'
-import { PluginScheduledTask } from './../../types'
 
 export async function loadPluginSchedule(piscina: Piscina, maxIterations = 2000): Promise<Hub['pluginSchedule']> {
     let allThreadsReady = false
@@ -29,17 +28,9 @@ export async function loadPluginSchedule(piscina: Piscina, maxIterations = 2000)
     throw new Error('Could not load plugin schedule in time')
 }
 
-// Triggered by a Graphile Worker cron task
-// Enqueue a job per <task,pluginConfigId> combination
-// This allows us to spread the load of processing plugin scheduled tasks across the fleet
-export async function runScheduledTasks(server: Hub, task: PluginScheduledTask): Promise<void> {
-    for (const pluginConfigId of server.pluginSchedule?.[task] || []) {
-        status.info('⬆️', 'Scheduling task', { task, pluginConfigId })
-
-        await server.graphileWorker.enqueue('pluginScheduledTask', {
-            pluginConfigId,
-            task: task,
-            timestamp: Date.now(),
-        })
+export async function runScheduledTasks(server: Hub, piscina: Piscina, taskType: string): Promise<void> {
+    for (const pluginConfigId of server.pluginSchedule?.[taskType] || []) {
+        status.info('⏲️', `Running ${taskType} for plugin config with ID ${pluginConfigId}`)
+        await piscina.run({ task: taskType, args: { pluginConfigId } })
     }
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -217,13 +217,7 @@ export interface PluginServerCapabilities {
     http?: boolean
 }
 
-export type PluginScheduledTask = 'runEveryMinute' | 'runEveryHour' | 'runEveryDay'
-
-export type EnqueuedJob =
-    | EnqueuedPluginJob
-    | EnqueuedBufferJob
-    | GraphileWorkerCronScheduleJob
-    | EnqueuedScheduledTaskJob
+export type EnqueuedJob = EnqueuedPluginJob | EnqueuedBufferJob | GraphileWorkerCronScheduleJob
 export interface EnqueuedPluginJob {
     type: string
     payload: Record<string, any>
@@ -240,13 +234,6 @@ export interface EnqueuedBufferJob {
 }
 
 export interface GraphileWorkerCronScheduleJob {
-    timestamp?: number
-    jobKey?: string
-}
-
-export interface EnqueuedScheduledTaskJob {
-    task: PluginScheduledTask
-    pluginConfigId: number
     timestamp?: number
     jobKey?: string
 }

--- a/plugin-server/tests/main/capabilities.test.ts
+++ b/plugin-server/tests/main/capabilities.test.ts
@@ -110,7 +110,6 @@ describe('capabilities', () => {
                     runEveryMinute: expect.anything(),
                     runEveryHour: expect.anything(),
                     runEveryDay: expect.anything(),
-                    pluginScheduledTask: expect.anything(),
                 },
                 [
                     {

--- a/plugin-server/tests/main/jobs/schedule.test.ts
+++ b/plugin-server/tests/main/jobs/schedule.test.ts
@@ -4,10 +4,6 @@ import { UUID } from '../../../src/utils/utils'
 import { PromiseManager } from '../../../src/worker/vm/promise-manager'
 
 const mockHub: Hub = {
-    graphileWorker: {
-        enqueue: jest.fn(),
-        addJob: jest.fn(),
-    } as any,
     instanceId: new UUID('F8B2F832-6639-4596-ABFC-F9664BC88E84'),
     promiseManager: new PromiseManager({ MAX_PENDING_PROMISES_PER_WORKER: 1 } as any),
     JOB_QUEUES: 'fs',
@@ -19,6 +15,10 @@ describe('Graphile Worker schedule', () => {
     })
 
     test('runScheduledTasks()', async () => {
+        const mockPiscina = {
+            run: jest.fn(),
+        }
+
         const mockHubWithPluginSchedule = {
             ...mockHub,
             pluginSchedule: {
@@ -28,56 +28,23 @@ describe('Graphile Worker schedule', () => {
             },
         }
 
-        await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryMinute')
+        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'iDontExist')
+        expect(mockPiscina.run).not.toHaveBeenCalled()
 
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(1, 'pluginScheduledTask', {
-            pluginConfigId: 1,
-            task: 'runEveryMinute',
-            timestamp: expect.any(Number),
-        })
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(2, 'pluginScheduledTask', {
-            pluginConfigId: 2,
-            task: 'runEveryMinute',
-            timestamp: expect.any(Number),
-        })
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(3, 'pluginScheduledTask', {
-            pluginConfigId: 3,
-            task: 'runEveryMinute',
-            timestamp: expect.any(Number),
-        })
+        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryMinute')
 
-        await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryHour')
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(4, 'pluginScheduledTask', {
-            pluginConfigId: 4,
-            task: 'runEveryHour',
-            timestamp: expect.any(Number),
-        })
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(5, 'pluginScheduledTask', {
-            pluginConfigId: 5,
-            task: 'runEveryHour',
-            timestamp: expect.any(Number),
-        })
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(6, 'pluginScheduledTask', {
-            pluginConfigId: 6,
-            task: 'runEveryHour',
-            timestamp: expect.any(Number),
-        })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(1, { args: { pluginConfigId: 1 }, task: 'runEveryMinute' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(2, { args: { pluginConfigId: 2 }, task: 'runEveryMinute' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(3, { args: { pluginConfigId: 3 }, task: 'runEveryMinute' })
 
-        await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryDay')
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(7, 'pluginScheduledTask', {
-            pluginConfigId: 7,
-            task: 'runEveryDay',
-            timestamp: expect.any(Number),
-        })
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(8, 'pluginScheduledTask', {
-            pluginConfigId: 8,
-            task: 'runEveryDay',
-            timestamp: expect.any(Number),
-        })
-        expect(mockHub.graphileWorker.enqueue).toHaveBeenNthCalledWith(9, 'pluginScheduledTask', {
-            pluginConfigId: 9,
-            task: 'runEveryDay',
-            timestamp: expect.any(Number),
-        })
+        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryHour')
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(4, { args: { pluginConfigId: 4 }, task: 'runEveryHour' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(5, { args: { pluginConfigId: 5 }, task: 'runEveryHour' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(6, { args: { pluginConfigId: 6 }, task: 'runEveryHour' })
+
+        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryDay')
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(7, { args: { pluginConfigId: 7 }, task: 'runEveryDay' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(8, { args: { pluginConfigId: 8 }, task: 'runEveryDay' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(9, { args: { pluginConfigId: 9 }, task: 'runEveryDay' })
     })
 })


### PR DESCRIPTION
Reverts PostHog/posthog#12477