### PR TITLE
fix: show spinner when heatmap isn't loading

### DIFF
--- a/frontend/src/toolbar/stats/HeatmapStats.tsx
+++ b/frontend/src/toolbar/stats/HeatmapStats.tsx
@@ -31,7 +31,7 @@ export function HeatmapStats(): JSX.Element {
                             getPopupContainer={getShadowRootPopupContainer}
                         />
 
-                        {!heatmapLoading ? <Spinner /> : null}
+                        {heatmapLoading ? <Spinner /> : null}
                     </div>
                     <div>
                         Found: {countedElements.length} elements / {clickCount} clicks!


### PR DESCRIPTION
## Problem

logic for whether to show spinner was wrong way around

<img width="226" alt="Screenshot 2022-11-08 at 12 36 15" src="https://user-images.githubusercontent.com/984817/200565375-1f0b4d78-a972-40ae-b881-290618a68a1e.png">

## Changes

not any more

## How did you test this code?

👀
