### PR TITLE
fix: Use modified org ID as distinctId if missing owner in usage report

### DIFF
--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -21,13 +21,13 @@ class Command(BaseCommand):
 
         results = send_all_org_usage_reports(dry_run, date, event_name)
 
-        if dry_run:
-            if options["print_reports"]:
-                print("")  # noqa T201
-                pprint.pprint(results)  # noqa T203
-                print("")  # noqa T201
+        if options["print_reports"]:
+            print("")  # noqa T201
+            pprint.pprint(results)  # noqa T203
+            print("")  # noqa T201
 
-            print(f"{len(results)} Reports sent!")  # noqa T201
+        if dry_run:
             print("Dry run so not sent.")  # noqa T201
         else:
+            print(f"{len(results)} Reports sent!")  # noqa T201
             print("Done!")  # noqa T201

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -246,7 +246,7 @@ def capture_event(
 ) -> None:
     if is_cloud():
         org_owner = get_org_owner_or_first_user(organization_id)
-        distinct_id = org_owner.distinct_id if org_owner else f"org-{organization_id}"
+        distinct_id = org_owner.distinct_id if org_owner and org_owner.distinct_id else f"org-{organization_id}"
         pha_client.capture(
             distinct_id,  # type: ignore
             name,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -244,11 +244,11 @@ def capture_event(
     properties: Dict[str, Any],
     timestamp: Optional[datetime] = None,
 ) -> None:
-
     if is_cloud():
         org_owner = get_org_owner_or_first_user(organization_id)
+        distinct_id = org_owner.distinct_id if org_owner else f"org-{organization_id}"
         pha_client.capture(
-            org_owner.distinct_id,  # type: ignore
+            distinct_id,  # type: ignore
             name,
             {**properties, "scope": "user"},
             groups={"organization": organization_id, "instance": settings.SITE_URL},


### PR DESCRIPTION
## Problem

Somehow some orgs don't have an owner. This crashes the flow atm


## Changes

* If the owner can't be found then we just use the `org-{id}` as distinctId


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Hard to test