### PR TITLE
chore(plugin-server): reduce amount of logging from Kafka consumers

### DIFF
--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -77,7 +77,9 @@ export const startAnonymousEventBufferConsumer = async ({
                 jobKey: message.headers.eventId.toString(), // Ensure we don't create duplicates
             }
 
-            status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
+            status.debug('⬆️', 'Enqueuing anonymous event for processing', {
+                eventId: message.headers.eventId.toString(),
+            })
             try {
                 await graphileWorker.enqueue(JobName.BUFFER_JOB, job, {
                     key: 'team_id',

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -42,7 +42,7 @@ export async function eachBatch(
             await heartbeat()
         }
 
-        status.info(
+        status.debug(
             '🧩',
             `Kafka batch of ${batch.messages.length} events completed in ${
                 new Date().valueOf() - batchStartTimer.valueOf()

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -182,20 +182,43 @@ export class KafkaQueue {
 }
 
 export const setupEventHandlers = (consumer: Consumer): void => {
-    const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
-    consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {
+    const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT, COMMIT_OFFSETS } = consumer.events
+    let offsets: { [key: string]: string } = {} // Keep a record of offsets so we can report on process periodically
+    let statusInterval: NodeJS.Timeout
+    let groupId: string
+
+    consumer.on(GROUP_JOIN, ({ payload }) => {
+        offsets = {}
+        groupId = payload.groupId
         status.info('✅', `Kafka consumer joined group ${groupId}!`)
+        clearInterval(statusInterval)
+        statusInterval = setInterval(() => {
+            status.info('ℹ️', 'consumer_status', { groupId, offsets })
+        }, 10000)
     })
     consumer.on(CRASH, ({ payload: { error, groupId } }) => {
+        offsets = {}
         status.error('⚠️', `Kafka consumer group ${groupId} crashed:\n`, error)
+        clearInterval(statusInterval)
         Sentry.captureException(error)
         killGracefully()
     })
     consumer.on(CONNECT, () => {
+        offsets = {}
         status.info('✅', 'Kafka consumer connected!')
     })
     consumer.on(DISCONNECT, () => {
+        status.info('ℹ️', 'consumer_status', { groupId, offsets })
+        offsets = {}
+        clearInterval(statusInterval)
         status.info('🛑', 'Kafka consumer disconnected!')
+    })
+    consumer.on(COMMIT_OFFSETS, ({ payload: { topics } }) => {
+        topics.forEach(({ topic, partitions }) => {
+            partitions.forEach(({ partition, offset }) => {
+                offsets[`${topic}:${partition}`] = offset
+            })
+        })
     })
 }
 
@@ -212,7 +235,7 @@ export const instrumentEachBatch = async (
         statsd?.increment('kafka_queue_each_batch_failed_events', eventCount, {
             topic: topic,
         })
-        status.info('💀', `Kafka batch of ${eventCount} events for topic ${topic} failed!`)
+        status.warn('💀', `Kafka batch of ${eventCount} events for topic ${topic} failed!`)
         if (error.type === 'UNKNOWN_MEMBER_ID') {
             status.info('💀', "Probably the batch took longer than the session and we couldn't commit the offset")
         }

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -27,7 +27,7 @@ export async function emitToBufferStep(
     if (shouldBuffer(runner.hub, event, person, event.team_id)) {
         const processEventAt = Date.now() + runner.hub.BUFFER_CONVERSION_SECONDS * 1000
         status.debug('🔁', 'Emitting event to buffer', {
-            event,
+            eventId: event.uuid,
             processEventAt,
             conversionBufferTopicEnabledTeams: runner.hub.conversionBufferTopicEnabledTeams,
         })


### PR DESCRIPTION
It's a bit nuts how much logging we get, instead let's only log offsets
every 10 seconds. We'll still get warnings/errors and you'll still get
each batch logged in dev.

Loki was actually lagging trying to keep up with everything, hopefully 
this will take off some of the stress.

The reason I'm doing this now is I'm debugging pipeline issues and I'd rather
reduce the amount of noise.

The reason I've kept at least some info logging is such that we can see that
something is happening.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
