### PR TITLE
chore(NodeJS): use Node.js v18

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,9 +30,8 @@ RUN apt-get update \
     "postgresql-client=13+*" \
     && rm -rf /var/lib/apt/lists/*
 
-# Install node
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="16"
+# Install node via NVM (https://github.com/nvm-sh/nvm)
+ARG NODE_VERSION="18"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 WORKDIR /workspace
@@ -49,4 +48,3 @@ WORKDIR /workspace
 COPY requirements.txt requirements-dev.txt ./
 RUN pip install -r requirements-dev.txt --compile --no-cache-dir && \
     pip install -r requirements.txt --compile --no-cache-dir
-

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -18,10 +18,10 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 16
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: pnpm
 
             - name: Install package.json dependencies with pnpm
@@ -36,8 +36,8 @@ jobs:
             - name: Serve Storybook and run tests
               run: |
                   pnpm dlx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-                    "pnpm dlx http-server storybook-static --port 6006 --silent" \
-                    "pnpm dlx wait-on tcp:6006 && pnpm dlx playwright test"
+                    "pnpm dlx http-server storybook-static --port 6006" \
+                    "pnpm dlx wait-on http://127.0.0.1:6006 --timeout 60 && pnpm dlx playwright test"
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -242,7 +242,7 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 18
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
                   node-version: 18

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -26,10 +26,10 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 16
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: pnpm
 
             - name: Install package.json dependencies with pnpm
@@ -56,11 +56,13 @@ jobs:
               uses: pnpm/action-setup@v2
               with:
                   version: 7.x.x
-            - name: Set up Node 16
+
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: pnpm
+
             - run: pnpm install --frozen-lockfile
             - id: set-test-chunks
               name: Set Chunks
@@ -93,10 +95,10 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 16
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: pnpm
 
             - name: Install package.json dependencies with pnpm

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -54,7 +54,7 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 18
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
                   node-version: 18
@@ -120,7 +120,7 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 18
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
                   node-version: 18
@@ -195,7 +195,7 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 18
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
                   node-version: 18

--- a/.github/workflows/storybook-chromatic-baselines-to-master.yml
+++ b/.github/workflows/storybook-chromatic-baselines-to-master.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 18
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
                   node-version: 18

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -16,10 +16,10 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 16
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: pnpm
 
             # there's no need to run chromatic on every commit,

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -22,10 +22,10 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 16
+            - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 18
                   cache: pnpm
                   cache-dependency-path: posthog/pnpm-lock.yaml
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/posthog/posthog#readme",
     "license": "MIT",
     "engines": {
-        "node": ">=16 <19"
+        "node": ">=18 <19"
     },
     "packageManager": "pnpm@7.14.2",
     "scripts": {
@@ -44,7 +44,7 @@
         "format:js": "pnpm prettier && pnpm eslint --fix",
         "format": "pnpm format:python && pnpm format:js",
         "storybook": "start-storybook -p 6006",
-        "build-storybook": "build-storybook",
+        "build-storybook": "export NODE_OPTIONS=--openssl-legacy-provider; build-storybook",
         "dev:migrate:postgres": "export DEBUG=1 && source env/bin/activate && python manage.py migrate",
         "dev:migrate:clickhouse": "export DEBUG=1 && source env/bin/activate && python manage.py migrate_clickhouse",
         "prepare": "husky install"

--- a/plugin-server/.babelrc
+++ b/plugin-server/.babelrc
@@ -4,7 +4,9 @@
             "@babel/preset-env",
             {
                 "loose": true,
-                "targets": { "node": 16 }
+                "targets": {
+                    "node": 18
+                }
             }
         ],
         "@babel/preset-typescript"


### PR DESCRIPTION
## Problem
We are running mixed versions of Node.js one of which (v16) is end of life since Oct 18th 2022. Let's switch to the next LTS.

## Changes
Use Node.js v18 everywhere (we were missing local dev + CI) instead of a mix between 16 and 18. Related to https://github.com/PostHog/posthog/pull/12520, https://github.com/PostHog/posthog/pull/12635, https://github.com/PostHog/posthog/issues/6570 and https://github.com/PostHog/posthog/issues/10471. Fixes https://github.com/PostHog/posthog/issues/6570.

Related docs PR is available at https://github.com/PostHog/posthog.com/pull/4880

## How did you test this code?
Tested locally + CI