### PR TITLE
chore: enable visual regression for stories in lib folder

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.stories.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.stories.tsx
@@ -11,6 +11,9 @@ import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
 export default {
     title: 'Components/ActivityLog',
     component: ActivityLog,
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/lib/components/ActivityLog/SentenceList.stories.tsx
+++ b/frontend/src/lib/components/ActivityLog/SentenceList.stories.tsx
@@ -4,6 +4,9 @@ import { SentenceList, SentenceListProps } from './SentenceList'
 export default {
     title: 'Components/SentenceList',
     component: SentenceList,
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
 } as ComponentMeta<typeof SentenceList>
 
 const Template: ComponentStory<typeof SentenceList> = (props: SentenceListProps) => {

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.stories.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.stories.tsx
@@ -5,7 +5,7 @@ export default {
     title: 'Lemon UI/Alert Message',
     component: AlertMessage,
     // See https://github.com/storybookjs/addon-smart-knobs/issues/63#issuecomment-995798227
-    parameters: { actions: { argTypesRegex: null } },
+    parameters: { actions: { argTypesRegex: null }, chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof AlertMessage>
 
 const Template: ComponentStory<typeof AlertMessage> = (props: AlertMessageProps) => {

--- a/frontend/src/lib/components/Animation/Animation.stories.tsx
+++ b/frontend/src/lib/components/Animation/Animation.stories.tsx
@@ -11,6 +11,7 @@ export default {
                     'Animations are [LottieFiles.com](https://lottiefiles.com/) animations that we load asynchronously.',
             },
         },
+        chromatic: { disableSnapshot: false },
     },
     argTypes: {
         size: {

--- a/frontend/src/lib/components/BillingAlerts.stories.tsx
+++ b/frontend/src/lib/components/BillingAlerts.stories.tsx
@@ -13,6 +13,7 @@ import { LemonSelect } from './LemonSelect'
 export default {
     title: 'Components/BillingAlerts',
     component: BillingAlerts,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof BillingAlerts>
 
 const Template = (): JSX.Element => {

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.stories.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.stories.tsx
@@ -279,6 +279,9 @@ const EXAMPLE_FUNNEL: InsightModel = {
 export default {
     title: 'Components/Cards/Insight Card',
     component: InsightCardComponent,
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
     argTypes: {
         insightName: {
             control: { type: 'text' },

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.stories.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.stories.tsx
@@ -5,6 +5,9 @@ import { TextCard } from './TextCard'
 export default {
     title: 'Components/Cards/Text Card',
     component: TextCard,
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
 } as Meta
 
 const makeTextTile = (body: string, color: InsightColor | null = null): DashboardTile => {

--- a/frontend/src/lib/components/CompactList/CompactList.stories.tsx
+++ b/frontend/src/lib/components/CompactList/CompactList.stories.tsx
@@ -8,6 +8,7 @@ import { PersonHeader } from 'scenes/persons/PersonHeader'
 export default {
     title: 'Components/Compact List',
     component: CompactList,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         loading: {
             control: {

--- a/frontend/src/lib/components/EditableField/EditableField.stories.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.stories.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react'
 export default {
     title: 'Components/Editable Field',
     component: EditableFieldComponent,
-    parameter: { chromatic: { disableSnapshot: false } },
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof EditableFieldComponent>
 
 export function EditableField_(): JSX.Element {

--- a/frontend/src/lib/components/EditableField/EditableField.stories.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.stories.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 export default {
     title: 'Components/Editable Field',
     component: EditableFieldComponent,
+    parameter: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof EditableFieldComponent>
 
 export function EditableField_(): JSX.Element {

--- a/frontend/src/lib/components/EmptyMessage/EmptyMessage.stories.tsx
+++ b/frontend/src/lib/components/EmptyMessage/EmptyMessage.stories.tsx
@@ -5,6 +5,7 @@ import { EmptyMessage } from './EmptyMessage'
 export default {
     title: 'Components/Empty Message',
     component: EmptyMessage,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof EmptyMessage>
 
 export function EmptyMessage_(): JSX.Element {

--- a/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
@@ -42,6 +42,9 @@ export default {
             },
         }),
     ],
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
 } as Meta
 
 export function EventSelect_(): JSX.Element {

--- a/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.stories.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.stories.tsx
@@ -4,6 +4,7 @@ import { HedgehogBuddy } from './HedgehogBuddy'
 export default {
     title: 'Components/Hedgehog Buddy',
     component: HedgehogBuddy,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof HedgehogBuddy>
 
 export const Template: ComponentStory<typeof HedgehogBuddy> = () => {

--- a/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.stories.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.stories.tsx
@@ -4,7 +4,6 @@ import { HedgehogBuddy } from './HedgehogBuddy'
 export default {
     title: 'Components/Hedgehog Buddy',
     component: HedgehogBuddy,
-    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof HedgehogBuddy>
 
 export const Template: ComponentStory<typeof HedgehogBuddy> = () => {

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -20,7 +20,7 @@ const types: LemonButtonProps['type'][] = ['primary', 'secondary', 'tertiary']
 export default {
     title: 'Lemon UI/Lemon Button',
     component: LemonButton,
-
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         icon: {
             defaultValue: <IconCalculate />,

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendar.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendar.stories.tsx
@@ -5,6 +5,7 @@ import { dayjs } from 'lib/dayjs'
 export default {
     title: 'Lemon UI/Lemon Calendar/Lemon Calendar',
     component: LemonCalendar,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         onClick: {
             defaultValue: (date: string) => {

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.stories.tsx
@@ -9,6 +9,7 @@ import { formatDate } from 'lib/utils'
 export default {
     title: 'Lemon UI/Lemon Calendar/Lemon Calendar Select',
     component: LemonCalendarSelect,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof LemonCalendarSelect>
 
 const BasicTemplate: ComponentStory<typeof LemonCalendarSelect> = (props: LemonCalendarSelectProps) => {

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.stories.tsx
@@ -9,6 +9,7 @@ import { formatDateRange } from 'lib/utils'
 export default {
     title: 'Lemon UI/Lemon Calendar/Lemon Calendar Range',
     component: LemonCalendarRange,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof LemonCalendarRange>
 
 const BasicTemplate: ComponentStory<typeof LemonCalendarRange> = (props: LemonCalendarRangeProps) => {

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRangeInline.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRangeInline.stories.tsx
@@ -8,6 +8,7 @@ import { LemonCalendarRangeInline } from './LemonCalendarRangeInline'
 export default {
     title: 'Lemon UI/Lemon Calendar/Lemon Calendar Range Inline',
     component: LemonCalendarRangeInline,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof LemonCalendarRangeInline>
 
 const BasicTemplate: ComponentStory<typeof LemonCalendarRangeInline> = (props: LemonCalendarRangeProps) => {

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
@@ -4,6 +4,7 @@ import { LemonCheckbox, LemonCheckboxProps } from './LemonCheckbox'
 export default {
     title: 'Lemon UI/Lemon Checkbox',
     component: LemonCheckbox,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof LemonCheckbox>
 
 const Template: ComponentStory<typeof LemonCheckbox> = (props: LemonCheckboxProps) => {

--- a/frontend/src/lib/components/LemonDialog/LemonDialog.stories.tsx
+++ b/frontend/src/lib/components/LemonDialog/LemonDialog.stories.tsx
@@ -40,6 +40,7 @@ Dialogs are opened imperatively (i.e. calling \`LemonDialog.open()\`) whereas Mo
             `,
             },
         },
+        chromatic: { disableSnapshot: false },
     },
 } as ComponentMeta<typeof LemonDialog>
 

--- a/frontend/src/lib/components/LemonDivider/LemonDivider.stories.tsx
+++ b/frontend/src/lib/components/LemonDivider/LemonDivider.stories.tsx
@@ -8,6 +8,7 @@ import { ProfileBubbles } from '../ProfilePicture'
 export default {
     title: 'Lemon UI/Lemon Divider',
     component: LemonDivider,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof LemonDivider>
 
 const HorizontalTemplate: ComponentStory<typeof LemonDivider> = (props: LemonDividerProps) => {

--- a/frontend/src/lib/components/LemonInput/LemonInput.stories.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.stories.tsx
@@ -8,6 +8,7 @@ import { LemonButtonWithPopup } from 'lib/components/LemonButton'
 export default {
     title: 'Lemon UI/Lemon Input',
     component: LemonInput,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         value: { defaultValue: 'Foo' },
     },

--- a/frontend/src/lib/components/LemonLabel/LemonLabel.stories.tsx
+++ b/frontend/src/lib/components/LemonLabel/LemonLabel.stories.tsx
@@ -6,6 +6,7 @@ import { LemonModal } from '@posthog/lemon-ui'
 export default {
     title: 'Lemon UI/Lemon Label',
     component: LemonLabel,
+    parameters: { chromatic: { disableSnapshot: false } },
     docs: {
         description: {
             component: `

--- a/frontend/src/lib/components/LemonModal/LemonModal.stories.tsx
+++ b/frontend/src/lib/components/LemonModal/LemonModal.stories.tsx
@@ -6,6 +6,7 @@ import { LemonButton } from '../LemonButton'
 export default {
     title: 'Lemon UI/Lemon Modal',
     component: LemonModal,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof LemonModal>
 
 export const _LemonModal: ComponentStory<typeof LemonModal> = (props: LemonModalProps) => {

--- a/frontend/src/lib/components/LemonRow/LemonRow.stories.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.stories.tsx
@@ -5,6 +5,7 @@ import { LemonRow, LemonRowProps } from './LemonRow'
 export default {
     title: 'Lemon UI/Lemon Row',
     component: LemonRow,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         icon: {
             defaultValue: <IconPremium />,

--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -5,6 +5,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 export default {
     title: 'Lemon UI/Lemon Select',
     component: LemonSelect,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         options: {
             defaultValue: [

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.stories.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.stories.tsx
@@ -7,6 +7,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 export default {
     title: 'Lemon UI/Lemon SelectMultiple',
     component: LemonSelectMultiple,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         options: {
             defaultValue: ['ben', 'marius', 'paul', 'tiina', 'li'].reduce(

--- a/frontend/src/lib/components/LemonSkeleton/LemonSkeleton.stories.tsx
+++ b/frontend/src/lib/components/LemonSkeleton/LemonSkeleton.stories.tsx
@@ -8,6 +8,7 @@ export default {
     title: 'Lemon UI/Lemon Skeleton',
     component: LemonSkeleton,
     parameters: {
+        chromatic: { disableSnapshot: false },
         docs: {
             description: {
                 component: `

--- a/frontend/src/lib/components/LemonSnack/LemonSnack.stories.tsx
+++ b/frontend/src/lib/components/LemonSnack/LemonSnack.stories.tsx
@@ -5,6 +5,7 @@ import { ProfilePicture } from '../ProfilePicture'
 export default {
     title: 'Lemon UI/Lemon Snack',
     component: LemonSnack,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         children: {
             defaultValue: 'Tasty snacks',

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
@@ -7,6 +7,7 @@ import { IconGlobeLock } from '../icons'
 export default {
     title: 'Lemon UI/Lemon Switch',
     component: RawLemonSwitch,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         label: {
             defaultValue: 'Switch this!',

--- a/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
@@ -4,6 +4,7 @@ import { LemonTable, LemonTableProps } from './LemonTable'
 export default {
     title: 'Lemon UI/Lemon Table',
     component: LemonTable,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof LemonTable>
 
 interface MockPerson {

--- a/frontend/src/lib/components/LemonTextArea/LemonTextArea.stories.tsx
+++ b/frontend/src/lib/components/LemonTextArea/LemonTextArea.stories.tsx
@@ -6,6 +6,7 @@ import { LemonTextArea, LemonTextAreaProps, LemonTextMarkdown as _LemonTextMarkd
 export default {
     title: 'Lemon UI/Lemon Text Area',
     component: LemonTextArea,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         value: {
             defaultValue:

--- a/frontend/src/lib/components/Lettermark/Lettermark.stories.tsx
+++ b/frontend/src/lib/components/Lettermark/Lettermark.stories.tsx
@@ -6,6 +6,7 @@ export default {
     title: 'Lemon UI/Lettermark',
     component: Lettermark,
     parameters: {
+        chromatic: { disableSnapshot: false },
         docs: {
             description: {
                 component:

--- a/frontend/src/lib/components/NotFound/NotFound.stories.tsx
+++ b/frontend/src/lib/components/NotFound/NotFound.stories.tsx
@@ -5,6 +5,7 @@ import { NotFound } from './index'
 export default {
     title: 'Components/Not Found',
     component: NotFound,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof NotFound>
 
 const Template: ComponentStory<typeof NotFound> = (args) => <NotFound {...args} />

--- a/frontend/src/lib/components/PaginationControl/PaginationControl.stories.tsx
+++ b/frontend/src/lib/components/PaginationControl/PaginationControl.stories.tsx
@@ -5,6 +5,7 @@ import { usePagination } from './usePagination'
 export default {
     title: 'Lemon UI/Pagination Control',
     component: PaginationControl,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof PaginationControl>
 
 const DATA_SOURCE = Array(43)

--- a/frontend/src/lib/components/PayCard/PayCard.stories.tsx
+++ b/frontend/src/lib/components/PayCard/PayCard.stories.tsx
@@ -6,6 +6,7 @@ import { AvailableFeature } from '~/types'
 export default {
     title: 'Components/Pay Card',
     component: PayCard,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof PayCard>
 
 const Template: ComponentStory<typeof PayCard> = (args) => {

--- a/frontend/src/lib/components/PersonPropertySelect/PersonPropertySelect.stories.tsx
+++ b/frontend/src/lib/components/PersonPropertySelect/PersonPropertySelect.stories.tsx
@@ -7,6 +7,7 @@ import { PersonPropertySelect } from './PersonPropertySelect'
 
 export default {
     title: 'Filters',
+    parameters: { chromatic: { disableSnapshot: false } },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/lib/components/Popup/Popup.stories.tsx
+++ b/frontend/src/lib/components/Popup/Popup.stories.tsx
@@ -6,6 +6,7 @@ import { IconArrowDropDown } from '../icons'
 export default {
     title: 'Lemon UI/Popup',
     component: Popup,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof Popup>
 
 const Template: ComponentStory<typeof Popup> = (args) => <Popup {...args} />

--- a/frontend/src/lib/components/ProfilePicture/ProfileBubbles.stories.tsx
+++ b/frontend/src/lib/components/ProfilePicture/ProfileBubbles.stories.tsx
@@ -12,6 +12,7 @@ const DUMMIES: ProfileBubblesProps['people'] = [
 export default {
     title: 'Lemon UI/Profile Bubbles',
     component: ProfileBubblesComponent,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         people: {
             defaultValue: DUMMIES,

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.stories.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.stories.tsx
@@ -8,6 +8,7 @@ import { personPropertiesModel } from '~/models/personPropertiesModel'
 export default {
     title: 'Filters/PropertyFilters',
     component: PropertyFilters,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof PropertyFilters>
 
 const propertyFilters = [

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.stories.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.stories.tsx
@@ -10,6 +10,7 @@ import { cohortsModel } from '~/models/cohortsModel'
 export default {
     title: 'Filters/PropertyGroupFilters',
     component: PropertyGroupFilters,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof PropertyGroupFilters>
 
 const propertyFilters = [

--- a/frontend/src/lib/components/PropertyIcon.stories.tsx
+++ b/frontend/src/lib/components/PropertyIcon.stories.tsx
@@ -6,6 +6,7 @@ import { countryCodeToName } from 'scenes/insights/views/WorldMap'
 export default {
     title: 'Lemon UI/Icons/Property Icon',
     component: PropertyIcon,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof PropertyIcon>
 
 const Template: ComponentStory<typeof PropertyIcon> = (args) => {

--- a/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
@@ -5,6 +5,7 @@ import { PropertyKeyInfo } from './PropertyKeyInfo'
 export default {
     title: 'Components/Property Key Info',
     component: PropertyKeyInfo,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof PropertyKeyInfo>
 
 const Template: ComponentStory<typeof PropertyKeyInfo> = (args) => {

--- a/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.stories.tsx
+++ b/frontend/src/lib/components/PropertyNamesSelect/PropertyNamesSelect.stories.tsx
@@ -5,6 +5,7 @@ import { personPropertiesModel } from '~/models/personPropertiesModel'
 
 export default {
     title: 'Filters',
+    parameters: { chromatic: { disableSnapshot: false } },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/lib/components/Sharing/SharingModal.stories.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.stories.tsx
@@ -15,7 +15,12 @@ const fakeInsight: Partial<InsightModel> = {
 export default {
     title: 'Components/Sharing',
     component: SharingModal,
-    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'story' },
+    parameters: {
+        layout: 'fullscreen',
+        options: { showPanel: false },
+        viewMode: 'story',
+        chromatic: { disableSnapshot: false },
+    },
 } as ComponentMeta<typeof SharingModal>
 
 const Template = (args: Partial<SharingModalProps> & { licensed?: boolean }): JSX.Element => {

--- a/frontend/src/lib/components/Spinner/Spinner.stories.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.stories.tsx
@@ -6,6 +6,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 export default {
     title: 'Lemon UI/Spinner',
     component: Spinner,
+    parameters: { chromatic: { disableSnapshot: false } },
 } as ComponentMeta<typeof Spinner>
 
 export function Default(): JSX.Element {

--- a/frontend/src/lib/components/Subscriptions/SubscriptionsModal.stories.tsx
+++ b/frontend/src/lib/components/Subscriptions/SubscriptionsModal.stories.tsx
@@ -12,7 +12,12 @@ import { createMockSubscription, mockIntegration, mockSlackChannels } from '~/te
 export default {
     title: 'Components/Subscriptions',
     component: SubscriptionsModal,
-    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'story' },
+    parameters: {
+        layout: 'fullscreen',
+        options: { showPanel: false },
+        viewMode: 'story',
+        chromatic: { disableSnapshot: false },
+    },
 } as ComponentMeta<typeof SubscriptionsModal>
 
 const Template = (

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
@@ -8,6 +8,7 @@ import { useMountedLogic } from 'kea'
 export default {
     title: 'Filters',
     decorators: [taxonomicFilterMocksDecorator],
+    parameters: { chromatic: { disableSnapshot: false } },
 }
 
 export function TaxonomicFilter_(): JSX.Element {

--- a/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.stories.tsx
@@ -11,6 +11,7 @@ import { ComponentMeta } from '@storybook/react'
 export default {
     title: 'Filters/TaxonomicPopup',
     component: TaxonomicPopup,
+    parameters: { chromatic: { disableSnapshot: false } },
     decorators: [taxonomicFilterMocksDecorator],
 } as ComponentMeta<typeof TaxonomicPopup>
 

--- a/frontend/src/lib/components/colors.stories.tsx
+++ b/frontend/src/lib/components/colors.stories.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 export default {
     title: 'Lemon UI/Colors',
     parameters: {
+        chromatic: { disableSnapshot: false },
         options: { showPanel: false },
         docs: {
             description: {

--- a/frontend/src/lib/components/hedgehogs.stories.tsx
+++ b/frontend/src/lib/components/hedgehogs.stories.tsx
@@ -15,6 +15,7 @@ const allHedgehogs: HedgehogDefinition[] = Object.entries(hedgehogs).map(([key, 
 export default {
     title: 'Lemon UI/Hog illustrations',
     parameters: {
+        chromatic: { disableSnapshot: false },
         options: { showPanel: false },
         docs: {
             description: {

--- a/frontend/src/lib/components/icons.stories.tsx
+++ b/frontend/src/lib/components/icons.stories.tsx
@@ -18,6 +18,7 @@ const allIcons: IconDefinition[] = Object.entries(icons)
 export default {
     title: 'Lemon UI/Icons',
     parameters: {
+        chromatic: { disableSnapshot: false },
         options: { showPanel: false },
         docs: {
             description: {

--- a/frontend/src/lib/components/icons/Splotch.stories.tsx
+++ b/frontend/src/lib/components/icons/Splotch.stories.tsx
@@ -4,6 +4,7 @@ import { Splotch, SplotchColor, SplotchProps } from './Splotch'
 export default {
     title: 'Lemon UI/Splotch',
     component: Splotch,
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         color: {
             defaultValue: SplotchColor.Purple,

--- a/frontend/src/lib/forms/Field.stories.tsx
+++ b/frontend/src/lib/forms/Field.stories.tsx
@@ -10,6 +10,7 @@ export default {
     title: 'Lemon UI/Forms and Fields',
     component: PureField,
     parameters: {
+        chromatic: { disableSnapshot: false },
         docs: {
             description: {
                 component: `

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
@@ -119,7 +119,7 @@ const data = {
 export default {
     title: 'Components/InsightTooltip',
     component: InsightTooltip,
-
+    parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         date: { defaultValue: data.date },
         timezone: { defaultValue: data.timezone },

--- a/frontend/src/scenes/project/Settings/SlackIntegration.stories.tsx
+++ b/frontend/src/scenes/project/Settings/SlackIntegration.stories.tsx
@@ -8,7 +8,12 @@ import { SlackIntegration } from './SlackIntegration'
 export default {
     title: 'Components/Integrations/Slack',
     component: SlackIntegration,
-    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'story' },
+    parameters: {
+        layout: 'fullscreen',
+        options: { showPanel: false },
+        viewMode: 'story',
+        chromatic: { disableSnapshot: false },
+    },
 } as ComponentMeta<typeof SlackIntegration>
 
 const Template = (args: { instanceConfigured?: boolean; integrated?: boolean }): JSX.Element => {

--- a/frontend/src/styles/utilities.stories.tsx
+++ b/frontend/src/styles/utilities.stories.tsx
@@ -2,6 +2,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 export default {
     title: 'Lemon UI/Utilities',
+    parameters: { chromatic: { disableSnapshot: false } },
 }
 
 export const Overview = (): JSX.Element => {


### PR DESCRIPTION
## Problem

Visual regression tests in chromatic are disabled across all components except LemonBadge

## Changes

This turns them on across components but not other areas

## How did you test this code?

opening the PR and seeing what ran