### PR TITLE
fix(app-metrics): surround cluster name with quotes in migration

### DIFF
--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -24,7 +24,7 @@ BASE_APP_METRICS_COLUMNS = """
 
 APP_METRICS_DATA_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE sharded_app_metrics ON CLUSTER {settings.CLICKHOUSE_CLUSTER}
+CREATE TABLE sharded_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     {BASE_APP_METRICS_COLUMNS}
     {KAFKA_COLUMNS_WITH_PARTITION}
@@ -38,7 +38,7 @@ ORDER BY (team_id, plugin_config_id, job_id, category, toStartOfHour(timestamp),
 
 DISTRIBUTED_APP_METRICS_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE app_metrics ON CLUSTER {settings.CLICKHOUSE_CLUSTER}
+CREATE TABLE app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     {BASE_APP_METRICS_COLUMNS}
     {KAFKA_COLUMNS_WITH_PARTITION}
@@ -49,7 +49,7 @@ ENGINE={Distributed(data_table="sharded_app_metrics", sharding_key="rand()")}
 
 KAFKA_APP_METRICS_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE kafka_app_metrics ON CLUSTER {settings.CLICKHOUSE_CLUSTER}
+CREATE TABLE kafka_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     team_id Int64,
     timestamp DateTime64(6, 'UTC'),


### PR DESCRIPTION
## Problem

A kubernetes cluster with the name `name-with-dash` causes the clickhouse migration `0033_app_metrics` to fail with

```
infi.clickhouse_orm.database.ServerError: Code: 62. DB::Exception: Syntax error: failed at position 50 ('-') (line 2, col 49): -with-dash
```

## Changes

Escapes a few instances of `settings.CLICKHOUSE_CLUSTER` with single quotes, like it's done elsewhere.

## How did you test this code?

Didn't. Will try to test the docker image built after this branch.