### PR TITLE
chore(api): return 400 on entity_id not provided by requests

### DIFF
--- a/posthog/api/test/test_persons_trends.py
+++ b/posthog/api/test/test_persons_trends.py
@@ -491,6 +491,18 @@ class TestPersonTrends(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(resp[1], "Distinct ID,Email,Internal ID,Name,Properties.name")
         self.assertEqual(resp[2].split(",")[0], "person1")
 
+    def test_people_csv_returns_400_on_no_entity_id_provided(self):
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/actions/people.csv",
+            data={
+                "date_from": "2020-01-01",
+                "date_to": "2020-01-07",
+                # Here we don't provide an entity_id or entity_type, which are
+                # required
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_breakdown_by_cohort_people_endpoint(self):
         person1, _, _, _ = self._create_multiple_people()
         cohort = _create_cohort(

--- a/posthog/api/test/test_persons_trends.py
+++ b/posthog/api/test/test_persons_trends.py
@@ -493,7 +493,7 @@ class TestPersonTrends(ClickhouseTestMixin, APIBaseTest):
 
     def test_people_csv_returns_400_on_no_entity_id_provided(self):
         response = self.client.get(
-            f"/api/projects/{self.team.id}/actions/people.csv",
+            f"/api/projects/{self.team.id}/actions/people",
             data={
                 "date_from": "2020-01-01",
                 "date_to": "2020-01-07",
@@ -502,6 +502,15 @@ class TestPersonTrends(ClickhouseTestMixin, APIBaseTest):
             },
         )
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content),
+            {
+                "type": "validation_error",
+                "code": "invalid_input",
+                "detail": "An entity id and the entity type must be provided to determine an entity",
+                "attr": None,
+            },
+        )
 
     def test_breakdown_by_cohort_people_endpoint(self):
         person1, _, _, _ = self._create_multiple_people()

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import structlog
 from django.db.models import QuerySet
 from rest_framework import request, status
+from rest_framework.exceptions import ValidationError
 from sentry_sdk import capture_exception
 from statshog.defaults.django import statsd
 
@@ -31,7 +32,7 @@ class PaginationMode(Enum):
 
 def get_target_entity(filter: Union[Filter, StickinessFilter]) -> Entity:
     if not filter.target_entity_id:
-        raise ValueError("An entity id and the entity type must be provided to determine an entity")
+        raise ValidationError("An entity id and the entity type must be provided to determine an entity")
 
     entity_math = filter.target_entity_math or "total"  # make math explicit
     possible_entity = entity_from_order(filter.target_entity_order, filter.entities)
@@ -47,7 +48,7 @@ def get_target_entity(filter: Union[Filter, StickinessFilter]) -> Entity:
     elif filter.target_entity_type:
         return Entity({"id": filter.target_entity_id, "type": filter.target_entity_type, "math": entity_math})
     else:
-        raise ValueError("An entity must be provided for target entity to be determined")
+        raise ValidationError("An entity must be provided for target entity to be determined")
 
 
 def entity_from_order(order: Optional[str], entities: List[Entity]) -> Optional[Entity]:


### PR DESCRIPTION
Previously we were raising a ValueError for this case, which results in
a 500 HTTP status code when caught by django-rest-framework. Instead we
raise a ValidationError which should result in a 400 status code along
with the validation error message.

This change was prompted by [this slack
conversation](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667802817723279)
where the user was missing an `entity_id` and `entity_type` param.

Previously users would see:

```
{
    "type": "server_error",
    "code": "error",
    "detail": "A server error occurred.",
    "attr": null
}
```

For endpoints that request an `entity_id` it should now look something like:

```
{
    "type": "validation_error",
    "code": "invalid_input",
    "detail": "An entity id and the entity type must be provided to determine an entity",
    "attr": null,
}
```

Not ideal but at least a little more informative.

NOTE: I checked the call sites of `get_target_entity` and it looks like none did anything with `ValueError` specifically
so I don't expect this to cause any side-effects other than changing 500 -> 400 errors and having a little 
more detail in the response body.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
