### PR TITLE
chore: Fix backend problems

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -504,8 +504,8 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         send_all_org_usage_reports(dry_run=False)
         mock_posthog.capture.assert_any_call(
             get_machine_id(),
-            "billing service usage report failure",
-            {"code": 404, "scope": "machine"},
+            "organization usage report to billing service failure",
+            {"err": ANY, "scope": "machine"},
             groups={"instance": ANY},
             timestamp=None,
         )

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -248,7 +248,7 @@ def capture_event(
         org_owner = get_org_owner_or_first_user(organization_id)
         distinct_id = org_owner.distinct_id if org_owner and org_owner.distinct_id else f"org-{organization_id}"
         pha_client.capture(
-            distinct_id,  # type: ignore
+            distinct_id,
             name,
             {**properties, "scope": "user"},
             groups={"organization": organization_id, "instance": settings.SITE_URL},


### PR DESCRIPTION
## Problem

Python code quality checks fail on `master` now with `posthog/tasks/usage_report.py:251: error: Unused "type: ignore" comment` after #12496.

## Changes

Removes the offending comment.