### PR TITLE
refactor(plugin-server): remove graphile dep for anonymous events

### DIFF
--- a/plugin-server/functional_tests/e2e.test.ts
+++ b/plugin-server/functional_tests/e2e.test.ts
@@ -309,8 +309,8 @@ describe.each([[startSingleServer], [startMultiServer]])('E2E', (pluginServer) =
                 $anon_distinct_id: returningDistinctId,
             })
 
-            await delayUntilEventIngested(() => fetchEvents(clickHouseClient, teamId), 3, 500, 40)
-            const events = await fetchEvents(clickHouseClient, teamId)
+            const events = await delayUntilEventIngested(() => fetchEvents(clickHouseClient, teamId), 3, 500, 40)
+            expect(events.length).toBe(3)
             expect(new Set(events.map((event) => event.person_id)).size).toBe(1)
 
             await delayUntilEventIngested(() => fetchPersons(clickHouseClient, teamId), 1, 500, 40)

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -231,9 +231,10 @@ export async function startPluginsServer(
 
         if (hub.capabilities.ingestion) {
             bufferConsumer = await startAnonymousEventBufferConsumer({
+                hub: hub,
+                piscina: piscina,
                 kafka: hub.kafka,
                 producer: hub.kafkaProducer,
-                graphileWorker: hub.graphileWorker,
                 statsd: hub.statsd,
             })
         }

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -27,6 +27,7 @@ export async function emitToBufferStep(
     if (shouldBuffer(runner.hub, event, person, event.team_id)) {
         const processEventAt = Date.now() + runner.hub.BUFFER_CONVERSION_SECONDS * 1000
         status.debug('🔁', 'Emitting event to buffer', {
+            event: event.event,
             eventId: event.uuid,
             processEventAt,
             conversionBufferTopicEnabledTeams: runner.hub.conversionBufferTopicEnabledTeams,

--- a/plugin-server/tests/e2e.buffer.test.ts
+++ b/plugin-server/tests/e2e.buffer.test.ts
@@ -1,7 +1,6 @@
 import IORedis from 'ioredis'
 
 import { ONE_HOUR } from '../src/config/constants'
-import { GraphileWorker } from '../src/main/graphile-worker/graphile-worker'
 import { startPluginsServer } from '../src/main/pluginsServer'
 import { LogLevel, PluginsServerConfig } from '../src/types'
 import { Hub } from '../src/types'
@@ -92,40 +91,6 @@ describe('E2E with buffer topic enabled', () => {
 
             // onEvent ran
             expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event via buffer']])
-        })
-
-        test('handles graphile worker db being down', async () => {
-            expect((await hub.db.fetchEvents()).length).toBe(0)
-
-            const uuid = new UUIDT().toString()
-
-            // Setup the GraphileWorker function to raise a connection error.
-            // NOTE: We want to retry on connection errors but not on other
-            // errors, e.g. programming errors. We don't handle these cases
-            // separately at the moment however.
-            const graphileWorkerEnqueue = jest.spyOn(GraphileWorker.prototype, 'enqueue').mockImplementation(() => {
-                const err = new Error('connection refused') as any
-                err.name = 'SystemError'
-                err.code = 'ECONNREFUSED'
-                throw err
-            })
-
-            await posthog.capture('custom event via buffer', { name: 'hehe', uuid })
-            await hub.kafkaProducer.flush()
-
-            // Wait up to 5 seconds for the mock to be called. Note we abused
-            // the delayUntilEventIngested function here.
-            await delayUntilEventIngested(() => graphileWorkerEnqueue.mock.calls.length, undefined, 100, 50)
-            expect(graphileWorkerEnqueue.mock.calls.length).toBeGreaterThan(0)
-            let events = await hub.db.fetchEvents()
-            expect(events.length).toBe(0)
-
-            // Now let's make the GraphileWorker function work again, then wait
-            // for the event to be ingested.
-            graphileWorkerEnqueue.mockRestore()
-            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, 100, 100)
-            events = await hub.db.fetchEvents()
-            expect(events.length).toBe(1)
         })
     })
 })


### PR DESCRIPTION
This removes the graphile dep for delaying events. Instead we just pause
the partition. Note that we also delay the each batch auto commit option
from KafkaJS. This is required as otherwise KafkaJS will simply commit
the offset. Throwing an error also avoids committing, but I think
disabling is probably better.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
