### PR TITLE
fix: events table ignores fetch months

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -45,7 +45,7 @@ const secondEvent = makeEvent('1', '2023-05-05T00:00:00.000Z')
 
 const beforeLastEventsTimestamp = '2023-05-05T00:00:00.000Z'
 const afterTheFirstEvent = 'the first timestamp'
-const afterOneYearAgo = '2020-05-05T00:00:00.000Z'
+const fourMonthsAgo = '2021-01-05T00:00:00.000Z'
 const fiveDaysAgo = '2021-04-30T00:00:00.000Z'
 const orderByTimestamp = '["-timestamp"]'
 const emptyProperties = '[]'
@@ -304,7 +304,7 @@ describe('eventsTableLogic', () => {
                     })
                 })
 
-                it('fetch events sets after to 5 days ago and then a year ago when there are no events', async () => {
+                it('fetch events sets after to 5 days ago and then fetchMonhs ago when there are no events', async () => {
                     ;(api.get as jest.Mock).mockClear() // because it will have been called on mount
 
                     await expectLogic(logic, () => {
@@ -323,7 +323,7 @@ describe('eventsTableLogic', () => {
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
-                        after: afterOneYearAgo,
+                        after: fourMonthsAgo,
                     })
                 })
 
@@ -531,7 +531,7 @@ describe('eventsTableLogic', () => {
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
-                        after: afterOneYearAgo,
+                        after: fourMonthsAgo,
                         before: beforeLastEventsTimestamp,
                     })
                 })
@@ -817,22 +817,6 @@ describe('eventsTableLogic', () => {
                 }).toMatchValues({
                     pollingIsActive: true,
                 })
-            })
-
-            it('fall back load after receiving no events respects fetchMonths', async () => {
-                ;(api.get as jest.Mock).mockClear() // because it will have been called on mount
-
-                await expectLogic(logic, () => {
-                    logic.actions.fetchEvents()
-                }).toFinishAllListeners()
-
-                const urlPrefix = `/api/projects/${MOCK_TEAM_ID}/events?properties=%5B%5D&orderBy=%5B%22-timestamp%22%5D`
-                const fiveDaysAgo = '2021-04-30'
-                const fourMonthsAgo = '2021-01-05'
-                expect((api.get as jest.Mock).mock.calls.map((c) => c[0])).toEqual([
-                    `${urlPrefix}&after=${fiveDaysAgo}T00%3A00%3A00.000Z`,
-                    `${urlPrefix}&after=${fourMonthsAgo}T00%3A00%3A00.000Z`,
-                ])
             })
         })
 

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -135,6 +135,7 @@ describe('eventsTableLogic', () => {
             logic = eventsTableLogic({
                 key: 'test-key',
                 sceneUrl: urls.events(),
+                fetchMonths: 4,
             })
             logic.mount()
         })
@@ -816,6 +817,22 @@ describe('eventsTableLogic', () => {
                 }).toMatchValues({
                     pollingIsActive: true,
                 })
+            })
+
+            it('fall back load after receiving no events respects fetchMonths', async () => {
+                ;(api.get as jest.Mock).mockClear() // because it will have been called on mount
+
+                await expectLogic(logic, () => {
+                    logic.actions.fetchEvents()
+                }).toFinishAllListeners()
+
+                const urlPrefix = `/api/projects/${MOCK_TEAM_ID}/events?properties=%5B%5D&orderBy=%5B%22-timestamp%22%5D`
+                const fiveDaysAgo = '2021-04-30'
+                const fourMonthsAgo = '2021-01-05'
+                expect((api.get as jest.Mock).mock.calls.map((c) => c[0])).toEqual([
+                    `${urlPrefix}&after=${fiveDaysAgo}T00%3A00%3A00.000Z`,
+                    `${urlPrefix}&after=${fourMonthsAgo}T00%3A00%3A00.000Z`,
+                ])
             })
         })
 

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -20,7 +20,6 @@ import { triggerExport } from 'lib/components/ExportButton/exporter'
 import equal from 'fast-deep-equal'
 
 const DAYS_FIRST_FETCH = 5
-const DAYS_SECOND_FETCH = 365
 
 const POLL_TIMEOUT = 5000
 
@@ -244,6 +243,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
                     })}`,
         ],
         months: [() => [(_, prop) => prop.fetchMonths], (months) => months || 12],
+        daysSecondFetch: [() => [selectors.months], (months) => now().diff(now().subtract(months, 'months'), 'day')],
         minimumExportDate: [() => [selectors.months], () => now().subtract(1, 'months').toISOString()],
         pollAfter: [
             () => [selectors.events],
@@ -352,7 +352,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
                 apiResponse = await getAPIResponse(daysAgo(DAYS_FIRST_FETCH))
 
                 if (apiResponse.results.length === 0) {
-                    apiResponse = await getAPIResponse(daysAgo(DAYS_SECOND_FETCH))
+                    apiResponse = await getAPIResponse(daysAgo(values.daysSecondFetch))
                     usedSecondFetch = true
                 }
             } catch (error) {


### PR DESCRIPTION
## Problem

The `EventsTable` is loaded on the actions page and we pass `fetchMonths=3` 

In this conversation with a customer in Slack: https://posthog.slack.com/archives/C03G21222QY/p1667401328116709 loading some Action pages fails.

`https://posthog.thecustomer.com/api/projects/2/events?action_id=596&properties=%5B%5D&orderBy=%5B%22-timestamp%22%5D&after=2021-11-02T14%3A50%3A36.293Z net::ERR_CONNECTION_CLOSED

Of note `&after=2021-11-02` is one year ago from today

On investigation we load 5 days of data, and if we don't match any events, we then load 12 months of data.

We can assume that for this combination of date range, self-hosted resources, and event count. That query can't complete in time.

The `eventsTableLogic` is not using the `fetchMonths` prop to limit the query date range.

## Changes

Keeps the behaviour of starting by querying 5 days of data. 

But falls back to `fetchMonths` number of days, not a constant of 365. 

If `fetchMonths` isn't set then the existing default of 12 months is used

## How did you test this code?

added a developer test for the behaviour
ran the site locally against an action with no matches doesn't try to load 12 months
