### PR TITLE
feat: Rollout billing v2

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -132,6 +132,9 @@ class BillingViewset(viewsets.GenericViewSet):
 
     def list(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Response:
         license = License.objects.first_valid()
+        if license and not license.is_v2_license:
+            raise NotFound("Billing V2 is not supported for this license type")
+
         org = self._get_org()
         distinct_id = None if self.request.user.is_anonymous else self.request.user.distinct_id
 

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -226,8 +226,13 @@ class BillingViewset(viewsets.GenericViewSet):
         if redirect_path.startswith("/"):
             redirect_path = redirect_path[1:]
 
+        plan = request.GET.get("plan", "standard")
+
+        if plan == "standard":
+            plan = self._default_plan_for_organization(organization)
+
         redirect_uri = f"{settings.SITE_URL or request.headers.get('Host')}/{redirect_path}"
-        url = f"{BILLING_SERVICE_URL}/activation?redirect_uri={redirect_uri}&organization_name={organization.name}&plan={request.GET.get('plan', self._default_plan_for_organization(organization))}"
+        url = f"{BILLING_SERVICE_URL}/activation?redirect_uri={redirect_uri}&organization_name={organization.name}&plan={plan}"
 
         if license:
             billing_service_token = build_billing_token(license, organization)

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -228,9 +228,6 @@ class BillingViewset(viewsets.GenericViewSet):
 
         plan = request.GET.get("plan", "standard")
 
-        if plan == "standard":
-            plan = self._default_plan_for_organization(organization)
-
         redirect_uri = f"{settings.SITE_URL or request.headers.get('Host')}/{redirect_path}"
         url = f"{BILLING_SERVICE_URL}/activation?redirect_uri={redirect_uri}&organization_name={organization.name}&plan={plan}"
 
@@ -292,7 +289,7 @@ class BillingViewset(viewsets.GenericViewSet):
         if license and organization:
             billing_service_token = build_billing_token(license, organization)
             headers = {"Authorization": f"Bearer {billing_service_token}"}
-            params = {"plan": self._default_plan_for_organization(organization)}
+            params = {"plan": "standard"}
 
         res = requests.get(
             f"{BILLING_SERVICE_URL}/api/products",
@@ -340,12 +337,6 @@ class BillingViewset(viewsets.GenericViewSet):
             license.save()
 
         return license
-
-    def _default_plan_for_organization(self, organization: Organization) -> str:
-        if is_cloud():
-            return "standard" if organization and organization.created_at > BILLING_V2_START_DATE else "earlybird"
-        else:
-            return "standard"
 
     def _update_org_details(self, organization: Organization, data: Dict[str, Any]) -> Organization:
         """

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -342,7 +342,10 @@ class BillingViewset(viewsets.GenericViewSet):
         return license
 
     def _default_plan_for_organization(self, organization: Organization) -> str:
-        return "standard" if organization and organization.created_at > BILLING_V2_START_DATE else "earlybird"
+        if is_cloud():
+            return "standard" if organization and organization.created_at > BILLING_V2_START_DATE else "earlybird"
+        else:
+            return "standard"
 
     def _update_org_details(self, organization: Organization, data: Dict[str, Any]) -> Organization:
         """

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -22,7 +22,6 @@ from rest_framework.response import Response
 from ee.models import License
 from ee.settings import BILLING_SERVICE_URL
 from posthog.auth import PersonalAPIKeyAuthentication
-from posthog.cloud_utils import is_cloud
 from posthog.models import Organization
 from posthog.models.event.util import get_event_count_for_team_and_period
 from posthog.models.organization import OrganizationUsageInfo
@@ -32,7 +31,6 @@ from posthog.models.team.team import Team
 logger = structlog.get_logger(__name__)
 
 BILLING_SERVICE_JWT_AUD = "posthog:license-key"
-BILLING_V2_START_DATE = datetime(2022, 11, 1, tzinfo=timezone.utc)
 
 
 class BillingSerializer(serializers.Serializer):

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -32,6 +32,7 @@ from posthog.models.team.team import Team
 logger = structlog.get_logger(__name__)
 
 BILLING_SERVICE_JWT_AUD = "posthog:license-key"
+BILLING_V2_START_DATE = datetime(2022, 11, 1, tzinfo=timezone.utc)
 
 
 class BillingSerializer(serializers.Serializer):
@@ -281,7 +282,7 @@ class BillingViewset(viewsets.GenericViewSet):
 
     def _get_products(self, license: Optional[License], organization: Optional[Organization]):
         headers = {}
-        params = {}
+        params = {"plan": "standard"}
 
         if license and organization:
             billing_service_token = build_billing_token(license, organization)
@@ -336,11 +337,7 @@ class BillingViewset(viewsets.GenericViewSet):
         return license
 
     def _default_plan_for_organization(self, organization: Organization) -> str:
-        return (
-            "standard"
-            if organization and organization.created_at > datetime(2022, 11, 1, tzinfo=timezone.utc)
-            else "earlybird"
-        )
+        return "standard" if organization and organization.created_at > BILLING_V2_START_DATE else "earlybird"
 
     def _update_org_details(self, organization: Organization, data: Dict[str, Any]) -> Organization:
         """

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -107,6 +107,14 @@ def create_billing_license_response(**kwargs) -> Dict[str, Any]:
 
 
 class TestBillingAPI(APILicensedTest):
+    def test_billing_v2_fails_for_old_license_type(self):
+        self.license.key = "test_key"
+        self.license.save()
+
+        res = self.client.get("/api/billing-v2")
+        assert res.status_code == 404
+        assert res.json()["detail"] == "Billing V2 is not supported for this license type"
+
     @patch("ee.api.billing.requests.get")
     @freeze_time("2022-01-01")
     def test_billing_v2_calls_the_service_with_appropriate_token(self, mock_request):

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -312,6 +312,8 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
         700: 'medium',
     })
 
+    const showFreeAllocationLimit = !billing?.has_active_subscription && product.free_allocation !== null
+
     const billingGaugeItems: BillingGaugeProps['items'] = useMemo(
         () =>
             [
@@ -319,14 +321,14 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                     tooltip: (
                         <>
                             <b>Free tier limit</b>
-                            {!billing?.has_active_subscription ? <div>(Subscribed)</div> : null}
+                            {showFreeAllocationLimit ? <div>(Subscribed)</div> : null}
                         </>
                     ),
                     color: billing?.has_active_subscription ? 'success-light' : 'success-highlight',
                     value: product.tiers?.[0]?.up_to || 0,
                     top: true,
                 },
-                !billing?.has_active_subscription
+                showFreeAllocationLimit
                     ? {
                           tooltip: (
                               <>

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -324,7 +324,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                             {showFreeAllocationLimit ? <div>(Subscribed)</div> : null}
                         </>
                     ),
-                    color: billing?.has_active_subscription ? 'success-light' : 'success-highlight',
+                    color: !showFreeAllocationLimit ? 'success-light' : 'success-highlight',
                     value: product.tiers?.[0]?.up_to || 0,
                     top: true,
                 },

--- a/frontend/src/scenes/billing/v2/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/billingLogic.ts
@@ -11,6 +11,7 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from '@posthog/lemon-ui'
 import { projectUsage } from './billing-utils'
 import posthog from 'posthog-js'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of event usage near limit
 
@@ -43,7 +44,7 @@ export const billingLogic = kea<billingLogicType>([
         reportBillingV2Shown: true,
     }),
     connect({
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [featureFlagLogic, ['featureFlags'], preflightLogic, ['preflight']],
     }),
     reducers({
         showLicenseDirectInput: [
@@ -89,9 +90,9 @@ export const billingLogic = kea<billingLogicType>([
         ],
 
         billingAlert: [
-            (s) => [s.billing],
-            (billing): BillingAlertConfig | undefined => {
-                if (!billing) {
+            (s) => [s.billing, s.preflight],
+            (billing, preflight): BillingAlertConfig | undefined => {
+                if (!billing || !preflight?.cloud) {
                     return
                 }
                 const productOverLimit = billing.products.find((x) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -817,7 +817,7 @@ export interface BillingProductV2Type {
     description: string
     price_description: string
     image_url?: string
-    free_allocation: number
+    free_allocation?: number
     tiers: {
         unit_amount_usd: string
         current_amount_usd?: string | null


### PR DESCRIPTION
## Problem

NOTE: Needs related billing service changes first

We want to move people onto the new billing ASAP but also respect the pricing that was on offer for signups pre Nov 22.

Also it seems the feature flag check wasn't so reliable...

## Changes

* Modified the new billing check to always show for those without v1 billing
* For cloud, chooses the appropriate billing plan based on the organisation signup date.
* Only shows billing limit alerts for cloud

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
