### PR TITLE
fix(login): Allow retrying login after invalid email/password attempt

### DIFF
--- a/cypress/e2e/auth.js
+++ b/cypress/e2e/auth.js
@@ -13,23 +13,30 @@ describe('Auth', () => {
     it('Logout and login', () => {
         cy.get('[data-attr=top-menu-item-logout]').click()
 
-        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com').blur()
+        cy.get('[data-attr=login-email]').type('test@posthog.com').should('have.value', 'test@posthog.com').blur()
         cy.get('[data-attr=password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
 
         cy.get('[data-attr=password]').type('12345678').should('have.value', '12345678')
 
         cy.get('[type=submit]').click()
+        // Login should have succeeded
+        cy.location('pathname').should('eq', '/home')
     })
 
-    it('Try logging in improperly', () => {
+    it('Try logging in improperly and then properly', () => {
         cy.get('[data-attr=top-menu-item-logout]').click()
 
-        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com').blur()
+        cy.get('[data-attr=login-email]').type('test@posthog.com').should('have.value', 'test@posthog.com').blur()
         cy.get('[data-attr=password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
         cy.get('[data-attr=password]').type('wrong password').should('have.value', 'wrong password')
         cy.get('[type=submit]').click()
-
+        // There should be an error message now
         cy.get('.AlertMessage').should('contain', 'Invalid email or password.')
+        // Now try with the right password
+        cy.get('[data-attr=password]').clear().type('12345678')
+        cy.get('[type=submit]').click()
+        // Login should have succeeded
+        cy.location('pathname').should('eq', '/home')
     })
 
     it('Redirect to appropriate place after login', () => {

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -74,8 +74,7 @@ function SSOLoginButton({
 
 export function Login(): JSX.Element {
     const { precheck } = useActions(loginLogic)
-    const { precheckResponse, precheckResponseLoading, login, isLoginSubmitting, loginManualErrors } =
-        useValues(loginLogic)
+    const { precheckResponse, precheckResponseLoading, login, isLoginSubmitting, generalError } = useValues(loginLogic)
     const { preflight } = useValues(preflightLogic)
 
     const passwordInputRef = useRef<HTMLInputElement>(null)
@@ -91,10 +90,10 @@ export function Login(): JSX.Element {
         <BridgePage view="login" noHedgehog>
             <div className="space-y-2">
                 <h2>Get started</h2>
-                {loginManualErrors.generic && (
+                {generalError && (
                     <AlertMessage type="error">
-                        {loginManualErrors.generic.detail ||
-                            ERROR_MESSAGES[loginManualErrors.generic.code] ||
+                        {generalError.detail ||
+                            ERROR_MESSAGES[generalError.code] ||
                             'Could not complete your login. Please try again.'}
                     </AlertMessage>
                 )}

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, connect, listeners } from 'kea'
+import { kea, path, connect, listeners, actions, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
 import { forms } from 'kea-forms'
@@ -45,6 +45,20 @@ export const loginLogic = kea<loginLogicType>([
     connect({
         values: [preflightLogic, ['preflight'], featureFlagLogic, ['featureFlags']],
     }),
+    actions({
+        setGeneralError: (code: string, detail: string) => ({ code, detail }),
+        clearGeneralError: true,
+    }),
+    reducers({
+        // This is separate from the login form, so that the form can be submitted even if a general error is present
+        generalError: [
+            null as { code: string; detail: string } | null,
+            {
+                setGeneralError: (_, error) => error,
+                clearGeneralError: () => null,
+            },
+        ],
+    }),
     loaders(() => ({
         precheckResponse: [
             { status: 'pending' } as PrecheckResponseType,
@@ -68,7 +82,6 @@ export const loginLogic = kea<loginLogicType>([
             },
         ],
     })),
-
     forms(({ actions, values }) => ({
         login: {
             defaults: { email: '', password: '' } as LoginForm,
@@ -88,14 +101,9 @@ export const loginLogic = kea<loginLogicType>([
                     const { code } = e as Record<string, any>
                     let { detail } = e as Record<string, any>
                     if (values.featureFlags[FEATURE_FLAGS.REGION_SELECT] && code === 'invalid_credentials') {
-                        detail = 'Invalid email or password. Make sure you have selected the right data region.'
+                        detail += ' Make sure you have selected the right data region.'
                     }
-                    actions.setLoginManualErrors({
-                        generic: {
-                            code,
-                            detail,
-                        },
-                    })
+                    actions.setGeneralError(code, detail)
                     throw e
                 }
             },
@@ -111,7 +119,7 @@ export const loginLogic = kea<loginLogicType>([
     urlToAction(({ actions }) => ({
         '/login': ({}, { error_code, error_detail }) => {
             if (error_code) {
-                actions.setLoginManualErrors({ generic: { code: error_code, detail: error_detail } })
+                actions.setGeneralError(error_code, error_detail)
                 router.actions.replace('/login', {})
             }
         },


### PR DESCRIPTION
## Problem

I noticed it's not possible to retry login once an invalid email/password combination is attempted.

## Changes

Looks like it's not possible to submit a Kea form with any error, and "Invalid email or password" was set as a Kea form error. This makes it so that it's just a regular reducer.

## How did you test this code?

Ensured this is tested E2E.