### PR TITLE
fix(app-metrics): Dont set defaultTab too eagerly to activity log

### DIFF
--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -348,7 +348,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                 } else {
                     if (params.tab && INITIAL_TABS.includes(params.tab as any) && params.tab !== values.activeTab) {
                         actions.setActiveTab(params.tab as AppMetricsTab)
-                    } else if (values.defaultTab && values.activeTab !== values.defaultTab) {
+                    } else if (!values.pluginConfigLoading && values.activeTab !== values.defaultTab) {
                         actions.setActiveTab(values.defaultTab)
                     }
                     if (params.from && values.selectedDateFrom !== params.from) {


### PR DESCRIPTION
## Problem

App metrics would default to activity log

## Changes

Wait for plugin config to finish loading before setting active tab.
