### PR TITLE
chore: simple filter validation

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -117,6 +117,12 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
 
         return value
 
+    def validate_filters(self, value) -> Dict:
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Filters must be a dictionary")
+
+        return value
+
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> Dashboard:
         request = self.context["request"]
         validated_data["created_by"] = request.user

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -95,6 +95,19 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         dashboard.refresh_from_db()
         self.assertEqual(dashboard.name, "dashboard new name")
 
+    def test_cannot_update_dashboard_with_invalid_filters(self):
+        dashboard = Dashboard.objects.create(
+            team=self.team, name="private dashboard", created_by=self.user, creation_mode="template"
+        )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{dashboard.id}",
+            {"filters": [{"key": "brand", "value": ["1"], "operator": "exact", "type": "event"}]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        dashboard.refresh_from_db()
+        self.assertEqual(dashboard.filters, {})
+
     def test_create_dashboard_item(self):
         dashboard = Dashboard.objects.create(team=self.team, name="public dashboard")
         self._create_insight(


### PR DESCRIPTION
## Problem

in this [community Slack thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667560381553349?thread_ts=1667552308.524279&cid=C01GLBKHKQT) a user reported they were able to patch a dashboard with invalid filters using the API

## Changes

Adds very simple validation to the filters field on the dashboard

## How did you test this code?

adding a developer test and checking dashboard interactions work locally