### PR TITLE
fix(saml): add default azure ad attributions

### DIFF
--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -117,10 +117,31 @@ class MultitenantSAMLAuth(SAMLAuth):
                 attributes, ["full_name", "FULL_NAME", "fullName", OID_COMMON_NAME], optional=True
             ),
             "first_name": self._get_attr(
-                attributes, ["first_name", "FIRST_NAME", "firstName", OID_GIVEN_NAME], optional=True
+                attributes,
+                [
+                    "first_name",
+                    "FIRST_NAME",
+                    "firstName",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+                    OID_GIVEN_NAME,
+                ],
+                optional=True,
             ),
-            "last_name": self._get_attr(attributes, ["last_name", "LAST_NAME", "lastName", OID_SURNAME], optional=True),
-            "email": self._get_attr(attributes, ["email", "EMAIL", OID_MAIL]),
+            "last_name": self._get_attr(
+                attributes,
+                [
+                    "last_name",
+                    "LAST_NAME",
+                    "lastName",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+                    OID_SURNAME,
+                ],
+                optional=True,
+            ),
+            "email": self._get_attr(
+                attributes,
+                ["email", "EMAIL", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", OID_MAIL],
+            ),
         }
 
     def get_user_id(self, details, response):


### PR DESCRIPTION
## Problem

Azure AD provides the user's email/name in a slightly different format. While it's possible to change the fields and be compliant with what we expect

<img width="812" alt="image" src="https://user-images.githubusercontent.com/53387/199799636-3dd941c9-7088-4bc0-b6b2-8b2f3c7800af.png">

... why would you have to?

## Changes

Adds a few long URLs that are used as keys

## How did you test this code?

Logged in via Azure AD locally.