### PR TITLE
fix(cohorts): Make sure field isnt a string before returning

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -175,7 +175,9 @@ class CohortSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance)
         representation["filters"] = (
-            instance.filters if instance.filters else {"properties": instance.properties.to_dict()}
+            instance.filters
+            if instance.filters and not isinstance(instance.filters, str)
+            else {"properties": instance.properties.to_dict()}
         )
         return representation
 


### PR DESCRIPTION
## Problem

- the conversion from cohort groups to filters is still causing some edge cases where the data transformation wasn't handled properly
- some cohorts have the filters set as `[object Object]` which means the conversion from old cohort groups to new isn't being applied and these cohorts end up causing a UI failure
- https://posthog.slack.com/archives/C034XD440RK/p1667416615053289

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- i've added a check that only allows the serialization of "filters" to happen if it's not a string. If it's a string, the logic will default to converting groups -> "properties" which should give the up to date result shape we want. If this cohort is saved again, the `[object Object]` will go away

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
