### PR TITLE
feat: view insights list filtered by dashboard

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -1,0 +1,99 @@
+import { LemonSelect } from 'lib/components/LemonSelect'
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { CalendarOutlined } from '@ant-design/icons'
+import { SavedInsightsTabs } from '~/types'
+import { INSIGHT_TYPE_OPTIONS } from 'scenes/saved-insights/SavedInsights'
+import { useActions, useValues } from 'kea'
+import { dashboardsModel } from '~/models/dashboardsModel'
+import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
+import { membersLogic } from 'scenes/organization/Settings/membersLogic'
+import { LemonInput } from 'lib/components/LemonInput/LemonInput'
+
+export function SavedInsightsFilters(): JSX.Element {
+    const { nameSortedDashboards } = useValues(dashboardsModel)
+    const { setSavedInsightsFilters } = useActions(savedInsightsLogic)
+    const { filters } = useValues(savedInsightsLogic)
+
+    const { tab, createdBy, insightType, dateFrom, dateTo, dashboardId, search } = filters
+
+    const { meFirstMembers } = useValues(membersLogic)
+
+    return (
+        <div className="flex justify-between gap-2 mb-2 items-center flex-wrap">
+            <LemonInput
+                type="search"
+                placeholder="Search for insights"
+                onChange={(value) => setSavedInsightsFilters({ search: value })}
+                value={search || ''}
+            />
+            <div className="flex items-center gap-2 flex-wrap">
+                <div className="flex items-center gap-2">
+                    <span>On dashboard:</span>
+                    <LemonSelect
+                        size="small"
+                        options={nameSortedDashboards.map((nsd) => ({
+                            value: nsd.id,
+                            label: nsd.name,
+                        }))}
+                        value={dashboardId}
+                        onChange={(newValue) => {
+                            setSavedInsightsFilters({ dashboardId: newValue })
+                        }}
+                        dropdownMatchSelectWidth={false}
+                        data-attr="insight-on-dashboard"
+                        allowClear={true}
+                    />
+                </div>
+                <div className="flex items-center gap-2">
+                    <span>Type:</span>
+                    <LemonSelect
+                        size="small"
+                        options={INSIGHT_TYPE_OPTIONS}
+                        value={insightType}
+                        onChange={(v: any): void => setSavedInsightsFilters({ insightType: v })}
+                        dropdownMatchSelectWidth={false}
+                        data-attr="insight-type"
+                    />
+                </div>
+                <div className="flex items-center gap-2">
+                    <span>Last modified:</span>
+                    <DateFilter
+                        disabled={false}
+                        dateFrom={dateFrom}
+                        dateTo={dateTo}
+                        onChange={(fromDate, toDate) =>
+                            setSavedInsightsFilters({ dateFrom: fromDate, dateTo: toDate ?? undefined })
+                        }
+                        makeLabel={(key) => (
+                            <>
+                                <CalendarOutlined />
+                                <span className="hide-when-small"> {key}</span>
+                            </>
+                        )}
+                    />
+                </div>
+                {tab !== SavedInsightsTabs.Yours ? (
+                    <div className="flex items-center gap-2">
+                        <span>Created by:</span>
+                        {/* TODO: Fix issues with user name order due to numbers having priority */}
+                        <LemonSelect
+                            size="small"
+                            options={[
+                                { value: 'All users' as number | 'All users', label: 'All Users' },
+                                ...meFirstMembers.map((x) => ({
+                                    value: x.user.id,
+                                    label: x.user.first_name,
+                                })),
+                            ]}
+                            value={createdBy}
+                            onChange={(v: any): void => {
+                                setSavedInsightsFilters({ createdBy: v })
+                            }}
+                            dropdownMatchSelectWidth={false}
+                        />
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -35,6 +35,7 @@ export interface SavedInsightFilters {
     dateFrom: string | dayjs.Dayjs | undefined | 'all' | null
     dateTo: string | dayjs.Dayjs | undefined | null
     page: number
+    dashboardId: number | undefined | null
 }
 
 function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters {
@@ -48,6 +49,7 @@ function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters
         dateFrom: values.dateFrom || 'all',
         dateTo: values.dateTo || undefined,
         page: parseInt(String(values.page)) || 1,
+        dashboardId: values.dashboardId,
     }
 }
 
@@ -186,6 +188,9 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
                         date_from: filters.dateFrom,
                         date_to: filters.dateTo,
                     }),
+                ...(!!filters.dashboardId && {
+                    dashboards: [filters.dashboardId],
+                }),
             }),
         ],
         pagination: [

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -498,7 +498,7 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestr
             elif key == "dashboards":
                 dashboards_filter = request.GET["dashboards"]
                 if dashboards_filter:
-                    dashboards_ids = json.loads(request.GET["dashboards"])
+                    dashboards_ids = json.loads(dashboards_filter)
                     for dashboard_id in dashboards_ids:
                         queryset = queryset.filter(dashboard_tiles__dashboard_id=dashboard_id)
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -499,7 +499,9 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestr
                 dashboards_filter = request.GET["dashboards"]
                 if dashboards_filter:
                     dashboards_ids = json.loads(request.GET["dashboards"])
-                    queryset = queryset.filter(dashboard_tiles__dashboard_id__in=dashboards_ids)
+                    for dashboard_id in dashboards_ids:
+                        queryset = queryset.filter(dashboard_tiles__dashboard_id=dashboard_id)
+
         return queryset
 
     def retrieve(self, request, *args, **kwargs):

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -495,6 +495,11 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestr
                 queryset = queryset.filter(
                     Q(name__icontains=request.GET["search"]) | Q(derived_name__icontains=request.GET["search"])
                 )
+            elif key == "dashboards":
+                dashboards_filter = request.GET["dashboards"]
+                if dashboards_filter:
+                    dashboards_ids = json.loads(request.GET["dashboards"])
+                    queryset = queryset.filter(dashboard_tiles__dashboard_id__in=dashboards_ids)
         return queryset
 
     def retrieve(self, request, *args, **kwargs):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -302,13 +302,13 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         matched_insights = [insight["id"] for insight in any_on_dashboard_one.json()["results"]]
         assert matched_insights == [insight_one_id, insight_two_id]
 
-        # match is OR, not AND
+        # match is AND, not OR
         any_on_dashboard_one_and_two = self.client.get(
             f"/api/projects/{self.team.id}/insights/?dashboards=[{dashboard_one_id}, {dashboard_two_id}]"
         )
         self.assertEqual(any_on_dashboard_one_and_two.status_code, status.HTTP_200_OK)
         matched_insights = [insight["id"] for insight in any_on_dashboard_one_and_two.json()["results"]]
-        assert matched_insights == [insight_one_id, insight_two_id]
+        assert matched_insights == [insight_two_id]
 
     @freeze_time("2012-01-14T03:21:34.000Z")
     def test_create_insight_items(self):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -285,6 +285,31 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             f"received query counts\n\n{query_counts}\n\nwith queries:\n\n{queries}",
         )
 
+    def test_can_list_insights_by_which_dashboards_they_are_in(self) -> None:
+        insight_one_id, _ = self._create_insight({"name": "insight 1", "filters": {"events": [{"id": "$pageview"}]}})
+        insight_two_id, _ = self._create_insight({"name": "insight 2", "filters": {"events": [{"id": "$pageview"}]}})
+        insight_three_id, _ = self._create_insight({"name": "insight 3", "filters": {"events": [{"id": "$pageview"}]}})
+
+        dashboard_one_id, _ = self._create_dashboard({"name": "dashboard 1", "filters": {"date_from": "-180d"}})
+        dashboard_two_id, _ = self._create_dashboard({"name": "dashboard 1", "filters": {"date_from": "-180d"}})
+        self._add_insight_to_dashboard([dashboard_one_id], insight_one_id)
+        self._add_insight_to_dashboard([dashboard_one_id, dashboard_two_id], insight_two_id)
+
+        any_on_dashboard_one = self.client.get(
+            f"/api/projects/{self.team.id}/insights/?dashboards=[{dashboard_one_id}]"
+        )
+        self.assertEqual(any_on_dashboard_one.status_code, status.HTTP_200_OK)
+        matched_insights = [insight["id"] for insight in any_on_dashboard_one.json()["results"]]
+        assert matched_insights == [insight_one_id, insight_two_id]
+
+        # match is OR, not AND
+        any_on_dashboard_one_and_two = self.client.get(
+            f"/api/projects/{self.team.id}/insights/?dashboards=[{dashboard_one_id}, {dashboard_two_id}]"
+        )
+        self.assertEqual(any_on_dashboard_one_and_two.status_code, status.HTTP_200_OK)
+        matched_insights = [insight["id"] for insight in any_on_dashboard_one_and_two.json()["results"]]
+        assert matched_insights == [insight_one_id, insight_two_id]
+
     @freeze_time("2012-01-14T03:21:34.000Z")
     def test_create_insight_items(self):
         response = self.client.post(

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -300,7 +300,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         )
         self.assertEqual(any_on_dashboard_one.status_code, status.HTTP_200_OK)
         matched_insights = [insight["id"] for insight in any_on_dashboard_one.json()["results"]]
-        assert matched_insights == [insight_one_id, insight_two_id]
+        assert sorted(matched_insights) == [insight_one_id, insight_two_id]
 
         # match is AND, not OR
         any_on_dashboard_one_and_two = self.client.get(


### PR DESCRIPTION
Adds a way to view the insights list by which dashboard an insight is on

![2022-11-05 15 47 01](https://user-images.githubusercontent.com/984817/200129298-0cbac746-d85f-46ac-bbfb-7f9ac8dd9567.gif)

## How did you test this code?

running it locally
adding developer tests