### PR TITLE
feat: throw DependencyUnavailableError on unexpected connection terminations

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -137,6 +137,7 @@ const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'no more connections allowed',
     'server closed the connection unexpectedly',
     'getaddrinfo EAI_AGAIN',
+    'Connection terminated unexpectedly',
 ]
 
 /** The recommended way of accessing the database. */


### PR DESCRIPTION
This mechanism of using error messages is terrible - as we discussed in https://github.com/PostHog/posthog/pull/12532. 

However, there's no great way of doing so otherwise at the moment. This PR handles this case: https://sentry.io/organizations/posthog/issues/3306272300/?project=6423401&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d

I actually suspect this doesn't get thrown when a query is executing but doesn't hurt to add.