### PR TITLE
chore: add missing test for URL query param matching in actions

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -72,13 +72,13 @@
       AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), '^"|"$', ''))  AND distinct_id IN (
       SELECT distinct_id
       FROM (
-
+          
       SELECT distinct_id, argMax(person_id, version) as person_id
       FROM person_distinct_id2
       WHERE team_id = 1
       GROUP BY distinct_id
       HAVING argMax(is_deleted, version) = 0
-
+      
       )
       WHERE person_id IN
       (

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -57,7 +57,7 @@
 ---
 # name: test_parse_groups_persons_edge_case_with_single_filter
   <class 'tuple'> (
-    'AND (  has(%(vglobalperson_0)s, "pmat_email"))',
+    'AND (  has(%(vglobalperson_0)s, replaceRegexpAll(JSONExtractRaw(person_props, %(kglobalperson_0)s), \'^"|"$\', \'\')))',
     <class 'dict'> {
       'kglobalperson_0': 'email',
       'vglobalperson_0': <class 'list'> [
@@ -72,13 +72,13 @@
       AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), '^"|"$', ''))  AND distinct_id IN (
       SELECT distinct_id
       FROM (
-          
+
       SELECT distinct_id, argMax(person_id, version) as person_id
       FROM person_distinct_id2
       WHERE team_id = 1
       GROUP BY distinct_id
       HAVING argMax(is_deleted, version) = 0
-      
+
       )
       WHERE person_id IN
       (
@@ -119,7 +119,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.2
   <class 'tuple'> (
-    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_1)s)',
+    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_1)s), \'^"|"$\', \'\') ILIKE %(vpersonquery_global_1)s)',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kpersonquery_global_1': 'email',

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -57,7 +57,7 @@
 ---
 # name: test_parse_groups_persons_edge_case_with_single_filter
   <class 'tuple'> (
-    'AND (  has(%(vglobalperson_0)s, replaceRegexpAll(JSONExtractRaw(person_props, %(kglobalperson_0)s), \'^"|"$\', \'\')))',
+    'AND (  has(%(vglobalperson_0)s, "pmat_email"))',
     <class 'dict'> {
       'kglobalperson_0': 'email',
       'vglobalperson_0': <class 'list'> [
@@ -119,7 +119,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.2
   <class 'tuple'> (
-    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_1)s), \'^"|"$\', \'\') ILIKE %(vpersonquery_global_1)s)',
+    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_1)s)',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kpersonquery_global_1': 'email',

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -72,7 +72,10 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(str(result[0][0]), event_target_uuid)
+        self.assertCountEqual(
+            [str(r[0]) for r in result],
+            [event_target_uuid],
+        )
 
     def test_filter_event_exact_url_with_query_params(self):
         first_match_uuid = _create_event(
@@ -109,8 +112,10 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
 
         self.assertEqual(len(result), 2)
-        self.assertEqual(str(result[0][0]), first_match_uuid)
-        self.assertEqual(str(result[1][0]), second_match_uuid)
+        self.assertCountEqual(
+            [str(r[0]) for r in result],
+            [first_match_uuid, second_match_uuid],
+        )
 
     def test_filter_event_contains_url(self):
 

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -70,19 +70,20 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         full_query = EVENT_UUID_QUERY.format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
-        assert len(result[0]) == 1
+
+        self.assertEqual(len(result), 1)
         self.assertEqual(str(result[0][0]), event_target_uuid)
 
     def test_filter_event_exact_url_with_query_params(self):
-        event_target_uuid = _create_event(
+        first_match_uuid = _create_event(
             event="$autocapture",
             team=self.team,
             distinct_id="whatever",
             properties={"$current_url": "https://posthog.com/feedback/123?vip=1"},
         )
 
-        _create_event(
-            event="autocapture",
+        second_match_uuid = _create_event(
+            event="$autocapture",
             team=self.team,
             distinct_id="whatever",
             properties={"$current_url": "https://posthog.com/feedback/123?vip=1"},
@@ -106,8 +107,10 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         full_query = EVENT_UUID_QUERY.format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
-        assert len(result[0]) == 2
-        self.assertEqual(str(result[0][0]), event_target_uuid)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(str(result[0][0]), first_match_uuid)
+        self.assertEqual(str(result[1][0]), second_match_uuid)
 
     def test_filter_event_contains_url(self):
 


### PR DESCRIPTION
## Problem

In this community slack thread https://posthogusers.slack.com/archives/C01GLBKHKQT/p1666985043373129 it is not clear if query params are matched in actions

Checking the tests didn't help me

## Changes

Adds a test to clarify that they are matched 

## How did you test this code?

it is a test
