### PR TITLE
fix: funnel step reference was ignored

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1190,7 +1190,6 @@ export const funnelLogic = kea<funnelLogicType>({
     listeners: ({ actions, values, props }) => ({
         setStepReference: ({ stepReference }) => {
             if (stepReference !== values.filters.funnel_step_reference) {
-                console.log('setting filters')
                 actions.setFilters({ funnel_step_reference: stepReference }, true, true)
             }
         },

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -305,12 +305,6 @@ export const funnelLogic = kea<funnelLogicType>({
         people: {
             clearFunnel: () => [],
         },
-        stepReference: [
-            FunnelStepReference.total as FunnelStepReference,
-            {
-                setStepReference: (_, { stepReference }) => stepReference,
-            },
-        ],
         isGroupingOutliers: [
             true,
             {
@@ -455,6 +449,10 @@ export const funnelLogic = kea<funnelLogicType>({
 
     selectors: ({ selectors }) => ({
         loadedFilters: [(s) => [s.insight], ({ filters }) => (filters?.insight === InsightType.FUNNELS ? filters : {})],
+        stepReference: [
+            (s) => [s.filters],
+            ({ funnel_step_reference }) => funnel_step_reference || FunnelStepReference.total,
+        ],
         results: [
             (s) => [s.insight],
             ({ filters, result }): FunnelAPIResponse => {
@@ -1190,6 +1188,12 @@ export const funnelLogic = kea<funnelLogicType>({
     }),
 
     listeners: ({ actions, values, props }) => ({
+        setStepReference: ({ stepReference }) => {
+            if (stepReference !== values.filters.funnel_step_reference) {
+                console.log('setting filters')
+                actions.setFilters({ funnel_step_reference: stepReference }, true, true)
+            }
+        },
         toggleVisibilityByBreakdown: ({ breakdownValue }) => {
             const key = getVisibilityKey(breakdownValue)
             const currentIsHidden = !!values.hiddenLegendKeys?.[key]

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -1,5 +1,5 @@
 import { cleanFilters } from './cleanFilters'
-import { FilterType, FunnelVizType, InsightType } from '~/types'
+import { FilterType, FunnelStepReference, FunnelVizType, InsightType } from '~/types'
 import { FEATURE_FLAGS, ShownAsValue } from 'lib/constants'
 
 describe('cleanFilters', () => {
@@ -239,5 +239,17 @@ describe('cleanFilters', () => {
         )
 
         expect(cleanedFilters).toHaveProperty('smoothing_intervals', 1)
+    })
+
+    it('can add funnel step reference', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                funnel_step_reference: FunnelStepReference.previous,
+                insight: InsightType.FUNNELS,
+            },
+            {}
+        )
+
+        expect(cleanedFilters).toHaveProperty('funnel_step_reference', FunnelStepReference.previous)
     })
 })

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -134,6 +134,7 @@ export function cleanFilters(
             ...(filters.funnel_step ? { funnel_step: filters.funnel_step } : {}),
             ...(filters.funnel_from_step ? { funnel_from_step: filters.funnel_from_step } : {}),
             ...(filters.funnel_to_step ? { funnel_to_step: filters.funnel_to_step } : {}),
+            ...(filters.funnel_step_reference ? { funnel_step_reference: filters.funnel_step_reference } : {}),
             ...(filters.funnel_viz_type
                 ? { funnel_viz_type: filters.funnel_viz_type }
                 : { funnel_viz_type: FunnelVizType.Steps }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1214,6 +1214,7 @@ export interface FilterType {
     funnel_viz_type?: FunnelVizType // parameter sent to funnels API for time conversion code path
     funnel_from_step?: number // used in time to convert: initial step index to compute time to convert
     funnel_to_step?: number // used in time to convert: ending step index to compute time to convert
+    funnel_step_reference?: FunnelStepReference // whether conversion shown in graph should be across all steps or just from the previous step
     funnel_step_breakdown?: string | number[] | number | null // used in steps breakdown: persons modal
     compare?: boolean
     bin_count?: BinCountValue // used in time to convert: number of bins to show in histogram


### PR DESCRIPTION
## Problem

fixes #12510 

The conversion rate calculation drop down wasn't wired into filters so it would update the UI value but not prompt for saving and even if saved was always the default value

## Changes

changes filters when the value changes, loads the value from filters so the UI shows the saved value when there is one

![conversion-rate](https://user-images.githubusercontent.com/984817/199724369-9e78390f-088c-4897-9ad9-a495bb69c92c.gif)

## How did you test this code?

developer test for clean filters change and using my 👀
