### PR TITLE
fix(data-management): utm_ prefixed properties should always be strings

### DIFF
--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -73,6 +73,14 @@ export const detectPropertyDefinitionTypes = (value: unknown, key: string): Prop
         })
     }
 
+    if (/^utm_/i.test(key)) {
+        // utm_ prefixed properties should always be detected as strings.
+        // Sometimes the first value sent looks like a number, event though
+        // subsequent values are not. See
+        // https://github.com/PostHog/posthog/issues/12529 for more context.
+        return PropertyType.String
+    }
+
     if (typeof value === 'number') {
         propertyType = PropertyType.Numeric
 


### PR DESCRIPTION
Sometimes they look like numbers and get misidentified as such. This
makes them always strings.

Parially resolves https://github.com/PostHog/posthog/issues/12529 except
we do not update old property definitions. I'll do this separately.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
