### PR TITLE
fix: deleted insights where tile is not deleted are still filtered from dashboard

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -262,7 +262,9 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
 
         serialized_tiles = []
 
-        for tile in dashboard.tiles.exclude(deleted=True).all():
+        for tile in (
+            dashboard.tiles.exclude(deleted=True).filter(Q(insight__deleted=False) | Q(insight__isnull=True)).all()
+        ):
             if isinstance(tile.layouts, str):
                 tile.layouts = json.loads(tile.layouts)
             self.context.update({"filters_hash": tile.filters_hash})


### PR DESCRIPTION
## Problem

In this community slack thread: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667385605703209 a user reports that they have deleted insights that still show on their shared dashboards (but not when they view the dashboard directly)

When viewing a dashboard the tiles are filtered using a queryset that accounts for deleted insights and tiles. But if you load the dashboard without using the viewset (like we do with a shared dashboard) then those filters are not applied

## Changes

Re-applies the filters the deleted tiles/insights in the dashboard serializer. 

## How did you test this code?

Added a developer test

locally ran 

```
update posthog_dashboardtile set deleted = null where insight_id = 105
update posthog_dashboarditem set deleted = True where id = 105
```

to force a shared dashboard into the same state and saw the tile appear and then stop appearing when the fix was applied
