### PR TITLE
chore: accept chromatic baselines on master

### DIFF
--- a/.github/workflows/storybook-chromatic-baselines-to-master.yml
+++ b/.github/workflows/storybook-chromatic-baselines-to-master.yml
@@ -32,9 +32,7 @@ jobs:
               # chromatic can't detect accepted baseline because we do squash merges
               # so whenever we merge frontend changes to master, we need to accept a new baseline
               # see https://www.chromatic.com/docs/github-actions#github-squashrebase-merge-and-the-main-branch
-              if: |
-                  github.ref == 'refs/heads/master'
-                  && steps.changes.outputs.frontend == 'true'
+              if: steps.changes.outputs.frontend == 'true'
               uses: chromaui/action@v1
               # Required options for the Chromatic GitHub Action
               with:

--- a/.github/workflows/storybook-chromatic-baselines-to-master.yml
+++ b/.github/workflows/storybook-chromatic-baselines-to-master.yml
@@ -1,0 +1,43 @@
+name: 'Storybook Chromatic'
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    storybook-chromatic-accept-baselines-to-master:
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.head.repo.full_name == github.repository # Don't run on forks
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0 # 👈 Required to retrieve git history (https://www.chromatic.com/docs/github-actions)
+
+            # there's no need to run chromatic on every commit,
+            # so we only run it if the frontend has changed
+            - uses: dorny/paths-filter@v2
+              id: changes
+              with:
+                  filters: |
+                      frontend:
+                        - 'frontend/**'
+                        - '.storybook/**'
+
+            - name: Install dependencies and chromatic
+              if: steps.changes.outputs.frontend == 'true'
+              run: yarn add --dev chromatic
+
+            - name: Publish to Chromatic and auto accept changes to add baseline to master
+              # chromatic can't detect accepted baseline because we do squash merges
+              # so whenever we merge frontend changes to master, we need to accept a new baseline
+              # see https://www.chromatic.com/docs/github-actions#github-squashrebase-merge-and-the-main-branch
+              if: |
+                  github.ref == 'refs/heads/master'
+                  && steps.changes.outputs.frontend == 'true'
+              uses: chromaui/action@v1
+              # Required options for the Chromatic GitHub Action
+              with:
+                  # 👇 Chromatic projectToken, refer to the manage page to obtain it.
+                  projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+                  autoAcceptChanges: true # 👈 Option to accept all changes

--- a/.github/workflows/storybook-chromatic-baselines-to-master.yml
+++ b/.github/workflows/storybook-chromatic-baselines-to-master.yml
@@ -1,4 +1,4 @@
-name: 'Storybook Chromatic'
+name: 'Storybook Chromatic - Add baselines on push to master'
 
 on:
     push:


### PR DESCRIPTION
## Problem

For UI Tests chromatic can't detect accepted baseline because we do squash merges

so, whenever we merge frontend changes to master, we need to accept a new baseline

see https://www.chromatic.com/docs/github-actions#github-squashrebase-merge-and-the-main-branch

## Changes

Adds a workflow to accept baseline images on master so that subsequent PRs can compare against them

## How did you test this code?

Opening this PR... annoyingly it runs on push to master so can only really test it by merging it