### PR TITLE
feat: Add management command to fix distinct ids after person deletion

### DIFF
--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -1,0 +1,84 @@
+from typing import List
+
+import structlog
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from posthog.client import sync_execute
+from posthog.models.person import PersonDistinctId
+from posthog.models.person.util import create_person_distinct_id
+
+logger = structlog.get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Fix state for person distinct IDs in ClickHouse after person deletion and id re-use for a single team"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", default=None, type=int, help="Specify a team to fix data for.")
+        parser.add_argument("--new-version", default=2500, type=int, help="New version value to use")
+        parser.add_argument("--live-run", action="store_true", help="Run changes, default is dry-run")
+
+    def handle(self, *args, **options):
+        run(options)
+
+
+def run(options):
+    live_run = options["live_run"]
+
+    if not options["team_id"]:
+        logger.error("You must specify --team-id to run this script")
+        exit(1)
+
+    team_id = options["team_id"]
+    version = options["new_version"]
+
+    distinct_ids = get_distinct_ids_tied_to_deleted_persons(team_id)
+
+    for distinct_id in distinct_ids:
+        # this can throw but this script can safely be re-ran as
+        # updated distinct_ids won't show up in the search anymore as they don't belong to deleted persons anymore
+        # it's safer to throw and exit if anything went wrong
+        update_distinct_id(distinct_id, version, team_id, live_run)
+
+
+def get_distinct_ids_tied_to_deleted_persons(team_id: int) -> List[int]:
+    # find distinct_ids where the person is set to be deleted
+    rows = sync_execute(
+        """
+            SELECT distinct_id FROM (
+                SELECT distinct_id, argMax(person_id, version) AS person_id FROM person_distinct_id2 WHERE team_id = %(team)s GROUP BY distinct_id
+            ) AS pdi2 INNER JOIN (
+                SELECT id FROM person WHERE team_id = %(team)s GROUP BY id having max(is_deleted) = 1
+            ) AS p
+            ON pdi2.person_id = p.id
+        """,
+        {
+            "team": team_id,
+        },
+    )
+    return [row[0] for row in rows]
+
+
+def update_distinct_id(distinct_id: str, version: int, team_id: int, live_run: bool):
+    # if the distinct_id exists in postgres, then update otherwise do nothing
+    # also to avoid collisions we're doing this one-by-one locking postgres for a transaction
+    with transaction.atomic():
+        person_distinct_id = PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).first()
+        if person_distinct_id is None:
+            logger.info(f"Distinct id {distinct_id} hasn't been re-used yet and can cause problems in the future")
+            return
+        logger.info(f"Updating {distinct_id} to version {version} for person uuid = {person_distinct_id.person.uuid}")
+        if live_run:
+            person_distinct_id.version = version
+            person_distinct_id.save()
+    # Update ClickHouse via Kafka message
+    if live_run:
+        create_person_distinct_id(
+            team_id=team_id,
+            distinct_id=distinct_id,
+            person_id=str(person_distinct_id.person.uuid),
+            version=version,
+            is_deleted=False,
+        )
+    # we don't update person info cache as it's not used in reality

--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -42,7 +42,7 @@ def run(options):
         update_distinct_id(distinct_id, version, team_id, live_run)
 
 
-def get_distinct_ids_tied_to_deleted_persons(team_id: int) -> List[int]:
+def get_distinct_ids_tied_to_deleted_persons(team_id: int) -> List[str]:
     # find distinct_ids where the person is set to be deleted
     rows = sync_execute(
         """

--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -37,7 +37,7 @@ def run(options):
 
     for distinct_id in distinct_ids:
         # this can throw but this script can safely be re-run as
-        # updated distinct_ids won't show up in the search anymore 
+        # updated distinct_ids won't show up in the search anymore
         # since they no longer belong to deleted persons
         # it's safer to throw and exit if anything went wrong
         update_distinct_id(distinct_id, version, team_id, live_run)

--- a/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
@@ -45,11 +45,11 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
         options = {"live_run": True, "team_id": self.team.pk, "new_version": 2500}
         run(options)
 
-        did1 = PersonDistinctId.objects.filter(distinct_id="did1").first()
-        did2 = PersonDistinctId.objects.filter(distinct_id="did2").first()
-        did3 = PersonDistinctId.objects.filter(distinct_id="did3").first()
-        did5 = PersonDistinctId.objects.filter(distinct_id="did5").first()
-        did6 = PersonDistinctId.objects.filter(distinct_id="did6").first()
+        did1 = PersonDistinctId.objects.get(distinct_id="did1")
+        did2 = PersonDistinctId.objects.get(distinct_id="did2")
+        did3 = PersonDistinctId.objects.get(distinct_id="did3")
+        did5 = PersonDistinctId.objects.get(distinct_id="did5")
+        did6 = PersonDistinctId.objects.get(distinct_id="did6")
 
         self.assertEqual(did1.version, 2500)
         self.assertEqual(did1.person.pk, person1.pk)

--- a/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
@@ -18,7 +18,7 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
     def test_dry_run(self):
         # clickhouse only deleted person and distinct id that should be updated
         ch_only_deleted_person_uuid = create_person(
-            uuid=uuid4(), team_id=self.team.pk, is_deleted=True, version=5, sync=True
+            uuid=str(uuid4()), team_id=self.team.pk, is_deleted=True, version=5, sync=True
         )
         create_person_distinct_id(
             team_id=self.team.pk,
@@ -62,7 +62,7 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
     def test_live_run(self):
         # clickhouse only deleted person and distinct id that should be updated
         ch_only_deleted_person_uuid = create_person(
-            uuid=uuid4(), team_id=self.team.pk, is_deleted=True, version=5, sync=True
+            uuid=str(uuid4()), team_id=self.team.pk, is_deleted=True, version=5, sync=True
         )
         create_person_distinct_id(
             team_id=self.team.pk,

--- a/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
@@ -130,6 +130,8 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
             ],
         )
         self.assertEqual(mocked_ch_call.call_count, 2)
+        run(options, True)
+        self.assertEqual(mocked_ch_call.call_count, 2)
 
     @mock.patch(
         f"{posthog.management.commands.fix_person_distinct_ids_after_delete.__name__}.create_person_distinct_id",

--- a/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
@@ -1,0 +1,83 @@
+import logging
+from typing import Dict
+from uuid import uuid4
+
+import pytest
+
+from posthog.client import sync_execute
+from posthog.management.commands.fix_person_distinct_ids_after_delete import run
+from posthog.models.person.person import Person, PersonDistinctId
+from posthog.models.person.sql import PERSON_DISTINCT_ID2_TABLE
+from posthog.models.person.util import create_person, create_person_distinct_id
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+
+@pytest.mark.ee
+class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
+    def create_test_person(self, distinct_ids: Dict[str, int]):
+        person = Person.objects.create(team_id=self.team.pk, version=0, uuid=uuid4())
+        create_person(uuid=str(person.uuid), team_id=person.team.pk, version=person.version)
+        for did, version in distinct_ids.items():
+            PersonDistinctId.objects.create(team=self.team, person=person, distinct_id=did, version=version)
+            create_person_distinct_id(
+                team_id=self.team.pk, distinct_id=did, person_id=str(person.uuid), is_deleted=False, version=version
+            )
+        return person
+
+    def test_live_run(self):
+        person1 = self.create_test_person({"did1": 1, "did2": 2, "did3": 3})
+        person2 = self.create_test_person({"did5": 11, "did6": 12})
+        deleted_uuid = str(uuid4())
+        deleted_uuid2 = str(uuid4())
+        create_person(uuid=deleted_uuid, team_id=self.team.pk, is_deleted=True, version=5)
+        create_person(uuid=deleted_uuid2, team_id=self.team.pk, is_deleted=True, version=5)
+
+        sync_execute(
+            f"""
+            INSERT INTO {PERSON_DISTINCT_ID2_TABLE} (team_id, distinct_id, person_id, is_deleted, version)
+            VALUES
+                ({self.team.pk}, 'did1', '{deleted_uuid}', 1, 25)
+                ({self.team.pk}, 'did2', '{deleted_uuid2}', 0, 44)
+                ({self.team.pk}, 'did6', '{deleted_uuid2}', 1, 50)
+            """
+        )
+
+        options = {"live_run": True, "team_id": self.team.pk, "new_version": 2500}
+        run(options)
+
+        did1 = PersonDistinctId.objects.filter(distinct_id="did1").first()
+        did2 = PersonDistinctId.objects.filter(distinct_id="did2").first()
+        did3 = PersonDistinctId.objects.filter(distinct_id="did3").first()
+        did5 = PersonDistinctId.objects.filter(distinct_id="did5").first()
+        did6 = PersonDistinctId.objects.filter(distinct_id="did6").first()
+
+        self.assertEqual(did1.version, 2500)
+        self.assertEqual(did1.person.pk, person1.pk)
+        self.assertEqual(did2.version, 2500)
+        self.assertEqual(did2.person.pk, person1.pk)
+        self.assertEqual(did3.version, 3)
+        self.assertEqual(did3.person.pk, person1.pk)
+        self.assertEqual(did5.version, 11)
+        self.assertEqual(did5.person.pk, person2.pk)
+        self.assertEqual(did6.version, 2500)
+        self.assertEqual(did6.person.pk, person2.pk)
+
+        sync_execute(f"OPTIMIZE TABLE {PERSON_DISTINCT_ID2_TABLE}")
+        distinct_ids_after = sync_execute(
+            f"select distinct_id, person_id, version from {PERSON_DISTINCT_ID2_TABLE} ORDER BY distinct_id"
+        )
+        self.assertEqual(
+            distinct_ids_after,
+            [
+                ("did1", person1.uuid, 2500),
+                ("did2", person1.uuid, 2500),
+                ("did3", person1.uuid, 3),
+                ("did5", person2.uuid, 11),
+                ("did6", person2.uuid, 2500),
+            ],
+        )
+
+
+@pytest.fixture(autouse=True)
+def set_log_level(caplog):
+    caplog.set_level(logging.INFO)

--- a/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
@@ -1,8 +1,10 @@
 import logging
+from unittest import mock
 from uuid import UUID, uuid4
 
 import pytest
 
+import posthog.management.commands.fix_person_distinct_ids_after_delete
 from posthog.client import sync_execute
 from posthog.management.commands.fix_person_distinct_ids_after_delete import run
 from posthog.models.person.person import Person, PersonDistinctId
@@ -15,7 +17,11 @@ from posthog.test.base import BaseTest, ClickhouseTestMixin
 class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
     CLASS_DATA_LEVEL_SETUP = False
 
-    def test_dry_run(self):
+    @mock.patch(
+        f"{posthog.management.commands.fix_person_distinct_ids_after_delete.__name__}.create_person_distinct_id",
+        wraps=posthog.management.commands.fix_person_distinct_ids_after_delete.create_person_distinct_id,
+    )
+    def test_dry_run(self, mocked_ch_call):
         # clickhouse only deleted person and distinct id that should be updated
         ch_only_deleted_person_uuid = create_person(
             uuid=str(uuid4()), team_id=self.team.pk, is_deleted=True, version=5, sync=True
@@ -58,8 +64,13 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
                 (UUID(ch_only_deleted_person_uuid), self.team.pk, "distinct_id", 7, True),
             ],
         )
+        mocked_ch_call.assert_not_called()
 
-    def test_live_run(self):
+    @mock.patch(
+        f"{posthog.management.commands.fix_person_distinct_ids_after_delete.__name__}.create_person_distinct_id",
+        wraps=posthog.management.commands.fix_person_distinct_ids_after_delete.create_person_distinct_id,
+    )
+    def test_live_run(self, mocked_ch_call):
         # clickhouse only deleted person and distinct id that should be updated
         ch_only_deleted_person_uuid = create_person(
             uuid=str(uuid4()), team_id=self.team.pk, is_deleted=True, version=5, sync=True
@@ -72,6 +83,14 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
             version=7,
             sync=True,
         )
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="distinct_id-2",
+            person_id=ch_only_deleted_person_uuid,
+            is_deleted=False,
+            version=9,
+            sync=True,
+        )
         # reuse
         person_linked_to_after = Person.objects.create(
             team_id=self.team.pk, properties={"abcdefg": 11112}, version=1, uuid=uuid4()
@@ -79,20 +98,27 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
         PersonDistinctId.objects.create(
             team=self.team, person=person_linked_to_after, distinct_id="distinct_id", version=0
         )
+        PersonDistinctId.objects.create(
+            team=self.team, person=person_linked_to_after, distinct_id="distinct_id-2", version=0
+        )
         options = {"live_run": True, "team_id": self.team.pk, "new_version": 2500}
         run(options, True)
 
         # postgres
         pg_distinct_ids = PersonDistinctId.objects.all()
-        self.assertEqual(len(pg_distinct_ids), 1)
+        self.assertEqual(len(pg_distinct_ids), 2)
         self.assertEqual(pg_distinct_ids[0].version, 2500)
-        self.assertEqual(pg_distinct_ids[0].distinct_id, "distinct_id")
+        self.assertEqual(pg_distinct_ids[1].version, 2500)
+        self.assertEqual(
+            {pg_distinct_ids[0].distinct_id, pg_distinct_ids[1].distinct_id}, {"distinct_id", "distinct_id-2"}
+        )
         self.assertEqual(pg_distinct_ids[0].person.uuid, person_linked_to_after.uuid)
+        self.assertEqual(pg_distinct_ids[1].person.uuid, person_linked_to_after.uuid)
 
         # CH
         ch_person_distinct_ids = sync_execute(
             f"""
-            SELECT person_id, team_id, distinct_id, version, is_deleted FROM {PERSON_DISTINCT_ID2_TABLE} FINAL WHERE team_id = %(team_id)s ORDER BY version
+            SELECT person_id, team_id, distinct_id, version, is_deleted FROM {PERSON_DISTINCT_ID2_TABLE} FINAL WHERE team_id = %(team_id)s ORDER BY version, distinct_id
             """,
             {"team_id": self.team.pk},
         )
@@ -100,10 +126,16 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
             ch_person_distinct_ids,
             [
                 (person_linked_to_after.uuid, self.team.pk, "distinct_id", 2500, False),
+                (person_linked_to_after.uuid, self.team.pk, "distinct_id-2", 2500, False),
             ],
         )
+        self.assertEqual(mocked_ch_call.call_count, 2)
 
-    def test_no_op(self):
+    @mock.patch(
+        f"{posthog.management.commands.fix_person_distinct_ids_after_delete.__name__}.create_person_distinct_id",
+        wraps=posthog.management.commands.fix_person_distinct_ids_after_delete.create_person_distinct_id,
+    )
+    def test_no_op(self, mocked_ch_call):
         # person who shouldn't be changed
         person_not_changed_1 = Person.objects.create(
             team_id=self.team.pk, properties={"abcdef": 1111}, version=0, uuid=uuid4()
@@ -147,6 +179,7 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
                 (person_deleted_1.uuid, self.team.pk, "distinct_id-del-1", 116, True),
             ],
         )
+        mocked_ch_call.assert_not_called()
 
 
 @pytest.fixture(autouse=True)

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -38,21 +38,28 @@ if TEST:
             uuid=str(instance.uuid),
             is_identified=instance.is_identified,
             version=instance.version or 0,
+            sync=True,
         )
 
     @mutable_receiver(post_save, sender=PersonDistinctId)
     def person_distinct_id_created(sender, instance: PersonDistinctId, created, **kwargs):
         create_person_distinct_id(
-            instance.team.pk, instance.distinct_id, str(instance.person.uuid), version=instance.version or 0
+            instance.team.pk,
+            instance.distinct_id,
+            str(instance.person.uuid),
+            version=instance.version or 0,
+            sync=True,
         )
 
     @receiver(post_delete, sender=Person)
     def person_deleted(sender, instance: Person, **kwargs):
-        delete_person(person=instance)
+        _delete_person(instance.team.id, instance.uuid, int(instance.version or 0), instance.created_at, sync=True)
 
     @receiver(post_delete, sender=PersonDistinctId)
     def person_distinct_id_deleted(sender, instance: PersonDistinctId, **kwargs):
-        create_person_distinct_id(instance.team.pk, instance.distinct_id, str(instance.person.uuid), is_deleted=True)
+        _delete_ch_distinct_id(
+            instance.team.pk, str(instance.person.uuid), instance.distinct_id, instance.version or 0, sync=True
+        )
 
     try:
         from freezegun import freeze_time
@@ -167,21 +174,24 @@ def get_persons_by_uuids(team: Team, uuids: List[str]) -> QuerySet:
     return Person.objects.filter(team_id=team.pk, uuid__in=uuids)
 
 
-def delete_person(person: Person) -> None:
+def delete_person(person: Person, sync: bool = False) -> None:
     # This is racy https://github.com/PostHog/posthog/issues/11590
     distinct_ids_to_version = _get_distinct_ids_with_version(person)
-    _delete_person(person.team.id, person.uuid, int(person.version or 0), person.created_at)
+    _delete_person(person.team.id, person.uuid, int(person.version or 0), person.created_at, sync)
     for distinct_id, version in distinct_ids_to_version.items():
-        _delete_ch_distinct_id(person.team.id, person.uuid, distinct_id, version)
+        _delete_ch_distinct_id(person.team.id, person.uuid, distinct_id, version, sync)
 
 
-def _delete_person(team_id: int, uuid: UUID, version: int, created_at: Optional[datetime.datetime] = None) -> None:
+def _delete_person(
+    team_id: int, uuid: UUID, version: int, created_at: Optional[datetime.datetime] = None, sync: bool = False
+) -> None:
     create_person(
         uuid=str(uuid),
         team_id=team_id,
         version=version + 100,  # keep in sync with deletePerson in plugin-server/src/utils/db/db.ts
         created_at=created_at,
         is_deleted=True,
+        sync=sync,
     )
 
 

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -58,7 +58,7 @@ if TEST:
     @receiver(post_delete, sender=PersonDistinctId)
     def person_distinct_id_deleted(sender, instance: PersonDistinctId, **kwargs):
         _delete_ch_distinct_id(
-            instance.team.pk, str(instance.person.uuid), instance.distinct_id, instance.version or 0, sync=True
+            instance.team.pk, instance.person.uuid, instance.distinct_id, instance.version or 0, sync=True
         )
 
     try:

--- a/posthog/models/test/test_person_model.py
+++ b/posthog/models/test/test_person_model.py
@@ -24,7 +24,7 @@ class TestPerson(BaseTest):
         person = Person.objects.create(
             team=self.team, version=15
         )  # version be > 0 to check that we don't just assume 0 in deletes
-        delete_person(person)
+        delete_person(person, sync=True)
         ch_persons = sync_execute(
             "SELECT toString(id), version, is_deleted, properties FROM person FINAL WHERE team_id = %(team_id)s and id = %(uuid)s",
             {"team_id": self.team.pk, "uuid": person.uuid},
@@ -41,7 +41,7 @@ class TestPerson(BaseTest):
         )
         self.assertEqual(ch_distinct_ids, [(0,)])
 
-        delete_person(person)
+        delete_person(person, sync=True)
         ch_distinct_ids = sync_execute(
             "SELECT toString(person_id), version, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
             {"team_id": self.team.pk, "distinct_id": "distinct_id1"},


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Due to https://github.com/PostHog/posthog/issues/11590 deletions have caused some teams data to be in a bad state, persons got deleted and distinct IDs were re-used, which meant that in ClickHouse the distinct_ids still point to the deleted person (as they had higher version values).

Proposed solution look up distinct id that point to deleted persons (in ClickHouse). For all these distinct IDs if they were re-used they would not be set properly as during person creation we set the distinctID version to 0. For the case where the distinct_id was already re-used we can fix the state by changing the version in Postgres and CH to be something higher.

Unfortunately for the case where the distinct_id isn't re-used yet we can't do anything other than fixing the bug 3 in https://github.com/PostHog/posthog/issues/11590 (afaik we can't reliably delete entries in CH). On that note once we fix bug 3 we might want to run this script / async migration across all teams who have deleted persons in the past.

Example user report https://posthog.slack.com/archives/C0441QU36RL/p1666697559927029 
where we need to update their data and it's about 1673 distinct_ids that need to be updated for that team https://metabase.posthog.net/question/475-aftership-v2 so we need a script + this could be a problem for other teams, making it solvable in the future.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Note: will add unit-tests once we agree that this is reasonable.

Testing locally
1. created 3 persons using python lib (using identify to not need to wait for buffer)
```
>>> posthog.identify('2022-11-03-1')
>>> posthog.identify('2022-11-03-2')
>>> posthog.identify('2022-11-03-3')
```
2. Merged person `2022-11-03-1'` and `2022-11-03-2` into two different persons, so their version would be 1
```
>>> posthog.identify('alias-target-1')
>>> posthog.identify('alias-target-2')
>>> posthog.alias('alias-target-1', '2022-11-03-1')
>>> posthog.alias('alias-target-2', '2022-11-03-2')
```
postgres
```
posthog=# select * from posthog_persondistinctid where distinct_id like '2022-11-03-%';
 id |  distinct_id  | person_id | team_id | version
----+---------------+-----------+---------+---------
 40 | 2022-11-03-3  |        37 |       1 |       0
 38 | 2022-11-03-1  |        33 |       1 |       1
 39 | 2022-11-03-2  |        34 |       1 |       1
```
CH
```
:) OPTIMIZE TABLE  person_distinct_id2
:) select * from person_distinct_id2 where distinct_id like '2022-11-03-%'

SELECT *
FROM person_distinct_id2
WHERE distinct_id LIKE '2022-11-03-%'

Query id: 42820c8b-8fcd-40a7-9adc-a0cf8790d593

┌─team_id─┬─distinct_id───┬─person_id────────────────────────────┬─is_deleted─┬─version─┬──────────_timestamp─┬─_offset─┬─_partition─┐
│       1 │ 2022-11-03-1  │ 01843e9e-ba4a-0000-6e0b-66ab54bf2c38 │          0 │       1 │ 2022-11-03 17:56:05 │      58 │          0 │
│       1 │ 2022-11-03-2  │ 01843e9e-c20e-0000-db87-a3e5a2782c47 │          0 │       1 │ 2022-11-03 17:56:10 │      59 │          0 │
│       1 │ 2022-11-03-3  │ 01843ea0-4f63-0000-4052-a1ee2353954a │          0 │       0 │ 2022-11-03 17:53:29 │      55 │          0 │
└─────────┴───────────────┴──────────────────────────────────────┴────────────┴─────────┴─────────────────────┴─────────┴────────────┘
```

3. deleted person `2022-11-03-1'` and `2022-11-03-2`  from the UI & restarted the local dev (to clear the cache for person creation)
```
posthog=# select * from posthog_persondistinctid where distinct_id like '2022-11-03-%';
 id | distinct_id  | person_id | team_id | version
----+--------------+-----------+---------+---------
 40 | 2022-11-03-3 |        37 |       1 |       0
(1 row)
```
CH (note that deletes write 0 version, so optimize ends up with non-deleted rows)
```
:) select * from person_distinct_id2 where distinct_id like '2022-11-03-%'

SELECT *
FROM person_distinct_id2
WHERE distinct_id LIKE '2022-11-03-%'

Query id: 8beb0830-91c5-4276-80b4-96b642bba0f7

┌─team_id─┬─distinct_id───┬─person_id────────────────────────────┬─is_deleted─┬─version─┬──────────_timestamp─┬─_offset─┬─_partition─┐
│       1 │ 2022-11-03-2  │ 01843e9e-c20e-0000-db87-a3e5a2782c47 │          1 │       0 │ 2022-11-03 17:59:50 │      67 │          0 │
│       1 │ 2022-11-03-1  │ 01843e9e-ba4a-0000-6e0b-66ab54bf2c38 │          0 │       1 │ 2022-11-03 17:56:05 │      58 │          0 │
│       1 │ 2022-11-03-2  │ 01843e9e-c20e-0000-db87-a3e5a2782c47 │          0 │       1 │ 2022-11-03 17:56:10 │      59 │          0 │
│       1 │ 2022-11-03-3  │ 01843ea0-4f63-0000-4052-a1ee2353954a │          0 │       0 │ 2022-11-03 17:53:29 │      55 │          0 │
│       1 │ 2022-11-03-1  │ 01843e9e-ba4a-0000-6e0b-66ab54bf2c38 │          1 │       0 │ 2022-11-03 17:59:47 │      63 │          0 │
└─────────┴───────────────┴──────────────────────────────────────┴────────────┴─────────┴─────────────────────┴─────────┴────────────┘

:) OPTIMIZE TABLE  person_distinct_id2
:) select * from person_distinct_id2 where distinct_id like '2022-11-03-%'

SELECT *
FROM person_distinct_id2
WHERE distinct_id LIKE '2022-11-03-%'

Query id: 8d6c2946-8c4d-4562-9d2a-a3c9c6b47455

┌─team_id─┬─distinct_id───┬─person_id────────────────────────────┬─is_deleted─┬─version─┬──────────_timestamp─┬─_offset─┬─_partition─┐
│       1 │ 2022-11-03-1  │ 01843e9e-ba4a-0000-6e0b-66ab54bf2c38 │          0 │       1 │ 2022-11-03 17:56:05 │      58 │          0 │
│       1 │ 2022-11-03-2  │ 01843e9e-c20e-0000-db87-a3e5a2782c47 │          0 │       1 │ 2022-11-03 17:56:10 │      59 │          0 │
│       1 │ 2022-11-03-3  │ 01843ea0-4f63-0000-4052-a1ee2353954a │          0 │       0 │ 2022-11-03 17:53:29 │      55 │          0 │
└─────────┴───────────────┴──────────────────────────────────────┴────────────┴─────────┴─────────────────────┴─────────┴────────────┘

```
4. Re-used distinct ids 
```
>>> posthog.identify('2022-11-03-1')
>>> posthog.identify('2022-11-03-2')
```
postgres
```
posthog=# select * from posthog_persondistinctid where distinct_id like '2022-11-03-%';
 id | distinct_id  | person_id | team_id | version
----+--------------+-----------+---------+---------
 40 | 2022-11-03-3 |        37 |       1 |       0
 43 | 2022-11-03-2 |        38 |       1 |       0
 44 | 2022-11-03-1 |        39 |       1 |       0
```
clickhouse
```
:) select * from person_distinct_id2 where distinct_id like '2022-11-03-%'

SELECT *
FROM person_distinct_id2
WHERE distinct_id LIKE '2022-11-03-%'

Query id: b793823a-7e9a-4cb6-9d0e-5bbd9099db6f

┌─team_id─┬─distinct_id──┬─person_id────────────────────────────┬─is_deleted─┬─version─┬──────────_timestamp─┬─_offset─┬─_partition─┐
│       1 │ 2022-11-03-1 │ 01843eac-dca1-0000-983b-617a542a8e54 │          0 │       0 │ 2022-11-03 18:07:11 │      69 │          0 │
│       1 │ 2022-11-03-2 │ 01843eac-dc02-0000-fd99-ef81b3c24089 │          0 │       0 │ 2022-11-03 18:07:11 │      68 │          0 │
│       1 │ 2022-11-03-1  │ 01843e9e-ba4a-0000-6e0b-66ab54bf2c38 │          0 │       1 │ 2022-11-03 17:56:05 │      58 │          0 │
│       1 │ 2022-11-03-2  │ 01843e9e-c20e-0000-db87-a3e5a2782c47 │          0 │       1 │ 2022-11-03 17:56:10 │      59 │          0 │
│       1 │ 2022-11-03-3  │ 01843ea0-4f63-0000-4052-a1ee2353954a │          0 │       0 │ 2022-11-03 17:53:29 │      55 │          0 │
└─────────┴───────────────┴──────────────────────────────────────┴────────────┴─────────┴─────────────────────┴─────────┴────────────┘
:) OPTIMIZE TABLE  person_distinct_id2
:) select * from person_distinct_id2 where distinct_id like '2022-11-03-%'

SELECT *
FROM person_distinct_id2
WHERE distinct_id LIKE '2022-11-03-%'

Query id: 6aca75b1-f050-4c12-b99b-210f03bf74f6

┌─team_id─┬─distinct_id───┬─person_id────────────────────────────┬─is_deleted─┬─version─┬──────────_timestamp─┬─_offset─┬─_partition─┐
│       1 │ 2022-11-03-1  │ 01843e9e-ba4a-0000-6e0b-66ab54bf2c38 │          0 │       1 │ 2022-11-03 17:56:05 │      58 │          0 │
│       1 │ 2022-11-03-2  │ 01843e9e-c20e-0000-db87-a3e5a2782c47 │          0 │       1 │ 2022-11-03 17:56:10 │      59 │          0 │
│       1 │ 2022-11-03-3  │ 01843ea0-4f63-0000-4052-a1ee2353954a │          0 │       0 │ 2022-11-03 17:53:29 │      55 │          0 │
└─────────┴───────────────┴──────────────────────────────────────┴────────────┴─────────┴─────────────────────┴─────────┴────────────┘
```
5. Running the script (dry-run)
```
DEBUG=1 python manage.py fix_person_distinct_ids_after_delete --team-id 1
2022-11-03 19:10.39 [warning  ] ['️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!', 'Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!']
2022-11-03T18:10:39.677319Z [warning  ] Skipping async migrations setup. This is unsafe in production! [posthog.apps] pid=91644 tid=4311745920
2022-11-03T18:10:39.680580Z [info     ] AXES: BEGIN LOG                [axes.apps] pid=91644 tid=4311745920
2022-11-03T18:10:39.681028Z [info     ] AXES: Using django-axes version 5.9.0 [axes.apps] pid=91644 tid=4311745920
2022-11-03T18:10:39.681075Z [info     ] AXES: blocking by IP only.     [axes.apps] pid=91644 tid=4311745920
2022-11-03T18:10:40.167802Z [info     ] Distinct id alias-target-1 hasn't been re-used yet and can cause problems in the future [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91644 tid=4311745920
2022-11-03T18:10:40.194968Z [info     ] Updating 2022-11-03-2 to version 2500 for person uuid = 01843eac-dc02-0000-fd99-ef81b3c24089 [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91644 tid=4311745920
022-11-03T18:10:40.202481Z [info     ] Distinct id alias-target-2 hasn't been re-used yet and can cause problems in the future [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91644 tid=4311745920
2022-11-03T18:10:40.207715Z [info     ] Updating 2022-11-03-1 to version 2500 for person uuid = 01843eac-dca1-0000-983b-617a542a8e54 [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91644 tid=4311745920
(env)
```
6. Running the script live
```
DEBUG=1 python manage.py fix_person_distinct_ids_after_delete --team-id 1 --live-run
2022-11-03 19:16.35 [warning  ] ['️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!', 'Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!']
2022-11-03T18:16:36.056803Z [warning  ] Skipping async migrations setup. This is unsafe in production! [posthog.apps] pid=91967 tid=4345480576
2022-11-03T18:16:36.060537Z [info     ] AXES: BEGIN LOG                [axes.apps] pid=91967 tid=4345480576
2022-11-03T18:16:36.060974Z [info     ] AXES: Using django-axes version 5.9.0 [axes.apps] pid=91967 tid=4345480576
2022-11-03T18:16:36.061021Z [info     ] AXES: blocking by IP only.     [axes.apps] pid=91967 tid=4345480576
2022-11-03T18:16:36.537364Z [info     ] Distinct id alias-target-1 hasn't been re-used yet and can cause problems in the future [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91967 tid=4345480576
2022-11-03T18:16:36.553387Z [info     ] Updating 2022-11-03-2 to version 2500 for person uuid = 01843eac-dc02-0000-fd99-ef81b3c24089 [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91967 tid=4345480576
2022-11-03T18:16:36.694880Z [info     ] Distinct id alias-target-2 hasn't been re-used yet and can cause problems in the future [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91967 tid=4345480576
2022-11-03T18:16:36.699638Z [info     ] Updating 2022-11-03-1 to version 2500 for person uuid = 01843eac-dca1-0000-983b-617a542a8e54 [posthog.management.commands.fix_person_distinct_ids_after_delete] pid=91967 tid=4345480576
2022-11-03T18:16:36.708955Z [info     ] Closing the Kafka producer with 0 secs timeout. [kafka.producer.kafka] pid=91967 tid=4345480576
2022-11-03T18:16:36.709012Z [info     ] Proceeding to force close the producer since pending requests could not be completed within timeout 0. [kafka.producer.kafka] pid=91967 tid=4345480576
(env)
```
7. waited for kafka messages to be flushed (not sure how I can do that?) 
End state Postgres
```
posthog=# select * from posthog_persondistinctid where distinct_id like '2022-11-03-%';
 id | distinct_id  | person_id | team_id | version
----+--------------+-----------+---------+---------
 40 | 2022-11-03-3 |        37 |       1 |       0
 43 | 2022-11-03-2 |        38 |       1 |    2500
 44 | 2022-11-03-1 |        39 |       1 |    2500
```
ClickHouse
```
select * from person_distinct_id2 where distinct_id like '2022-11-03-%'

SELECT *
FROM person_distinct_id2
WHERE distinct_id LIKE '2022-11-03-%'

Query id: ff408c42-b765-445d-b7c5-3efdc2ba6700

┌─team_id─┬─distinct_id───┬─person_id────────────────────────────┬─is_deleted─┬─version─┬──────────_timestamp─┬─_offset─┬─_partition─┐
│       1 │ 2022-11-03-1  │ 01843eac-dca1-0000-983b-617a542a8e54 │          0 │    2500 │ 2022-11-03 18:27:41 │      72 │          0 │
│       1 │ 2022-11-03-2  │ 01843eac-dc02-0000-fd99-ef81b3c24089 │          0 │    2500 │ 2022-11-03 18:27:41 │      71 │          0 │
│       1 │ 2022-11-03-3  │ 01843ea0-4f63-0000-4052-a1ee2353954a │          0 │       0 │ 2022-11-03 17:53:29 │      55 │          0 │
└─────────┴───────────────┴──────────────────────────────────────┴────────────┴─────────┴─────────────────────┴─────────┴────────────┘
```
