### PR TITLE
fix(app-metrics): fix app history pagination, rename

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -109,11 +109,13 @@ export const activityLogLogic = kea<activityLogLogicType>({
         const onPageChange = (
             searchParams: Record<string, any>,
             hashParams: Record<string, any>,
-            pageScope: ActivityScope
+            pageScope: ActivityScope,
+            forceUsePageParam?: boolean
         ): void => {
             const pageInURL = searchParams['page']
 
             const shouldPage =
+                forceUsePageParam ||
                 (pageScope === ActivityScope.PERSON && hashParams['activeTab'] === 'history') ||
                 ([ActivityScope.FEATURE_FLAG, ActivityScope.INSIGHT, ActivityScope.PLUGIN].includes(pageScope) &&
                     searchParams['tab'] === 'history')
@@ -127,7 +129,7 @@ export const activityLogLogic = kea<activityLogLogicType>({
                 ([ActivityScope.FEATURE_FLAG, ActivityScope.INSIGHT, ActivityScope.PLUGIN].includes(pageScope) &&
                     searchParams['tab'] !== 'history')
 
-            if (shouldRemovePageParam && 'page' in router.values.searchParams) {
+            if (!forceUsePageParam && shouldRemovePageParam && 'page' in router.values.searchParams) {
                 const { page: _, ...newSearchParams } = router.values.searchParams
                 router.actions.replace(
                     router.values.currentLocation.pathname,
@@ -144,6 +146,8 @@ export const activityLogLogic = kea<activityLogLogicType>({
                 onPageChange(searchParams, hashParams, ActivityScope.INSIGHT),
             [urls.projectApps()]: ({}, searchParams, hashParams) =>
                 onPageChange(searchParams, hashParams, ActivityScope.PLUGIN),
+            [urls.appActivity(':pluginConfigId')]: ({}, searchParams, hashParams) =>
+                onPageChange(searchParams, hashParams, ActivityScope.PLUGIN, true),
         }
     },
     events: ({ actions }) => ({

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -146,6 +146,8 @@ export const activityLogLogic = kea<activityLogLogicType>({
                 onPageChange(searchParams, hashParams, ActivityScope.INSIGHT),
             [urls.projectApps()]: ({}, searchParams, hashParams) =>
                 onPageChange(searchParams, hashParams, ActivityScope.PLUGIN),
+            [urls.featureFlag(':id')]: ({}, searchParams, hashParams) =>
+                onPageChange(searchParams, hashParams, ActivityScope.FEATURE_FLAG, true),
             [urls.appActivity(':pluginConfigId')]: ({}, searchParams, hashParams) =>
                 onPageChange(searchParams, hashParams, ActivityScope.PLUGIN, true),
         }

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -148,7 +148,7 @@ export const activityLogLogic = kea<activityLogLogicType>({
                 onPageChange(searchParams, hashParams, ActivityScope.PLUGIN),
             [urls.featureFlag(':id')]: ({}, searchParams, hashParams) =>
                 onPageChange(searchParams, hashParams, ActivityScope.FEATURE_FLAG, true),
-            [urls.appActivity(':pluginConfigId')]: ({}, searchParams, hashParams) =>
+            [urls.appHistory(':pluginConfigId')]: ({}, searchParams, hashParams) =>
                 onPageChange(searchParams, hashParams, ActivityScope.PLUGIN, true),
         }
     },

--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -82,7 +82,7 @@ export function AppMetrics(): JSX.Element {
                             <HistoricalExportsTab />
                         </Tabs.TabPane>
                     )}
-                    <Tabs.TabPane tab="Activity history" key={AppMetricsTab.Activity}>
+                    <Tabs.TabPane tab="History" key={AppMetricsTab.History}>
                         <ActivityLog scope={ActivityScope.PLUGIN} id={pluginConfig?.id} />
                     </Tabs.TabPane>
                 </Tabs>

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -31,7 +31,7 @@ export enum AppMetricsTab {
     ExportEvents = 'exportEvents',
     ScheduledTask = 'scheduledTask',
     HistoricalExports = 'historical_exports',
-    Activity = 'activity',
+    History = 'history',
 }
 
 export type TabWithMetrics =
@@ -209,7 +209,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
 
         defaultTab: [
             (s) => [s.pluginConfig],
-            () => INITIAL_TABS.filter((tab) => values.showTab(tab))[0] ?? AppMetricsTab.Activity,
+            () => INITIAL_TABS.filter((tab) => values.showTab(tab))[0] ?? AppMetricsTab.History,
         ],
 
         currentTime: [() => [], () => Date.now()],
@@ -252,7 +252,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                     const capabilities = values.pluginConfig.plugin_info.capabilities
                     const isExportEvents = capabilities.methods.includes('exportEvents')
 
-                    if (tab === AppMetricsTab.Activity) {
+                    if (tab === AppMetricsTab.History) {
                         return true
                     }
 
@@ -314,7 +314,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
         setActiveTab: ({ tab }) => {
             if (tab === AppMetricsTab.HistoricalExports) {
                 actions.loadHistoricalExports()
-            } else if (tab !== AppMetricsTab.Activity) {
+            } else if (tab !== AppMetricsTab.History) {
                 actions.loadMetrics()
             }
         },
@@ -344,8 +344,8 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                 }
                 if (url.page === AppMetricsTab.HistoricalExports) {
                     actions.setActiveTab(AppMetricsTab.HistoricalExports)
-                } else if (url.page === AppMetricsTab.Activity) {
-                    actions.setActiveTab(AppMetricsTab.Activity)
+                } else if (url.page === AppMetricsTab.History) {
+                    actions.setActiveTab(AppMetricsTab.History)
                 } else {
                     if (params.tab && INITIAL_TABS.includes(params.tab as any) && params.tab !== values.activeTab) {
                         actions.setActiveTab(params.tab as AppMetricsTab)
@@ -374,8 +374,8 @@ function getUrl(values: appMetricsSceneLogicType['values'], props: appMetricsSce
     if (values.activeTab === AppMetricsTab.HistoricalExports) {
         return urls.appHistoricalExports(props.pluginConfigId)
     }
-    if (values.activeTab === AppMetricsTab.Activity) {
-        return urls.appActivity(props.pluginConfigId, router.values.searchParams)
+    if (values.activeTab === AppMetricsTab.History) {
+        return urls.appHistory(props.pluginConfigId, router.values.searchParams)
     }
 
     const params: AppMetricsUrlParams = {}

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -12,6 +12,7 @@ import { HISTORICAL_EXPORT_JOB_NAME_V2 } from 'scenes/plugins/edit/interface-job
 import { interfaceJobsLogic, InterfaceJobsProps } from '../plugins/edit/interface-jobs/interfaceJobsLogic'
 import { dayjs } from 'lib/dayjs'
 import { userLogic } from 'scenes/userLogic'
+import { router } from 'kea-router'
 
 export interface AppMetricsLogicProps {
     /** Used as the logic's key */
@@ -374,7 +375,7 @@ function getUrl(values: appMetricsSceneLogicType['values'], props: appMetricsSce
         return urls.appHistoricalExports(props.pluginConfigId)
     }
     if (values.activeTab === AppMetricsTab.Activity) {
-        return urls.appActivity(props.pluginConfigId)
+        return urls.appActivity(props.pluginConfigId, router.values.searchParams)
     }
 
     const params: AppMetricsUrlParams = {}

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -239,7 +239,7 @@ export function PluginCard({
                                                 disabled={rearranging}
                                                 data-attr="plugin-history"
                                             >
-                                                <Link to={urls.appActivity(pluginConfig.id)}>
+                                                <Link to={urls.appHistory(pluginConfig.id)}>
                                                     <ClockCircleOutlined />
                                                 </Link>
                                             </Button>

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -296,7 +296,7 @@ export const routes: Record<string, Scene> = {
     [urls.frontendApp(':id')]: Scene.FrontendAppScene,
     [urls.appMetrics(':pluginConfigId')]: Scene.AppMetrics,
     [urls.appHistoricalExports(':pluginConfigId')]: Scene.AppMetrics,
-    [urls.appActivity(':pluginConfigId')]: Scene.AppMetrics,
+    [urls.appHistory(':pluginConfigId')]: Scene.AppMetrics,
     [urls.projectCreateFirst()]: Scene.ProjectCreateFirst,
     [urls.organizationSettings()]: Scene.OrganizationSettings,
     [urls.organizationBilling()]: Scene.Billing,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -70,7 +70,8 @@ export const urls = {
     appMetrics: (pluginConfigId: string | number, params: AppMetricsUrlParams = {}): string =>
         combineUrl(`/app/${pluginConfigId}/metrics`, params).url,
     appHistoricalExports: (pluginConfigId: string | number): string => `/app/${pluginConfigId}/historical_exports`,
-    appActivity: (pluginConfigId: string | number): string => `/app/${pluginConfigId}/activity`,
+    appActivity: (pluginConfigId: string | number, searchParams?: Record<string, any>): string =>
+        combineUrl(`/app/${pluginConfigId}/activity`, searchParams).url,
     projectCreateFirst: (): string => '/project/create',
     projectHomepage: (): string => '/home',
     projectSettings: (section?: string): string => `/project/settings${section ? `#${section}` : ''}`,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -70,8 +70,8 @@ export const urls = {
     appMetrics: (pluginConfigId: string | number, params: AppMetricsUrlParams = {}): string =>
         combineUrl(`/app/${pluginConfigId}/metrics`, params).url,
     appHistoricalExports: (pluginConfigId: string | number): string => `/app/${pluginConfigId}/historical_exports`,
-    appActivity: (pluginConfigId: string | number, searchParams?: Record<string, any>): string =>
-        combineUrl(`/app/${pluginConfigId}/activity`, searchParams).url,
+    appHistory: (pluginConfigId: string | number, searchParams?: Record<string, any>): string =>
+        combineUrl(`/app/${pluginConfigId}/history`, searchParams).url,
     projectCreateFirst: (): string => '/project/create',
     projectHomepage: (): string => '/home',
     projectSettings: (section?: string): string => `/project/settings${section ? `#${section}` : ''}`,


### PR DESCRIPTION
## Problem

App activity history pagination didn't work due to crossed wires - actions weren't reaching the right place

## Changes

- Fix app metrics (and feature flag) history pagination
- Rename "Activity History" -> "History" to be more consistent with the rest of the app.