### PR TITLE
chore(plugin-server): Enforce strict timestamp types throughout ingesion

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -518,6 +518,7 @@ interface BaseEvent {
 
 export type ISOTimestamp = Brand<string, 'ISOTimestamp'>
 export type ClickHouseTimestamp = Brand<string, 'ClickHouseTimestamp'>
+export type ClickHouseTimestampSecondPrecision = Brand<string, 'ClickHouseTimestamp'>
 
 /** Raw event row from ClickHouse. */
 export interface RawClickHouseEvent extends BaseEvent {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1713,7 +1713,7 @@ export class DB {
         if (options?.cache) {
             await this.updateGroupCache(teamId, groupTypeIndex, groupKey, {
                 properties: groupProperties,
-                created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse) as ClickHouseTimestamp,
+                created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse),
             })
         }
     }
@@ -1755,7 +1755,7 @@ export class DB {
 
         await this.updateGroupCache(teamId, groupTypeIndex, groupKey, {
             properties: groupProperties,
-            created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse) as ClickHouseTimestamp,
+            created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse),
         })
     }
 

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -8,6 +8,7 @@ import { Readable } from 'stream'
 
 import {
     ClickHouseTimestamp,
+    ClickHouseTimestampSecondPrecision,
     ISOTimestamp,
     LogLevel,
     Plugin,
@@ -233,8 +234,20 @@ export class UUIDT extends UUID {
 /** Format timestamp for ClickHouse. */
 export function castTimestampOrNow(
     timestamp?: DateTime | string | null,
+    timestampFormat?: TimestampFormat.ISO
+): ISOTimestamp
+export function castTimestampOrNow(
+    timestamp: DateTime | string | null,
+    timestampFormat: TimestampFormat.ClickHouse
+): ClickHouseTimestamp
+export function castTimestampOrNow(
+    timestamp: DateTime | string | null,
+    timestampFormat: TimestampFormat.ClickHouseSecondPrecision
+): ClickHouseTimestampSecondPrecision
+export function castTimestampOrNow(
+    timestamp?: DateTime | string | null,
     timestampFormat: TimestampFormat = TimestampFormat.ISO
-): string {
+): ISOTimestamp | ClickHouseTimestamp | ClickHouseTimestampSecondPrecision {
     if (!timestamp) {
         timestamp = DateTime.utc()
     } else if (typeof timestamp === 'string') {
@@ -247,18 +260,31 @@ export function castTimestampOrNow(
 const DATETIME_FORMAT_CLICKHOUSE_SECOND_PRECISION = 'yyyy-MM-dd HH:mm:ss'
 const DATETIME_FORMAT_CLICKHOUSE = 'yyyy-MM-dd HH:mm:ss.u'
 
+export function castTimestampToClickhouseFormat(timestamp: DateTime, timestampFormat: TimestampFormat.ISO): ISOTimestamp
+export function castTimestampToClickhouseFormat(
+    timestamp: DateTime,
+    timestampFormat: TimestampFormat.ClickHouse
+): ClickHouseTimestamp
+export function castTimestampToClickhouseFormat(
+    timestamp: DateTime,
+    timestampFormat: TimestampFormat.ClickHouseSecondPrecision
+): ClickHouseTimestampSecondPrecision
+export function castTimestampToClickhouseFormat(
+    timestamp: DateTime,
+    timestampFormat: TimestampFormat
+): ISOTimestamp | ClickHouseTimestamp | ClickHouseTimestampSecondPrecision
 export function castTimestampToClickhouseFormat(
     timestamp: DateTime,
     timestampFormat: TimestampFormat = TimestampFormat.ISO
-): string {
+): ISOTimestamp | ClickHouseTimestamp | ClickHouseTimestampSecondPrecision {
     timestamp = timestamp.toUTC()
     switch (timestampFormat) {
         case TimestampFormat.ClickHouseSecondPrecision:
-            return timestamp.toFormat(DATETIME_FORMAT_CLICKHOUSE_SECOND_PRECISION)
+            return timestamp.toFormat(DATETIME_FORMAT_CLICKHOUSE_SECOND_PRECISION) as ClickHouseTimestampSecondPrecision
         case TimestampFormat.ClickHouse:
-            return timestamp.toFormat(DATETIME_FORMAT_CLICKHOUSE)
+            return timestamp.toFormat(DATETIME_FORMAT_CLICKHOUSE) as ClickHouseTimestamp
         case TimestampFormat.ISO:
-            return timestamp.toUTC().toISO()
+            return timestamp.toUTC().toISO() as ISOTimestamp
         default:
             throw new Error(`Unrecognized timestamp format ${timestampFormat}!`)
     }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -4,7 +4,6 @@ import { DateTime } from 'luxon'
 
 import { KAFKA_SESSION_RECORDING_EVENTS } from '../../config/kafka-topics'
 import {
-    ClickHouseTimestamp,
     Element,
     GroupTypeIndex,
     Hub,
@@ -214,18 +213,15 @@ export class EventsProcessor {
             uuid,
             event: safeClickhouseString(event),
             properties: JSON.stringify(properties ?? {}),
-            timestamp: castTimestampOrNow(timestamp, TimestampFormat.ClickHouse) as ClickHouseTimestamp,
+            timestamp: castTimestampOrNow(timestamp, TimestampFormat.ClickHouse),
             team_id: teamId,
             distinct_id: safeClickhouseString(distinctId),
             elements_chain: safeClickhouseString(elementsChain),
-            created_at: castTimestampOrNow(null, TimestampFormat.ClickHouse) as ClickHouseTimestamp,
+            created_at: castTimestampOrNow(null, TimestampFormat.ClickHouse),
             person_id: personInfo?.uuid,
             person_properties: eventPersonProperties ?? undefined,
             person_created_at: personInfo
-                ? (castTimestampOrNow(
-                      personInfo?.created_at,
-                      TimestampFormat.ClickHouseSecondPrecision
-                  ) as ClickHouseTimestamp)
+                ? castTimestampOrNow(personInfo?.created_at, TimestampFormat.ClickHouseSecondPrecision)
                 : undefined,
             ...groupsColumns,
         }
@@ -254,10 +250,7 @@ export class EventsProcessor {
         properties: Properties,
         ip: string | null
     ): Promise<PostIngestionEvent> {
-        const timestampString = castTimestampOrNow(
-            timestamp,
-            this.kafkaProducer ? TimestampFormat.ClickHouse : TimestampFormat.ISO
-        )
+        const timestampString = castTimestampOrNow(timestamp, TimestampFormat.ClickHouse)
 
         const data: RawSessionRecordingEvent = {
             uuid,


### PR DESCRIPTION
Depends on https://github.com/PostHog/posthog/pull/12547

We have had multiple bugs relating to various timestamp formats in the past - most systems use iso8601 whilst clickhouse uses its own format and we've frequently got these mixed up. See https://github.com/PostHog/posthog/pull/12547 for a recent example.

We have had a pattern for a while for the use of specific types (ClickHouseTimestamp, ISOTimestamp) in the code, but this was not enforced and some functions in the code did not return appropriate values.

This PR changes that