### PR TITLE
feat: Update onboarding to support billing V2

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -212,7 +212,11 @@ class BillingViewset(viewsets.GenericViewSet):
         license = License.objects.first_valid()
         organization = self._get_org_required()
 
-        redirect_uri = f"{settings.SITE_URL or request.headers.get('Host')}/organization/billing"
+        redirect_path = request.GET.get("redirect_path") or "organization/billing"
+        if redirect_path.startswith("/"):
+            redirect_path = redirect_path[1:]
+
+        redirect_uri = f"{settings.SITE_URL or request.headers.get('Host')}/{redirect_path}"
         url = f"{BILLING_SERVICE_URL}/activation?redirect_uri={redirect_uri}&organization_name={organization.name}&plan={request.GET.get('plan', 'standard')}"
 
         if license:

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -24,7 +24,12 @@ export function Billing(): JSX.Element {
     }
 
     if (billingVersion === 'v2') {
-        return <BillingV2 />
+        return (
+            <div>
+                <PageHeader title="Billing &amp; usage" />
+                <BillingV2 />
+            </div>
+        )
     }
 
     return (

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -385,10 +385,13 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
             ref={ref}
         >
             <div className="flex-1 py-4 pr-2 space-y-4">
-                <div className="flex justify-between items-start">
+                <div className="flex gap-4 items-center">
+                    {product.image_url ? (
+                        <img className="w-10 h-10" alt="Logo for product" src={product.image_url} />
+                    ) : null}
                     <div>
-                        <h3 className="font-bold">{product.name}</h3>
-                        <p>{product.description}</p>
+                        <h3 className="font-bold mb-0">{product.name}</h3>
+                        <div>{product.description}</div>
                     </div>
                 </div>
 

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -74,26 +74,25 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
                 <div className="flex">
                     <div className="flex-1">
                         {billing?.billing_period ? (
-                            <>
+                            <div className="space-y-2">
                                 <p>
                                     Your current billing period is from{' '}
                                     <b>{billing.billing_period.current_period_start.format('LL')}</b> to{' '}
                                     <b>{billing.billing_period.current_period_end.format('LL')}</b>
                                 </p>
 
-                                <div className="space-y-2">
-                                    <LemonLabel
-                                        info={'This is the current amount you have been billed for this month so far.'}
-                                    >
-                                        Current bill total
-                                    </LemonLabel>
-                                    <div className="font-bold text-4xl">${billing.current_total_amount_usd}</div>
-                                </div>
+                                <LemonLabel
+                                    info={'This is the current amount you have been billed for this month so far.'}
+                                >
+                                    Current bill total
+                                </LemonLabel>
+                                <div className="font-bold text-4xl">${billing.current_total_amount_usd}</div>
+
                                 <p>
                                     <b>{billing.billing_period.current_period_end.diff(dayjs(), 'days')} days</b>{' '}
                                     remaining in your billing period.
                                 </p>
-                            </>
+                            </div>
                         ) : (
                             <>
                                 <h2 className="font-bold">Add payment method</h2>

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -278,6 +278,12 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
     }
 
     useEffect(() => {
+        if (!billingLoading) {
+            setIsEditingBillingLimit(false)
+        }
+    }, [billingLoading])
+
+    useEffect(() => {
         setBillingLimitInput(
             parseInt(customLimitUsd || '0') ||
                 parseInt(convertUsageToAmount((product.projected_usage || 0) * 1.5, product.tiers)) ||

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -285,7 +285,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
 
     const { ref, size } = useResizeBreakpoints({
         0: 'small',
-        [750]: 'medium',
+        750: 'medium',
     })
 
     const onBillingLimitToggle = (): void => {

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -24,9 +24,11 @@ import { convertAmountToUsage, convertUsageToAmount, summarizeUsage } from './bi
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
+import { BillingHero } from './BillingHero'
 
 export type BillingV2Props = {
     redirectPath?: string
+    compact?: boolean
 }
 
 export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
@@ -52,8 +54,13 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
     const products =
         enterprisePackage && billing?.products_enterprise ? billing?.products_enterprise : billing?.products
 
+    const { ref, size } = useResizeBreakpoints({
+        0: 'small',
+        1000: 'medium',
+    })
+
     return (
-        <div>
+        <div ref={ref}>
             {!billing && !billingLoading ? (
                 <div className="space-y-4">
                     <AlertMessage type="error">
@@ -71,7 +78,12 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
                     ) : null}
                 </div>
             ) : (
-                <div className="flex">
+                <div
+                    className={clsx('flex flex-wrap gap-4', {
+                        'flex-col pb-4 items-stretch': size === 'small',
+                        'items-center': size !== 'small',
+                    })}
+                >
                     <div className="flex-1">
                         {billing?.billing_period ? (
                             <div className="space-y-2">
@@ -94,21 +106,17 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
                                 </p>
                             </div>
                         ) : (
-                            <>
-                                <h2 className="font-bold">Add payment method</h2>
-                                <p>
-                                    Unlock premium features such as Experimentation, advanced product analytics, user
-                                    permissions and more. Subscribed users also have an increased free tier allocation{' '}
-                                    <b>every month!</b> Once setup, you can configure your billing limits to ensure you
-                                    are never billed for more than you need.
-                                </p>
-                            </>
+                            <BillingHero />
                         )}
                     </div>
 
-                    <LemonDivider vertical dashed />
-
-                    <div className="p-4 space-y-2" style={{ width: '20rem' }}>
+                    <div
+                        className={clsx('space-y-2', {
+                            'p-4': size === 'medium',
+                        })}
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ width: size === 'medium' ? '20rem' : undefined }}
+                    >
                         {billing?.has_active_subscription ? (
                             <LemonButton
                                 type="primary"
@@ -285,7 +293,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
 
     const { ref, size } = useResizeBreakpoints({
         0: 'small',
-        750: 'medium',
+        700: 'medium',
     })
 
     const onBillingLimitToggle = (): void => {

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react'
-import { PageHeader } from 'lib/components/PageHeader'
 import { billingLogic } from './billingLogic'
 import {
     LemonButton,
@@ -11,7 +10,7 @@ import {
     Link,
 } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { Spinner, SpinnerOverlay } from 'lib/components/Spinner/Spinner'
+import { SpinnerOverlay } from 'lib/components/Spinner/Spinner'
 import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
 import { AlertMessage } from 'lib/components/AlertMessage'
@@ -25,8 +24,13 @@ import { convertAmountToUsage, convertUsageToAmount, summarizeUsage } from './bi
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
+import { IconDelete, IconEdit } from 'lib/components/icons'
 
-export function BillingV2(): JSX.Element {
+export type BillingV2Props = {
+    redirectPath?: string
+}
+
+export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
     const { billing, billingLoading, isActivateLicenseSubmitting, showLicenseDirectInput } = useValues(billingLogic)
     const { setShowLicenseDirectInput } = useActions(billingLogic)
     const { preflight } = useValues(preflightLogic)
@@ -51,8 +55,6 @@ export function BillingV2(): JSX.Element {
 
     return (
         <div>
-            <PageHeader title="Billing &amp; usage" />
-
             {!billing && !billingLoading ? (
                 <div className="space-y-4">
                     <AlertMessage type="error">
@@ -73,35 +75,33 @@ export function BillingV2(): JSX.Element {
                 <div className="flex">
                     <div className="flex-1">
                         {billing?.billing_period ? (
-                            <>
+                            <div className="space-y-2">
                                 <p>
                                     Your current billing period is from{' '}
                                     <b>{billing.billing_period.current_period_start.format('LL')}</b> to{' '}
                                     <b>{billing.billing_period.current_period_end.format('LL')}</b>
                                 </p>
 
-                                <div className="space-y-2">
-                                    <LemonLabel
-                                        info={'This is the current amount you have been billed for this month so far.'}
-                                    >
-                                        Current bill total
-                                    </LemonLabel>
-                                    <div className="font-bold text-4xl">${billing.current_total_amount_usd}</div>
-                                </div>
+                                <LemonLabel
+                                    info={'This is the current amount you have been billed for this month so far.'}
+                                >
+                                    Current bill total
+                                </LemonLabel>
+                                <div className="font-bold text-4xl">${billing.current_total_amount_usd}</div>
+
                                 <p>
                                     <b>{billing.billing_period.current_period_end.diff(dayjs(), 'days')} days</b>{' '}
                                     remaining in your billing period.
                                 </p>
-                            </>
+                            </div>
                         ) : (
                             <>
-                                <h2 className="font-bold">
-                                    Unlock a massive free tier simply by setting up your billing
-                                </h2>
+                                <h2 className="font-bold">Add payment method</h2>
                                 <p>
-                                    Simply set up your payment details to unlock a massive free allocation of events and
-                                    recordings <b>every month!</b> Once setup, you can configure your billing limits to
-                                    ensure you are never billed for more than you need.
+                                    Unlock premium features such as Experimentation, advanced product analytics, user
+                                    permissions and more. Subscribed users also have an increased free tier allocation{' '}
+                                    <b>every month!</b> Once setup, you can configure your billing limits to ensure you
+                                    are never billed for more than you need.
                                 </p>
                             </>
                         )}
@@ -149,7 +149,7 @@ export function BillingV2(): JSX.Element {
                                 <LemonButton
                                     to={`/api/billing-v2/activation?plan=${
                                         enterprisePackage ? 'enterprise' : 'standard'
-                                    }`}
+                                    }&redirect_path=${redirectPath}`}
                                     type="primary"
                                     size="large"
                                     fullWidth
@@ -216,14 +216,18 @@ export function BillingV2(): JSX.Element {
 const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Element => {
     const { billing, billingLoading } = useValues(billingLogic)
     const { updateBillingLimits } = useActions(billingLogic)
-
-    const customLimitUsd = billing?.custom_limits_usd?.[product.type]
-
     const [tierAmountType, setTierAmountType] = useState<'individual' | 'total'>('individual')
-    const [showBillingLimit, setShowBillingLimit] = useState(false)
-    const [billingLimit, setBillingLimit] = useState<number | undefined>(100)
-    const billingLimitInputChanged = parseInt(customLimitUsd || '-1') !== billingLimit
-    const billingLimitAsUsage = showBillingLimit ? convertAmountToUsage(`${billingLimit}`, product.tiers) : 0
+
+    // The actual stored billing limit
+    const customLimitUsd = billing?.custom_limits_usd?.[product.type]
+    const [isEditingBillingLimit, setIsEditingBillingLimit] = useState(false)
+    const [billingLimitInput, setBillingLimitInput] = useState<number | undefined>(100)
+
+    const billingLimitAsUsage = isEditingBillingLimit
+        ? convertAmountToUsage(`${billingLimitInput}`, product.tiers)
+        : convertAmountToUsage(customLimitUsd || '', product.tiers)
+
+    const productType = { plural: product.type, singular: product.type.slice(0, -1) }
 
     const updateBillingLimit = (value: number | undefined): any => {
         const actuallyUpdateLimit = (): void => {
@@ -274,8 +278,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
     }
 
     useEffect(() => {
-        setShowBillingLimit(!!customLimitUsd)
-        setBillingLimit(
+        setBillingLimitInput(
             parseInt(customLimitUsd || '0') ||
                 parseInt(convertUsageToAmount((product.projected_usage || 0) * 1.5, product.tiers)) ||
                 100
@@ -284,18 +287,8 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
 
     const { ref, size } = useResizeBreakpoints({
         0: 'small',
-        1000: 'medium',
+        750: 'medium',
     })
-
-    const onBillingLimitToggle = (): void => {
-        if (!showBillingLimit) {
-            return setShowBillingLimit(true)
-        }
-        if (!customLimitUsd) {
-            return setShowBillingLimit(false)
-        }
-        updateBillingLimit(undefined)
-    }
 
     const billingGaugeItems: BillingGaugeProps['items'] = useMemo(
         () =>
@@ -304,7 +297,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                     tooltip: (
                         <>
                             <b>Free tier limit</b>
-                            {!billing?.has_active_subscription ? <div>(With subscription)</div> : null}
+                            {!billing?.has_active_subscription ? <div>(Subscribed)</div> : null}
                         </>
                     ),
                     color: billing?.has_active_subscription ? 'success-light' : 'success-highlight',
@@ -316,7 +309,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                           tooltip: (
                               <>
                                   <b>Free tier limit</b>
-                                  <div>(Without subscription)</div>
+                                  <div>(Unsubscribed)</div>
                               </>
                           ),
                           color: 'success-light',
@@ -363,7 +356,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
     )
 
     const tierDisplayOptions: LemonSelectOptions<string> = [
-        { label: `Per ${product.type.toLowerCase()}`, value: 'individual' },
+        { label: `Per ${productType.singular}`, value: 'individual' },
     ]
 
     if (billing?.has_active_subscription) {
@@ -410,8 +403,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                             : '0.00'}
                                     </div>
                                 </div>
-                                <div className="flex-1" />
-                                <div className="space-y-2 text-right">
+                                <div className="space-y-2">
                                     <LemonLabel
                                         info={
                                             <>
@@ -420,51 +412,76 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                                     Your critical data will still be ingested and available in the
                                                     product
                                                 </b>
-                                                . Some features may cease operation if your usage greatly exceeds your
+                                                . Some features may stop working if your usage greatly exceeds your
                                                 billing cap.
                                             </>
                                         }
                                     >
                                         Billing limit
                                     </LemonLabel>
-                                    <div className="flex justify-end gap-2 items-center">
-                                        {showBillingLimit ? (
-                                            <div style={{ maxWidth: 180 }}>
-                                                <LemonInput
-                                                    type="number"
-                                                    fullWidth={false}
-                                                    value={billingLimit}
-                                                    onChange={setBillingLimit}
-                                                    prefix={<b>$</b>}
-                                                    disabled={billingLoading}
-                                                    min={0}
-                                                    step={10}
-                                                    suffix={<>/month</>}
+                                    <div className="flex items-center gap-2">
+                                        {!isEditingBillingLimit ? (
+                                            <>
+                                                <div
+                                                    className={clsx(
+                                                        'text-muted font-semibold',
+                                                        customLimitUsd && 'font-semibold text-muted text-2xl'
+                                                    )}
+                                                >
+                                                    {customLimitUsd ? `$${customLimitUsd}` : 'No limit'}
+                                                </div>
+                                                <LemonButton
+                                                    icon={<IconEdit />}
+                                                    status="primary-alt"
+                                                    size="small"
+                                                    tooltip="Edit billing limit"
+                                                    onClick={() => setIsEditingBillingLimit(true)}
                                                 />
-                                            </div>
+                                                {customLimitUsd ? (
+                                                    <LemonButton
+                                                        icon={<IconDelete />}
+                                                        status="primary-alt"
+                                                        size="small"
+                                                        tooltip="Remove billing limit"
+                                                        onClick={() => updateBillingLimit(undefined)}
+                                                    />
+                                                ) : null}
+                                            </>
                                         ) : (
-                                            <span className="text-muted">No limit set</span>
-                                        )}
+                                            <>
+                                                <div style={{ maxWidth: 180 }}>
+                                                    <LemonInput
+                                                        type="number"
+                                                        fullWidth={false}
+                                                        value={billingLimitInput}
+                                                        onChange={setBillingLimitInput}
+                                                        prefix={<b>$</b>}
+                                                        disabled={billingLoading}
+                                                        min={0}
+                                                        step={10}
+                                                        suffix={<>/month</>}
+                                                    />
+                                                </div>
 
-                                        {showBillingLimit && billingLimitInputChanged ? (
-                                            <LemonButton
-                                                onClick={() => updateBillingLimit(billingLimit)}
-                                                loading={billingLoading}
-                                                type="secondary"
-                                            >
-                                                Save
-                                            </LemonButton>
-                                        ) : billingLoading ? (
-                                            <Spinner className="text-lg" />
-                                        ) : (
-                                            <LemonSwitch
-                                                className="my-2"
-                                                checked={showBillingLimit}
-                                                onChange={onBillingLimitToggle}
-                                            />
+                                                <LemonButton
+                                                    onClick={() => setIsEditingBillingLimit(false)}
+                                                    disabled={billingLoading}
+                                                    type="secondary"
+                                                >
+                                                    Cancel
+                                                </LemonButton>
+                                                <LemonButton
+                                                    onClick={() => updateBillingLimit(billingLimitInput)}
+                                                    loading={billingLoading}
+                                                    type="primary"
+                                                >
+                                                    Save
+                                                </LemonButton>
+                                            </>
                                         )}
                                     </div>
                                 </div>
+                                <div className="flex-1" />
                             </>
                         )}
                     </div>
@@ -499,13 +516,17 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                         <div className="flex justify-between items-center">
                             <b>Pricing breakdown</b>
 
-                            <LemonSelect
-                                size="small"
-                                value={tierAmountType}
-                                options={tierDisplayOptions}
-                                dropdownMatchSelectWidth={false}
-                                onChange={(val: any) => setTierAmountType(val)}
-                            />
+                            {billing?.has_active_subscription ? (
+                                <LemonSelect
+                                    size="small"
+                                    value={tierAmountType}
+                                    options={tierDisplayOptions}
+                                    dropdownMatchSelectWidth={false}
+                                    onChange={(val: any) => setTierAmountType(val)}
+                                />
+                            ) : (
+                                <span className="font-semibold">Per {productType.singular}</span>
+                            )}
                         </div>
 
                         <ul>
@@ -519,7 +540,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                 >
                                     <span>
                                         {i === 0
-                                            ? `First ${summarizeUsage(tier.up_to)} ${product.type.toLowerCase()} / mo`
+                                            ? `First ${summarizeUsage(tier.up_to)} ${productType.plural} / mo`
                                             : tier.up_to
                                             ? `${summarizeUsage(product.tiers[i - 1].up_to)} - ${summarizeUsage(
                                                   tier.up_to

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -51,8 +51,6 @@ export function BillingV2(): JSX.Element {
 
     return (
         <div>
-            <PageHeader title="Billing &amp; usage" />
-
             {!billing && !billingLoading ? (
                 <div className="space-y-4">
                     <AlertMessage type="error">

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -10,7 +10,7 @@ import {
     Link,
 } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { Spinner, SpinnerOverlay } from 'lib/components/Spinner/Spinner'
+import { SpinnerOverlay } from 'lib/components/Spinner/Spinner'
 import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
 import { AlertMessage } from 'lib/components/AlertMessage'
@@ -421,7 +421,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                                     Your critical data will still be ingested and available in the
                                                     product
                                                 </b>
-                                                . Some features may cease operation if your usage greatly exceeds your
+                                                . Some features may stop working if your usage greatly exceeds your
                                                 billing cap.
                                             </>
                                         }
@@ -455,13 +455,12 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                             >
                                                 Save
                                             </LemonButton>
-                                        ) : billingLoading ? (
-                                            <Spinner className="text-lg" />
                                         ) : (
                                             <LemonSwitch
                                                 className="my-2"
                                                 checked={showBillingLimit}
                                                 onChange={onBillingLimitToggle}
+                                                disabled={billingLoading}
                                             />
                                         )}
                                     </div>

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -425,13 +425,13 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                     >
                                         Billing limit
                                     </LemonLabel>
-                                    <div className="flex items-center gap-2">
+                                    <div className="flex items-center gap-1">
                                         {!isEditingBillingLimit ? (
                                             <>
                                                 <div
                                                     className={clsx(
-                                                        'text-muted font-semibold',
-                                                        customLimitUsd && 'font-semibold text-muted text-2xl'
+                                                        'text-muted font-semibold mr-2',
+                                                        customLimitUsd && 'text-2xl'
                                                     )}
                                                 >
                                                     {customLimitUsd ? `$${customLimitUsd}` : 'No limit'}

--- a/frontend/src/scenes/billing/v2/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/v2/BillingGauge.tsx
@@ -47,7 +47,7 @@ export type BillingGaugeProps = {
 export function BillingGauge({ items }: BillingGaugeProps): JSX.Element {
     const [expanded, setExpanded] = useState(false)
     const maxScale = useMemo(() => {
-        return Math.max(100, ...items.map((item) => item.value)) * 1.2
+        return Math.max(100, ...items.map((item) => item.value)) * 1.3
     }, [items])
 
     useEffect(() => {

--- a/frontend/src/scenes/billing/v2/BillingHero.scss
+++ b/frontend/src/scenes/billing/v2/BillingHero.scss
@@ -1,0 +1,22 @@
+.BillingHero {
+    background-color: var(--mark-color);
+    border-radius: 0.5rem;
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.BillingHero__hog {
+    overflow: hidden;
+    position: relative;
+    width: 200px;
+    padding-top: 1rem;
+}
+
+.BillingHero__hog__img {
+    height: 200px;
+    width: 200px;
+    margin: -20px -30px;
+}

--- a/frontend/src/scenes/billing/v2/BillingHero.tsx
+++ b/frontend/src/scenes/billing/v2/BillingHero.tsx
@@ -1,0 +1,18 @@
+import { BlushingHog } from 'lib/components/hedgehogs'
+import './BillingHero.scss'
+
+export const BillingHero = (): JSX.Element => {
+    return (
+        <div className="BillingHero">
+            <div className="p-4">
+                <p className="text-xs uppercase my-0">How pricing works</p>
+                <h1 className="ingestion-title">Pay per event sent to PostHog.</h1>
+                <h1 className="ingestion-title text-danger">Get access to all features.</h1>
+                <p className="mt-2 mb-0">Product analytics, session recording, feature flags, a/b testing, and more.</p>
+            </div>
+            <div className="BillingHero__hog">
+                <BlushingHog className="BillingHero__hog__img" />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/billing/v2/billing-utils.ts
+++ b/frontend/src/scenes/billing/v2/billing-utils.ts
@@ -57,6 +57,10 @@ export const convertUsageToAmount = (usage: number, tiers: BillingProductV2Type[
 }
 
 export const convertAmountToUsage = (amount: string, tiers: BillingProductV2Type['tiers']): number => {
+    if (!amount) {
+        return 0
+    }
+
     let remainingAmount = parseFloat(amount)
     let usage = 0
     let previousTier: BillingProductV2Type['tiers'][0] | undefined = undefined

--- a/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
@@ -12,8 +12,8 @@ import { billingLogic } from 'scenes/billing/billingLogic'
 import { billingLogic as billingLogicV2 } from 'scenes/billing/v2/billingLogic'
 import { Plan } from 'scenes/billing/Plan'
 import { BillingV2 } from 'scenes/billing/v2/Billing'
-import { Spinner } from 'lib/components/Spinner/Spinner'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
+import { urls } from 'scenes/urls'
 
 export function BillingPanel(): JSX.Element {
     const { completeOnboarding } = useActions(ingestionLogic)
@@ -43,6 +43,11 @@ export function BillingPanel(): JSX.Element {
                 {billingV2?.has_active_subscription ? (
                     <div className="flex flex-col space-y-4">
                         <h1 className="ingestion-title">You're good to go!</h1>
+
+                        <p>
+                            Your organisation is setup for billing with premium features and the increased free tiers
+                            enabled.
+                        </p>
                         <LemonButton
                             size="large"
                             fullWidth
@@ -57,7 +62,7 @@ export function BillingPanel(): JSX.Element {
                     </div>
                 ) : (
                     <div className="text-left">
-                        <BillingV2 />
+                        <BillingV2 redirectPath={urls.ingestion() + '/billing'} />
 
                         <LemonButton
                             size="large"

--- a/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
@@ -4,7 +4,6 @@ import { ingestionLogic } from 'scenes/ingestion/ingestionLogic'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { BlushingHog } from 'lib/components/hedgehogs'
 import { BillingEnrollment } from 'scenes/billing/BillingEnrollment'
 import { LemonDivider } from '@posthog/lemon-ui'
 import { IconOpenInNew } from 'lib/components/icons'
@@ -66,12 +65,8 @@ export function BillingPanel(): JSX.Element {
                         <h1 className="ingestion-title">Add payment method</h1>
                         <BillingV2 redirectPath={urls.ingestion() + '/billing'} />
 
-                        <LemonDivider thick dashed />
-                        <a href="https://posthog.com/pricing" target="_blank">
-                            <LemonButton fullWidth center type="secondary" size="large" icon={<IconOpenInNew />}>
-                                View pricing
-                            </LemonButton>
-                        </a>
+                        <LemonDivider dashed />
+
                         <LemonButton
                             size="large"
                             fullWidth

--- a/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
@@ -14,6 +14,7 @@ import { Plan } from 'scenes/billing/Plan'
 import { BillingV2 } from 'scenes/billing/v2/Billing'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
 import { urls } from 'scenes/urls'
+import { BillingHero } from 'scenes/billing/v2/BillingHero'
 
 export function BillingPanel(): JSX.Element {
     const { completeOnboarding } = useActions(ingestionLogic)
@@ -61,9 +62,16 @@ export function BillingPanel(): JSX.Element {
                         </LemonButton>
                     </div>
                 ) : (
-                    <div className="text-left">
+                    <div className="text-left flex flex-col space-y-4">
+                        <h1 className="ingestion-title">Add payment method</h1>
                         <BillingV2 redirectPath={urls.ingestion() + '/billing'} />
 
+                        <LemonDivider thick dashed />
+                        <a href="https://posthog.com/pricing" target="_blank">
+                            <LemonButton fullWidth center type="secondary" size="large" icon={<IconOpenInNew />}>
+                                View pricing
+                            </LemonButton>
+                        </a>
                         <LemonButton
                             size="large"
                             fullWidth
@@ -91,19 +99,7 @@ export function BillingPanel(): JSX.Element {
                         Your first million events every month are free. We'll let you know if you exceed this, so you
                         never get an unexpected bill.
                     </p>
-                    <div className="billing-pricing-explanation-box">
-                        <div className="p-4">
-                            <p className="text-xs uppercase my-0">How pricing works</p>
-                            <h1 className="ingestion-title">Pay per event sent to PostHog.</h1>
-                            <h1 className="ingestion-title text-danger">Get access to all features.</h1>
-                            <p className="mt-2 mb-0">
-                                Product analytics, session recording, feature flags, a/b testing, and more.
-                            </p>
-                        </div>
-                        <div className="billing-hog">
-                            <BlushingHog className="billing-hog-img" />
-                        </div>
-                    </div>
+                    <BillingHero />
                     <BillingEnrollment />
                     <div>
                         <h3 className="font-bold">No surprise bills</h3>

--- a/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
@@ -9,12 +9,73 @@ import { BillingEnrollment } from 'scenes/billing/BillingEnrollment'
 import { LemonDivider } from '@posthog/lemon-ui'
 import { IconOpenInNew } from 'lib/components/icons'
 import { billingLogic } from 'scenes/billing/billingLogic'
+import { billingLogic as billingLogicV2 } from 'scenes/billing/v2/billingLogic'
 import { Plan } from 'scenes/billing/Plan'
+import { BillingV2 } from 'scenes/billing/v2/Billing'
+import { Spinner } from 'lib/components/Spinner/Spinner'
+import { LemonSkeleton } from 'lib/components/LemonSkeleton'
 
 export function BillingPanel(): JSX.Element {
     const { completeOnboarding } = useActions(ingestionLogic)
     const { reportIngestionContinueWithoutBilling } = useActions(eventUsageLogic)
-    const { billing } = useValues(billingLogic)
+    const { billing, billingVersion } = useValues(billingLogic)
+    const { billing: billingV2 } = useValues(billingLogicV2)
+
+    if (!billingVersion) {
+        return (
+            <CardContainer>
+                <div className="space-y-4" style={{ width: 800 }}>
+                    <LemonSkeleton className="w-full h-10" />
+                    <LemonSkeleton className="w-full" />
+                    <LemonSkeleton className="w-full" />
+                    <div className="h-20" />
+                    <div className="h-20" />
+                    <LemonSkeleton className="w-full h-10" />
+                    <LemonSkeleton className="w-full h-10" />
+                </div>
+            </CardContainer>
+        )
+    }
+
+    if (billingVersion == 'v2') {
+        return (
+            <CardContainer>
+                {billingV2?.has_active_subscription ? (
+                    <div className="flex flex-col space-y-4">
+                        <h1 className="ingestion-title">You're good to go!</h1>
+                        <LemonButton
+                            size="large"
+                            fullWidth
+                            center
+                            type="primary"
+                            onClick={() => {
+                                completeOnboarding()
+                            }}
+                        >
+                            Complete
+                        </LemonButton>
+                    </div>
+                ) : (
+                    <div className="text-left">
+                        <BillingV2 />
+
+                        <LemonButton
+                            size="large"
+                            fullWidth
+                            center
+                            type="tertiary"
+                            onClick={() => {
+                                completeOnboarding()
+                                reportIngestionContinueWithoutBilling()
+                            }}
+                        >
+                            Skip for now
+                        </LemonButton>
+                    </div>
+                )}
+            </CardContainer>
+        )
+    }
 
     return (
         <CardContainer>

--- a/frontend/src/scenes/ingestion/panels/Panels.scss
+++ b/frontend/src/scenes/ingestion/panels/Panels.scss
@@ -45,31 +45,3 @@
     text-align: center;
     margin-bottom: 1rem;
 }
-
-.billing-pricing-explanation-box {
-    background-color: var(--mark-color);
-    border-radius: 0.5rem;
-    position: relative;
-    display: flex;
-    flex-direction: row;
-}
-
-.billing-hog {
-    overflow: hidden;
-    position: relative;
-    width: 200px;
-    padding-top: 1rem;
-}
-
-@media screen and (max-width: 767px) {
-    .billing-hog {
-        display: none;
-    }
-}
-
-.billing-hog-img {
-    position: absolute;
-    top: 0;
-    height: 200px;
-    width: 200px;
-}

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -22,7 +22,8 @@ export function Elements(): JSX.Element {
         highlightElementMeta,
     } = useValues(elementsLogic)
     const { setHoverElement, selectElement } = useActions(elementsLogic)
-    const { highestClickCount } = useValues(heatmapLogic)
+    const { highestClickCount, shiftPressed } = useValues(heatmapLogic)
+    const heatmapPointerEvents = shiftPressed ? 'none' : 'all'
 
     return (
         <>
@@ -59,7 +60,7 @@ export function Elements(): JSX.Element {
                         key={`inspect-${index}`}
                         rect={rect}
                         style={{
-                            pointerEvents: 'all',
+                            pointerEvents: heatmapPointerEvents,
                             cursor: 'pointer',
                             zIndex: 0,
                             opacity:
@@ -83,7 +84,7 @@ export function Elements(): JSX.Element {
                             <HeatmapElement
                                 rect={rect}
                                 style={{
-                                    pointerEvents: inspectEnabled ? 'none' : 'all',
+                                    pointerEvents: inspectEnabled ? 'none' : heatmapPointerEvents,
                                     zIndex: 1,
                                     opacity: !hoverElement || hoverElement === element ? 1 : 0.4,
                                     transition: 'opacity 0.2s, box-shadow 0.2s',
@@ -101,7 +102,7 @@ export function Elements(): JSX.Element {
                             <HeatmapLabel
                                 rect={rect}
                                 style={{
-                                    pointerEvents: 'all',
+                                    pointerEvents: heatmapPointerEvents,
                                     zIndex: 5,
                                     opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
                                     transition: 'opacity 0.2s, transform 0.2s linear',
@@ -136,7 +137,7 @@ export function Elements(): JSX.Element {
                                     opacity: hoverElement && hoverElement !== element ? 0.4 : 1,
                                     transition: 'opacity 0.2s, transform 0.2s linear',
                                     transform: hoverElement === element ? 'scale(1.3)' : 'none',
-                                    pointerEvents: 'all',
+                                    pointerEvents: heatmapPointerEvents,
                                     cursor: 'pointer',
                                     color: 'hsla(141, 21%, 12%, 1)',
                                     background: 'hsl(147, 100%, 62%)',

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -17,6 +17,7 @@ export const heatmapLogic = kea<heatmapLogicType>({
         enableHeatmap: true,
         disableHeatmap: true,
         setShowHeatmapTooltip: (showHeatmapTooltip: boolean) => ({ showHeatmapTooltip }),
+        setShiftPressed: (shiftPressed: boolean) => ({ shiftPressed }),
         setHeatmapFilter: (filter: Partial<FilterType>) => ({ filter }),
     },
 
@@ -42,6 +43,12 @@ export const heatmapLogic = kea<heatmapLogicType>({
             false,
             {
                 setShowHeatmapTooltip: (_, { showHeatmapTooltip }) => showHeatmapTooltip,
+            },
+        ],
+        shiftPressed: [
+            false,
+            {
+                setShiftPressed: (_, { shiftPressed }) => shiftPressed,
             },
         ],
         heatmapFilter: [
@@ -210,11 +217,27 @@ export const heatmapLogic = kea<heatmapLogicType>({
         ],
     },
 
-    events: ({ actions, values }) => ({
+    events: ({ actions, values, cache }) => ({
         afterMount() {
             if (values.heatmapEnabled) {
                 actions.getEvents()
             }
+            cache.keyDownListener = (event: KeyboardEvent) => {
+                if (event.shiftKey && !values.shiftPressed) {
+                    actions.setShiftPressed(true)
+                }
+            }
+            cache.keyUpListener = (event: KeyboardEvent) => {
+                if (!event.shiftKey && values.shiftPressed) {
+                    actions.setShiftPressed(false)
+                }
+            }
+            window.addEventListener('keydown', cache.keyDownListener)
+            window.addEventListener('keyup', cache.keyUpListener)
+        },
+        beforeUnmount() {
+            window.removeEventListener('keydown', cache.keyDownListener)
+            window.removeEventListener('keyup', cache.keyUpListener)
         },
     }),
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -817,6 +817,7 @@ export interface BillingProductV2Type {
     name: string
     description: string
     price_description: string
+    image_url?: string
     free_allocation: number
     tiers: {
         unit_amount_usd: string

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -18,6 +18,7 @@ from posthog.models.property.util import (
 from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.column_optimizer.column_optimizer import ColumnOptimizer
 from posthog.queries.person_distinct_id_query import get_team_distinct_ids_query
+from posthog.queries.trends.util import COUNT_PER_ACTOR_MATH_FUNCTIONS
 
 
 class PersonQuery:
@@ -138,8 +139,11 @@ class PersonQuery:
         "Returns whether properties or any other columns are actually being queried"
         if any(self._uses_person_id(prop) for prop in self._filter.property_groups.flat):
             return True
-        if any(self._uses_person_id(prop) for entity in self._filter.entities for prop in entity.property_groups.flat):
-            return True
+        for entity in self._filter.entities:
+            if entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS or any(
+                self._uses_person_id(prop) for prop in entity.property_groups.flat
+            ):
+                return True
 
         return len(self._column_optimizer.person_columns_to_query) > 0
 

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -147,27 +147,19 @@ def trend_test_factory(trends):
             _create_action(team=self.team, name="sign up")
 
         def _create_event_count_per_user_events(self):
-            _create_person(team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"])
-            _create_person(team_id=self.team.pk, distinct_ids=["tintin"])
-            _create_person(team_id=self.team.pk, distinct_ids=["murmur"])
-            _create_person(team_id=self.team.pk, distinct_ids=["reeree"])
+            _create_person(team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"fruit": "mango"})
+            _create_person(team_id=self.team.pk, distinct_ids=["tintin"], properties={"fruit": "mango"})
+            _create_person(team_id=self.team.pk, distinct_ids=["murmur"], properties={})  # No fruit here
+            _create_person(team_id=self.team.pk, distinct_ids=["reeree"], properties={"fruit": "tomato"})
 
             with freeze_time("2020-01-01 00:06:02"):
                 _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="anonymous_id",
+                    team=self.team, event="viewed video", distinct_id="anonymous_id", properties={"color": "red"}
                 )
                 _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="blabla",
+                    team=self.team, event="viewed video", distinct_id="blabla", properties={}  # No color here
                 )
-                _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="reeree",
-                )
+                _create_event(team=self.team, event="viewed video", distinct_id="reeree", properties={"color": "blue"})
                 _create_event(
                     team=self.team,
                     event="sign up",
@@ -182,33 +174,13 @@ def trend_test_factory(trends):
                 )
 
             with freeze_time("2020-01-04 23:17:00"):
-                _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="tintin",
-                )
+                _create_event(team=self.team, event="viewed video", distinct_id="tintin", properties={"color": "red"})
 
             with freeze_time("2020-01-05 19:06:34"):
-                _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="blabla",
-                )
-                _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="tintin",
-                )
-                _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="tintin",
-                )
-                _create_event(
-                    team=self.team,
-                    event="viewed video",
-                    distinct_id="tintin",
-                )
+                _create_event(team=self.team, event="viewed video", distinct_id="blabla", properties={"color": "blue"})
+                _create_event(team=self.team, event="viewed video", distinct_id="tintin", properties={"color": "red"})
+                _create_event(team=self.team, event="viewed video", distinct_id="tintin", properties={"color": "red"})
+                _create_event(team=self.team, event="viewed video", distinct_id="tintin", properties={"color": "blue"})
 
         def test_trends_per_day(self):
             self._create_events()
@@ -5116,6 +5088,98 @@ def trend_test_factory(trends):
                 "2020-01-07",
             ]
             assert daily_response[0]["data"] == [2.0, 0.0, 0.0, 1.0, 3.0, 0.0, 0.0]
+
+        def test_trends_volume_per_user_average_with_event_property_breakdown(self):
+            self._create_event_count_per_user_events()
+
+            daily_response = trends().run(
+                Filter(
+                    data={
+                        "display": TRENDS_LINEAR,
+                        "breakdown": "color",
+                        "events": [{"id": "viewed video", "math": "avg_count_per_actor"}],
+                        "date_from": "2020-01-01",
+                        "date_to": "2020-01-07",
+                    }
+                ),
+                self.team,
+            )
+
+            assert len(daily_response) == 3
+            assert daily_response[0]["breakdown_value"] == "red"
+            assert daily_response[1]["breakdown_value"] == "blue"
+            assert daily_response[2]["breakdown_value"] == ""
+            assert daily_response[0]["days"] == [
+                "2020-01-01",
+                "2020-01-02",
+                "2020-01-03",
+                "2020-01-04",
+                "2020-01-05",
+                "2020-01-06",
+                "2020-01-07",
+            ]
+            assert daily_response[1]["days"] == daily_response[0]["days"]
+            assert daily_response[2]["days"] == daily_response[0]["days"]
+            assert daily_response[0]["data"] == [1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0]  # red
+            assert daily_response[1]["data"] == [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]  # blue
+            assert daily_response[2]["data"] == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # none
+
+        def test_trends_volume_per_user_average_with_person_property_breakdown(self):
+            self._create_event_count_per_user_events()
+
+            daily_response = trends().run(
+                Filter(
+                    data={
+                        "display": TRENDS_LINEAR,
+                        "breakdown": "fruit",
+                        "breakdown_type": "person",
+                        "events": [{"id": "viewed video", "math": "avg_count_per_actor"}],
+                        "date_from": "2020-01-01",
+                        "date_to": "2020-01-07",
+                    }
+                ),
+                self.team,
+            )
+
+            assert len(daily_response) == 2
+            assert daily_response[0]["breakdown_value"] == "mango"
+            assert daily_response[1]["breakdown_value"] == "tomato"
+            assert daily_response[0]["days"] == [
+                "2020-01-01",
+                "2020-01-02",
+                "2020-01-03",
+                "2020-01-04",
+                "2020-01-05",
+                "2020-01-06",
+                "2020-01-07",
+            ]
+            assert daily_response[1]["days"] == daily_response[0]["days"]
+            assert daily_response[0]["data"] == [2.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0]  # red
+            assert daily_response[1]["data"] == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # blue
+
+        def test_trends_volume_per_user_average_aggregated_with_event_property_breakdown(self):
+            self._create_event_count_per_user_events()
+
+            daily_response = trends().run(
+                Filter(
+                    data={
+                        "display": TRENDS_TABLE,
+                        "breakdown": "color",
+                        "events": [{"id": "viewed video", "math": "avg_count_per_actor"}],
+                        "date_from": "2020-01-01",
+                        "date_to": "2020-01-07",
+                    }
+                ),
+                self.team,
+            )
+
+            assert len(daily_response) == 3
+            assert daily_response[0]["breakdown_value"] == "red"
+            assert daily_response[1]["breakdown_value"] == "blue"
+            assert daily_response[2]["breakdown_value"] == ""
+            assert daily_response[0]["aggregated_value"] == 2.0  # red
+            assert daily_response[1]["aggregated_value"] == 1.0  # blue
+            assert daily_response[2]["aggregated_value"] == 1.0  # none
 
     return TestTrends
 

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -11,6 +11,7 @@ from posthog.constants import (
     NON_TIME_SERIES_DISPLAY_TYPES,
     TREND_FILTER_TYPE_ACTIONS,
     TRENDS_CUMULATIVE,
+    UNIQUE_USERS,
     WEEKLY_ACTIVE,
     PropertyOperatorType,
 )
@@ -45,10 +46,19 @@ from posthog.queries.trends.sql import (
     BREAKDOWN_INNER_SQL,
     BREAKDOWN_PROP_JOIN_SQL,
     BREAKDOWN_QUERY_SQL,
-    SESSION_MATH_BREAKDOWN_AGGREGATE_QUERY_SQL,
-    SESSION_MATH_BREAKDOWN_INNER_SQL,
+    SESSION_DURATION_BREAKDOWN_AGGREGATE_QUERY_SQL,
+    SESSION_DURATION_BREAKDOWN_INNER_SQL,
+    VOLUME_PER_ACTOR_BREAKDOWN_AGGREGATE_SQL,
+    VOLUME_PER_ACTOR_BREAKDOWN_INNER_SQL,
 )
-from posthog.queries.trends.util import enumerate_time_range, get_active_user_params, parse_response, process_math
+from posthog.queries.trends.util import (
+    COUNT_PER_ACTOR_MATH_FUNCTIONS,
+    PROPERTY_MATH_FUNCTIONS,
+    enumerate_time_range,
+    get_active_user_params,
+    parse_response,
+    process_math,
+)
 from posthog.queries.util import start_of_week_fix
 from posthog.utils import encode_get_request_params
 
@@ -79,6 +89,12 @@ class TrendsBreakdown:
             if not self.using_person_on_events
             else PersonPropertiesMode.DIRECT_ON_EVENTS
         )
+
+    @cached_property
+    def actor_aggregator(self) -> str:
+        if self.team.aggregate_users_by_distinct_id:
+            return "e.distinct_id"
+        return f"{'e' if self._person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS else 'pdi'}.person_id"
 
     @cached_property
     def _props_to_filter(self) -> Tuple[str, Dict]:
@@ -161,8 +177,13 @@ class TrendsBreakdown:
         if self.filter.breakdown_type == "cohort":
             _params, breakdown_filter, _breakdown_filter_params, breakdown_value = self._breakdown_cohort_params()
         else:
+            aggregate_operation_for_breakdown_init = (
+                "count(*)"
+                if self.entity.math == "dau" or self.entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS
+                else aggregate_operation
+            )
             _params, breakdown_filter, _breakdown_filter_params, breakdown_value = self._breakdown_prop_params(
-                "count(*)" if self.entity.math == "dau" else aggregate_operation, math_params
+                aggregate_operation_for_breakdown_init, math_params
             )
 
         if len(_params["values"]) == 0:
@@ -181,10 +202,10 @@ class TrendsBreakdown:
         if self.filter.display in NON_TIME_SERIES_DISPLAY_TYPES:
             breakdown_filter = breakdown_filter.format(**breakdown_filter_params)
 
-            if self.entity.math_property == "$session_duration":
+            if self.entity.math in PROPERTY_MATH_FUNCTIONS and self.entity.math_property == "$session_duration":
                 # TODO: When we add more person/group properties to math_property,
                 # generalise this query to work for everything, not just sessions.
-                content_sql = SESSION_MATH_BREAKDOWN_AGGREGATE_QUERY_SQL.format(
+                content_sql = SESSION_DURATION_BREAKDOWN_AGGREGATE_QUERY_SQL.format(
                     breakdown_filter=breakdown_filter,
                     person_join=person_join_condition,
                     groups_join=groups_join_condition,
@@ -192,6 +213,16 @@ class TrendsBreakdown:
                     aggregate_operation=aggregate_operation,
                     breakdown_value=breakdown_value,
                     event_sessions_table_alias=SessionQuery.SESSION_TABLE_ALIAS,
+                )
+            elif self.entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS:
+                content_sql = VOLUME_PER_ACTOR_BREAKDOWN_AGGREGATE_SQL.format(
+                    breakdown_filter=breakdown_filter,
+                    person_join=person_join_condition,
+                    groups_join=groups_join_condition,
+                    sessions_join_condition=sessions_join_condition,
+                    aggregate_operation=aggregate_operation,
+                    aggregator=self.actor_aggregator,
+                    breakdown_value=breakdown_value,
                 )
             else:
                 content_sql = BREAKDOWN_AGGREGATE_QUERY_SQL.format(
@@ -249,10 +280,10 @@ class TrendsBreakdown:
                     start_of_week_fix=start_of_week_fix(self.filter.interval),
                     **breakdown_filter_params,
                 )
-            elif self.entity.math_property == "$session_duration":
+            elif self.entity.math in PROPERTY_MATH_FUNCTIONS and self.entity.math_property == "$session_duration":
                 # TODO: When we add more person/group properties to math_property,
                 # generalise this query to work for everything, not just sessions.
-                inner_sql = SESSION_MATH_BREAKDOWN_INNER_SQL.format(
+                inner_sql = SESSION_DURATION_BREAKDOWN_INNER_SQL.format(
                     breakdown_filter=breakdown_filter,
                     person_join=person_join_condition,
                     groups_join=groups_join_condition,
@@ -262,6 +293,19 @@ class TrendsBreakdown:
                     breakdown_value=breakdown_value,
                     start_of_week_fix=start_of_week_fix(self.filter.interval),
                     event_sessions_table_alias=SessionQuery.SESSION_TABLE_ALIAS,
+                    **breakdown_filter_params,
+                )
+            elif self.entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS:
+                inner_sql = VOLUME_PER_ACTOR_BREAKDOWN_INNER_SQL.format(
+                    breakdown_filter=breakdown_filter,
+                    person_join=person_join_condition,
+                    groups_join=groups_join_condition,
+                    sessions_join=sessions_join_condition,
+                    aggregate_operation=aggregate_operation,
+                    interval_annotation=interval_annotation,
+                    aggregator=self.actor_aggregator,
+                    breakdown_value=breakdown_value,
+                    start_of_week_fix=start_of_week_fix(self.filter.interval),
                     **breakdown_filter_params,
                 )
             else:
@@ -523,7 +567,8 @@ class TrendsBreakdown:
                 params,
             )
         elif (
-            self.entity.math in ["dau", WEEKLY_ACTIVE, MONTHLY_ACTIVE] and not self.team.aggregate_users_by_distinct_id
+            self.entity.math in [UNIQUE_USERS, WEEKLY_ACTIVE, MONTHLY_ACTIVE]
+            and not self.team.aggregate_users_by_distinct_id
         ) or self.column_optimizer.is_using_cohort_propertes:
             # Only join distinct_ids
             return event_join, {}

--- a/posthog/queries/trends/trends_event_query.py
+++ b/posthog/queries/trends/trends_event_query.py
@@ -10,7 +10,7 @@ from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.event_query import EventQuery
 from posthog.queries.person_query import PersonQuery
 from posthog.queries.query_date_range import QueryDateRange
-from posthog.queries.trends.util import COUNT_PER_ACTOR_MATH_FUNCTIONS, get_active_user_params
+from posthog.queries.trends.util import get_active_user_params
 
 
 class TrendsEventQuery(EventQuery):
@@ -142,7 +142,7 @@ class TrendsEventQuery(EventQuery):
             )
 
     def _determine_should_join_distinct_ids(self) -> None:
-        is_entity_per_user = self._entity.math == UNIQUE_USERS or self._entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS
+        is_entity_per_user = self._entity.math == UNIQUE_USERS
         if (
             is_entity_per_user and not self._aggregate_users_by_distinct_id
         ) or self._column_optimizer.is_using_cohort_propertes:


### PR DESCRIPTION
## Problem

Our onboarding flow didn't suppport the new billing.

## Changes

* Detect if billing v2 is enabled and show a different flow
* Fix up some text and layout for the billing page

**Gif**
![2022-11-02 15 02 30](https://user-images.githubusercontent.com/2536520/199509516-ac129b40-9fc3-4626-bad4-5f213758c552.gif)

**Pre payment**

<img width="906" alt="Screenshot 2022-11-02 at 14 54 35" src="https://user-images.githubusercontent.com/2536520/199507665-90e3352c-7788-4ba8-b278-e6f76f0881f2.png">

**Post payment**
<img width="821" alt="Screenshot 2022-11-02 at 10 28 12" src="https://user-images.githubusercontent.com/2536520/199453789-b8f98ce2-0b0c-4a20-baee-dba37dd66e04.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
