### PR TITLE
fix: revert changes from autorollback

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -10,13 +10,18 @@ import { ConfigMode, systemStatusLogic } from './systemStatusLogic'
 import { InstanceConfigSaveModal } from './InstanceConfigSaveModal'
 import { pluralize } from 'lib/utils'
 import { LemonButton } from '@posthog/lemon-ui'
+import { useEffect } from 'react'
 
 export function InstanceConfigTab(): JSX.Element {
     const { configOptions, preflightLoading } = useValues(preflightLogic)
     const { editableInstanceSettings, instanceSettingsLoading, instanceConfigMode, instanceConfigEditingState } =
         useValues(systemStatusLogic)
-    const { setInstanceConfigMode, updateInstanceConfigValue, clearInstanceConfigEditing } =
+    const { loadInstanceSettings, setInstanceConfigMode, updateInstanceConfigValue, clearInstanceConfigEditing } =
         useActions(systemStatusLogic)
+
+    useEffect(() => {
+        loadInstanceSettings()
+    }, [])
 
     useKeyboardHotkeys({
         e: {


### PR DESCRIPTION
## Problem

- use the original pattern for loading instance settings before autorollback was introduced
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
