### PR TITLE
chore: turn off chromatic visual regression tests for all but one component

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -19,6 +19,7 @@ jobs:
                   filters: |
                       frontend:
                         - 'frontend/**'
+                        - '.storybook/**'
 
             - name: Install dependencies and chromatic
               if: steps.changes.outputs.frontend == 'true'

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -29,6 +29,7 @@ setupPosthogJs()
 
 // Setup storybook global parameters. See https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {
+    chromatic: { disableSnapshot: true },
     actions: { argTypesRegex: '^on[A-Z].*', disabled: true },
     controls: {
         matchers: {

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
@@ -6,6 +6,9 @@ import { LemonButton } from '../LemonButton'
 export default {
     title: 'Lemon UI/Lemon Badge',
     component: LemonBadge,
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
 } as ComponentMeta<typeof LemonBadge>
 
 const Template: ComponentStory<typeof LemonBadge> = ({ count, ...props }: LemonBadgeProps) => {


### PR DESCRIPTION
…ponent

## Problem

Adding visual regression tests to our cypress e2e tests is fiddly

Adding visual regression tests to our entire storybook is expensive

## Changes

Globally turn off storybook visual regression testing and turn it on for one component. So we can prove the workflow and then incrementally add tests

## How did you test this code?

Opening the PR
