### PR TITLE
test(plugin-server): add historical exports functional test

### DIFF
--- a/plugin-server/functional_tests/e2e.test.ts
+++ b/plugin-server/functional_tests/e2e.test.ts
@@ -326,7 +326,7 @@ describe.each([[startSingleServer], [startMultiServer]])('E2E', (pluginServer) =
             }
         `
 
-        test('exporting events', async () => {
+        test('exporting events on ingestion', async () => {
             const plugin = await createPlugin(postgres, {
                 organization_id: organizationId,
                 name: 'export plugin',
@@ -374,7 +374,17 @@ describe.each([[startSingleServer], [startMultiServer]])('E2E', (pluginServer) =
                     }),
                     timestamp: expect.any(String),
                     uuid: uuid,
-                    elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, text: '💻', attributes: {} }],
+                    elements: [
+                        {
+                            tag_name: 'div',
+                            nth_child: 1,
+                            nth_of_type: 2,
+                            order: 0,
+                            $el_text: '💻',
+                            text: '💻',
+                            attributes: {},
+                        },
+                    ],
                 }),
             ])
         })

--- a/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
@@ -55,7 +55,12 @@ export const startJobsConsumer = async ({
                 continue
             }
 
-            status.debug('⬆️', 'Enqueuing plugin job', { job })
+            status.debug('⬆️', 'Enqueuing plugin job', {
+                type: job.type,
+                pluginConfigId: job.pluginConfigId,
+                pluginConfigTeam: job.pluginConfigTeam,
+            })
+
             try {
                 await graphileWorker.enqueue(JobName.PLUGIN_JOB, job)
                 resolveOffset(message.offset)

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -51,9 +51,13 @@ export class KafkaQueue {
 
         if (this.pluginsServer.capabilities.ingestion) {
             topics.push(this.ingestionTopic)
-        } else if (this.pluginsServer.capabilities.processAsyncHandlers) {
+        }
+
+        if (this.pluginsServer.capabilities.processAsyncHandlers) {
             topics.push(this.eventsTopic)
-        } else {
+        }
+
+        if (topics.length === 0) {
             throw Error('No topics to consume, KafkaQueue should not be started')
         }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -267,6 +267,10 @@ export async function startPluginsServer(
                     hub.pluginSchedule = await loadPluginSchedule(piscina)
                 }
             },
+            ['reload-actions']: async () => {
+                status.info('⚡', 'Reloading actions!')
+                await piscina?.broadcastTask({ task: 'reloadAllActions' })
+            },
             'reset-available-features-cache': async (message) => {
                 await piscina?.broadcastTask({ task: 'resetAvailableFeaturesCache', args: JSON.parse(message) })
             },

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1325,7 +1325,7 @@ export class DB {
                 'fetchActions'
             )
         ).rows
-        console.log(rawActions)
+
         const pluginIds: number[] = rawActions.map(({ id }) => id)
         const actionSteps: (ActionStep & { team_id: Team['id'] })[] = (
             await this.postgresQuery(

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1325,7 +1325,7 @@ export class DB {
                 'fetchActions'
             )
         ).rows
-
+        console.log(rawActions)
         const pluginIds: number[] = rawActions.map(({ id }) => id)
         const actionSteps: (ActionStep & { team_id: Team['id'] })[] = (
             await this.postgresQuery(

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -18,7 +18,7 @@ export function convertToProcessedPluginEvent(event: PostIngestionEvent): Proces
         $set: event.properties.$set,
         $set_once: event.properties.$set_once,
         uuid: event.eventUuid,
-        elements: convertDatabaseElementsToRawElements(event.elementsList),
+        elements: convertDatabaseElementsToRawElements(event.elementsList ?? []),
     }
 }
 

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -2,6 +2,7 @@ import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 import { KafkaMessage } from 'kafkajs'
 
 import { ClickHouseEvent, PostIngestionEvent, RawClickHouseEvent } from '../types'
+import { convertDatabaseElementsToRawElements } from '../worker/vm/upgrades/utils/fetchEventsForInterval'
 import { chainToElements } from './db/elements-chain'
 import { personInitialAndUTMProperties } from './db/utils'
 import { clickHouseTimestampToDateTime, clickHouseTimestampToISO } from './utils'
@@ -17,7 +18,7 @@ export function convertToProcessedPluginEvent(event: PostIngestionEvent): Proces
         $set: event.properties.$set,
         $set_once: event.properties.$set_once,
         uuid: event.eventUuid,
-        elements: event.elementsList,
+        elements: convertDatabaseElementsToRawElements(event.elementsList),
     }
 }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-createEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-createEventStep.ts
@@ -7,6 +7,9 @@ export async function createEventStep(
     event: PreIngestionEvent,
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
-    const ingestionEvent = await runner.hub.eventsProcessor.createEvent(event, personContainer)
-    return runner.nextStep('runAsyncHandlersStep', ingestionEvent, personContainer)
+    await runner.hub.eventsProcessor.createEvent(event, personContainer)
+    // NOTE: we always stop here. Previously we had an optimization to run the
+    // async functions within this pipeline. Instead we unify how the pipeline
+    // runs no matter how you have PLUGIN_SERVER_MODE set.
+    return null
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
@@ -10,12 +10,10 @@ export async function runAsyncHandlersStep(
     event: PostIngestionEvent,
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
-    if (runner.hub.capabilities.processAsyncHandlers) {
-        await Promise.all([
-            processOnEvent(runner, event),
-            processWebhooks(runner, event, personContainer, event.elementsList),
-        ])
-    }
+    await Promise.all([
+        processOnEvent(runner, event),
+        processWebhooks(runner, event, personContainer, event.elementsList),
+    ])
 
     return null
 }

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -5,6 +5,7 @@ import { format } from 'util'
 import { Action, Hook, IngestionPersonData, PostIngestionEvent } from '../../types'
 import { DB } from '../../utils/db/db'
 import fetch from '../../utils/fetch'
+import { status } from '../../utils/status'
 import { stringify } from '../../utils/utils'
 import { OrganizationManager } from './organization-manager'
 import { SiteUrlManager } from './site-url-manager'
@@ -183,9 +184,12 @@ export class HookCommander {
         person: IngestionPersonData | undefined,
         actionMatches: Action[]
     ): Promise<void> {
+        status.debug('🔍', `Looking for hooks to fire for event "${event.event}"`)
         if (!actionMatches.length) {
+            status.debug('🔍', `No hooks to fire for event "${event.event}"`)
             return
         }
+        status.debug('🔍', `Found ${actionMatches.length} matching actions`)
 
         const team = await this.teamManager.fetchTeam(event.teamId)
 

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -81,15 +81,14 @@ const addHistoricalExportEventProperties = (event: HistoricalExportEvent): Histo
     return event
 }
 
-const convertDatabaseElementsToRawElements = (elements: RawElement[]): RawElement[] => {
+export const convertDatabaseElementsToRawElements = (elements: RawElement[]): RawElement[] => {
     for (const element of elements) {
         if (element.attributes && element.attributes.attr__class) {
             element.attr_class = element.attributes.attr__class
         }
-
-        // Unify with the format used when processEvent is called with
-        // non-historically exported events.
-        element['order'] = undefined
+        if (element.text) {
+            element.$el_text = element.text
+        }
     }
     return elements
 }

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -55,14 +55,15 @@ export const fetchEventsForInterval = async (
 
 const convertClickhouseEventToPluginEvent = (event: RawClickHouseEvent): HistoricalExportEvent => {
     const clickhouseEvent = parseRawClickHouseEvent(event)
-    if (clickhouseEvent.event === '$autocapture' && clickhouseEvent.elements_chain) {
-        clickhouseEvent.properties['$elements'] = convertDatabaseElementsToRawElements(clickhouseEvent.elements_chain)
-    }
     const parsedEvent = {
         uuid: clickhouseEvent.uuid,
         team_id: clickhouseEvent.team_id,
         distinct_id: clickhouseEvent.distinct_id,
         properties: clickhouseEvent.properties,
+        elements:
+            clickhouseEvent.event === '$autocapture' && clickhouseEvent.elements_chain
+                ? convertDatabaseElementsToRawElements(clickhouseEvent.elements_chain)
+                : undefined,
         timestamp: clickhouseEvent.timestamp.toISO(),
         now: DateTime.now().toISO(),
         event: clickhouseEvent.event || '',
@@ -85,9 +86,10 @@ const convertDatabaseElementsToRawElements = (elements: RawElement[]): RawElemen
         if (element.attributes && element.attributes.attr__class) {
             element.attr_class = element.attributes.attr__class
         }
-        if (element.text) {
-            element.$el_text = element.text
-        }
+
+        // Unify with the format used when processEvent is called with
+        // non-historically exported events.
+        element['order'] = undefined
     }
     return elements
 }

--- a/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
@@ -29,10 +29,10 @@ describe('createEventStep()', () => {
         }
     })
 
-    it('calls `createEvent` and forwards to `runAsyncHandlersStep`', async () => {
+    it("calls `createEvent` and doesn't advance to the async handlers step", async () => {
         const personContainer = new LazyPersonContainer(2, 'my_id', runner.hub)
         const response = await createEventStep(runner, preIngestionEvent, personContainer)
 
-        expect(response).toEqual(['runAsyncHandlersStep', preIngestionEvent, personContainer])
+        expect(response).toEqual(null) // async handlers are handled separately by reading from the clickhouse events topic
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
@@ -78,16 +78,6 @@ describe('runAsyncHandlersStep()', () => {
         expect(runOnEvent).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(ingestionEvent))
     })
 
-    it('stops processing if not capabilities.processAsyncHandlers', async () => {
-        runner.hub.capabilities.processAsyncHandlers = false
-
-        const result = await runAsyncHandlersStep(runner, ingestionEvent, personContainer)
-
-        expect(result).toEqual(null)
-        expect(runOnSnapshot).not.toHaveBeenCalled()
-        expect(runOnEvent).not.toHaveBeenCalled()
-    })
-
     describe('$snapshot events', () => {
         it('does not do action matching or webhook firing', async () => {
             await runAsyncHandlersStep(runner, snapshotEvent, personContainer)

--- a/plugin-server/tests/worker/worker.test.ts
+++ b/plugin-server/tests/worker/worker.test.ts
@@ -82,7 +82,7 @@ describe('worker', () => {
 
         const ingestResponse2 = await ingestEvent(createEvent())
         expect(ingestResponse2).toEqual({
-            lastStep: 'createEvent',
+            lastStep: 'createEventStep',
             args: expect.anything(),
             event: expect.anything(),
         })

--- a/plugin-server/tests/worker/worker.test.ts
+++ b/plugin-server/tests/worker/worker.test.ts
@@ -82,7 +82,7 @@ describe('worker', () => {
 
         const ingestResponse2 = await ingestEvent(createEvent())
         expect(ingestResponse2).toEqual({
-            lastStep: 'runAsyncHandlersStep',
+            lastStep: 'createEvent',
             args: expect.anything(),
             event: expect.anything(),
         })


### PR DESCRIPTION
This required some changes to ensure that we always have the same format
for the events passed to processEvent. I believe this is the source of a few issues
we've had with e.g. `elements` being in different formats according to if async 
handles were run "sync" with the events pipeline, or run via the historical exports
flow.

See for example [this issue](https://github.com/PostHog/snowflake-export-plugin/issues/31) 
where elements is not set.

NOTE: the big change is that we don't try to be clever and either use the result of the 
event ingestion pipeline OR the clickhouse_events_json result. We just use clickhouse_event_json 
all the time, meaning be do not need to consider the two cases separately.

As I'm changing webhook functionality that doesn't have a functional test and is 
requiring unittest changes, I've added a slack webhook functional test also, to ensure 
I haven't broken this.

NOTE: as a result of the webhook test, I add a method to reload actions via PubSub, as 
we do with plugins.

The big question here is which functionality is the one we want, as the exports all 
have slightly different outcomes as it stands. I've chosen to test one of them, but 
I don't have a good view on what plugins/apps are expecting to receive.

NOTE: it appears that [some plugins](https://github.com/PostHog/snowflake-export-plugin/blob/main/index.ts#L121) are expecting $elements to be part of the `properties`. 
As far as I can tell this isn't the case in either of the configurations of PLUGIN_SERVER_MODE atm so 
I believe these should be updated to instead expect `elements` at the top level. It is deleted [here](https://github.com/PostHog/posthog/blob/tests/add-historical-exports-tess/plugin-server/src/worker/ingestion/process-event.ts#L135:L135)

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
