### PR TITLE
feat(toolbar): disable heatmap clicks when holding down shift

### DIFF
--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -22,7 +22,8 @@ export function Elements(): JSX.Element {
         highlightElementMeta,
     } = useValues(elementsLogic)
     const { setHoverElement, selectElement } = useActions(elementsLogic)
-    const { highestClickCount } = useValues(heatmapLogic)
+    const { highestClickCount, shiftPressed } = useValues(heatmapLogic)
+    const heatmapPointerEvents = shiftPressed ? 'none' : 'all'
 
     return (
         <>
@@ -59,7 +60,7 @@ export function Elements(): JSX.Element {
                         key={`inspect-${index}`}
                         rect={rect}
                         style={{
-                            pointerEvents: 'all',
+                            pointerEvents: heatmapPointerEvents,
                             cursor: 'pointer',
                             zIndex: 0,
                             opacity:
@@ -83,7 +84,7 @@ export function Elements(): JSX.Element {
                             <HeatmapElement
                                 rect={rect}
                                 style={{
-                                    pointerEvents: inspectEnabled ? 'none' : 'all',
+                                    pointerEvents: inspectEnabled ? 'none' : heatmapPointerEvents,
                                     zIndex: 1,
                                     opacity: !hoverElement || hoverElement === element ? 1 : 0.4,
                                     transition: 'opacity 0.2s, box-shadow 0.2s',
@@ -101,7 +102,7 @@ export function Elements(): JSX.Element {
                             <HeatmapLabel
                                 rect={rect}
                                 style={{
-                                    pointerEvents: 'all',
+                                    pointerEvents: heatmapPointerEvents,
                                     zIndex: 5,
                                     opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
                                     transition: 'opacity 0.2s, transform 0.2s linear',
@@ -136,7 +137,7 @@ export function Elements(): JSX.Element {
                                     opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
                                     transition: 'opacity 0.2s, transform 0.2s linear',
                                     transform: hoverElement === element ? 'scale(1.3)' : 'none',
-                                    pointerEvents: 'all',
+                                    pointerEvents: heatmapPointerEvents,
                                     cursor: 'pointer',
                                     color: 'hsla(141, 21%, 12%, 1)',
                                     background: 'hsl(147, 100%, 62%)',

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -17,6 +17,7 @@ export const heatmapLogic = kea<heatmapLogicType>({
         enableHeatmap: true,
         disableHeatmap: true,
         setShowHeatmapTooltip: (showHeatmapTooltip: boolean) => ({ showHeatmapTooltip }),
+        setShiftPressed: (shiftPressed: boolean) => ({ shiftPressed }),
         setHeatmapFilter: (filter: Partial<FilterType>) => ({ filter }),
     },
 
@@ -42,6 +43,12 @@ export const heatmapLogic = kea<heatmapLogicType>({
             false,
             {
                 setShowHeatmapTooltip: (_, { showHeatmapTooltip }) => showHeatmapTooltip,
+            },
+        ],
+        shiftPressed: [
+            false,
+            {
+                setShiftPressed: (_, { shiftPressed }) => shiftPressed,
             },
         ],
         heatmapFilter: [
@@ -210,11 +217,27 @@ export const heatmapLogic = kea<heatmapLogicType>({
         ],
     },
 
-    events: ({ actions, values }) => ({
+    events: ({ actions, values, cache }) => ({
         afterMount() {
             if (values.heatmapEnabled) {
                 actions.getEvents()
             }
+            cache.keyDownListener = (event: KeyboardEvent) => {
+                if (event.shiftKey && !values.shiftPressed) {
+                    actions.setShiftPressed(true)
+                }
+            }
+            cache.keyUpListener = (event: KeyboardEvent) => {
+                if (!event.shiftKey && values.shiftPressed) {
+                    actions.setShiftPressed(false)
+                }
+            }
+            window.addEventListener('keydown', cache.keyDownListener)
+            window.addEventListener('keyup', cache.keyUpListener)
+        },
+        beforeUnmount() {
+            window.removeEventListener('keydown', cache.keyDownListener)
+            window.removeEventListener('keyup', cache.keyUpListener)
         },
     }),
 


### PR DESCRIPTION
## Problem

When using the heatmap, there are situations when you'd like to view the toolbar on e.g. a menu item that you can't normally click.

## Changes

Holding down shift will temporarily disable the heatmap:

![2022-10-28 16 13 23](https://user-images.githubusercontent.com/53387/198637387-9249d468-d730-478a-b444-61f7231f9100.gif)

## How did you test this code?

Clicked around locally