### PR TITLE
ci(plugin-server): run plugin server CI on master

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -12,6 +12,19 @@ on:
             - 'posthog/plugins/**'
             - 'docker*.yml'
             - '*Dockerfile'
+    push:
+        branches:
+            - master
+        paths:
+            - .github/workflows/ci-plugin-server.yml
+            - 'plugin-server/**'
+            - 'ee/clickhouse/migrations/**'
+            - 'ee/migrations/**'
+            - 'ee/management/commands/setup_test_environment.py'
+            - 'posthog/migrations/**'
+            - 'posthog/plugins/**'
+            - 'docker*.yml'
+            - '*Dockerfile'
 
 env:
     OBJECT_STORAGE_ENABLED: true


### PR DESCRIPTION
At the moment we're just running on PRs, which means we're not testing
the master branch. We're also not taking full advantage of github
actions caching as there will be no cache in the master branch scope.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
