### PR TITLE
chore: report PR age to PostHog on merge

### DIFF
--- a/.github/workflows/report-pr-age.yml
+++ b/.github/workflows/report-pr-age.yml
@@ -1,0 +1,23 @@
+name: Report PR Age
+
+on:
+    pull_request:
+        types:
+            - closed
+
+jobs:
+    report-pr-age:
+        name: Report age of PR
+        runs-on: ubuntu-20.04
+        if: github.event.pull_request.merged == true
+        steps:
+            - name: get PR age
+              run: |
+                  pr_age=$((($(date '+%s') - $(date -d "${{ github.event.pull_request.created_at }}" '+%s'))))
+                  echo pr_age=$pr_age >> $GITHUB_ENV
+            - name: capture PR age to PostHog
+              uses: PostHog/posthog-github-action@v0.1
+              with:
+                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
+                  event: 'posthog-ci-pr-age-when-closed'
+                  properties: '{"prAgeInSeconds": ${{ env.pr_age }}}'


### PR DESCRIPTION
## Problem

We aim for one-day PRs https://posthog.com/handbook/engineering/development-process#2-sizing-a-task-and-reducing-wip

But do we achieve that? Who knows?!

## Changes

Uses the new PostHog GitHub actions bot to report the age of a PR in seconds when it is closed by merging.

## How did you test this code?

Testing a repo that runs this on every push https://github.com/pauldambra/test-something/actions/runs/3340389707/jobs/5530427955

<img width="669" alt="Screenshot 2022-10-27 at 20 46 34" src="https://user-images.githubusercontent.com/984817/198384268-8748b1a8-1b4f-4cfc-ade8-ddfa4944577a.png">

<img width="1215" alt="Screenshot 2022-10-27 at 20 50 05" src="https://user-images.githubusercontent.com/984817/198384868-0da18508-c101-4812-9d79-f64ccb9b9f81.png">
