### PR TITLE
fix: Fully rollout new recordings list icons

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -127,7 +127,6 @@ export const FEATURE_FLAGS = {
     SESSION_RESET_ON_LOAD: 'session-reset-on-load', // owner: @benjackwhite
     CURRENCY_UNITS: 'currency-units', // owner: @pauldambra
     FEEDBACK_BUTTON: 'feedback-button', // owner: @luke
-    RECORDING_LIST_ICONS: 'recording-list-icons', // owner: @benjackwhite
     RECORDINGS_ON_FEATURE_FLAGS: 'recordings-on-feature-flags', // owner: @EDsCODE
 }
 

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -18,13 +18,10 @@ import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { CSSTransition } from 'react-transition-group'
 import { Tooltip } from 'lib/components/Tooltip'
 import { PropertyIcon } from 'lib/components/PropertyIcon'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
     const {
         sessionPerson,
-        description,
         resolution,
         lastPageviewEvent,
         scale,
@@ -38,10 +35,6 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
     const { setIsMetadataExpanded } = useActions(playerSettingsLogic)
 
     const iconProperties = lastPageviewEvent?.properties || sessionPerson?.properties
-
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    const listIcons = featureFlags[FEATURE_FLAGS.RECORDING_LIST_ICONS] || 'none'
 
     return (
         <div
@@ -94,50 +87,44 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                     <div className="text-muted">
                         {loading ? (
                             <LemonSkeleton className="w-1/4 my-1" />
-                        ) : listIcons != 'none' ? (
-                            iconProperties ? (
-                                <div className="flex flex-row flex-nowrap shrink-0 gap-2 text-muted-alt">
-                                    <span className="flex items-center gap-1 whitespace-nowrap">
-                                        <PropertyIcon
-                                            noTooltip={!isFullScreen}
-                                            property="$browser"
-                                            value={iconProperties['$browser']}
-                                        />
-                                        {!isFullScreen ? iconProperties['$browser'] : null}
-                                    </span>
-                                    <span className="flex items-center gap-1 whitespace-nowrap">
-                                        <PropertyIcon
-                                            noTooltip={!isFullScreen}
-                                            property="$device_type"
-                                            value={
-                                                iconProperties['$device_type'] || iconProperties['$initial_device_type']
-                                            }
-                                        />
-                                        {!isFullScreen
-                                            ? iconProperties['$device_type'] || iconProperties['$initial_device_type']
-                                            : null}
-                                    </span>
-                                    <span className="flex items-center gap-1 whitespace-nowrap">
-                                        <PropertyIcon
-                                            noTooltip={!isFullScreen}
-                                            property="$os"
-                                            value={iconProperties['$os']}
-                                        />
-                                        {!isFullScreen ? iconProperties['$os'] : null}
-                                    </span>
-                                    <span className="flex items-center gap-1 whitespace-nowrap">
-                                        <PropertyIcon
-                                            noTooltip={!isFullScreen}
-                                            property="$geoip_country_code"
-                                            value={iconProperties['$geoip_country_code']}
-                                        />
-                                        {!isFullScreen ? iconProperties['$geoip_city_name'] : null}
-                                    </span>
-                                </div>
-                            ) : null
-                        ) : (
-                            description
-                        )}
+                        ) : iconProperties ? (
+                            <div className="flex flex-row flex-nowrap shrink-0 gap-2 text-muted-alt">
+                                <span className="flex items-center gap-1 whitespace-nowrap">
+                                    <PropertyIcon
+                                        noTooltip={!isFullScreen}
+                                        property="$browser"
+                                        value={iconProperties['$browser']}
+                                    />
+                                    {!isFullScreen ? iconProperties['$browser'] : null}
+                                </span>
+                                <span className="flex items-center gap-1 whitespace-nowrap">
+                                    <PropertyIcon
+                                        noTooltip={!isFullScreen}
+                                        property="$device_type"
+                                        value={iconProperties['$device_type'] || iconProperties['$initial_device_type']}
+                                    />
+                                    {!isFullScreen
+                                        ? iconProperties['$device_type'] || iconProperties['$initial_device_type']
+                                        : null}
+                                </span>
+                                <span className="flex items-center gap-1 whitespace-nowrap">
+                                    <PropertyIcon
+                                        noTooltip={!isFullScreen}
+                                        property="$os"
+                                        value={iconProperties['$os']}
+                                    />
+                                    {!isFullScreen ? iconProperties['$os'] : null}
+                                </span>
+                                <span className="flex items-center gap-1 whitespace-nowrap">
+                                    <PropertyIcon
+                                        noTooltip={!isFullScreen}
+                                        property="$geoip_country_code"
+                                        value={iconProperties['$geoip_country_code']}
+                                    />
+                                    {!isFullScreen ? iconProperties['$geoip_city_name'] : null}
+                                </span>
+                            </div>
+                        ) : null}
                     </div>
                 </div>
                 <Tooltip

--- a/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
@@ -8,13 +8,6 @@ import { ceilMsToClosestSecond, findLastIndex } from 'lib/utils'
 import { getEpochTimeFromPlayerPosition } from './playerUtils'
 import { sessionRecordingsListLogic } from '../playlist/sessionRecordingsListLogic'
 
-const getPersonProperties = (person: Partial<PersonType>, keys: string[]): string | null => {
-    if (keys.some((k) => !person?.properties?.[k])) {
-        return null
-    }
-    return keys.map((k) => person?.properties?.[k]).join(', ')
-}
-
 export const playerMetaLogic = kea<playerMetaLogicType>({
     path: (key) => ['scenes', 'session-recordings', 'player', 'playerMetaLogic', key],
     props: {} as SessionRecordingPlayerProps,
@@ -50,16 +43,6 @@ export const playerMetaLogic = kea<playerMetaLogicType>({
                     sessionRecordings.find((sessionRecording) => sessionRecording.id === props.sessionRecordingId)
                         ?.person ?? null
                 )
-            },
-        ],
-        description: [
-            (selectors) => [selectors.sessionPerson],
-            (person) => {
-                const location = person
-                    ? getPersonProperties(person, ['$geoip_city_name', '$geoip_country_code'])
-                    : null
-                const device = person ? getPersonProperties(person, ['$browser', '$os']) : null
-                return [device, location].filter((s) => s).join(' · ')
             },
         ],
         resolution: [

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
@@ -1,8 +1,5 @@
 import { SessionRecordingType } from '~/types'
 import { colonDelimitedDuration } from 'lib/utils'
-import { useValues } from 'kea'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import clsx from 'clsx'
 import { PropertyIcon } from 'lib/components/PropertyIcon'
 import { IconSchedule } from 'lib/components/icons'

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
@@ -31,9 +31,6 @@ export function SessionRecordingPlaylistItem({
     const formattedDuration = colonDelimitedDuration(recording.recording_duration)
     const durationParts = formattedDuration.split(':')
 
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    const listIcons = featureFlags[FEATURE_FLAGS.RECORDING_LIST_ICONS] || 'none'
     const iconClassnames = clsx(
         'SessionRecordingsPlaylist__list-item__property-icon text-base text-muted-alt',
         !isActive && 'opacity-75'
@@ -44,10 +41,8 @@ export function SessionRecordingPlaylistItem({
             ? recordingProperties
             : recording.person?.properties || {}
 
-    const indicatorRight = listIcons === 'bottom' || listIcons === 'none' || listIcons === 'middle' || !listIcons
-
     const propertyIcons = (
-        <div className="flex flex-row flex-nowrap shrink-0 gap-1">
+        <div className="flex flex-row flex-nowrap shrink-0 gap-1 h-6">
             {!recordingPropertiesLoading ? (
                 iconPropertyKeys.map((property) => {
                     const value =
@@ -72,26 +67,9 @@ export function SessionRecordingPlaylistItem({
                     )
                 })
             ) : (
-                <LemonSkeleton className="w-16 py-1" />
+                <LemonSkeleton className="w-18 my-1" />
             )}
         </div>
-    )
-
-    const duration = (
-        <span className="flex items-center font-semibold">
-            <IconSchedule className={iconClassnames} />
-            <span>
-                <span className={clsx(durationParts[0] === '00' && 'opacity-50 font-normal')}>{durationParts[0]}:</span>
-                <span
-                    className={clsx({
-                        'opacity-50 font-normal': durationParts[0] === '00' && durationParts[1] === '00',
-                    })}
-                >
-                    {durationParts[1]}:
-                </span>
-                {durationParts[2]}
-            </span>
-        </span>
     )
 
     return (
@@ -100,23 +78,20 @@ export function SessionRecordingPlaylistItem({
             className={clsx(
                 'SessionRecordingsPlaylist__list-item',
                 'flex flex-row py-2 pr-4 pl-0 cursor-pointer relative overflow-hidden',
-                isActive && 'bg-primary-highlight font-semibold',
-                indicatorRight && 'pl-4'
+                isActive && 'bg-primary-highlight font-semibold'
             )}
             onClick={() => onClick()}
         >
-            {!indicatorRight && (
-                <div className="w-2 h-2 mx-2">
-                    {!recording.viewed ? (
-                        <Tooltip title={'Indicates the recording has not been watched yet'}>
-                            <div
-                                className="w-2 h-2 mt-2 rounded-full bg-primary-light"
-                                aria-label="unwatched-recording-label"
-                            />
-                        </Tooltip>
-                    ) : null}
-                </div>
-            )}
+            <div className="w-2 h-2 mx-2">
+                {!recording.viewed ? (
+                    <Tooltip title={'Indicates the recording has not been watched yet'}>
+                        <div
+                            className="w-2 h-2 mt-2 rounded-full bg-primary-light"
+                            aria-label="unwatched-recording-label"
+                        />
+                    </Tooltip>
+                ) : null}
+            </div>
             <div className="grow">
                 <div className="flex items-center justify-between">
                     <div className="truncate font-medium text-primary ph-no-capture">
@@ -125,19 +100,8 @@ export function SessionRecordingPlaylistItem({
 
                     <div className="flex-1" />
 
-                    {listIcons === 'top-right' && propertyIcons}
-                    {listIcons === 'bottom-right' && duration}
-                    {indicatorRight && !recording.viewed && (
-                        <Tooltip title={'Indicates the recording has not been watched yet'}>
-                            <div
-                                className="w-2 h-2 rounded-full bg-primary-light"
-                                aria-label="unwatched-recording-label"
-                            />
-                        </Tooltip>
-                    )}
+                    {propertyIcons}
                 </div>
-
-                {listIcons === 'middle' && <div>{propertyIcons}</div>}
 
                 <div className="flex items-center justify-between">
                     <TZLabel
@@ -146,9 +110,21 @@ export function SessionRecordingPlaylistItem({
                         formatDate="MMMM DD, YYYY"
                         formatTime="h:mm A"
                     />
-                    <div className="flex items-center gap-2 flex-1 justify-end">
-                        {listIcons === 'bottom' && propertyIcons}
-                        {listIcons !== 'bottom-right' ? duration : propertyIcons}
+                    <div className="flex items-center flex-1 justify-end font-semibold">
+                        <IconSchedule className={iconClassnames} />
+                        <span>
+                            <span className={clsx(durationParts[0] === '00' && 'opacity-50 font-normal')}>
+                                {durationParts[0]}:
+                            </span>
+                            <span
+                                className={clsx({
+                                    'opacity-50 font-normal': durationParts[0] === '00' && durationParts[1] === '00',
+                                })}
+                            >
+                                {durationParts[1]}:
+                            </span>
+                            {durationParts[2]}
+                        </span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Problem

Settled on the top-right position for icons so now we can fully rollout

## Changes

* Removes feature flags and alternative styles

![2022-10-31 14 53 02](https://user-images.githubusercontent.com/2536520/199024279-dd0fa249-29e1-46c3-91b9-790e71f7fe36.gif)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

N/A