### PR TITLE
fix: listing org members was n+1

### DIFF
--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -79,6 +79,7 @@ class OrganizationMemberViewSet(
         .filter(
             user__is_active=True,
         )
+        .select_related("user")
     )
     lookup_field = "user__uuid"
 

--- a/posthog/api/test/__snapshots__/test_organization_members.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_members.ambr
@@ -1,0 +1,289 @@
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21 /**/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.1
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.10
+  '
+  SELECT (1) AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.11
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_user" ON ("posthog_organizationmembership"."user_id" = "posthog_user"."id")
+  WHERE (NOT ("posthog_user"."email"::text LIKE '%@posthogbot.user')
+         AND "posthog_user"."is_active"
+         AND "posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid) /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.12
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_user" ON ("posthog_organizationmembership"."user_id" = "posthog_user"."id")
+  WHERE (NOT ("posthog_user"."email"::text LIKE '%@posthogbot.user')
+         AND "posthog_user"."is_active"
+         AND "posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)
+  ORDER BY "posthog_user"."first_name" ASC,
+           "posthog_organizationmembership"."joined_at" DESC
+  LIMIT 100 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.2
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.3
+  '
+  SELECT (1) AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.4
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_user" ON ("posthog_organizationmembership"."user_id" = "posthog_user"."id")
+  WHERE (NOT ("posthog_user"."email"::text LIKE '%@posthogbot.user')
+         AND "posthog_user"."is_active"
+         AND "posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid) /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.5
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_user" ON ("posthog_organizationmembership"."user_id" = "posthog_user"."id")
+  WHERE (NOT ("posthog_user"."email"::text LIKE '%@posthogbot.user')
+         AND "posthog_user"."is_active"
+         AND "posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)
+  ORDER BY "posthog_user"."first_name" ASC,
+           "posthog_organizationmembership"."joined_at" DESC
+  LIMIT 100 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.6
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+  ORDER BY "posthog_team"."access_control" ASC,
+           "posthog_team"."id" ASC
+  LIMIT 1
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.7
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21 /**/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.8
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.9
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  '
+---

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -2,10 +2,10 @@ from rest_framework import status
 
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.user import User
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries
 
 
-class TestOrganizationMembersAPI(APIBaseTest):
+class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
     def test_list_organization_members(self):
         User.objects.create_and_join(self.organization, "1@posthog.com", None)
         User.objects.create_and_join(self.organization, "2@posthog.com", None, is_active=False)
@@ -19,6 +19,18 @@ class TestOrganizationMembersAPI(APIBaseTest):
         self.assertEqual(len(response_data), 2)
         self.assertEqual(response_data[0]["user"]["uuid"], str(instance.user.uuid))
         self.assertEqual(response_data[0]["user"]["first_name"], instance.user.first_name)
+
+    @snapshot_postgres_queries
+    def test_list_organization_members_is_not_nplus1(self):
+        with self.assertNumQueries(7):
+            response = self.client.get("/api/organizations/@current/members/")
+            assert len(response.json()["results"]) == 1
+
+        User.objects.create_and_join(self.organization, "1@posthog.com", None)
+
+        with self.assertNumQueries(7):
+            response = self.client.get("/api/organizations/@current/members/")
+            assert len(response.json()["results"]) == 2
 
     def test_cant_list_members_for_an_alien_organization(self):
         org = Organization.objects.create(name="Alien Org")


### PR DESCRIPTION
## Problem

https://sentry.io/organizations/posthog/issues/3708039537/events/d0a4d5042ddf482f963714168ee00c50/?project=1899813&query=is%3Aunresolved&referrer=previous-event&statsPeriod=14d

sentry reports listing org members is nplus1

## Changes

loads all users along with the org

## How did you test this code?

added developer test