### PR TITLE
feat(lemon-ui): Allow nested selects

### DIFF
--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -85,6 +85,21 @@ MixedValuesTypes.args = {
     ] as LemonSelectOptions<string | number>,
 }
 
+export const NestedSelect = Template.bind({})
+NestedSelect.args = {
+    dropdownMatchSelectWidth: false,
+    options: [
+        { label: 'Capybara', value: 'capybara' },
+        {
+            label: 'Elephant',
+            options: [
+                { label: 'African elephant', value: 'elephant-african' },
+                { label: 'Asian elephant', value: 'elephant-asian' },
+            ],
+        },
+    ] as LemonSelectOptions<string | number>,
+}
+
 export const Clearable = Template.bind({})
 Clearable.args = { allowClear: true, value: 'poodle' }
 

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -6,17 +6,27 @@ import { PopupProps } from './Popup/Popup'
 import './LemonSelect.scss'
 import clsx from 'clsx'
 import { TooltipProps } from './Tooltip'
+import { TooltipPlacement } from 'antd/lib/tooltip'
 
-export interface LemonSelectOption<T> {
-    value: T
+interface LemonSelectOptionBase {
     label: string | JSX.Element
     icon?: React.ReactElement
     sideIcon?: React.ReactElement
     disabled?: boolean
     tooltip?: string | JSX.Element
     'data-attr'?: string
-    element?: React.ReactElement // TODO: Unify with `label`
 }
+
+export interface LemonSelectOptionLeaf<T> extends LemonSelectOptionBase {
+    value: T
+    element?: React.ReactElement
+}
+
+export interface LemonSelectOptionNode<T> extends LemonSelectOptionBase {
+    options: LemonSelectOption<T>[]
+}
+
+export type LemonSelectOption<T> = LemonSelectOptionLeaf<T> | LemonSelectOptionNode<T>
 
 export type LemonSelectOptions<T> = LemonSelectSection<T>[] | LemonSelectOption<T>[]
 
@@ -53,7 +63,19 @@ export interface LemonSelectProps<T>
 
 export const isLemonSelectSection = <T extends any>(
     candidate: LemonSelectSection<T> | LemonSelectOption<T>
-): candidate is LemonSelectSection<T> => candidate && 'options' in candidate
+): candidate is LemonSelectSection<T> => candidate && 'options' in candidate && !('label' in candidate)
+
+function extractLeafOptions<T>(options: LemonSelectOption<T>[]): LemonSelectOptionLeaf<T>[] {
+    const leafOptions: LemonSelectOptionLeaf<T>[] = []
+    for (const option of options) {
+        if ('options' in option) {
+            leafOptions.push(...extractLeafOptions(option.options))
+        } else {
+            leafOptions.push(option)
+        }
+    }
+    return leafOptions
+}
 
 /**
  * The select can receive `options` that are either Options or Sections.
@@ -63,8 +85,8 @@ export const isLemonSelectSection = <T extends any>(
  * */
 export const boxToSections = <T,>(
     sectionsAndOptions: LemonSelectSection<T>[] | LemonSelectOption<T>[]
-): [LemonSelectSection<T>[], LemonSelectOption<T>[]] => {
-    let allOptions: LemonSelectOption<T>[] = []
+): [LemonSelectSection<T>[], LemonSelectOptionLeaf<T>[]] => {
+    const allOptions: LemonSelectOptionLeaf<T>[] = []
     const sections: LemonSelectSection<T>[] = []
     let implicitSection: LemonSelectSection<T> = { options: [] }
     for (const sectionOrOption of sectionsAndOptions) {
@@ -74,9 +96,9 @@ export const boxToSections = <T,>(
                 implicitSection = { options: [] }
             }
             sections.push(sectionOrOption)
-            allOptions = allOptions.concat(sectionOrOption.options)
+            allOptions.push(...extractLeafOptions(sectionOrOption.options))
         } else {
-            allOptions.push(sectionOrOption)
+            allOptions.push(...extractLeafOptions([sectionOrOption]))
             implicitSection.options.push(sectionOrOption)
         }
     }
@@ -112,7 +134,7 @@ export function LemonSelect<T>({
         }
     }, [value, buttonProps.loading])
 
-    const [sections, allOptions] = useMemo(() => boxToSections(options), [options])
+    const [sections, allLeafOptions] = useMemo(() => boxToSections(options), [options])
 
     return (
         <div className="flex">
@@ -121,41 +143,34 @@ export function LemonSelect<T>({
                 popup={{
                     ref: popup?.ref,
                     overlay: sections.map((section, i) => (
-                        <div key={i} className="space-y-px">
-                            {section.title ? (
-                                typeof section.title === 'string' ? (
-                                    <h5>{section.title}</h5>
-                                ) : (
-                                    section.title
-                                )
-                            ) : null}
-                            {section.options.map((option, index) => (
-                                <LemonButton
-                                    key={index}
-                                    icon={option.icon}
-                                    sideIcon={option.sideIcon}
-                                    tooltip={option.tooltip}
-                                    tooltipPlacement={optionTooltipPlacement}
-                                    onClick={() => {
-                                        if (option.value !== localValue) {
-                                            onChange?.(option.value)
-                                            setLocalValue(option.value)
-                                        }
-                                        onSelect?.(option.value)
-                                    }}
-                                    status="stealth"
-                                    active={option.value === localValue}
-                                    disabled={option.disabled}
-                                    fullWidth
-                                    data-attr={option['data-attr']}
-                                >
-                                    {option.label ?? option.value}
-                                    {option.element}
-                                </LemonButton>
-                            ))}
-                            {section.footer ? <div>{section.footer}</div> : null}
+                        <>
+                            <div key={i} className="space-y-px">
+                                {section.title ? (
+                                    typeof section.title === 'string' ? (
+                                        <h5>{section.title}</h5>
+                                    ) : (
+                                        section.title
+                                    )
+                                ) : null}
+                                {section.options.map((option, index) => (
+                                    <LemonSelectOptionRow
+                                        key={index}
+                                        option={option}
+                                        onSelect={(newValue) => {
+                                            if (newValue !== localValue) {
+                                                onChange?.(newValue)
+                                                setLocalValue(newValue)
+                                            }
+                                            onSelect?.(newValue)
+                                        }}
+                                        activeValue={localValue}
+                                        tooltipPlacement={optionTooltipPlacement}
+                                    />
+                                ))}
+                                {section.footer ? <div>{section.footer}</div> : null}
+                            </div>
                             {i < sections.length - 1 ? <LemonDivider /> : null}
-                        </div>
+                        </>
                     )),
                     sameWidth: dropdownMatchSelectWidth,
                     placement: dropdownPlacement,
@@ -163,7 +178,7 @@ export function LemonSelect<T>({
                     className: popup?.className,
                     maxContentWidth: dropdownMaxContentWidth,
                 }}
-                icon={allOptions.find((o) => o.value === localValue)?.icon}
+                icon={allLeafOptions.find((o) => o.value === localValue)?.icon}
                 // so that the pop-up isn't shown along with the close button
                 sideIcon={isClearButtonShown ? <div /> : undefined}
                 type="secondary"
@@ -171,7 +186,7 @@ export function LemonSelect<T>({
                 {...buttonProps}
             >
                 <span>
-                    {allOptions.find((o) => o.value === localValue)?.label ?? localValue ?? (
+                    {allLeafOptions.find((o) => o.value === localValue)?.label ?? localValue ?? (
                         <span className="text-muted">{placeholder}</span>
                     )}
                 </span>
@@ -191,5 +206,80 @@ export function LemonSelect<T>({
                 )}
             </LemonButtonWithPopup>
         </div>
+    )
+}
+
+function doOptionsContainActiveValue<T>(options: LemonSelectOption<T>[], activeValue: T | null): boolean {
+    for (const option of options) {
+        if ('options' in option) {
+            if (doOptionsContainActiveValue(option.options, activeValue)) {
+                return true
+            }
+        } else if (option.value === activeValue) {
+            return true
+        }
+    }
+    return false
+}
+
+function LemonSelectOptionRow<T>({
+    option,
+    activeValue,
+    onSelect,
+    tooltipPlacement,
+}: {
+    option: LemonSelectOption<T>
+    activeValue: T | undefined
+    onSelect: (value: T) => void
+    tooltipPlacement: TooltipPlacement | undefined
+}): JSX.Element {
+    return 'options' in option ? (
+        <LemonButtonWithPopup
+            icon={option.icon}
+            sideIcon={option.sideIcon}
+            tooltip={option.tooltip}
+            tooltipPlacement={tooltipPlacement}
+            status="stealth"
+            disabled={option.disabled}
+            fullWidth
+            data-attr={option['data-attr']}
+            active={doOptionsContainActiveValue(option.options, activeValue)}
+            popup={{
+                overlay: (
+                    <div className="space-y-px">
+                        {option.options.map((option, index) => (
+                            <LemonSelectOptionRow
+                                key={index}
+                                option={option}
+                                onSelect={onSelect}
+                                activeValue={activeValue}
+                                tooltipPlacement={tooltipPlacement}
+                            />
+                        ))}
+                    </div>
+                ),
+                placement: 'right-start',
+                actionable: true,
+                closeParentPopupOnClickInside: true,
+            }}
+        >
+            {option.label}
+        </LemonButtonWithPopup>
+    ) : (
+        <LemonButton
+            icon={option.icon}
+            sideIcon={option.sideIcon}
+            tooltip={option.tooltip}
+            tooltipPlacement={tooltipPlacement}
+            status="stealth"
+            disabled={option.disabled}
+            fullWidth
+            data-attr={option['data-attr']}
+            active={option.value === activeValue}
+            onClick={() => onSelect(option.value)}
+        >
+            {option.label ?? option.value}
+            {option.element}
+        </LemonButton>
     )
 }

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -65,16 +65,14 @@ export const isLemonSelectSection = <T extends any>(
     candidate: LemonSelectSection<T> | LemonSelectOption<T>
 ): candidate is LemonSelectSection<T> => candidate && 'options' in candidate && !('label' in candidate)
 
-function extractLeafOptions<T>(options: LemonSelectOption<T>[]): LemonSelectOptionLeaf<T>[] {
-    const leafOptions: LemonSelectOptionLeaf<T>[] = []
+function extractLeafOptions<T>(targetArray: LemonSelectOptionLeaf<T>[], options: LemonSelectOption<T>[]): void {
     for (const option of options) {
         if ('options' in option) {
-            leafOptions.push(...extractLeafOptions(option.options))
+            extractLeafOptions(targetArray, option.options)
         } else {
-            leafOptions.push(option)
+            targetArray.push(option)
         }
     }
-    return leafOptions
 }
 
 /**
@@ -96,9 +94,9 @@ export const boxToSections = <T,>(
                 implicitSection = { options: [] }
             }
             sections.push(sectionOrOption)
-            allOptions.push(...extractLeafOptions(sectionOrOption.options))
+            extractLeafOptions(allOptions, sectionOrOption.options)
         } else {
-            allOptions.push(...extractLeafOptions([sectionOrOption]))
+            extractLeafOptions(allOptions, [sectionOrOption])
             implicitSection.options.push(sectionOrOption)
         }
     }

--- a/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
+++ b/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
@@ -1,8 +1,4 @@
-import {
-    AggregationAxisFormat,
-    aggregationAxisFormatSelectOptions,
-    axisLabel,
-} from 'scenes/insights/aggregationAxisFormat'
+import { AggregationAxisFormat, INSIGHT_UNIT_OPTIONS, axisLabel } from 'scenes/insights/aggregationAxisFormat'
 import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { useMemo, useRef, useState } from 'react'
@@ -17,7 +13,7 @@ interface UnitPickerProps {
     setFilters: (filters: Partial<FilterType>, insightMode?: ItemMode | undefined) => void
 }
 
-const aggregationDisplayMap = aggregationAxisFormatSelectOptions.reduce((acc, option) => {
+const aggregationDisplayMap = INSIGHT_UNIT_OPTIONS.reduce((acc, option) => {
     acc[option.value] = option.label
     return acc
 }, {})
@@ -108,7 +104,7 @@ export function UnitPicker({ filters, setFilters }: UnitPickerProps): JSX.Elemen
                     visible: isVisible,
                     overlay: (
                         <>
-                            {aggregationAxisFormatSelectOptions.map(({ value, label }, index) => (
+                            {INSIGHT_UNIT_OPTIONS.map(({ value, label }, index) => (
                                 <LemonButton
                                     key={index}
                                     onClick={() => handleChange({ format: value })}

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -1,11 +1,11 @@
-import { LemonSelectOption } from 'lib/components/LemonSelect'
+import { LemonSelectOptionLeaf } from 'lib/components/LemonSelect'
 import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
 import { ChartDisplayType, FilterType } from '~/types'
 
 const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled'] as const
 export type AggregationAxisFormat = typeof formats[number]
 
-export const aggregationAxisFormatSelectOptions: LemonSelectOption<AggregationAxisFormat>[] = [
+export const INSIGHT_UNIT_OPTIONS: LemonSelectOptionLeaf<AggregationAxisFormat>[] = [
     { value: 'numeric', label: 'None' },
     { value: 'duration', label: 'Duration (s)' },
     { value: 'duration_ms', label: 'Duration (ms)' },

--- a/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
@@ -7,10 +7,10 @@ import { IconWindow } from 'scenes/session-recordings/player/icons'
 import { boxToSections } from 'lib/components/LemonSelect'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { PlayerListExpandableConfig } from 'scenes/session-recordings/player/list/PlayerList'
-import { LemonSelectOption } from '@posthog/lemon-ui'
+import { LemonSelectOptionLeaf } from '@posthog/lemon-ui'
 
 export interface ListRowOption<T>
-    extends Pick<LemonSelectOption<T>, 'value' | 'label' | 'tooltip' | 'disabled' | 'data-attr'> {
+    extends Pick<LemonSelectOptionLeaf<T>, 'value' | 'label' | 'tooltip' | 'disabled' | 'data-attr'> {
     onClick?: (record: T) => void
 }
 
@@ -134,13 +134,13 @@ function PlayerListRowRaw<T extends Record<string, any>>({
                                     placement: 'bottom-end',
                                     overlay: sections.map((section, i) => (
                                         <React.Fragment key={i}>
-                                            {section.options.map((option: ListRowOption<T>, index) => (
+                                            {section.options.map((option, index) => (
                                                 <LemonButton
                                                     key={index}
                                                     tooltip={option.tooltip}
                                                     onClick={(event) => {
                                                         event.stopPropagation()
-                                                        option?.onClick?.(record)
+                                                        ;(option as ListRowOption<T> | undefined)?.onClick?.(record)
                                                     }}
                                                     status="stealth"
                                                     disabled={option.disabled}


### PR DESCRIPTION
## Problem

#12444 requires nested selects, so that we don't overwhelm users with a bunch of embedded selects.

## Changes

This adds arbitrarily nested selects:

<img width="281" alt="Screenshot 2022-11-04 at 19 17 44" src="https://user-images.githubusercontent.com/4550621/200047652-dac5bf39-2c2e-464d-8a9a-68f1561b1d9c.png">

## How did you test this code?

No component tests. Play with this in Storybook.