### PR TITLE
feat: add basic self-hosted CTA to sign-up page

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -15,6 +15,7 @@ export type BridgePageProps = {
     noLogo?: boolean
     sideLogo?: boolean
     message?: React.ReactNode
+    showSelfHostCta?: boolean
     fixedWidth?: boolean
 }
 
@@ -29,6 +30,7 @@ export function BridgePage({
     noLogo = false,
     sideLogo = false,
     fixedWidth = true,
+    showSelfHostCta = false,
 }: BridgePageProps): JSX.Element {
     const [messageShowing, setMessageShowing] = useState(false)
 
@@ -54,6 +56,23 @@ export function BridgePage({
                                 <div className="BridgePage__art__message">{message}</div>
                             </CSSTransition>
                         ) : null}
+
+                        {showSelfHostCta && (
+                            <div
+                                style={{
+                                    border: '1px solid var(--border)',
+                                    borderRadius: 'var(--radius)',
+                                    padding: '1rem',
+                                    marginTop: '2rem',
+                                    textAlign: 'center',
+                                }}
+                            >
+                                Interested in self-hosting PostHog?&nbsp;
+                                <a href="https://license.posthog.com">
+                                    <strong>Get a license key</strong>
+                                </a>
+                            </div>
+                        )}
                     </div>
                 ) : null}
                 <div className="BridgePage__content-wrapper">

--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -58,15 +58,7 @@ export function BridgePage({
                         ) : null}
 
                         {showSelfHostCta && (
-                            <div
-                                style={{
-                                    border: '1px solid var(--border)',
-                                    borderRadius: 'var(--radius)',
-                                    padding: '1rem',
-                                    marginTop: '2rem',
-                                    textAlign: 'center',
-                                }}
-                            >
+                            <div className="border rounded p-4 mt-8 text-center">
                                 Interested in{' '}
                                 <a href="https://posthog.com/docs/self-host">
                                     <strong>self-hosting PostHog</strong>

--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -67,10 +67,11 @@ export function BridgePage({
                                     textAlign: 'center',
                                 }}
                             >
-                                Interested in self-hosting PostHog?&nbsp;
-                                <a href="https://license.posthog.com">
-                                    <strong>Get a license key</strong>
+                                Interested in{' '}
+                                <a href="https://posthog.com/docs/self-host">
+                                    <strong>self-hosting PostHog</strong>
                                 </a>
+                                ?
                             </div>
                         )}
                     </div>

--- a/frontend/src/scenes/authentication/Signup.tsx
+++ b/frontend/src/scenes/authentication/Signup.tsx
@@ -65,7 +65,7 @@ export function Signup(): JSX.Element | null {
                 </>
             }
             sideLogo={showRegionSelect}
-            showSelfHostCta={preflight?.cloud === true}
+            showSelfHostCta={preflight?.cloud}
         >
             <div className="space-y-2">
                 <h2>{!preflight?.demo ? 'Get started' : 'Explore PostHog yourself'}</h2>

--- a/frontend/src/scenes/authentication/Signup.tsx
+++ b/frontend/src/scenes/authentication/Signup.tsx
@@ -65,6 +65,7 @@ export function Signup(): JSX.Element | null {
                 </>
             }
             sideLogo={showRegionSelect}
+            showSelfHostCta={preflight?.cloud === true}
         >
             <div className="space-y-2">
                 <h2>{!preflight?.demo ? 'Get started' : 'Explore PostHog yourself'}</h2>


### PR DESCRIPTION
## Problem

Currently, with changes we've made to the login flow which funnel people to a single location to 'Sign-up for Cloud' and then give them the option to sign up for self-host.

## Changes

Note: This is a pretty hacky way of accomplishing this and is just meant to get something out quick.

<img width="1512" alt="Screen Shot 2022-10-27 at 7 34 39 PM" src="https://user-images.githubusercontent.com/39424187/199565553-0c6356b1-c64b-4fe1-8c2f-afc8d9bc4b6b.png">
