### PR TITLE
chore: better heatmap logging

### DIFF
--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -107,8 +107,8 @@ export const heatmapLogic = kea<heatmapLogicType>({
                 const allElements = collectAllElementsDeep('*', document)
                 const elements: CountedHTMLElement[] = []
                 events.forEach((event) => {
-                    let combinedSelector
-                    let lastSelector
+                    let combinedSelector: string
+                    let lastSelector: string | undefined
                     for (let i = 0; i < event.elements.length; i++) {
                         const selector = elementToSelector(event.elements[i], dataAttributes) || '*'
                         combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
@@ -147,7 +147,7 @@ export const heatmapLogic = kea<heatmapLogicType>({
 
                             if (domElements.length === 0) {
                                 if (i === event.elements.length - 1) {
-                                    console.error('Found a case with 0 elements')
+                                    console.error('Found a case with 0 elements using: ', combinedSelector)
                                     return null
                                 } else if (i > 0 && lastSelector) {
                                     // We already have something, but found nothing when adding the next selector.

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -147,7 +147,12 @@ export const heatmapLogic = kea<heatmapLogicType>({
 
                             if (domElements.length === 0) {
                                 if (i === event.elements.length - 1) {
-                                    console.error('Found a case with 0 elements using: ', combinedSelector)
+                                    console.error(
+                                        'For event: ',
+                                        event,
+                                        '. Found a case with 0 elements using: ',
+                                        combinedSelector
+                                    )
                                     return null
                                 } else if (i > 0 && lastSelector) {
                                     // We already have something, but found nothing when adding the next selector.


### PR DESCRIPTION
## Problem

In this slack thread https://posthog.slack.com/archives/C043ZNMAHQX/p1666348200664229 a customer reports they have elements that are unexpectedly not matching in the toolbar heatmap overlay

The page in question has `Found a case with 0 elements` logged multiple times. But that gives no actionable information

## Changes

adds more logging to that error case

## How did you test this code?

I didn't 🙈 
