### PR TITLE
feat: Added billing event tracking

### DIFF
--- a/frontend/src/layout/navigation/Navigation.tsx
+++ b/frontend/src/layout/navigation/Navigation.tsx
@@ -18,11 +18,11 @@ export function Navigation({ children }: { children: any }): JSX.Element {
                 <Layout.Content className={!sceneConfig?.plain ? 'main-app-content' : undefined}>
                     {!sceneConfig?.plain && (
                         <>
+                            <BillingAlertsV2 />
                             {!sceneConfig?.hideProjectNotice && <ProjectNotice />}
                             <Breadcrumbs />
                         </>
                     )}
-                    <BillingAlertsV2 />
                     {children}
                 </Layout.Content>
             </SideBar>

--- a/frontend/src/lib/components/BillingAlertsV2.tsx
+++ b/frontend/src/lib/components/BillingAlertsV2.tsx
@@ -1,24 +1,33 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import { useEffect } from 'react'
 import { billingLogic } from 'scenes/billing/v2/billingLogic'
 import { urls } from 'scenes/urls'
 import { AlertMessage } from './AlertMessage'
 
 export function BillingAlertsV2(): JSX.Element | null {
     const { billingAlert, billingVersion } = useValues(billingLogic)
+    const { reportBillingAlertShown } = useActions(billingLogic)
     const { currentLocation } = useValues(router)
+
+    const showAlert = billingAlert && billingVersion !== 'v2'
+
+    useEffect(() => {
+        if (showAlert) {
+            reportBillingAlertShown(billingAlert)
+        }
+    }, [showAlert])
 
     if (!billingAlert || billingVersion !== 'v2') {
         return null
     }
 
     const showButton = currentLocation.pathname !== urls.organizationBilling()
-
     return (
         <div className="my-4">
             <AlertMessage
                 type={billingAlert.status}
-                action={showButton ? { to: urls.organizationBilling(), children: 'Setup billing' } : undefined}
+                action={showButton ? { to: urls.organizationBilling(), children: 'Manage billing' } : undefined}
             >
                 <b>{billingAlert.title}</b>
                 <br />

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -36,9 +36,15 @@ const DEFAULT_BILLING_LIMIT = 500
 
 export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
     const { billing, billingLoading, isActivateLicenseSubmitting, showLicenseDirectInput } = useValues(billingLogic)
-    const { setShowLicenseDirectInput } = useActions(billingLogic)
+    const { setShowLicenseDirectInput, reportBillingV2Shown } = useActions(billingLogic)
     const { preflight } = useValues(preflightLogic)
     const [enterprisePackage, setEnterprisePackage] = useState(false)
+
+    useEffect(() => {
+        if (billing) {
+            reportBillingV2Shown()
+        }
+    }, [!!billing])
 
     if (!billing && billingLoading) {
         return <SpinnerOverlay />

--- a/frontend/src/scenes/billing/v2/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/billingLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, actions, connect, reducers, afterMount, selectors } from 'kea'
+import { kea, path, actions, connect, reducers, afterMount, selectors, listeners } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import type { billingLogicType } from './billingLogicType'
@@ -6,20 +6,13 @@ import { BillingProductV2Type, BillingV2Type, BillingVersion } from '~/types'
 import { router } from 'kea-router'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urlToAction } from 'kea-router'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { forms } from 'kea-forms'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from '@posthog/lemon-ui'
 import { projectUsage } from './billing-utils'
+import posthog from 'posthog-js'
 
 export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of event usage near limit
-
-export enum BillingAlertType {
-    SetupBilling = 'setup_billing',
-    UsageNearLimit = 'usage_near_limit',
-    UsageLimitExceeded = 'usage_limit_exceeded',
-    FreeUsageNearLimit = 'free_usage_near_limit',
-}
 
 export interface BillingAlertConfig {
     status: 'info' | 'warning' | 'error'
@@ -46,10 +39,11 @@ export const billingLogic = kea<billingLogicType>([
     path(['scenes', 'billing', 'v2', 'billingLogic']),
     actions({
         setShowLicenseDirectInput: (show: boolean) => ({ show }),
+        reportBillingAlertShown: (alertConfig: BillingAlertConfig) => ({ alertConfig }),
+        reportBillingV2Shown: true,
     }),
     connect({
         values: [featureFlagLogic, ['featureFlags']],
-        actions: [eventUsageLogic, ['reportIngestionBillingCancelled']],
     }),
     reducers({
         showLicenseDirectInput: [
@@ -59,7 +53,7 @@ export const billingLogic = kea<billingLogicType>([
             },
         ],
     }),
-    loaders(({}) => ({
+    loaders(() => ({
         billing: [
             null as BillingV2Type | null,
             {
@@ -71,6 +65,7 @@ export const billingLogic = kea<billingLogicType>([
 
                 updateBillingLimits: async (limits: { [key: string]: string | null }) => {
                     const response = await api.update('api/billing-v2', { custom_limits_usd: limits })
+
                     lemonToast.success('Billing limits updated')
                     return parseBillingResponse(response)
                 },
@@ -152,6 +147,17 @@ export const billingLogic = kea<billingLogicType>([
                     throw e
                 }
             },
+        },
+    })),
+
+    listeners(() => ({
+        reportBillingV2Shown: () => {
+            posthog.capture('billing v2 shown')
+        },
+        reportBillingAlertShown: ({ alertConfig }) => {
+            posthog.capture('billing alert shown', {
+                ...alertConfig,
+            })
         },
     })),
 


### PR DESCRIPTION
## Problem

We should track the important things for billing

## Changes

* Tracks when billing v2 is shown
* Tracks when the alert message is shown
* Tracks when billing limits are updated including group properties for the limits
* Only show billing alert on non-simple pages and change the button cta

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
