### PR TITLE
fix: Usage report org ids

### DIFF
--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -13,6 +13,9 @@ class Command(BaseCommand):
         parser.add_argument("--print-reports", type=bool, help="Print the reports in full")
         parser.add_argument("--date", type=str, help="The date to be ran in format YYYY-MM-DD")
         parser.add_argument("--event-name", type=str, help="Override the event name to be sent - for testing")
+        parser.add_argument(
+            "--skip-capture-event", type=str, help="Skip the posthog capture events - for retrying to billing service"
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -271,7 +271,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "organization_name": "Test",
                     "organization_created_at": "2022-01-10T00:01:00+00:00",
                     "organization_user_count": 1,
-                    "team_count": 1,
+                    "team_count": 2,
                     "teams": {
                         self.org_1_team_1.id: {
                             "event_count_lifetime": 32,


### PR DESCRIPTION
## Problem

Org IDs are uuids which was causing issues when creating hashmaps. 

## Changes

* Fixes this by always using stringified org ID
* Also fixes team count
* Also adds flag to allow rerunning only to the billing service


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
