### PR TITLE
fix: celery is making strings not soup in production (but not in the tests)

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import structlog
 from celery import group
 from celery.canvas import Signature
+from dateutil.parser import parser
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.cache import cache
@@ -56,6 +57,14 @@ CACHE_TYPE_TO_INSIGHT_CLASS = {
 }
 
 IN_A_DAY = 86_400
+
+
+def ensure_is_date(candidate: Optional[Union[str, datetime.datetime]]) -> Optional[datetime.datetime]:
+    if candidate is None:
+        return None
+    if isinstance(candidate, datetime.datetime):
+        return candidate
+    return parser().parse(candidate)
 
 
 @dataclasses.dataclass
@@ -326,9 +335,7 @@ def _cache_includes_latest_events(
     then there's no point re-calculating
     """
 
-    # dashboards mostly use trends and funnels so concentrate on items that have filter.events to interrogate
-
-    last_refresh = payload.get("last_refresh", None)
+    last_refresh = ensure_is_date(payload.get("last_refresh", None))
     if last_refresh:
         event_names = _events_from_filter(filter)
 

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -343,7 +343,7 @@ def _cache_includes_latest_events(
             EventDefinition.objects.filter(name__in=event_names).values_list("last_seen_at", flat=True)
         )
         if len(event_names) > 0 and len(event_names) == len(event_last_seen_at):
-            return all(last_refresh >= last_seen_at for last_seen_at in event_last_seen_at)
+            return all(last_seen_at is not None and last_refresh >= last_seen_at for last_seen_at in event_last_seen_at)
 
     return False
 


### PR DESCRIPTION
## Problem

We don't exercise celery coordinating tasks in the tests. When running the tests the `last_refresh` in the `update_cache_item` payload is a datetime instance but in reality it is an ISO string of the provided date causing

https://sentry.io/organizations/posthog/issues/3713095655/?project=1899813&referrer=slack

## Changes

ensures the value is an `Optional[datetime]` before using it in comparisons

## How did you test this code?

adding a developer test