### PR TITLE
feat: let bold numbers be less tall

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -577,6 +577,9 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             tile.insight.filters.insight === InsightType.RETENTION &&
                             tile.insight.filters.display === ChartDisplayType.ActionsLineGraph
                         const isPathsViz = !!tile.insight && tile.insight.filters.display === ChartDisplayType.PathsViz
+                        const isBoldNumber =
+                            !!tile.insight && tile.insight.filters.display === ChartDisplayType.BoldNumber
+
                         const defaultWidth = isRetention || isPathsViz ? 8 : 6
                         const defaultHeight = !!tile.text ? minH + 1 : isRetention ? 8 : isPathsViz ? 12.5 : 5
                         const layout = tile.layouts && tile.layouts[col]
@@ -589,7 +592,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             w: width,
                             h: h || defaultHeight,
                             minW,
-                            minH: tile.text ? 2 : minH,
+                            minH: tile.text ? 2 : isBoldNumber ? 4 : minH,
                         }
                     })
 


### PR DESCRIPTION
## Problem

see #12560 where a customer reports that they would like less whitespace on dashboards

## Changes

Pulls out of that PR allowing bold number to have a minimum height of 4 units instead of 5

## How did you test this code?

👀 
