### PR TITLE
fix(insights): Reduce unit picker width

### DIFF
--- a/frontend/src/lib/components/UnitPicker/UnitPicker.scss
+++ b/frontend/src/lib/components/UnitPicker/UnitPicker.scss
@@ -1,3 +1,0 @@
-.UnitPopup {
-    width: 20rem;
-}

--- a/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
+++ b/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
@@ -1,4 +1,3 @@
-import './UnitPicker.scss'
 import {
     AggregationAxisFormat,
     aggregationAxisFormatSelectOptions,
@@ -107,7 +106,6 @@ export function UnitPicker({ filters, setFilters }: UnitPickerProps): JSX.Elemen
                     onClickOutside: () => setIsVisible(false),
                     additionalRefs: [customUnitModalRef],
                     visible: isVisible,
-                    className: 'UnitPopup',
                     overlay: (
                         <>
                             {aggregationAxisFormatSelectOptions.map(({ value, label }, index) => (


### PR DESCRIPTION
## Problem

Noticed this is super wide:

<img width="334" alt="Screenshot 2022-11-04 at 15 03 18" src="https://user-images.githubusercontent.com/4550621/199991778-c0d81270-f9d6-42ce-b3db-bdd86c384ad3.png">

I think this might have been needed when inputs were inlined, but this is no longer the case.

## Changes

Now auto width is used:

<img width="237" alt="Screenshot 2022-11-04 at 15 03 27" src="https://user-images.githubusercontent.com/4550621/199992196-ed329a71-7be4-4fa3-9c68-ff10f6fb83b9.png">
