### PR TITLE
fix: bigger billing numbers

### DIFF
--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -107,7 +107,7 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
                                 >
                                     Current bill total
                                 </LemonLabel>
-                                <div className="font-bold text-4xl">${billing.current_total_amount_usd}</div>
+                                <div className="font-bold text-6xl">${billing.current_total_amount_usd}</div>
 
                                 <p>
                                     <b>{billing.billing_period.current_period_end.diff(dayjs(), 'days')} days</b>{' '}


### PR DESCRIPTION
## Problem
Current billing total is visually undifferentiated from the per-product sub-totals

## Changes
- Current billing total is now bigger and better
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/7335343/200373472-5785fbb8-2958-4155-a992-d76b2679e67c.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
No need, visually checked that it looks good
