### PR TITLE
fix(ch_client): `ch_client`, change scope & close connections 

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -320,6 +320,8 @@ def execute_with_progress(
 
         raise err
     finally:
+        ch_client.disconnect()
+
         execution_time = perf_counter() - start_time
 
         QUERY_TIMEOUT_THREAD.cancel(timeout_task)

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -100,17 +100,6 @@ def make_ch_pool(**overrides) -> ChPool:
     return ChPool(**kwargs)
 
 
-ch_client = SyncClient(
-    host=CLICKHOUSE_HOST,
-    database=CLICKHOUSE_DATABASE,
-    secure=CLICKHOUSE_SECURE,
-    user=CLICKHOUSE_USER,
-    password=CLICKHOUSE_PASSWORD,
-    ca_certs=CLICKHOUSE_CA,
-    verify=CLICKHOUSE_VERIFY,
-    settings={"mutations_sync": "1"} if TEST else {},
-)
-
 ch_pool = make_ch_pool()
 
 
@@ -418,6 +407,16 @@ def substitute_params(query, params):
     containing code is only responsible for it's parameters, and we can
     avoid any potential param collisions.
     """
+    ch_client = SyncClient(
+        host=CLICKHOUSE_HOST,
+        database=CLICKHOUSE_DATABASE,
+        secure=CLICKHOUSE_SECURE,
+        user=CLICKHOUSE_USER,
+        password=CLICKHOUSE_PASSWORD,
+        ca_certs=CLICKHOUSE_CA,
+        verify=CLICKHOUSE_VERIFY,
+        settings={"mutations_sync": "1"} if TEST else {},
+    )
     return cast(SyncClient, ch_client).substitute_params(query, params)
 
 

--- a/posthog/version_requirement.py
+++ b/posthog/version_requirement.py
@@ -56,6 +56,8 @@ def get_clickhouse_version() -> Version:
 
     client = default_client()
     rows = client.execute("SELECT version()")
+    client.disconnect()
+
     version = rows[0][0]
 
     return version_string_to_semver(version)


### PR DESCRIPTION
## Problem
We currently have a global `ch_client` that is unnecessary. We also do not close connections when needed.

## Changes
Remove global `ch_client` & call `self.disconnect()`.

## How did you test this code?
I hope CI will pick any regression.