### PR TITLE
chore: add is revert flag and rename event in pr stats

### DIFF
--- a/.github/workflows/report-pr-age.yml
+++ b/.github/workflows/report-pr-age.yml
@@ -15,9 +15,16 @@ jobs:
               run: |
                   pr_age=$((($(date '+%s') - $(date -d "${{ github.event.pull_request.created_at }}" '+%s'))))
                   echo pr_age=$pr_age >> $GITHUB_ENV
+                  first_commit_message_in_pr=$(curl -s "${{github.event.pull_request._links.commits.href}}" | jq '.[0].commit.message')
+                  echo first_commit_message_in_pr=$first_commit_message_in_pr >> $GITHUB_ENV
+                  if [[ $first_commit_message_in_pr =~ Revert[[:space:]] ]]; then
+                      echo is_revert=true >> $GITHUB_ENV
+                  else
+                      echo is_revert=false >> $GITHUB_ENV
+                  fi
             - name: capture PR age to PostHog
               uses: PostHog/posthog-github-action@v0.1
               with:
                   posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
-                  event: 'posthog-ci-pr-age-when-closed'
-                  properties: '{"prAgeInSeconds": ${{ env.pr_age }}}'
+                  event: 'posthog-ci-pr-stats'
+                  properties: '{"prAgeInSeconds": ${{ env.pr_age }}, "isRevert": ${{env.is_revert}} }'


### PR DESCRIPTION
## Problem

I want to measure revert to not revert PR ratio as a proxy for "change fail rate"

## Changes

Does that by checking the message of the first commit in the PR's history. If that starts with "revert " then this is a revert PR

## How did you test this code?

in a separate repo to figure out how to check whether a PR is a revert.