### PR TITLE
test(plugin-server): remove reload-actions, enable app metrics

### DIFF
--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -15,6 +15,7 @@ export WORKER_CONCURRENCY=1
 export CONVERSION_BUFFER_ENABLED=true
 export BUFFER_CONVERSION_SECONDS=2 # Make sure we don't have to wait for the default 60 seconds
 export KAFKA_MAX_MESSAGE_BATCH_SIZE=0
+export APP_METRICS_GATHERED_FOR_ALL=true
 
 ./node_modules/.bin/c8 --reporter html node dist/index.js &
 SERVER_PID=$!

--- a/plugin-server/functional_tests/e2e.test.ts
+++ b/plugin-server/functional_tests/e2e.test.ts
@@ -932,7 +932,7 @@ test.concurrent(`webhooks: fires slack webhook`, async () => {
 
         const teamId = await createTeam(postgres, organizationId, `http://localhost:${server.address()?.port}`)
         const user = await createUser(postgres, teamId, new UUIDT().toString())
-        await createAction(
+        const action = await createAction(
             postgres,
             {
                 team_id: teamId,
@@ -962,7 +962,7 @@ test.concurrent(`webhooks: fires slack webhook`, async () => {
             ]
         )
 
-        await reloadActions(redis)
+        await reloadAction(redis, teamId, action.id)
 
         await capture(producer, teamId, distinctId, new UUIDT().toString(), '$autocapture', {
             name: 'hehe',
@@ -1111,8 +1111,8 @@ const createAndReloadPluginConfig = async (pgClient: Pool, teamId: number, plugi
     return pluginConfig
 }
 
-const reloadActions = async (redis: Redis.Redis) => {
-    await redis.publish('reload-actions', '')
+const reloadAction = async (redis: Redis.Redis, teamId: number, actionId: number) => {
+    await redis.publish('reload-action', JSON.stringify({ teamId, actionId }))
 }
 
 const fetchEvents = async (clickHouseClient: ClickHouse, teamId: number, uuid?: string) => {
@@ -1212,7 +1212,7 @@ const createAction = async (
             action_id: actionRow.id,
         })
     }
-    return action
+    return actionRow
 }
 
 const createUser = async (pgClient: Pool, teamId: number, email: string) => {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -263,10 +263,6 @@ export async function startPluginsServer(
                     hub.pluginSchedule = await loadPluginSchedule(piscina)
                 }
             },
-            ['reload-actions']: async () => {
-                status.info('⚡', 'Reloading actions!')
-                await piscina?.broadcastTask({ task: 'reloadAllActions' })
-            },
             'reset-available-features-cache': async (message) => {
                 await piscina?.broadcastTask({ task: 'resetAvailableFeaturesCache', args: JSON.parse(message) })
             },


### PR DESCRIPTION
I had added `reload-actions` specifically for testing in
https://github.com/PostHog/posthog/pull/12521/files#diff-817bc42d0008d9b475bf2736d21dcfd35bfad26a11b97340e8917b1eee5b58a6

Turns out there was already a `reload-action` which is more targeted and
a better fit. Plus it means we're actually testing code that's used in
production ✅

I also enabled app metrics, although don't test any of it. At least the
code will have been run.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
