### PR TITLE
fix: add condition to exposures and recordings on feature flags

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -94,6 +94,12 @@ export const defaultPropertyOnFlag = (flagKey: string): AnyPropertyFilter[] => [
         operator: PropertyOperator.IsNot,
     },
     {
+        key: '$feature/' + flagKey,
+        type: 'event',
+        value: 'is_set',
+        operator: PropertyOperator.IsSet,
+    },
+    {
         key: '$feature_flag',
         type: 'event',
         value: flagKey,


### PR DESCRIPTION
## Problem

- the condition to filter for recordings and exposures isn't specific enough
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- add an is_set filter so that recordings and exposures are filtered more

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
