### PR TITLE
fix: Billing limit for tiers that are essentially free

### DIFF
--- a/frontend/src/scenes/billing/v2/billing-utils.ts
+++ b/frontend/src/scenes/billing/v2/billing-utils.ts
@@ -72,9 +72,9 @@ export const convertAmountToUsage = (amount: string, tiers: BillingProductV2Type
         return 0
     }
 
-    const allTiersZeo = tiers.every((tier) => !parseFloat(tier.unit_amount_usd))
+    const allTiersZero = tiers.every((tier) => !parseFloat(tier.unit_amount_usd))
 
-    if (allTiersZeo) {
+    if (allTiersZero) {
         // Free plan - usage cannot be calculated
         return tiers[0].up_to || 0
     }

--- a/frontend/src/scenes/billing/v2/billing-utils.ts
+++ b/frontend/src/scenes/billing/v2/billing-utils.ts
@@ -72,6 +72,13 @@ export const convertAmountToUsage = (amount: string, tiers: BillingProductV2Type
         return 0
     }
 
+    const allTiersZeo = tiers.every((tier) => !parseFloat(tier.unit_amount_usd))
+
+    if (allTiersZeo) {
+        // Free plan - usage cannot be calculated
+        return tiers[0].up_to || 0
+    }
+
     for (const tier of tiers) {
         if (remainingAmount <= 0) {
             break


### PR DESCRIPTION
## Problem

Fixes edge case issue where billing limit gets stuck in math errors as there is no upper bounds.

## Changes

* If all tiers are free then just return 0

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
