### PR TITLE
feat(ingestion): buffer events in kafka if postgres is down

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -239,6 +239,11 @@ export class DB {
                 return response
             } catch (e) {
                 await client.query('ROLLBACK')
+
+                // if Postgres is down the ROLLBACK above won't work, but the transaction shouldn't be committed either
+                if (e.message && POSTGRES_UNAVAILABLE_ERROR_MESSAGES.some((message) => e.message.includes(message))) {
+                    throw new DependencyUnavailableError(e.message, 'Postgres', e)
+                }
                 throw e
             } finally {
                 client.release()

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -137,6 +137,7 @@ const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'server conn crashed',
     'no more connections allowed',
     'server closed the connection unexpectedly',
+    'getaddrinfo EAI_AGAIN',
 ]
 
 /** The recommended way of accessing the database. */

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -4,10 +4,10 @@ import { captureException } from '@sentry/node'
 import { Hub, PluginConfig, PluginError } from '../../types'
 import { setError } from './sql'
 
-export class DependencyUnavailable extends Error {
+export class DependencyUnavailableError extends Error {
     constructor(message: string, dependencyName: string, error: Error) {
         super(message)
-        this.name = 'DependencyUnavailable'
+        this.name = 'DependencyUnavailableError'
         this.dependencyName = dependencyName
         this.error = error
     }
@@ -26,7 +26,7 @@ export async function processError(
         return
     }
 
-    if (error instanceof DependencyUnavailable) {
+    if (error instanceof DependencyUnavailableError) {
         // For errors relating to PostHog dependencies that are unavailable,
         // e.g. Postgres, Kafka, Redis, we don't want to log the error to Sentry
         // but rather bubble this up the stack for someone else to decide on

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -40,7 +40,7 @@ import { PluginsApiKeyManager } from './../../worker/vm/extensions/helpers/api-k
 import { RootAccessManager } from './../../worker/vm/extensions/helpers/root-acess-manager'
 import { PromiseManager } from './../../worker/vm/promise-manager'
 import { DB } from './db'
-import { DependencyUnavailable } from './error'
+import { DependencyUnavailableError } from './error'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
 
 const { version } = require('../../../package.json')
@@ -247,11 +247,11 @@ export async function createHub(
         } catch (error) {
             if (error instanceof KafkaJSError) {
                 // If we get a retriable Kafka error (maybe it's down for
-                // example), rethrow the error as a generic `DependencyUnavailable`
+                // example), rethrow the error as a generic `DependencyUnavailableError`
                 // passing through retriable such that we can decide if this is
                 // something we should retry at the consumer level.
                 if (error.retriable) {
-                    throw new DependencyUnavailable(error.message, 'Kafka', error)
+                    throw new DependencyUnavailableError(error.message, 'Kafka', error)
                 }
             }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node'
 
 import { runInSpan } from '../../../sentry'
 import { Hub, PostIngestionEvent } from '../../../types'
-import { DependencyUnavailable } from '../../../utils/db/error'
+import { DependencyUnavailableError } from '../../../utils/db/error'
 import { timeoutGuard } from '../../../utils/db/utils'
 import { status } from '../../../utils/status'
 import { LazyPersonContainer } from '../lazy-person-container'
@@ -173,7 +173,7 @@ export class EventPipelineRunner {
         Sentry.captureException(err, { extra: { currentStepName, serializedArgs, originalEvent: this.originalEvent } })
         this.hub.statsd?.increment('kafka_queue.event_pipeline.step.error', { step: currentStepName })
 
-        if (err instanceof DependencyUnavailable) {
+        if (err instanceof DependencyUnavailableError) {
             // If this is an error with a dependency that we control, we want to
             // ensure that the caller knows that the event was not processed,
             // for a reason that we control and that is transient.

--- a/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
@@ -11,7 +11,7 @@
 // integration test between the two:
 //
 //  1. using the Piscina task runner to run the pipeline results in the
-//     DependencyUnavailable Error being thrown.
+//     DependencyUnavailableError Error being thrown.
 //  2. the KafkaQueue consumer handler will let the error bubble up to the
 //     KafkaJS consumer runner, which we assume will handle retries.
 
@@ -22,7 +22,7 @@ import { KafkaJSError } from 'kafkajs'
 import { KAFKA_EVENTS_JSON } from '../../../src/config/kafka-topics'
 import { KafkaQueue } from '../../../src/main/ingestion-queues/kafka-queue'
 import { Hub } from '../../../src/types'
-import { DependencyUnavailable } from '../../../src/utils/db/error'
+import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { createHub } from '../../../src/utils/db/hub'
 import { UUIDT } from '../../../src/utils/utils'
 import { setupPlugins } from '../../../src/worker/plugins/setup'
@@ -75,7 +75,7 @@ describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
     test('throws on produce errors', async () => {
         // To ensure that producer errors are retried and not swallowed, we need
         // to ensure that these are bubbled up to the main consumer loop. Note
-        // that the `KafkaJSError` is translated to a generic `DependencyUnavailable`.
+        // that the `KafkaJSError` is translated to a generic `DependencyUnavailableError`.
         // This is to allow the specific decision of whether the error is
         // retriable to happen as close to the dependency as possible.
         const organizationId = await createOrganization(hub.postgres)
@@ -118,7 +118,7 @@ describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
                 },
             })
         ).rejects.toEqual(
-            new DependencyUnavailable('Failed to produce', 'Kafka', new KafkaJSError('Failed to produce'))
+            new DependencyUnavailableError('Failed to produce', 'Kafka', new KafkaJSError('Failed to produce'))
         )
     })
 
@@ -185,7 +185,7 @@ describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
 
     test(`doesn't throw on arbitrary failures`, async () => {
         // If we receive an arbitrary error, we should just skip the event. We
-        // only want to retry on `RetryError` and `DependencyUnavailable` as these are
+        // only want to retry on `RetryError` and `DependencyUnavailableError` as these are
         // things under our control.
         const organizationId = await createOrganization(hub.postgres)
         const plugin = await createPlugin(hub.postgres, {
@@ -245,10 +245,18 @@ describe('eachBatchAsyncHandlers', () => {
     test('rejections from piscina are bubbled up to the consumer', async () => {
         const kafkaQueue = new KafkaQueue(hub, {
             runAsyncHandlersEventPipeline: () => {
-                throw new DependencyUnavailable('Failed to produce', 'Kafka', new KafkaJSError('Failed to produce'))
+                throw new DependencyUnavailableError(
+                    'Failed to produce',
+                    'Kafka',
+                    new KafkaJSError('Failed to produce')
+                )
             },
             runEventPipeline: () => {
-                throw new DependencyUnavailable('Failed to produce', 'Kafka', new KafkaJSError('Failed to produce'))
+                throw new DependencyUnavailableError(
+                    'Failed to produce',
+                    'Kafka',
+                    new KafkaJSError('Failed to produce')
+                )
             },
         })
 
@@ -293,7 +301,7 @@ describe('eachBatchAsyncHandlers', () => {
                 pause: jest.fn(),
             })
         ).rejects.toEqual(
-            new DependencyUnavailable('Failed to produce', 'Kafka', new KafkaJSError('Failed to produce'))
+            new DependencyUnavailableError('Failed to produce', 'Kafka', new KafkaJSError('Failed to produce'))
         )
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
@@ -1,0 +1,65 @@
+import Redis from 'ioredis'
+
+import { Hub } from '../../../src/types'
+import { DependencyUnavailableError } from '../../../src/utils/db/error'
+import { createHub } from '../../../src/utils/db/hub'
+import { UUIDT } from '../../../src/utils/utils'
+import { createTaskRunner } from '../../../src/worker/worker'
+import { createOrganization, createTeam, POSTGRES_DELETE_TABLES_QUERY } from '../../helpers/sql'
+
+describe('workerTasks.runEventPipeline()', () => {
+    let hub: Hub
+    let redis: Redis.Redis
+    let closeHub: () => Promise<void>
+    let piscinaTaskRunner: ({ task, args }) => Promise<any>
+
+    beforeAll(async () => {
+        ;[hub, closeHub] = await createHub()
+        redis = await hub.redisPool.acquire()
+        piscinaTaskRunner = createTaskRunner(hub)
+        await hub.postgres.query(POSTGRES_DELETE_TABLES_QUERY) // Need to clear the DB to avoid unique constraint violations on ids
+    })
+
+    afterAll(async () => {
+        await hub.redisPool.release(redis)
+        await closeHub()
+    })
+
+    beforeEach(() => {
+        // Use fake timers to ensure that we don't need to wait on e.g. retry logic.
+        jest.useFakeTimers({ advanceTimers: 30 })
+    })
+
+    afterEach(() => {
+        jest.clearAllTimers()
+        jest.useRealTimers()
+        jest.clearAllMocks()
+    })
+
+    test('throws DependencyUnavailableError on postgres errors', async () => {
+        const errorMessage =
+            'connection to server at "posthog-pgbouncer" (171.20.65.128), port 6543 failed: server closed the connection unexpectedly'
+        const organizationId = await createOrganization(hub.postgres)
+        const teamId = await createTeam(hub.postgres, organizationId)
+
+        jest.spyOn(hub.db.postgres, 'query').mockImplementationOnce(() => {
+            return Promise.reject(new Error(errorMessage))
+        })
+
+        await expect(
+            piscinaTaskRunner({
+                task: 'runEventPipeline',
+                args: {
+                    event: {
+                        distinctId: 'asdf',
+                        ip: '',
+                        teamId: teamId,
+                        event: 'some event',
+                        properties: {},
+                        eventUuid: new UUIDT().toString(),
+                    },
+                },
+            })
+        ).rejects.toEqual(new DependencyUnavailableError(errorMessage, 'Postgres', new Error(errorMessage)))
+    })
+})


### PR DESCRIPTION
## Problem

Currently, if our main Postgres database is unavailable, we send events to the dead letter queue.

In reality, this is a temporary issue that we should handle via retries.

## Changes

Throws a `DependencyUnavailableError` if we can't connect to Postgres. This will cause the Kafka consumer to throw and us to stop consuming. The consumer will retry consuming messages and a) come back up or b) crash. If it crashes, the cluster will kill the pods and keep trying to bring them back up until Postgres is working again.

At which point we'll consume from where we left off.

## How did you test this code?

Added a test for the functionality, tested manually
