### PR TITLE
fix(recordings): muted styling in recording player meta

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -177,7 +177,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                                         <Link
                                             to={lastPageviewEvent?.properties['$current_url']}
                                             target="_blank"
-                                            className="truncate text-muted-alt"
+                                            className="truncate"
                                         >
                                             {lastPageviewEvent?.properties['$current_url']}
                                         </Link>

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -167,33 +167,38 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                     <LemonSkeleton className="w-1/3 my-1" />
                 ) : (
                     <>
-                        <IconWindow value={currentWindowIndex + 1} className="text-muted" />
-                        {!isSmallPlayer && <div className="window-number">Window {currentWindowIndex + 1}</div>}
+                        <IconWindow value={currentWindowIndex + 1} className="text-muted-alt" />
+                        {!isSmallPlayer && <div className="text-muted-alt">Window {currentWindowIndex + 1}</div>}
                         {lastPageviewEvent?.properties?.['$current_url'] && (
                             <span className="flex items-center gap-2 truncate">
                                 <span>·</span>
-                                <Link
-                                    to={lastPageviewEvent?.properties['$current_url']}
-                                    target="_blank"
-                                    className="truncate"
-                                >
-                                    {lastPageviewEvent?.properties['$current_url']}
-                                </Link>
-                                <span className="flex items-center">
-                                    <CopyToClipboardInline
-                                        description="current url"
-                                        explicitValue={lastPageviewEvent?.properties['$current_url']}
-                                    />
+                                <span className="flex items-center gap-1 truncate">
+                                    <Tooltip title="Click to open url">
+                                        <Link
+                                            to={lastPageviewEvent?.properties['$current_url']}
+                                            target="_blank"
+                                            className="truncate text-muted-alt"
+                                        >
+                                            {lastPageviewEvent?.properties['$current_url']}
+                                        </Link>
+                                    </Tooltip>
+                                    <span className="flex items-center">
+                                        <CopyToClipboardInline
+                                            description="current url"
+                                            explicitValue={lastPageviewEvent?.properties['$current_url']}
+                                            iconStyle={{ color: 'var(--muted-alt)' }}
+                                        />
+                                    </span>
                                 </span>
                             </span>
                         )}
                     </>
                 )}
-                <div className="flex-1 min-w-20" />
+                <div className={clsx('flex-1', isSmallPlayer ? 'min-w-4' : 'min-w-20')} />
                 {loading ? (
                     <LemonSkeleton className="w-1/3" />
                 ) : (
-                    <span>
+                    <span className="text-muted-alt">
                         {resolution && (
                             <>
                                 Resolution: {resolution.width} x {resolution.height}{' '}


### PR DESCRIPTION
## Problem

It's getting a bit visually overcrowded as we add more functionality to the session recording player.

## Changes

- [ ] Consistent muted colors with icons in playlist list
- [ ] Better spacing between meta elements

|Before|After|
|-|-|
|<img width="550" alt="Screen Shot 2022-11-03 at 1 44 38 PM" src="https://user-images.githubusercontent.com/13460330/199796089-8fcd0d5d-a842-4522-abdf-31bcac4534bf.png">|<img width="550" alt="Screen Shot 2022-11-03 at 1 44 21 PM" src="https://user-images.githubusercontent.com/13460330/199796099-680a89a2-f748-404c-b572-56d0439a3e68.png">|

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
