### PR TITLE
fix(lemon-ui): Make sure `LemonSelect` popover fits into viewport

### DIFF
--- a/frontend/src/lib/components/Popup/Popup.scss
+++ b/frontend/src/lib/components/Popup/Popup.scss
@@ -2,6 +2,8 @@
     perspective: 80rem;
     perspective-origin: top;
     z-index: var(--z-popup);
+    display: flex;
+    flex-direction: column;
     h5 {
         margin: 0.25rem 0.5rem;
     }
@@ -27,8 +29,6 @@
     padding: 0.5rem;
     border-radius: var(--radius);
     border: 1px solid var(--border);
-    max-width: calc(100vw - 1rem);
-    max-height: calc(90vh - 1rem);
     overflow: auto;
 
     [data-floating-placement^='top'] & {

--- a/frontend/src/lib/components/Popup/Popup.tsx
+++ b/frontend/src/lib/components/Popup/Popup.tsx
@@ -115,13 +115,13 @@ export const Popup = React.forwardRef<HTMLDivElement, PopupProps>(
                 ...(fallbackPlacements ? [flip({ fallbackPlacements, fallbackStrategy: 'initialPlacement' })] : []),
                 shift(),
                 size({
-                    padding: 5,
-                    apply({ rects, elements: { floating } }) {
-                        if (sameWidth) {
-                            Object.assign(floating.style, {
-                                width: `${rects.reference.width}px`,
-                            })
-                        }
+                    padding: 4,
+                    apply({ availableWidth, availableHeight, rects, elements: { floating } }) {
+                        Object.assign(floating.style, {
+                            maxHeight: `${availableHeight}px`,
+                            maxWidth: `${availableWidth}px`,
+                            width: sameWidth ? rects.reference.width : undefined,
+                        })
                     },
                 }),
                 arrow({ element: arrowRef, padding: 8 }),


### PR DESCRIPTION
## Problem

While working on #12444 I noticed the select menu can overflow the viewport, and there's no way of accessing the out-of-bounds options then:

<img width="313" alt="Screenshot 2022-11-04 at 18 22 20" src="https://user-images.githubusercontent.com/4550621/200037703-37b1b979-15b3-42ca-a9fe-244fcdc79992.png">


## Changes

This makes is to that the menu is always sized to fit into the viewport:

<img width="326" alt="Screenshot 2022-11-04 at 18 19 39" src="https://user-images.githubusercontent.com/4550621/200037758-b3abf883-6e40-4021-b314-3e7d43248fd0.png">