### PR TITLE
chore: fetch more history for dockerfile lint changed files detection

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -10,6 +10,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
             - name: Check if any Dockerfile has changed
               id: changed-files


### PR DESCRIPTION
## Problem

the dockerfile-lint workflow is failing because the changed file detection says 

`Unable to find merge-base in shallow clone. Please increase 'max_fetch_depth' to at least 180.`

https://github.com/PostHog/posthog/actions/runs/3364213815/jobs/5578302353
https://github.com/PostHog/posthog/actions/runs/3363891605/jobs/5578429679

## Changes

grabs all history

## How did you test this code?

opening this PR and seeing if the job runs
