### PR TITLE
fix(person-on-events): Fix groups caching in ingestion

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -17,6 +17,7 @@ import {
     ClickhouseGroup,
     ClickHousePerson,
     ClickHousePersonDistinctId2,
+    ClickHouseTimestamp,
     Cohort,
     CohortPeople,
     Database,
@@ -122,13 +123,11 @@ export interface CreatePersonalApiKeyPayload {
     created_at: Date
 }
 
-export type GroupType = number
-
-export type GroupId = [GroupType, GroupKey]
+export type GroupId = [GroupTypeIndex, GroupKey]
 
 export interface CachedGroupData {
     properties: Properties
-    created_at: string
+    created_at: ClickHouseTimestamp
 }
 
 const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
@@ -550,7 +549,7 @@ export class DB {
     REDIS_PERSON_UUID_PREFIX = 'person_uuid'
     REDIS_PERSON_CREATED_AT_PREFIX = 'person_created_at'
     REDIS_PERSON_PROPERTIES_PREFIX = 'person_props'
-    REDIS_GROUP_DATA_PREFIX = 'group_data_cache'
+    REDIS_GROUP_DATA_PREFIX = 'group_data_cache_v2'
 
     private getPersonIdCacheKey(teamId: number, distinctId: string): string {
         return `${this.REDIS_PERSON_ID_PREFIX}:${teamId}:${distinctId}`
@@ -568,7 +567,7 @@ export class DB {
         return `${this.REDIS_PERSON_PROPERTIES_PREFIX}:${teamId}:${personId}`
     }
 
-    private getGroupDataCacheKey(teamId: number, groupTypeIndex: number, groupKey: string): string {
+    public getGroupDataCacheKey(teamId: number, groupTypeIndex: number, groupKey: string): string {
         return `${this.REDIS_GROUP_DATA_PREFIX}:${teamId}:${groupTypeIndex}:${groupKey}`
     }
 
@@ -681,8 +680,12 @@ export class DB {
         await this.redisSet(groupCacheKey, groupData)
     }
 
-    public async getGroupsColumns(teamId: number, groupIds: GroupId[]): Promise<Record<string, any>> {
-        const groupColumns: Record<string, any> = {}
+    public async getGroupsColumns(
+        teamId: number,
+        groupIds: GroupId[]
+    ): Promise<Record<string, string | ClickHouseTimestamp>> {
+        const groupPropertiesColumns: Record<string, string> = {}
+        const groupCreatedAtColumns: Record<string, ClickHouseTimestamp> = {}
 
         for (const [groupTypeIndex, groupKey] of groupIds) {
             const groupCacheKey = this.getGroupDataCacheKey(teamId, groupTypeIndex, groupKey)
@@ -695,11 +698,8 @@ export class DB {
 
                 if (cachedGroupData) {
                     this.statsd?.increment('group_info_cache.hit')
-                    groupColumns[propertiesColumnName] = JSON.stringify(cachedGroupData.properties)
-                    groupColumns[createdAtColumnName] = castTimestampOrNow(
-                        cachedGroupData.created_at,
-                        TimestampFormat.ClickHouse
-                    )
+                    groupPropertiesColumns[propertiesColumnName] = JSON.stringify(cachedGroupData.properties)
+                    groupCreatedAtColumns[createdAtColumnName] = cachedGroupData.created_at
 
                     continue
                 }
@@ -713,11 +713,14 @@ export class DB {
             const storedGroupData = await this.fetchGroup(teamId, groupTypeIndex as GroupTypeIndex, groupKey)
 
             if (storedGroupData) {
-                groupColumns[propertiesColumnName] = JSON.stringify(storedGroupData.group_properties)
+                groupPropertiesColumns[propertiesColumnName] = JSON.stringify(storedGroupData.group_properties)
 
-                const createdAt = castTimestampOrNow(storedGroupData.created_at.toUTC(), TimestampFormat.ClickHouse)
+                const createdAt = castTimestampOrNow(
+                    storedGroupData.created_at.toUTC(),
+                    TimestampFormat.ClickHouse
+                ) as ClickHouseTimestamp
 
-                groupColumns[createdAtColumnName] = createdAt
+                groupCreatedAtColumns[createdAtColumnName] = createdAt
 
                 // We found data in Postgres, so update the cache
                 // We also don't want to throw here, worst case is we'll have to fetch from Postgres again next time
@@ -734,15 +737,18 @@ export class DB {
                 this.statsd?.increment('groups_data_missing_entirely')
                 status.debug('🔍', `Could not find group data for group ${groupCacheKey} in cache or storage`)
 
-                groupColumns[propertiesColumnName] = '{}'
-                groupColumns[createdAtColumnName] = castTimestampOrNow(
+                groupPropertiesColumns[propertiesColumnName] = '{}'
+                groupCreatedAtColumns[createdAtColumnName] = castTimestampOrNow(
                     DateTime.fromJSDate(new Date(0)).toUTC(),
                     TimestampFormat.ClickHouse
-                )
+                ) as ClickHouseTimestamp
             }
         }
 
-        return groupColumns
+        return {
+            ...groupPropertiesColumns,
+            ...groupCreatedAtColumns,
+        }
     }
 
     public async fetchPersons(database?: Database.Postgres): Promise<Person[]>
@@ -1707,7 +1713,7 @@ export class DB {
         if (options?.cache) {
             await this.updateGroupCache(teamId, groupTypeIndex, groupKey, {
                 properties: groupProperties,
-                created_at: castTimestampOrNow(createdAt),
+                created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse) as ClickHouseTimestamp,
             })
         }
     }
@@ -1749,7 +1755,7 @@ export class DB {
 
         await this.updateGroupCache(teamId, groupTypeIndex, groupKey, {
             properties: groupProperties,
-            created_at: castTimestampOrNow(createdAt),
+            created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse) as ClickHouseTimestamp,
         })
     }
 

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -6,6 +6,7 @@ import { KAFKA_SESSION_RECORDING_EVENTS } from '../../config/kafka-topics'
 import {
     ClickHouseTimestamp,
     Element,
+    GroupTypeIndex,
     Hub,
     IngestionPersonData,
     ISOTimestamp,
@@ -160,10 +161,10 @@ export class EventsProcessor {
 
     getGroupIdentifiers(properties: Properties): GroupId[] {
         const res: GroupId[] = []
-        for (let groupIndex = 0; groupIndex < this.db.MAX_GROUP_TYPES_PER_TEAM; ++groupIndex) {
-            const key = `$group_${groupIndex}`
+        for (let groupTypeIndex = 0; groupTypeIndex < this.db.MAX_GROUP_TYPES_PER_TEAM; ++groupTypeIndex) {
+            const key = `$group_${groupTypeIndex}`
             if (key in properties) {
-                res.push([groupIndex, properties[key]])
+                res.push([groupTypeIndex as GroupTypeIndex, properties[key]])
             }
         }
         return res

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -1,7 +1,15 @@
 import { DateTime } from 'luxon'
 
-import { Cohort, Hub, Person, PropertyOperator, PropertyUpdateOperation, Team } from '../../src/types'
-import { DB } from '../../src/utils/db/db'
+import {
+    ClickHouseTimestamp,
+    Cohort,
+    Hub,
+    Person,
+    PropertyOperator,
+    PropertyUpdateOperation,
+    Team,
+} from '../../src/types'
+import { DB, GroupId } from '../../src/utils/db/db'
 import { createHub } from '../../src/utils/db/hub'
 import { generateKafkaPersonUpdateMessage } from '../../src/utils/db/utils'
 import { RaceConditionError, UUIDT } from '../../src/utils/utils'
@@ -20,6 +28,10 @@ describe('DB', () => {
         ;[hub, closeServer] = await createHub()
         await resetTestDatabase(undefined, {}, {}, { withExtendedTestData: false })
         db = hub.db
+
+        const redis = await hub.redisPool.acquire()
+        await redis.flushdb()
+        await db.redisPool.release(redis)
     })
 
     afterEach(async () => {
@@ -28,6 +40,11 @@ describe('DB', () => {
     })
 
     const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
+    const CLICKHOUSE_TIMESTAMP = '2000-10-14 11:42:06.502' as ClickHouseTimestamp
+
+    function fetchGroupCache(teamId: number, groupTypeIndex: number, groupKey: string) {
+        return db.redisGet(db.getGroupDataCacheKey(teamId, groupTypeIndex, groupKey), null)
+    }
 
     describe('fetchAllActionsGroupedByTeam() and fetchAction()', () => {
         beforeEach(async () => {
@@ -605,121 +622,154 @@ describe('DB', () => {
                 version: 2,
             })
         })
+
+        describe('with caching', () => {
+            it('insertGroup() and updateGroup() update cache', async () => {
+                expect(await fetchGroupCache(2, 0, 'group_key')).toEqual(null)
+
+                await db.insertGroup(
+                    2,
+                    0,
+                    'group_key',
+                    { prop: 'val' },
+                    TIMESTAMP,
+                    { prop: TIMESTAMP.toISO() },
+                    { prop: PropertyUpdateOperation.Set },
+                    1,
+                    undefined,
+                    { cache: true }
+                )
+
+                expect(await fetchGroupCache(2, 0, 'group_key')).toEqual({
+                    created_at: CLICKHOUSE_TIMESTAMP,
+                    properties: { prop: 'val' },
+                })
+
+                await db.updateGroup(
+                    2,
+                    0,
+                    'group_key',
+                    { prop: 'newVal', prop2: 2 },
+                    TIMESTAMP,
+                    { prop: TIMESTAMP.toISO(), prop2: TIMESTAMP.toISO() },
+                    { prop: PropertyUpdateOperation.Set, prop2: PropertyUpdateOperation.Set },
+                    2
+                )
+
+                expect(await fetchGroupCache(2, 0, 'group_key')).toEqual({
+                    created_at: CLICKHOUSE_TIMESTAMP,
+                    properties: { prop: 'newVal', prop2: 2 },
+                })
+            })
+        })
+    })
+
+    describe('updateGroupCache()', () => {
+        it('updates redis', async () => {
+            await db.updateGroupCache(2, 0, 'group_key', {
+                created_at: CLICKHOUSE_TIMESTAMP,
+                properties: { prop: 'val' },
+            })
+
+            expect(await fetchGroupCache(2, 0, 'group_key')).toEqual({
+                created_at: CLICKHOUSE_TIMESTAMP,
+                properties: { prop: 'val' },
+            })
+        })
     })
 
     describe('getGroupsColumns()', () => {
+        beforeEach(() => {
+            jest.spyOn(db, 'fetchGroup')
+            jest.spyOn(db, 'redisGet')
+            db.statsd = { increment: jest.fn(), timing: jest.fn() } as any
+        })
+
         describe('one group', () => {
             it('tries to fetch data from the cache first, avoiding the database', async () => {
-                const fetchGroupSpy = jest.spyOn(db, 'fetchGroup')
-                const redisGetSpy = jest
-                    .spyOn(db, 'redisGet')
-                    .mockImplementationOnce(
-                        jest.fn(() => Promise.resolve({ properties: { foo: 'bar' }, created_at: '2020-01-01' }))
-                    )
-                const res = await db.getGroupsColumns(1, [[0, '0']])
-
-                expect(redisGetSpy).toHaveBeenCalled()
-                expect(fetchGroupSpy).not.toHaveBeenCalled()
-
-                expect(res).toEqual({
-                    group0_properties: JSON.stringify({ foo: 'bar' }),
-                    group0_created_at: '2020-01-01 00:00:00.000',
+                await db.updateGroupCache(2, 0, 'group_key', {
+                    properties: { foo: 'bar' },
+                    created_at: CLICKHOUSE_TIMESTAMP,
                 })
+
+                const result = await db.getGroupsColumns(2, [[0, 'group_key']])
+                expect(result).toEqual({
+                    group0_properties: JSON.stringify({ foo: 'bar' }),
+                    group0_created_at: CLICKHOUSE_TIMESTAMP,
+                })
+
+                expect(db.fetchGroup).not.toHaveBeenCalled()
             })
 
             it('tries to fetch data from Postgres if Redis is down', async () => {
-                const fetchGroupSpy = jest.spyOn(db, 'fetchGroup').mockImplementationOnce(
-                    jest.fn(() =>
-                        Promise.resolve({
-                            group_properties: { foo: 'bar' },
-                            created_at: DateTime.fromISO('2022-01-01T00:00:00.000Z'),
-                        } as any)
-                    )
-                )
-                const redisGetSpy = jest.spyOn(db, 'redisGet').mockImplementationOnce(
-                    jest.fn(() => {
-                        throw new Error()
-                    })
-                )
-
-                const res = await db.getGroupsColumns(1, [[0, '0']])
-
-                expect(redisGetSpy).toHaveBeenCalled()
-                expect(fetchGroupSpy).toHaveBeenCalled()
-                expect(res).toEqual({
-                    group0_properties: JSON.stringify({ foo: 'bar' }),
-                    group0_created_at: '2022-01-01 00:00:00.000',
+                await db.insertGroup(2, 0, 'group_key', { foo: 'bar' }, TIMESTAMP, {}, {}, 0, undefined, {
+                    cache: false,
                 })
+
+                jest.spyOn(db, 'redisGet').mockRejectedValue(new Error())
+
+                const result = await db.getGroupsColumns(2, [[0, 'group_key']])
+
+                expect(result).toEqual({
+                    group0_properties: JSON.stringify({ foo: 'bar' }),
+                    group0_created_at: CLICKHOUSE_TIMESTAMP,
+                })
+                expect(db.fetchGroup).toHaveBeenCalled()
             })
 
             it('tries to fetch data from Postgres if there is no cached data', async () => {
-                const fetchGroupSpy = jest.spyOn(db, 'fetchGroup').mockImplementationOnce(
-                    jest.fn(() =>
-                        Promise.resolve({
-                            group_properties: { foo: 'bar' },
-                            created_at: DateTime.fromISO('2022-01-01T00:00:00.000Z'),
-                        } as any)
-                    )
-                )
-                const redisGetSpy = jest
-                    .spyOn(db, 'redisGet')
-                    .mockImplementationOnce(jest.fn(() => Promise.resolve(null)))
-
-                const res = await db.getGroupsColumns(1, [[0, '0']])
-
-                expect(redisGetSpy).toHaveBeenCalled()
-                expect(fetchGroupSpy).toHaveBeenCalled()
-                expect(res).toEqual({
-                    group0_properties: JSON.stringify({ foo: 'bar' }),
-                    group0_created_at: '2022-01-01 00:00:00.000',
+                await db.insertGroup(2, 0, 'group_key', { foo: 'bar' }, TIMESTAMP, {}, {}, 0, undefined, {
+                    cache: false,
                 })
+
+                const result = await db.getGroupsColumns(2, [[0, 'group_key']])
+
+                expect(result).toEqual({
+                    group0_properties: JSON.stringify({ foo: 'bar' }),
+                    group0_created_at: CLICKHOUSE_TIMESTAMP,
+                })
+                expect(db.fetchGroup).toHaveBeenCalled()
             })
 
             it('triggers a statsd metric if the data doesnt exist in Postgres or Redis', async () => {
-                const fetchGroupSpy = jest
-                    .spyOn(db, 'fetchGroup')
-                    .mockImplementationOnce(jest.fn(() => Promise.resolve(undefined)))
-                const redisGetSpy = jest
-                    .spyOn(db, 'redisGet')
-                    .mockImplementationOnce(jest.fn(() => Promise.resolve(null)))
+                await db.getGroupsColumns(2, [[0, 'unknown_key']])
 
-                db.statsd = {
-                    increment: jest.fn(),
-                } as any
-
-                await db.getGroupsColumns(1, [[0, '0']])
-
-                expect(redisGetSpy).toHaveBeenCalled()
-                expect(fetchGroupSpy).toHaveBeenCalled()
-                expect(db.statsd?.increment).toHaveBeenCalledTimes(2)
                 expect(db.statsd?.increment).toHaveBeenLastCalledWith('groups_data_missing_entirely')
             })
         })
 
         describe('multiple groups', () => {
             it('fetches data from cache for some groups and postgres for others', async () => {
-                const fetchGroupSpy = jest.spyOn(db, 'fetchGroup').mockImplementation(
-                    jest.fn(() =>
-                        Promise.resolve({
-                            group_properties: { cached: false },
-                            created_at: DateTime.fromISO('2022-01-01T00:00:00.000Z'),
-                        } as any)
-                    )
-                )
+                const groupIds: GroupId[] = [
+                    [0, '0'],
+                    [1, '1'],
+                    [2, '2'],
+                    [3, '3'],
+                    [4, '4'],
+                ]
 
-                let call = 0
-                const redisGetSpy = jest.spyOn(db, 'redisGet').mockImplementation(
-                    jest.fn(() => {
-                        // return a cached result on the first and fourth calls and null otherwise
-                        // we should fetch data from postgres for the non-cached results
-                        ++call
-                        if (call === 1 || call === 4) {
-                            return Promise.resolve({ properties: { cached: true }, created_at: '2020-01-01' })
-                        }
-                        return Promise.resolve(null)
+                for (const [groupTypeIndex, groupKey] of [groupIds[0], groupIds[3]]) {
+                    await db.updateGroupCache(2, groupTypeIndex, groupKey, {
+                        properties: { cached: true },
+                        created_at: CLICKHOUSE_TIMESTAMP,
                     })
-                )
-                const res = await db.getGroupsColumns(1, [
+                }
+
+                for (const [groupTypeIndex, groupKey] of groupIds) {
+                    await db.insertGroup(
+                        2,
+                        groupTypeIndex,
+                        groupKey,
+                        { cached: false },
+                        TIMESTAMP,
+                        {},
+                        {},
+                        0,
+                        undefined,
+                        { cache: false }
+                    )
+                }
+                const result = await db.getGroupsColumns(2, [
                     [0, '0'],
                     [1, '1'],
                     [2, '2'],
@@ -727,32 +777,32 @@ describe('DB', () => {
                     [4, '4'],
                 ])
 
-                expect(redisGetSpy).toHaveBeenCalledTimes(5)
-                expect(fetchGroupSpy).toHaveBeenCalledTimes(3)
-
                 // verify that the first and fourth calls have cached=true and all other have cached=false
-                expect(res).toEqual({
-                    group0_created_at: '2020-01-01 00:00:00.000',
+                expect(result).toEqual({
+                    group0_created_at: CLICKHOUSE_TIMESTAMP,
                     group0_properties: JSON.stringify({
                         cached: true,
                     }),
-                    group1_created_at: '2022-01-01 00:00:00.000',
+                    group1_created_at: CLICKHOUSE_TIMESTAMP,
                     group1_properties: JSON.stringify({
                         cached: false,
                     }),
-                    group2_created_at: '2022-01-01 00:00:00.000',
+                    group2_created_at: CLICKHOUSE_TIMESTAMP,
                     group2_properties: JSON.stringify({
                         cached: false,
                     }),
-                    group3_created_at: '2020-01-01 00:00:00.000',
+                    group3_created_at: CLICKHOUSE_TIMESTAMP,
                     group3_properties: JSON.stringify({
                         cached: true,
                     }),
-                    group4_created_at: '2022-01-01 00:00:00.000',
+                    group4_created_at: CLICKHOUSE_TIMESTAMP,
                     group4_properties: JSON.stringify({
                         cached: false,
                     }),
                 })
+
+                expect(db.redisGet).toHaveBeenCalledTimes(5)
+                expect(db.fetchGroup).toHaveBeenCalledTimes(3)
             })
         })
     })


### PR DESCRIPTION
We were seeing some groups-related events never get ingested in playground. Digging in, it turned out that these events were serialized with invalid timestamps due to cache containing dates in different formats.

These events would get dropped by ClickHouse as the resulting date would be in an invalid format.

The bug was introduced in https://github.com/PostHog/posthog/pull/12403 and makes for a good case study for this common class of errors

There were multiple practices that could have indicated the error sooner:
1. Tests for the feature mocked out the DB and used a different data format than what is used properly
2. Some methods related to caching were not properly updated to test the caching logic
3. timestamps-as-strings: we deal with both ISO and clickhouse-format timestamps, and the code didn't differentiate between them properly
4. `getGroupsColumns` signature was very loose, allowing for everything to pass by

This change fixes the issue as well as updates relevant code to be more in-line with best practices.