### PR TITLE
chore(ingestion): remove graphile as dependency of ingestion pipeline

### DIFF
--- a/plugin-server/src/main/graphile-worker/worker-setup.ts
+++ b/plugin-server/src/main/graphile-worker/worker-setup.ts
@@ -7,12 +7,6 @@ import { pauseQueueIfWorkerFull } from '../ingestion-queues/queue'
 import { GraphileWorker } from './graphile-worker'
 import { loadPluginSchedule, runScheduledTasks } from './schedule'
 
-export const createGraphileWorker = async (hub: Hub) => {
-    const graphileWorker = new GraphileWorker(hub)
-    await graphileWorker.connectProducer()
-    return graphileWorker
-}
-
 export async function startGraphileWorker(hub: Hub, graphileWorker: GraphileWorker, piscina: Piscina) {
     status.info('🔄', 'Starting Graphile Worker...')
 

--- a/plugin-server/src/main/graphile-worker/worker-setup.ts
+++ b/plugin-server/src/main/graphile-worker/worker-setup.ts
@@ -4,17 +4,28 @@ import { CronItem, TaskList } from 'graphile-worker'
 import { EnqueuedPluginJob, Hub } from '../../types'
 import { status } from '../../utils/status'
 import { pauseQueueIfWorkerFull } from '../ingestion-queues/queue'
+import { GraphileWorker } from './graphile-worker'
 import { loadPluginSchedule, runScheduledTasks } from './schedule'
 
-export async function startGraphileWorker(hub: Hub, piscina: Piscina): Promise<Error | undefined> {
+export const createGraphileWorker = async (hub: Hub) => {
+    const graphileWorker = new GraphileWorker(hub)
+    await graphileWorker.connectProducer()
+    return graphileWorker
+}
+
+export async function startGraphileWorker(hub: Hub, graphileWorker: GraphileWorker, piscina: Piscina) {
     status.info('🔄', 'Starting Graphile Worker...')
+
+    piscina.on('drain', () => {
+        void graphileWorker.resumeConsumer()
+    })
 
     let jobHandlers: TaskList = {}
 
     const crontab: CronItem[] = []
 
     if (hub.capabilities.processPluginJobs) {
-        jobHandlers = { ...jobHandlers, ...getPluginJobHandlers(hub, piscina) }
+        jobHandlers = { ...jobHandlers, ...getPluginJobHandlers(hub, graphileWorker, piscina) }
         status.info('🔄', 'Graphile Worker: set up plugin job handlers ...')
     }
 
@@ -53,17 +64,14 @@ export async function startGraphileWorker(hub: Hub, piscina: Piscina): Promise<E
         status.info('🔄', 'Graphile Worker: set up scheduled task handlers...')
     }
 
-    try {
-        await hub.graphileWorker.start(jobHandlers, crontab)
-    } catch (error) {
-        return error
-    }
+    await graphileWorker.start(jobHandlers, crontab)
+    return graphileWorker
 }
 
-export function getPluginJobHandlers(hub: Hub, piscina: Piscina): TaskList {
+export function getPluginJobHandlers(hub: Hub, graphileWorker: GraphileWorker, piscina: Piscina): TaskList {
     const pluginJobHandlers: TaskList = {
         pluginJob: async (job) => {
-            pauseQueueIfWorkerFull(() => hub.graphileWorker.pause(), hub, piscina)
+            pauseQueueIfWorkerFull(() => graphileWorker.pause(), hub, piscina)
             hub.statsd?.increment('triggered_job', {
                 instanceId: hub.instanceId.toString(),
             })

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -14,8 +14,9 @@ import { captureEventLoopMetrics } from '../utils/metrics'
 import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
-import { delay, getPiscinaStats, logOrThrowJobQueueError, stalenessCheck } from '../utils/utils'
+import { delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
 import { makePiscina as defaultMakePiscina } from '../worker/piscina'
+import { GraphileWorker } from './graphile-worker/graphile-worker'
 import { loadPluginSchedule } from './graphile-worker/schedule'
 import { startGraphileWorker } from './graphile-worker/worker-setup'
 import { startAnonymousEventBufferConsumer } from './ingestion-queues/anonymous-event-buffer-consumer'
@@ -88,6 +89,8 @@ export async function startPluginsServer(
     let httpServer: Server | undefined // healthcheck server
     let mmdbServer: net.Server | undefined // geoip server
 
+    let graphileWorker: GraphileWorker | undefined
+
     let closeHub: () => Promise<void> | undefined
 
     let lastActivityCheck: NodeJS.Timeout | undefined
@@ -103,7 +106,7 @@ export async function startPluginsServer(
         await Promise.allSettled([
             queue?.stop(),
             pubSub?.stop(),
-            hub?.graphileWorker.stop(),
+            graphileWorker?.stop(),
             bufferConsumer?.disconnect(),
             jobsConsumer?.disconnect(),
         ])
@@ -219,13 +222,24 @@ export async function startPluginsServer(
         }
 
         if (hub.capabilities.processPluginJobs || hub.capabilities.pluginScheduledTasks) {
-            const graphileWorkerError = await startGraphileWorker(hub, piscina)
-            if (graphileWorkerError instanceof Error) {
-                try {
-                    logOrThrowJobQueueError(hub, graphileWorkerError, `Cannot start job queue consumer!`)
-                } catch {
-                    killProcess()
-                }
+            graphileWorker = new GraphileWorker(hub)
+            // `connectProducer` just runs the PostgreSQL migrations. Ideally it
+            // would be great to move the migration to bin/migrate and ensure we
+            // have a way for the pods to wait for the migrations to complete as
+            // we do with other migrations. However, I couldn't find a
+            // `graphile-worker` supported way to do this, and I don't think
+            // it's that heavy so it may be fine, but something to watch out
+            // for.
+            await graphileWorker.connectProducer()
+            await startGraphileWorker(hub, graphileWorker, piscina)
+
+            if (hub.capabilities.processPluginJobs) {
+                jobsConsumer = await startJobsConsumer({
+                    kafka: hub.kafka,
+                    producer: hub.kafkaProducer.producer,
+                    graphileWorker: graphileWorker,
+                    statsd: hub.statsd,
+                })
             }
         }
 
@@ -239,23 +253,10 @@ export async function startPluginsServer(
             })
         }
 
-        if (hub.capabilities.processPluginJobs) {
-            jobsConsumer = await startJobsConsumer({
-                kafka: hub.kafka,
-                producer: hub.kafkaProducer.producer,
-                graphileWorker: hub.graphileWorker,
-                statsd: hub.statsd,
-            })
-        }
-
         const queues = await startQueues(hub, piscina)
 
         // `queue` refers to the ingestion queue.
         queue = queues.ingestion
-
-        piscina.on('drain', () => {
-            void hub?.graphileWorker.resumeConsumer()
-        })
 
         // use one extra Redis connection for pub-sub
         pubSub = new PubSub(hub, {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -375,7 +375,7 @@ export async function startPluginsServer(
         return serverInstance as ServerInstance
     } catch (error) {
         Sentry.captureException(error)
-        status.error('💥', 'Launchpad failure!', error)
+        status.error('💥', 'Launchpad failure!', { error: error.stack ?? error })
         void Sentry.flush().catch(() => null) // Flush Sentry in the background
         await closeJobs()
         process.exit(1)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -17,7 +17,6 @@ import { Job } from 'node-schedule'
 import { Pool } from 'pg'
 import { VM } from 'vm2'
 
-import { GraphileWorker } from './main/graphile-worker/graphile-worker'
 import { ObjectStorage } from './main/services/object_storage'
 import { DB } from './utils/db/db'
 import { KafkaProducerWrapper } from './utils/db/kafka-producer-wrapper'
@@ -200,7 +199,6 @@ export interface Hub extends PluginsServerConfig {
     personManager: PersonManager
     siteUrlManager: SiteUrlManager
     appMetrics: AppMetrics
-    graphileWorker: GraphileWorker
     // diagnostics
     lastActivity: number
     lastActivityType: string

--- a/plugin-server/tests/main/capabilities.test.ts
+++ b/plugin-server/tests/main/capabilities.test.ts
@@ -19,7 +19,7 @@ describe('capabilities', () => {
         ;[hub, closeHub] = await createHub({
             LOG_LEVEL: LogLevel.Warn,
         })
-        piscina = { run: jest.fn() } as any
+        piscina = { run: jest.fn(), on: jest.fn() } as any
     })
 
     afterEach(async () => {
@@ -75,7 +75,7 @@ describe('capabilities', () => {
 
             await startGraphileWorker(hub, graphileWorker, piscina)
 
-            expect(hub.graphileWorker.start).toHaveBeenCalledWith(
+            expect(graphileWorker.start).toHaveBeenCalledWith(
                 {
                     runEveryMinute: expect.anything(),
                     runEveryHour: expect.anything(),

--- a/plugin-server/tests/main/capabilities.test.ts
+++ b/plugin-server/tests/main/capabilities.test.ts
@@ -1,5 +1,6 @@
 import Piscina from '@posthog/piscina'
 
+import { GraphileWorker } from '../../src/main/graphile-worker/graphile-worker'
 import { startGraphileWorker } from '../../src/main/graphile-worker/worker-setup'
 import { KafkaQueue } from '../../src/main/ingestion-queues/kafka-queue'
 import { startQueues } from '../../src/main/ingestion-queues/queue'
@@ -48,14 +49,15 @@ describe('capabilities', () => {
 
     describe('startGraphileWorker()', () => {
         it('sets up pluginJob handler if processPluginJobs is on', async () => {
-            jest.spyOn(hub.graphileWorker, 'start').mockImplementation(jest.fn())
+            const graphileWorker = new GraphileWorker(hub)
+            jest.spyOn(graphileWorker, 'start').mockImplementation(jest.fn())
             hub.capabilities.ingestion = false
             hub.capabilities.processPluginJobs = true
             hub.capabilities.pluginScheduledTasks = false
 
-            await startGraphileWorker(hub, piscina)
+            await startGraphileWorker(hub, graphileWorker, piscina)
 
-            expect(hub.graphileWorker.start).toHaveBeenCalledWith(
+            expect(graphileWorker.start).toHaveBeenCalledWith(
                 {
                     pluginJob: expect.anything(),
                 },
@@ -64,13 +66,14 @@ describe('capabilities', () => {
         })
 
         it('sets up scheduled task handlers if pluginScheduledTasks is on', async () => {
-            jest.spyOn(hub.graphileWorker, 'start').mockImplementation(jest.fn())
+            const graphileWorker = new GraphileWorker(hub)
+            jest.spyOn(graphileWorker, 'start').mockImplementation(jest.fn())
 
             hub.capabilities.ingestion = false
             hub.capabilities.processPluginJobs = false
             hub.capabilities.pluginScheduledTasks = true
 
-            await startGraphileWorker(hub, piscina)
+            await startGraphileWorker(hub, graphileWorker, piscina)
 
             expect(hub.graphileWorker.start).toHaveBeenCalledWith(
                 {

--- a/plugin-server/tests/main/teardown.test.ts
+++ b/plugin-server/tests/main/teardown.test.ts
@@ -7,7 +7,6 @@ import { makePiscina } from '../../src/worker/piscina'
 import { pluginConfig39 } from '../helpers/plugins'
 import { getErrorForPluginConfig, resetTestDatabase } from '../helpers/sql'
 
-jest.mock('@graphile/logger')
 jest.mock('../../src/utils/status')
 jest.setTimeout(60000) // 60 sec timeout
 


### PR DESCRIPTION
This allows us to run just the ingestion part of the plugin-server
without needing to perform any graphile operations e.g. creating
connections to the graphile database.

This has the advantage that:

 1. if the graphile database is down, the ingestion pods can still start
    up and will function correctly.
 2. avoids creating a connection pool to the graphile database for each
    ingestion pod, which could be a lot of connections and could cause
    the database to scale.
 3. avoids running the graphile migrations on each ingestion pod, which
    is unnecessary and could cause unnecessary database load.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
