### PR TITLE
chore: Clarify disabled "Create project" and lemonize `CreateProjectModal`

### DIFF
--- a/frontend/src/layout/ErrorProjectUnavailable.tsx
+++ b/frontend/src/layout/ErrorProjectUnavailable.tsx
@@ -3,13 +3,13 @@ import { useValues } from 'kea'
 import { organizationLogic } from '../scenes/organizationLogic'
 
 export function ErrorProjectUnavailable(): JSX.Element {
-    const { isProjectCreationForbidden } = useValues(organizationLogic)
+    const { projectCreationForbiddenReason } = useValues(organizationLogic)
 
     return (
         <div>
             <PageHeader title="Project Unavailable" />
             <p>
-                {isProjectCreationForbidden
+                {projectCreationForbiddenReason
                     ? "Switch to a project that you have access to. If you need a new project or access to an existing one that's private, ask a team member with administrator permissions."
                     : 'You can create a new project.'}
             </p>

--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -12,7 +12,7 @@ import { AvailableFeature, TeamBasicType } from '~/types'
 import { navigationLogic } from './navigationLogic'
 
 export function ProjectSwitcherOverlay(): JSX.Element {
-    const { currentOrganization, isProjectCreationForbidden } = useValues(organizationLogic)
+    const { currentOrganization, projectCreationForbiddenReason } = useValues(organizationLogic)
     const { currentTeam } = useValues(teamLogic)
     const { guardAvailableFeature } = useActions(sceneLogic)
     const { showCreateProjectModal, hideProjectSwitcher } = useActions(navigationLogic)
@@ -31,12 +31,8 @@ export function ProjectSwitcherOverlay(): JSX.Element {
             <LemonButton
                 icon={<IconPlus />}
                 fullWidth
-                disabled={isProjectCreationForbidden}
-                title={
-                    isProjectCreationForbidden
-                        ? "You aren't allowed to create a project. Your organization access level is probably insufficient."
-                        : undefined
-                }
+                disabled={!!projectCreationForbiddenReason}
+                tooltip={projectCreationForbiddenReason}
                 onClick={() => {
                     hideProjectSwitcher()
                     guardAvailableFeature(

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -125,7 +125,8 @@ function LemonButtonInternal(
     if (tooltip) {
         workingButton = (
             <Tooltip title={tooltip} placement={tooltipPlacement}>
-                {workingButton}
+                {/* If the button is disabled, wrap it in a div so that the tooltip can still work */}
+                {disabled ? <div>{workingButton}</div> : workingButton}
             </Tooltip>
         )
     }

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -43,11 +43,13 @@ export const organizationLogic = kea<organizationLogicType>({
             (currentOrganization, currentOrganizationLoading): boolean =>
                 !currentOrganization?.membership_level && !currentOrganizationLoading,
         ],
-        isProjectCreationForbidden: [
+        projectCreationForbiddenReason: [
             (s) => [s.currentOrganization],
-            (currentOrganization) =>
+            (currentOrganization): string | null =>
                 !currentOrganization?.membership_level ||
-                currentOrganization.membership_level < OrganizationMembershipLevel.Admin,
+                currentOrganization.membership_level < OrganizationMembershipLevel.Admin
+                    ? 'You need to be an organization admin or above to create new projects.'
+                    : null,
         ],
     },
     loaders: ({ values }) => ({

--- a/frontend/src/scenes/project/Create/index.tsx
+++ b/frontend/src/scenes/project/Create/index.tsx
@@ -1,6 +1,9 @@
 import { CreateProjectModal } from '../CreateProjectModal'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
+import { useValues } from 'kea'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { AlertMessage } from 'lib/components/AlertMessage'
 
 export const scene: SceneExport = {
     component: ProjectCreate,
@@ -8,5 +11,13 @@ export const scene: SceneExport = {
 }
 
 export function ProjectCreate(): JSX.Element {
-    return <CreateProjectModal isVisible mask={false} />
+    const { projectCreationForbiddenReason } = useValues(organizationLogic)
+
+    return projectCreationForbiddenReason ? (
+        <AlertMessage type="warning" className="mt-5">
+            {projectCreationForbiddenReason}
+        </AlertMessage>
+    ) : (
+        <CreateProjectModal isVisible inline />
+    )
 }

--- a/frontend/src/scenes/project/CreateProjectModal.tsx
+++ b/frontend/src/scenes/project/CreateProjectModal.tsx
@@ -1,117 +1,81 @@
-import { Alert, Input, Modal } from 'antd'
+import { LemonButton, LemonInput, LemonModal, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { PureField } from 'lib/forms/Field'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { teamLogic } from 'scenes/teamLogic'
 import { organizationLogic } from '../organizationLogic'
 
 export function CreateProjectModal({
     isVisible,
     onClose,
-    title,
-    caption,
-    mask,
+    inline = false,
 }: {
     isVisible: boolean
     onClose?: () => void
-    title?: string
-    caption?: JSX.Element
-    mask?: boolean
+    inline?: boolean
 }): JSX.Element {
     const { createTeam } = useActions(teamLogic)
-    const { currentOrganization, isProjectCreationForbidden } = useValues(organizationLogic)
+    const { currentOrganization } = useValues(organizationLogic)
     const { reportProjectCreationSubmitted } = useActions(eventUsageLogic)
-    const [errorMessage, setErrorMessage] = useState<string | null>(null)
-    const inputRef = useRef<Input | null>(null)
+    const [name, setName] = useState<string>('')
 
     const closeModal: () => void = useCallback(() => {
         if (onClose) {
-            setErrorMessage(null)
             onClose()
-            if (inputRef.current) {
-                inputRef.current.setValue('')
+            if (name) {
+                setName('')
             }
         }
-    }, [inputRef, onClose])
+    }, [name, onClose])
 
     const handleSubmit = (): void => {
-        const name = inputRef.current?.state.value?.trim()
-        if (name) {
-            reportProjectCreationSubmitted(
-                currentOrganization?.teams ? currentOrganization.teams.length : 0,
-                name.length
-            )
-            setErrorMessage(null)
-            createTeam(name)
-            closeModal()
-        } else {
-            setErrorMessage('Your project needs a name!')
-        }
+        createTeam(name)
+        reportProjectCreationSubmitted(currentOrganization?.teams ? currentOrganization.teams.length : 0, name.length)
+        closeModal()
     }
 
-    const defaultCaption = (
-        <p>
-            Projects are a way of tracking multiple products under the umbrella of a single organization.
-            <br />
-            All organization members will be able to access the new project upon creation, but you can make it private
-            in its settings to restrict access.
-            <br />
-            <a href="https://posthog.com/docs/user-guides/organizations-and-projects" target="_blank" rel="noopener">
-                Learn more about projects in Docs.
-            </a>
-        </p>
-    )
-
-    return isProjectCreationForbidden ? (
-        <Modal
-            title={
-                currentOrganization
-                    ? `You cannot create a project in ${currentOrganization.name}`
-                    : 'You cannot create a project'
+    return (
+        <LemonModal
+            title={currentOrganization ? `Create a project in ${currentOrganization.name}` : 'Create a project'}
+            description={
+                <p>
+                    Safely silo data by using multiple projects.{' '}
+                    <Link to="https://posthog.com/manual/organizations-and-projects#projects" target="_blank">
+                        Learn more in Docs.
+                    </Link>
+                </p>
             }
-            okButtonProps={onClose ? undefined : { style: { display: 'none' } }}
-            onCancel={closeModal}
-            visible={isVisible}
-            mask={mask}
-            wrapProps={isVisible && !mask ? { style: { pointerEvents: 'none' } } : undefined}
-            closeIcon={null}
-        >
-            Your organization access level is insufficient for creating a new project.
-            <br />
-            Project creation requires administrator access.
-        </Modal>
-    ) : (
-        <Modal
-            title={
-                title ||
-                (currentOrganization ? `Creating a project in ${currentOrganization.name}` : 'Creating a project')
+            footer={
+                <>
+                    {onClose && (
+                        <LemonButton type="secondary" onClick={() => onClose()}>
+                            Cancel
+                        </LemonButton>
+                    )}
+                    <LemonButton type="primary" onClick={() => handleSubmit()} disabled={!name}>
+                        Create project
+                    </LemonButton>
+                </>
             }
-            okText="Create project"
-            cancelButtonProps={onClose ? undefined : { style: { display: 'none' } }}
-            onOk={handleSubmit}
-            onCancel={closeModal}
-            visible={isVisible}
-            mask={mask}
-            wrapProps={isVisible && !mask ? { style: { pointerEvents: 'none' } } : undefined}
-            closeIcon={null}
+            isOpen={isVisible}
+            onClose={onClose}
+            inline={inline}
         >
-            {caption || defaultCaption}
-            <div className="input-set">
-                <label htmlFor="projectName">Project Name</label>
-                <Input
-                    ref={inputRef}
-                    placeholder='for example "Web app", "Mobile app", "Production", "Landing website"'
+            <PureField label="Project name">
+                <LemonInput
+                    placeholder="The Next Big Thing"
                     maxLength={64}
                     autoFocus
-                    name="projectName"
+                    value={name}
+                    onChange={(value) => setName(value)}
                     onKeyDown={(e) => {
                         if (e.key === 'Enter') {
                             handleSubmit()
                         }
                     }}
                 />
-            </div>
-            {errorMessage && <Alert message={errorMessage} type="error" />}
-        </Modal>
+            </PureField>
+        </LemonModal>
     )
 }


### PR DESCRIPTION
## Problem

In break the release I was confused why "Create project" was disabled. Turns out my access level was too low, but this isn't said anywhere.

Also noticed that the modal that shows up when the button isn't disabled seems quite dated, and there's more text than I'm prepared to read as a user:

<img width="553" alt="Screenshot 2022-11-02 at 12 32 03" src="https://user-images.githubusercontent.com/4550621/199480183-58b73789-bdf9-48b3-9aa3-46446d666a74.png">

## Changes

Added a tooltip to explain why the button is disabled:

<img width="373" alt="Screenshot 2022-11-02 at 12 29 52" src="https://user-images.githubusercontent.com/4550621/199480033-93bedcc0-41b6-4eba-8a92-6a7f35d1619e.png">

We're using a `LemonModal` too:
<img width="507" alt="Screenshot 2022-11-02 at 12 30 14" src="https://user-images.githubusercontent.com/4550621/199480271-d8f78a23-0a57-4930-a6c2-c17ab1dd584c.png">
