### PR TITLE
chore: reduce context needed to understand tests

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -44,9 +44,9 @@ class TestAbsoluteUrls(TestCase):
                 "https://app.posthog.com/some/path?=something",
             ),
             (
-                "an.attackers.domain.com/bitcoin-miner.exe",
+                "an.external.domain.com/something-outside-posthog",
                 "https://app.posthog.com",
-                "https://app.posthog.com/an.attackers.domain.com/bitcoin-miner.exe",
+                "https://app.posthog.com/an.external.domain.com/something-outside-posthog",
             ),
             ("/api/path", "", "/api/path"),  # current behavior whether correct or not
             (
@@ -67,17 +67,17 @@ class TestAbsoluteUrls(TestCase):
     def test_absolute_uri_can_not_escape_out_host(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):
             with pytest.raises(PotentialSecurityProblemException):
-                absolute_uri("https://an.attackers.domain.com/bitcoin-miner.exe"),
+                absolute_uri("https://an.external.domain.com/something-outside-posthog"),
 
     def test_absolute_uri_can_not_escape_out_host_on_different_scheme(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):
             with pytest.raises(PotentialSecurityProblemException):
-                absolute_uri("ftp://an.attackers.domain.com/bitcoin-miner.exe"),
+                absolute_uri("ftp://an.external.domain.com/something-outside-posthog"),
 
     def test_absolute_uri_can_not_escape_out_host_when_site_url_is_the_empty_string(self) -> None:
         with self.settings(SITE_URL=""):
             with pytest.raises(PotentialSecurityProblemException):
-                absolute_uri("https://an.attackers.domain.com/bitcoin-miner.exe"),
+                absolute_uri("https://an.external.domain.com/something-outside-posthog"),
 
 
 class TestFormatUrls(TestCase):


### PR DESCRIPTION
## Problem

In this community thread: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667289030132659 a user asks why the repo references bitcoin miners 🙀 

https://github.com/PostHog/posthog/blob/66fbf2a2547a22259a0d876fbb33b03bd5bf211e/posthog/test/test_utils.py#L49

The reference is in tests that check we're not vulnerable to an external redirect attack. We can test that without having the string "bitcoin-miner" in the repo which probably makes things clearer

## Changes

uses different language without changing the text

## How did you test this code?

it is a test