### PR TITLE
fix: Don't load instance settings always

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -243,7 +243,6 @@ export const systemStatusLogic = kea<systemStatusLogicType>({
     events: ({ actions }) => ({
         afterMount: () => {
             actions.loadSystemStatus()
-            actions.loadInstanceSettings()
         },
     }),
 


### PR DESCRIPTION
## Problem

Resolves #12588 which was introduced by #12485.

## Changes

We can't always load instance settings, because those are only available to staff users. Other users will see (and are seeing) an error message due to insufficient permissions.

## How did you test this code?

I've no idea if this breaks anything in feature flag auto-rollback or not, but that's better than showing an error message to all users.