### PR TITLE
refactor(plugin-server): only run App methods in a worker

### DIFF
--- a/plugin-server/src/main/graphile-worker/buffer.ts
+++ b/plugin-server/src/main/graphile-worker/buffer.ts
@@ -2,8 +2,11 @@ import Piscina from '@posthog/piscina'
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { Hub } from 'types'
 
-export function runBufferEventPipeline(hub: Hub, piscina: Piscina, event: PluginEvent): Promise<void> {
+import { EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+
+export async function runBufferEventPipeline(hub: Hub, piscina: Piscina, event: PluginEvent): Promise<void> {
     hub.lastActivity = new Date().valueOf()
     hub.lastActivityType = 'runBufferEventPipeline'
-    return piscina.run({ task: 'runBufferEventPipeline', args: { event } })
+    const runner = new EventPipelineRunner(hub, piscina, event)
+    await runner.runBufferEventPipeline(event)
 }

--- a/plugin-server/src/utils/internal-metrics.ts
+++ b/plugin-server/src/utils/internal-metrics.ts
@@ -2,6 +2,7 @@ import Piscina from '@posthog/piscina'
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { Hub, TeamId } from '../types'
+import { EventPipelineRunner } from '../worker/ingestion/event-pipeline/runner'
 import { UUIDT } from './utils'
 
 export class InternalMetrics {
@@ -43,7 +44,8 @@ export class InternalMetrics {
                 uuid: new UUIDT().toString(),
             }
 
-            promises.push(piscina.run({ task: 'runEventPipeline', args: { event } }))
+            const runner = new EventPipelineRunner(this.hub, piscina, event)
+            promises.push(runner.runEventPipeline(event))
         }
 
         await Promise.all(promises)

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-pluginsProcessEventStep.ts
@@ -1,7 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { runInstrumentedFunction } from '../../../main/utils'
-import { runProcessEvent } from '../../plugins/run'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { EventPipelineRunner, StepResult } from './runner'
 
@@ -17,7 +16,7 @@ export async function pluginsProcessEventStep(
         processedEvent = await runInstrumentedFunction({
             server: runner.hub,
             event,
-            func: (event) => runProcessEvent(runner.hub, event),
+            func: (event) => runner.piscina.run({ task: 'runProcessEvent', args: event }),
             statsKey: 'kafka_queue.single_event',
             timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
         })

--- a/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
@@ -20,7 +20,7 @@ export async function runAsyncHandlersStep(
 async function processOnEvent(runner: EventPipelineRunner, event: PostIngestionEvent) {
     const processedPluginEvent = convertToProcessedPluginEvent(event)
     const isSnapshot = event.event === '$snapshot'
-    if (isSnapshot) {return}
+    if (isSnapshot) { return }
 
     await runInstrumentedFunction({
         server: runner.hub,

--- a/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
@@ -20,7 +20,9 @@ export async function runAsyncHandlersStep(
 async function processOnEvent(runner: EventPipelineRunner, event: PostIngestionEvent) {
     const processedPluginEvent = convertToProcessedPluginEvent(event)
     const isSnapshot = event.event === '$snapshot'
-    if (isSnapshot) { return }
+    if (isSnapshot) {
+        return
+    }
 
     await runInstrumentedFunction({
         server: runner.hub,

--- a/plugin-server/tests/worker/worker.test.ts
+++ b/plugin-server/tests/worker/worker.test.ts
@@ -1,8 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
-import { DateTime } from 'luxon'
 
 import { loadPluginSchedule } from '../../src/main/graphile-worker/schedule'
-import { Hub, PreIngestionEvent } from '../../src/types'
+import { Hub } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 import { KafkaProducerWrapper } from '../../src/utils/db/kafka-producer-wrapper'
 import { delay, UUIDT } from '../../src/utils/utils'
@@ -63,11 +62,11 @@ describe('worker', () => {
     `
         await resetTestDatabase(testCode)
         const piscina = setupPiscina(workerThreads, 10)
-        const [hub, closeHub] = await createHub()
+        const [hub] = await createHub()
 
         const runEveryDay = (pluginConfigId: number) => piscina.run({ task: 'runEveryDay', args: { pluginConfigId } })
         const ingestEvent = async (event: PluginEvent) => {
-            const result = await (new EventPipelineRunner(hub, piscina, event)).runEventPipeline(event)
+            const result = await new EventPipelineRunner(hub, piscina, event).runEventPipeline(event)
             return { ...result, event: result.args[0] }
         }
 
@@ -127,7 +126,7 @@ describe('worker', () => {
 
         try {
             await piscina.destroy()
-        } catch { }
+        } catch {}
     })
 
     describe('createTaskRunner()', () => {


### PR DESCRIPTION
At the moment we're running the whole pipeline in a worker. This is
great for CPU bound tasks, but not so useful for IO bound tasks.

The reason we still run the App methods in a worker is just to give us a
bit of isolation from badly behaving App code. This way we avoid using
the main thread event loop for this code, so worker threads can lock but
the main thread can still keep running. Piscina should hopefully reap
the problematic worker threads and respawn :fingercrossed:

Reducing the amount running in the worker thread helps e.g. with
debugging the plugin server, plays a little more nicely with e.g.
coverage reports (although it's possible to get coverage reports from
workers too), and makes it easier to reason about the code.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
