### PR TITLE
fix(plugin-server): shutdown httpserver early

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -102,8 +102,8 @@ export async function startPluginsServer(
         status.info('💤', ' Shutting down gracefully...')
         lastActivityCheck && clearInterval(lastActivityCheck)
 
-        // Stop all consumers and the graphile worker, as well as the http
-        // server. Note that we close the http server before the others to
+        // HACKY: Stop all consumers and the graphile worker, as well as the
+        // http server. Note that we close the http server before the others to
         // ensure that e.g. if something goes wrong and we deadlock, then if
         // we're running in k8s, the liveness check will fail, and thus k8s will
         // kill the pod.

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -107,43 +107,35 @@ export async function startPluginsServer(
         // ensure that e.g. if something goes wrong and we deadlock, then if
         // we're running in k8s, the liveness check will fail, and thus k8s will
         // kill the pod.
-        //
-        // Note also that we give the shutdown process 10 seconds to complete,
-        // otherwise we exit uncleanly.
-        await Promise.race([
-            (async () => {
-                cancelAllScheduledJobs()
-                stopEventLoopMetrics?.()
-                await Promise.allSettled([
-                    queue?.stop(),
-                    pubSub?.stop(),
-                    graphileWorker?.stop(),
-                    bufferConsumer?.disconnect(),
-                    jobsConsumer?.disconnect(),
-                    httpServer?.close(),
-                ])
-
-                await new Promise<void>((resolve, reject) =>
-                    !mmdbServer
-                        ? resolve()
-                        : mmdbServer.close((error) => {
-                              if (error) {
-                                  reject(error)
-                              } else {
-                                  status.info('🛑', 'Closed internal MMDB server!')
-                                  resolve()
-                              }
-                          })
-                )
-
-                if (piscina) {
-                    await stopPiscina(piscina)
-                }
-
-                await closeHub?.()
-            })(),
-            new Promise(() => setTimeout(() => process.exit(1), 10000)),
+        cancelAllScheduledJobs()
+        stopEventLoopMetrics?.()
+        await Promise.allSettled([
+            queue?.stop(),
+            pubSub?.stop(),
+            graphileWorker?.stop(),
+            bufferConsumer?.disconnect(),
+            jobsConsumer?.disconnect(),
+            httpServer?.close(),
         ])
+
+        await new Promise<void>((resolve, reject) =>
+            !mmdbServer
+                ? resolve()
+                : mmdbServer.close((error) => {
+                      if (error) {
+                          reject(error)
+                      } else {
+                          status.info('🛑', 'Closed internal MMDB server!')
+                          resolve()
+                      }
+                  })
+        )
+
+        if (piscina) {
+            await stopPiscina(piscina)
+        }
+
+        await closeHub?.()
 
         status.info('👋', 'Over and out!')
     }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -107,6 +107,9 @@ export async function startPluginsServer(
         // ensure that e.g. if something goes wrong and we deadlock, then if
         // we're running in k8s, the liveness check will fail, and thus k8s will
         // kill the pod.
+        //
+        // I say hacky because we've got a weak dependency on the liveness check
+        // configuration.
         httpServer?.close()
         cancelAllScheduledJobs()
         stopEventLoopMetrics?.()

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -103,10 +103,11 @@ export async function startPluginsServer(
         lastActivityCheck && clearInterval(lastActivityCheck)
 
         // Stop all consumers and the graphile worker, as well as the http
-        // server. Note that we close the http server along with the others to
+        // server. Note that we close the http server before the others to
         // ensure that e.g. if something goes wrong and we deadlock, then if
         // we're running in k8s, the liveness check will fail, and thus k8s will
         // kill the pod.
+        httpServer?.close()
         cancelAllScheduledJobs()
         stopEventLoopMetrics?.()
         await Promise.allSettled([
@@ -115,7 +116,6 @@ export async function startPluginsServer(
             graphileWorker?.stop(),
             bufferConsumer?.disconnect(),
             jobsConsumer?.disconnect(),
-            httpServer?.close(),
         ])
 
         await new Promise<void>((resolve, reject) =>

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -111,7 +111,7 @@ export async function startPluginsServer(
         // Note also that we give the shutdown process 10 seconds to complete,
         // otherwise we exit uncleanly.
         await Promise.race([
-            async () => {
+            (async () => {
                 cancelAllScheduledJobs()
                 stopEventLoopMetrics?.()
                 await Promise.allSettled([
@@ -141,7 +141,7 @@ export async function startPluginsServer(
                 }
 
                 await closeHub?.()
-            },
+            })(),
             new Promise(() => setTimeout(() => process.exit(1), 10000)),
         ])
 

--- a/plugin-server/tests/http-server.test.ts
+++ b/plugin-server/tests/http-server.test.ts
@@ -40,10 +40,13 @@ describe('http server', () => {
                 { http: true }
             )
 
-            http.get(`http://localhost:${HTTP_SERVER_PORT}/_health`, (res) => {
-                const { statusCode } = res
-                expect(statusCode).toEqual(200)
-            })
+            await new Promise((resolve) =>
+                http.get(`http://localhost:${HTTP_SERVER_PORT}/_health`, (res) => {
+                    const { statusCode } = res
+                    expect(statusCode).toEqual(200)
+                    resolve(null)
+                })
+            )
 
             await pluginsServer.stop()
         })
@@ -65,10 +68,13 @@ describe('http server', () => {
                 { http: true, ingestion: true }
             )
 
-            http.get(`http://localhost:${HTTP_SERVER_PORT}/_ready`, (res) => {
-                const { statusCode } = res
-                expect(statusCode).toEqual(200)
-            })
+            await new Promise((resolve) =>
+                http.get(`http://localhost:${HTTP_SERVER_PORT}/_ready`, (res) => {
+                    const { statusCode } = res
+                    expect(statusCode).toEqual(200)
+                    resolve(null)
+                })
+            )
 
             expect(pluginsServer.queue?.consumerReady).toBeTruthy()
             await pluginsServer.stop()


### PR DESCRIPTION
We were having an issue where a Kafka version upgrade caused the
plugin-server to hang on shutdown. This was because the Kafka producer
was not able to flush its messages to Kafka. ~~This commit adds a timeout
to the shutdown process, so that the plugin-server will exit even if
something hangs.~~

This commit orignally had a timeout, but I just went with shutting down the http server.

See https://posthog.slack.com/archives/C046SERP277/p1667878901739969 for
details

I wasn't exactly sure how to make this a little more testable, but there
is clearly a blind spot for certain failure cases.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
