### PR TITLE
chore(ingestion): remove old graphile bufferJob handling

### DIFF
--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -70,8 +70,6 @@ export class GraphileWorker {
         let jobPayload: Record<string, any> = {}
         if ('payload' in job) {
             jobPayload = job.payload
-        } else if ('eventPayload' in job) {
-            jobPayload = job.eventPayload
         }
 
         let enqueueFn = () => this._enqueue(jobName, job)

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -48,7 +48,7 @@ export const startAnonymousEventBufferConsumer = async ({
     status.info('🔁', 'Starting anonymous event buffer consumer')
 
     const eachBatch: EachBatchHandler = async ({ batch, resolveOffset, heartbeat, pause }) => {
-        status.info('🔁', 'Processing batch', { size: batch.messages.length })
+        status.debug('🔁', 'Processing batch', { size: batch.messages.length })
         for (const message of batch.messages) {
             if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
                 status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {

--- a/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
@@ -29,7 +29,7 @@ export const startJobsConsumer = async ({
     status.info('🔁', 'Starting jobs consumer')
 
     const eachBatch: EachBatchHandler = async ({ batch, resolveOffset, heartbeat }) => {
-        status.info('🔁', 'Processing batch', { size: batch.messages.length })
+        status.debug('🔁', 'Processing batch', { size: batch.messages.length })
         for (const message of batch.messages) {
             if (!message.value) {
                 status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -218,7 +218,7 @@ export async function startPluginsServer(
             httpServer = createHttpServer(hub!, serverInstance as ServerInstance)
         }
 
-        if (hub.capabilities.ingestion || hub.capabilities.processPluginJobs || hub.capabilities.pluginScheduledTasks) {
+        if (hub.capabilities.processPluginJobs || hub.capabilities.pluginScheduledTasks) {
             const graphileWorkerError = await startGraphileWorker(hub, piscina)
             if (graphileWorkerError instanceof Error) {
                 try {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -206,7 +206,6 @@ export interface Hub extends PluginsServerConfig {
     lastActivityType: string
     statelessVms: StatelessVmMap
     conversionBufferEnabledTeams: Set<number>
-    conversionBufferTopicEnabledTeams: Set<number>
 }
 
 export interface PluginServerCapabilities {
@@ -217,19 +216,13 @@ export interface PluginServerCapabilities {
     http?: boolean
 }
 
-export type EnqueuedJob = EnqueuedPluginJob | EnqueuedBufferJob | GraphileWorkerCronScheduleJob
+export type EnqueuedJob = EnqueuedPluginJob | GraphileWorkerCronScheduleJob
 export interface EnqueuedPluginJob {
     type: string
     payload: Record<string, any>
     timestamp: number
     pluginConfigId: number
     pluginConfigTeam: number
-    jobKey?: string
-}
-
-export interface EnqueuedBufferJob {
-    eventPayload: PluginEvent
-    timestamp: number
     jobKey?: string
 }
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -81,10 +81,6 @@ export async function createHub(
         serverConfig.CONVERSION_BUFFER_ENABLED_TEAMS.split(',').filter(String).map(Number)
     )
 
-    const conversionBufferTopicEnabledTeams = new Set(
-        serverConfig.CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS.split(',').filter(String).map(Number)
-    )
-
     if (serverConfig.STATSD_HOST) {
         status.info('🤔', `Connecting to StatsD...`)
         statsd = new StatsD({
@@ -295,7 +291,6 @@ export async function createHub(
         actionManager,
         actionMatcher: new ActionMatcher(db, actionManager, statsd),
         conversionBufferEnabledTeams,
-        conversionBufferTopicEnabledTeams,
     }
 
     // :TODO: This is only used on worker threads, not main

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { KAFKA_BUFFER } from '../../../config/kafka-topics'
-import { Hub, IngestionPersonData, JobName, TeamId } from '../../../types'
+import { Hub, IngestionPersonData, TeamId } from '../../../types'
 import { status } from '../../../utils/status'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { EventPipelineRunner, StepResult } from './runner'
@@ -30,46 +30,22 @@ export async function emitToBufferStep(
             event: event.event,
             eventId: event.uuid,
             processEventAt,
-            conversionBufferTopicEnabledTeams: runner.hub.conversionBufferTopicEnabledTeams,
         })
 
-        // Only enable for teams that have conversionBuffer enabled, otherwise
-        // use the old logic.
-        // TODO: If we want to enable this for all teams, we can remove this
-        // check.
-        if (
-            runner.hub.CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS === '*' ||
-            runner.hub.conversionBufferTopicEnabledTeams.has(event.team_id)
-        ) {
-            // TODO: handle delaying offset commit for this message, according to
-            // producer acknowledgement. It's a little tricky as it stands as we do
-            // not have the a reference to resolveOffset here. Rather than do a
-            // refactor I'm just going to let this hang and resolve as a followup.
-            await runner.hub.kafkaProducer.queueMessage({
-                topic: KAFKA_BUFFER,
-                messages: [
-                    {
-                        key: event.team_id.toString(),
-                        value: JSON.stringify(event),
-                        headers: { processEventAt: processEventAt.toString(), eventId: event.uuid },
-                    },
-                ],
-            })
-        } else {
-            const job = {
-                eventPayload: event,
-                timestamp: processEventAt,
-            }
-            await runner.hub.graphileWorker.enqueue(
-                JobName.BUFFER_JOB,
-                job,
+        // TODO: handle delaying offset commit for this message, according to
+        // producer acknowledgement. It's a little tricky as it stands as we do
+        // not have the a reference to resolveOffset here. Rather than do a
+        // refactor I'm just going to let this hang and resolve as a followup.
+        await runner.hub.kafkaProducer.queueMessage({
+            topic: KAFKA_BUFFER,
+            messages: [
                 {
-                    key: 'team_id',
-                    tag: event.team_id.toString(),
+                    key: event.team_id.toString(),
+                    value: JSON.stringify(event),
+                    headers: { processEventAt: processEventAt.toString(), eventId: event.uuid },
                 },
-                true
-            )
-        }
+            ],
+        })
 
         runner.hub.statsd?.increment('events_sent_to_buffer')
         return null

--- a/plugin-server/tests/main/capabilities.test.ts
+++ b/plugin-server/tests/main/capabilities.test.ts
@@ -47,22 +47,6 @@ describe('capabilities', () => {
     })
 
     describe('startGraphileWorker()', () => {
-        it('sets up bufferJob handler if ingestion is on', async () => {
-            jest.spyOn(hub.graphileWorker, 'start').mockImplementation(jest.fn())
-            hub.capabilities.ingestion = true
-            hub.capabilities.processPluginJobs = false
-            hub.capabilities.pluginScheduledTasks = false
-
-            await startGraphileWorker(hub, piscina)
-
-            expect(hub.graphileWorker.start).toHaveBeenCalledWith(
-                {
-                    bufferJob: expect.anything(),
-                },
-                []
-            )
-        })
-
         it('sets up pluginJob handler if processPluginJobs is on', async () => {
             jest.spyOn(hub.graphileWorker, 'start').mockImplementation(jest.fn())
             hub.capabilities.ingestion = false
@@ -73,23 +57,6 @@ describe('capabilities', () => {
 
             expect(hub.graphileWorker.start).toHaveBeenCalledWith(
                 {
-                    pluginJob: expect.anything(),
-                },
-                []
-            )
-        })
-
-        it('sets up bufferJob and pluginJob handlers if ingestion and processPluginJobs are on', async () => {
-            jest.spyOn(hub.graphileWorker, 'start').mockImplementation(jest.fn())
-            hub.capabilities.ingestion = true
-            hub.capabilities.processPluginJobs = true
-            hub.capabilities.pluginScheduledTasks = false
-
-            await startGraphileWorker(hub, piscina)
-
-            expect(hub.graphileWorker.start).toHaveBeenCalledWith(
-                {
-                    bufferJob: expect.anything(),
                     pluginJob: expect.anything(),
                 },
                 []


### PR DESCRIPTION
This removes the emitting of graphile-worker events from the ingestion
anonymous events path. Note that we still have the graphile worker
running on ingestion, as we need to ensure that we have drained all of
these jobs. I'll handle this by first enabling the topic for all users
on prod then deploying this.

For self hosted I suggest we just go with adding a comment that
anonymous events that have been send to graphile in the meantime will be
lost. Or something else that makes sense.

NOTE: I add a test for `runNow` triggering from processEvent to ensure that this 
is still functional given we don't run `startGraphileWorker` now. We still do however 
initialise `GraphileWorker` in `createHub`, which is no longer necessary.

TODO: do not initialise `GraphileWorker` in `createHub`

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
