### PR TITLE
fix: null check on activity for feature flags

### DIFF
--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -225,12 +225,15 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
                 continue // feature flag updates have to have a "field" to be described
             }
 
-            const { description, suffix } = featureFlagActionsMapping[change.field](change, logItem)
-            if (description) {
-                changes = changes.concat(description)
-            }
-            if (suffix) {
-                changeSuffix = suffix
+            const possibleLogItem = featureFlagActionsMapping[change.field](change, logItem)
+            if (possibleLogItem) {
+                const { description, suffix } = possibleLogItem
+                if (description) {
+                    changes = changes.concat(description)
+                }
+                if (suffix) {
+                    changeSuffix = suffix
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

- null value was not handled in the feature flag activity log mapping
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- add a null check

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
