### PR TITLE
chore: wait for page to settle before starting tests

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -36,12 +36,16 @@ beforeEach(() => {
         })
         cy.visit('/?no-preloaded-app-context=true')
     } else {
+        cy.intercept('GET', /\/api\/projects\/\d+\/insights\/?\?/).as('getInsights')
+
         cy.request('POST', '/api/login/', {
             email: 'test@posthog.com',
             password: '12345678',
         })
         cy.visit('/insights')
-        cy.get('.saved-insights').should('exist')
+        cy.wait('@getInsights').then(() => {
+            cy.get('.saved-insights tr').should('exist')
+        })
     }
 })
 


### PR DESCRIPTION
## Problem

the licenses.js e2e test is flapping

## Changes

* All tests start on the saved insights page. Waits for the insights page to finish loading before carrying on

## How did you test this code?

it is tests