### PR TITLE
fix(ingestion-warnings): enable on self-hosted

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -120,7 +120,7 @@ export const FEATURE_FLAGS = {
     HISTORICAL_EXPORTS_V2: 'historical-exports-v2', // owner @macobo
     ACTOR_ON_EVENTS_QUERYING: 'person-on-events-enabled', //owner: @EDsCODE
     REGION_SELECT: 'region-select', //owner: @kappa90
-    INGESTION_WARNINGS_ENABLED: 'ingestion-warnings-enabled', // owner: @macobo
+    INGESTION_WARNINGS_ENABLED: 'ingestion-warnings-enabled', // owner: @tiina303
     HOG_BOOK: 'hog-book', // owner: @pauldambra
     EVENT_COUNT_PER_ACTOR: 'event-count-per-actor', // owner: @Twixes
     TEXT_CARDS: 'text-cards', // owner: @pauldambra

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -9,4 +9,5 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "historical-exports-v2",
     "text-cards",
     "event-count-per-actor",
+    "ingestion-warnings-enabled",
 ]


### PR DESCRIPTION
## Problem

Ingestion warnings were not released as part of 1.41.0 since we didn't enable the flag for self-hosted

@tiina303 will take care of getting this in from here.