### PR TITLE
feat(ingestion-buffer): also buffer events with non-existent groups

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/2-pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-pluginsProcessEventStep.ts
@@ -2,13 +2,15 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { runInstrumentedFunction } from '../../../main/utils'
 import { runProcessEvent } from '../../plugins/run'
+import { LazyGroupsContainer } from '../lazy-groups-container'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { EventPipelineRunner, StepResult } from './runner'
 
 export async function pluginsProcessEventStep(
     runner: EventPipelineRunner,
     event: PluginEvent,
-    personContainer: LazyPersonContainer
+    personContainer: LazyPersonContainer,
+    groupsContainer: LazyGroupsContainer
 ): Promise<StepResult> {
     let processedEvent: PluginEvent | null = event
 
@@ -24,7 +26,7 @@ export async function pluginsProcessEventStep(
     }
 
     if (processedEvent) {
-        return runner.nextStep('processPersonsStep', processedEvent, personContainer)
+        return runner.nextStep('processPersonsStep', processedEvent, personContainer, groupsContainer)
     } else {
         // processEvent might not return an event. This is expected and plugins, e.g. downsample plugin uses it.
         runner.hub.statsd?.increment('kafka_queue.dropped_event', {

--- a/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
@@ -1,6 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { normalizeEvent } from '../../../utils/event'
+import { LazyGroupsContainer } from '../lazy-groups-container'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { updatePersonState } from '../person-state'
 import { parseEventTimestamp } from '../timestamps'
@@ -9,7 +10,8 @@ import { EventPipelineRunner, StepResult } from './runner'
 export async function processPersonsStep(
     runner: EventPipelineRunner,
     pluginEvent: PluginEvent,
-    personContainer: LazyPersonContainer
+    personContainer: LazyPersonContainer,
+    groupsContainer: LazyGroupsContainer
 ): Promise<StepResult> {
     const event = normalizeEvent(pluginEvent)
     const timestamp = parseEventTimestamp(event, runner.hub.statsd)
@@ -25,5 +27,5 @@ export async function processPersonsStep(
         personContainer
     )
 
-    return runner.nextStep('prepareEventStep', event, newPersonContainer)
+    return runner.nextStep('prepareEventStep', event, newPersonContainer, groupsContainer)
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/4-prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/4-prepareEventStep.ts
@@ -1,6 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { PostIngestionEvent } from '../../../types'
+import { LazyGroupsContainer } from '../lazy-groups-container'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { parseEventTimestamp } from '../timestamps'
 import { EventPipelineRunner, StepResult } from './runner'
@@ -8,7 +9,8 @@ import { EventPipelineRunner, StepResult } from './runner'
 export async function prepareEventStep(
     runner: EventPipelineRunner,
     event: PluginEvent,
-    personContainer: LazyPersonContainer
+    personContainer: LazyPersonContainer,
+    groupsContainer: LazyGroupsContainer
 ): Promise<StepResult> {
     const { ip, site_url, team_id, uuid } = event
     const preIngestionEvent = await runner.hub.eventsProcessor.processEvent(
@@ -23,7 +25,7 @@ export async function prepareEventStep(
     await runner.hub.siteUrlManager.updateIngestionSiteUrl(site_url)
 
     if (preIngestionEvent && preIngestionEvent.event !== '$snapshot') {
-        return runner.nextStep('createEventStep', preIngestionEvent, personContainer)
+        return runner.nextStep('createEventStep', preIngestionEvent, personContainer, groupsContainer)
     } else if (preIngestionEvent && preIngestionEvent.event === '$snapshot') {
         return runner.nextStep('runAsyncHandlersStep', preIngestionEvent as PostIngestionEvent, personContainer)
     } else {

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-createEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-createEventStep.ts
@@ -1,13 +1,15 @@
 import { PreIngestionEvent } from '../../../types'
+import { LazyGroupsContainer } from '../lazy-groups-container'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { EventPipelineRunner, StepResult } from './runner'
 
 export async function createEventStep(
     runner: EventPipelineRunner,
     event: PreIngestionEvent,
-    personContainer: LazyPersonContainer
+    personContainer: LazyPersonContainer,
+    groupsContainer: LazyGroupsContainer
 ): Promise<StepResult> {
-    await runner.hub.eventsProcessor.createEvent(event, personContainer)
+    await runner.hub.eventsProcessor.createEvent(event, personContainer, groupsContainer)
     // NOTE: we always stop here. Previously we had an optimization to run the
     // async functions within this pipeline. Instead we unify how the pipeline
     // runs no matter how you have PLUGIN_SERVER_MODE set.

--- a/plugin-server/src/worker/ingestion/lazy-groups-container.ts
+++ b/plugin-server/src/worker/ingestion/lazy-groups-container.ts
@@ -1,0 +1,32 @@
+import { DB, GroupId, GroupsData } from '../../utils/db/db'
+
+export class LazyGroupsContainer {
+    teamId: number
+    groupIds: GroupId[]
+
+    loaded: boolean
+
+    private db: DB
+    private promise: Promise<GroupsData> | null
+
+    constructor(teamId: number, groupIds: GroupId[], db: DB) {
+        this.teamId = teamId
+        this.groupIds = groupIds
+        this.db = db
+
+        this.promise = null
+        this.loaded = false
+    }
+
+    async get(): Promise<GroupsData> {
+        if (!this.promise) {
+            this.promise = this.db.getGroupsData(this.teamId, this.groupIds).then((groupsData) => {
+                if (groupsData) {
+                    this.loaded = true
+                }
+                return groupsData
+            })
+        }
+        return this.promise
+    }
+}

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -24,6 +24,7 @@ import { safeClickhouseString, sanitizeEventName, timeoutGuard } from '../../uti
 import { castTimestampOrNow, UUID } from '../../utils/utils'
 import { GroupTypeManager } from './group-type-manager'
 import { addGroupProperties } from './groups'
+import { LazyGroupsContainer } from './lazy-groups-container'
 import { LazyPersonContainer } from './lazy-person-container'
 import { upsertGroup } from './properties-updater'
 import { TeamManager } from './team-manager'
@@ -172,7 +173,8 @@ export class EventsProcessor {
 
     async createEvent(
         preIngestionEvent: PreIngestionEvent,
-        personContainer: LazyPersonContainer
+        personContainer: LazyPersonContainer,
+        groupsContainer: LazyGroupsContainer
     ): Promise<PostIngestionEvent> {
         const {
             eventUuid: uuid,
@@ -186,8 +188,8 @@ export class EventsProcessor {
 
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
-        const groupIdentifiers = this.getGroupIdentifiers(properties)
-        const groupsColumns = await this.db.getGroupsColumns(teamId, groupIdentifiers)
+        const groupsData = await groupsContainer.get()
+        const groupsColumns = this.db.parseGroupColumnsFromData(groupsData)
 
         let eventPersonProperties: string | null = null
         let personInfo: IngestionPersonData | undefined = await personContainer.get()

--- a/plugin-server/src/worker/ingestion/utils.ts
+++ b/plugin-server/src/worker/ingestion/utils.ts
@@ -1,9 +1,9 @@
-import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { PluginEvent, ProcessedPluginEvent, Properties } from '@posthog/plugin-scaffold'
 import { ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
 
-import { TeamId, TimestampFormat } from '../../types'
-import { DB } from '../../utils/db/db'
+import { GroupTypeIndex, TeamId, TimestampFormat } from '../../types'
+import { DB, GroupId } from '../../utils/db/db'
 import { safeClickhouseString } from '../../utils/db/utils'
 import { castTimestampOrNow, castTimestampToClickhouseFormat, UUIDT } from '../../utils/utils'
 import { KAFKA_EVENTS_DEAD_LETTER_QUEUE, KAFKA_INGESTION_WARNINGS } from './../../config/kafka-topics'
@@ -76,4 +76,15 @@ export function captureIngestionWarning(db: DB, teamId: TeamId, type: string, de
             ],
         })
     )
+}
+
+export function getGroupIdentifiers(properties: Properties, maxGroupTypes: number): GroupId[] {
+    const res: GroupId[] = []
+    for (let groupTypeIndex = 0; groupTypeIndex < maxGroupTypes; ++groupTypeIndex) {
+        const key = `$group_${groupTypeIndex}`
+        if (key in properties) {
+            res.push([groupTypeIndex as GroupTypeIndex, properties[key]])
+        }
+    }
+    return res
 }


### PR DESCRIPTION
# WIP

I didn't have time to finish this before wrapping up. Tests will probably fail and I anyway need to write a bunch of tests for new functionality.

## Problem

We have a race condition with groups creation. The same race condition we account for with persons by buffering events that don't have a person yet and processing in order.

There are a lot of events missing groups data because of this. See [investigation doc [internal]](https://docs.google.com/document/d/1KCna5W8WOOZ-N3N0RUdFgYBtucBai6lRsOv0N1DHh7Y/edit?usp=sharing) for more details.

## Changes

- Implements a lazy container for groups in the same fashion as the persons container
- Buffers events that have at least one group tagged that doesn't exist

## How did you test this code?

I didn't yet. 
