### PR TITLE
chore(insights): Clean up date selector a bit

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -115,9 +115,6 @@ export function DateFilter({
                         </Tooltip>
                     )
                 })}
-                <LemonButton onClick={openDateToNow} active={isDateToNow} status="stealth" fullWidth>
-                    {'Date to Now'}
-                </LemonButton>
                 {showRollingRangePicker && (
                     <RollingDateRangeFilter
                         dateFrom={dateFrom}
@@ -132,8 +129,11 @@ export function DateFilter({
                     />
                 )}
                 <LemonDivider />
+                <LemonButton onClick={openDateToNow} active={isDateToNow} status="stealth" fullWidth>
+                    From custom date until now…
+                </LemonButton>
                 <LemonButton onClick={openFixedRange} active={isFixedRange} status="stealth" fullWidth>
-                    {'Custom fixed time period'}
+                    Custom fixed date range…
                 </LemonButton>
             </div>
         )

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
@@ -36,7 +36,7 @@
     display: flex;
     margin: 0;
     height: 2rem;
-    border: 1px solid var(--border-light);
+    border: 1px solid var(--border);
     border-radius: 0.25rem;
     background-color: #fff;
     box-sizing: border-box;

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
@@ -55,15 +55,15 @@ describe('dateFilterLogic', () => {
         props = {
             key: 'test',
             onChange,
-            dateFrom: '-1d',
-            dateTo: null,
+            dateFrom: '-1dStart',
+            dateTo: 'dStart',
             dateOptions: dateMapping,
             isDateFormatted: false,
         }
         const withDateFrom = dateFilterLogic(props)
         withDateFrom.mount()
 
-        await expectLogic(withDateFrom).toMatchValues({ dateFrom: '-1d', dateTo: null, label: 'Yesterday' })
+        await expectLogic(withDateFrom).toMatchValues({ dateFrom: '-1dStart', dateTo: 'dStart', label: 'Yesterday' })
         expect(onChange).not.toHaveBeenCalled()
     })
 

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
@@ -89,7 +89,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
                 isFixedRange
                     ? formatDateRange(dayjs(dateFrom), dayjs(dateTo))
                     : isDateToNow
-                    ? `${formatDate(dayjs(dateFrom))} to Now`
+                    ? `${formatDate(dayjs(dateFrom))} to now`
                     : dateFilterToText(dateFrom, dateTo, 'Custom', dateOptions, false),
         ],
     }),

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.tsx
@@ -18,7 +18,7 @@ export function LemonCalendarSelect({ value, onChange, months, onClose }: LemonC
     return (
         <div className="LemonCalendarSelect" data-attr="lemon-calendar-select">
             <div className="flex justify-between border-b p-2 pb-4">
-                <h3 className="mb-0">Select a date</h3>
+                <h3 className="text-base mb-0">Select a date</h3>
                 {onClose && (
                     <LemonButton
                         icon={<IconClose />}

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.tsx
@@ -23,7 +23,7 @@ export function LemonCalendarRange({ value, onChange, onClose, months }: LemonCa
     return (
         <div className="LemonCalendarRange" data-attr="lemon-calendar-range">
             <div className="flex justify-between border-b p-2 pb-4">
-                <h3 className="mb-0">Select a fixed time period</h3>
+                <h3 className="text-base mb-0">Select a date range</h3>
                 {onClose && (
                     <LemonButton
                         icon={<IconClose />}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -270,7 +270,8 @@ describe('dateFilterToText()', () => {
             expect(dateFilterToText(null, null, 'default')).toEqual('default')
             expect(dateFilterToText('-24h', null, 'default')).toEqual('Last 24 hours')
             expect(dateFilterToText('-48h', undefined, 'default')).toEqual('Last 48 hours')
-            expect(dateFilterToText('-1d', null, 'default')).toEqual('Yesterday')
+            expect(dateFilterToText('-1d', null, 'default')).toEqual('Last 1 day')
+            expect(dateFilterToText('-1dStart', 'dStart', 'default')).toEqual('Yesterday')
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default')).toEqual('Previous month')
         })
 
@@ -300,7 +301,8 @@ describe('dateFilterToText()', () => {
             expect(dateFilterToText('-48h', undefined, 'default', dateMapping, true)).toEqual(
                 'February 29 - March 2, 2012'
             )
-            expect(dateFilterToText('-1d', null, 'default', dateMapping, true)).toEqual('March 1, 2012')
+            expect(dateFilterToText('-1d', null, 'default', dateMapping, true)).toEqual('March 1 - March 2, 2012')
+            expect(dateFilterToText('-1dStart', 'dStart', 'default', dateMapping, true)).toEqual('March 1, 2012')
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default', dateMapping, true)).toEqual(
                 'March 1 - March 31, 2012'
             )

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -850,7 +850,7 @@ export function dateFilterToText(
     if (isDate.test(dateFrom || '') && !isDate.test(dateTo || '')) {
         const days = dayjs().diff(dayjs(dateFrom), 'days')
         if (days > 366) {
-            return isDateFormatted ? `${dateFrom} - Today` : formatDateRange(dayjs(dateFrom), dayjs())
+            return isDateFormatted ? `${dateFrom} - today` : formatDateRange(dayjs(dateFrom), dayjs())
         } else if (days > 0) {
             return isDateFormatted ? formatDateRange(dayjs(dateFrom), dayjs()) : `Last ${days} days`
         } else if (days === 0) {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -738,7 +738,7 @@ export const dateMapping: DateMappingOption[] = [
     },
     {
         key: 'Yesterday',
-        values: ['-1d'],
+        values: ['-1dStart', 'dStart'],
         getFormattedDate: (date: dayjs.Dayjs): string => date.subtract(1, 'd').format(DATE_FORMAT),
         defaultInterval: 'hour',
     },
@@ -789,7 +789,6 @@ export const dateMapping: DateMappingOption[] = [
         key: 'This month',
         values: ['mStart'],
         getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.startOf('m'), date.endOf('d')),
-        inactive: true,
         defaultInterval: 'day',
     },
     {


### PR DESCRIPTION
## Changes

Based on [this internal thread](https://posthog.slack.com/archives/C0368RPHLQH/p1666958544868069), I restored "This month" as a date range option. Also I was actually surprised to find out we support selecting a custom start date as "Date to Now". 😅 That is probably because it was nestled between "Last x foo" options, and not besides "Custom fixed time period". So I moved it to the bottom. I put an ellipsis after those two calendar-dependent options' names, as that's the conventional way to indicate that an option involves extra user interaction (in this case: selection within calendar).

| Before | After |
| --- | --- |
| <img width="316" alt="before" src="https://user-images.githubusercontent.com/4550621/198619972-231fe483-5f05-4b13-8117-98dd708d4225.png"> | <img width="313" alt="after" src="https://user-images.githubusercontent.com/4550621/198622792-5f58617e-59e6-4d20-8571-b8edb414e24b.png"> |