### PR TITLE
feat: added image url to billing if present

### DIFF
--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -385,10 +385,13 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
             ref={ref}
         >
             <div className="flex-1 py-4 pr-2 space-y-4">
-                <div className="flex justify-between items-start">
+                <div className="flex gap-4 items-center">
+                    {product.image_url ? (
+                        <img className="w-10 h-10" alt="Logo for product" src={product.image_url} />
+                    ) : null}
                     <div>
-                        <h3 className="font-bold">{product.name}</h3>
-                        <p>{product.description}</p>
+                        <h3 className="font-bold mb-0">{product.name}</h3>
+                        <div>{product.description}</div>
                     </div>
                 </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -817,6 +817,7 @@ export interface BillingProductV2Type {
     name: string
     description: string
     price_description: string
+    image_url?: string
     free_allocation: number
     tiers: {
         unit_amount_usd: string


### PR DESCRIPTION
## Problem

Needs https://github.com/PostHog/billing/pull/27

The website has nice icons that our app does not.

## Changes

Adds logos from stripe if present.

<img width="883" alt="Screenshot 2022-11-02 at 15 36 22" src="https://user-images.githubusercontent.com/2536520/199517974-16aaefb7-1700-4892-bef7-3e11253b2807.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


FYI @corywatilo in case you change them let me know