### PR TITLE
chore(ingestion): add resume log for anonymous buffer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -64,16 +64,25 @@ export const startAnonymousEventBufferConsumer = async ({
             const processEventAt = Number.parseInt(message.headers.processEventAt.toString())
             const now = Date.now()
             if (processEventAt > now) {
+                const eventId = message.headers.eventId.toString()
                 status.info('🔁', 'Delaying event processing', {
                     topic: batch.topic,
                     partition: batch.partition,
-                    eventId: message.headers.eventId.toString(),
+                    eventId: eventId,
                     delayMs: processEventAt - now,
                     processEventAt,
                     now,
                 })
                 const resume = pause()
-                setTimeout(resume, processEventAt - now)
+                setTimeout(() => {
+                    status.info('🔁', 'Resuming event processing', {
+                        topic: batch.topic,
+                        partition: batch.partition,
+                        eventId: eventId,
+                        delayMs: processEventAt - now,
+                    })
+                    resume()
+                }, processEventAt - now)
 
                 return
             }


### PR DESCRIPTION
I had a log for the pause, but then not for the resume. I've also
included e.g. the eventId for which the pause was issued along with the
topic/partition so we can match them up.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
