### PR TITLE
fix(column-configrator): access level bug

### DIFF
--- a/frontend/src/lib/components/ResizableTable/TableConfig.tsx
+++ b/frontend/src/lib/components/ResizableTable/TableConfig.tsx
@@ -21,7 +21,7 @@ import {
     SortableHandle as sortableHandle,
 } from 'react-sortable-hoc'
 import { RestrictedArea, RestrictedComponentProps, RestrictionScope } from '../RestrictedArea'
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { TeamMembershipLevel } from 'lib/constants'
 
 const DragHandle = sortableHandle(() => (
     <span className="drag-handle">
@@ -229,7 +229,7 @@ function ColumnConfigurator({ immutableColumns, defaultColumns }: TableConfigPro
                 </Row>
                 <RestrictedArea
                     Component={SaveColumnsAsDefault}
-                    minimumAccessLevel={OrganizationMembershipLevel.Owner}
+                    minimumAccessLevel={TeamMembershipLevel.Admin}
                     scope={RestrictionScope.Project}
                 />
             </div>


### PR DESCRIPTION
## Problem

As a project admin, you couldn't save the default columns for the project. 

## Changes

Now it works. This is just a frontend fix, the API allowed it.

## How did you test this code?

Changed columns locally as the project admin user, and saw them appear for the different organization admin user.