### PR TITLE
chore: turn on text cards for self hosted

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -7,4 +7,5 @@ from posthog.settings.utils import get_list
 PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "simplify-actions",
     "historical-exports-v2",
+    "text-cards",
 ]


### PR DESCRIPTION
## Problem

We want to turn on text cards for self-hosted release. But still behind a flag

## Changes

Turns on the flag for self-hosted

## How did you test this code?

I didn't 🙀 
