### PR TITLE
feat: Support running individual usage reports

### DIFF
--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -16,13 +16,18 @@ class Command(BaseCommand):
         parser.add_argument(
             "--skip-capture-event", type=str, help="Skip the posthog capture events - for retrying to billing service"
         )
+        parser.add_argument("--organization-id", type=str, help="Only send the report for this organization ID")
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         date = options["date"]
         event_name = options["event_name"]
+        skip_capture_event = options["skip_capture_event"]
+        organization_id = options["organization_id"]
 
-        results = send_all_org_usage_reports(dry_run, date, event_name)
+        results = send_all_org_usage_reports(
+            dry_run, date, event_name, skip_capture_event=skip_capture_event, only_organization_id=organization_id
+        )
 
         if options["print_reports"]:
             print("")  # noqa T201

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -370,6 +370,7 @@ def send_all_org_usage_reports(
     at: Optional[str] = None,
     capture_event_name: Optional[str] = None,
     skip_capture_event: bool = False,
+    only_organization_id: str = None,
 ) -> List[dict]:  # Dict[str, OrgReport]:
     pha_client = Client("sTMFPsFhdP1Ssg")
     capture_event_name = capture_event_name or "organization usage report"
@@ -487,6 +488,11 @@ def send_all_org_usage_reports(
     all_reports = []
 
     for org_report in org_reports.values():
+        org_id = org_report.organization_id
+
+        if only_organization_id and only_organization_id != org_id:
+            continue
+
         full_report = FullUsageReport(
             **dataclasses.asdict(org_report),
             **dataclasses.asdict(instance_metadata),
@@ -496,8 +502,6 @@ def send_all_org_usage_reports(
 
         if dry_run:
             continue
-
-        org_id = org_report.organization_id
 
         # First capture the events to PostHog
         try:

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -370,7 +370,7 @@ def send_all_org_usage_reports(
     at: Optional[str] = None,
     capture_event_name: Optional[str] = None,
     skip_capture_event: bool = False,
-    only_organization_id: str = None,
+    only_organization_id: Optional[str] = None,
 ) -> List[dict]:  # Dict[str, OrgReport]:
     pha_client = Client("sTMFPsFhdP1Ssg")
     capture_event_name = capture_event_name or "organization usage report"


### PR DESCRIPTION
## Problem

For debugging reports it is useful to be able to run for only one organisation

## Changes

* Adds support for this 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
