### PR TITLE
fix(trends): Show appropriate nested math value immediately

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -414,18 +414,29 @@ interface MathSelectorProps {
     style?: React.CSSProperties
 }
 
-function useMathSelectorOptions(
-    index: number,
-    mathAvailability: MathAvailability,
-    onMathSelect: (index: number, value: any) => any
-): LemonSelectOptions<string> {
+function isPropertyValueMath(math: string | undefined): math is PropertyMathType {
+    return !!math && math in PROPERTY_MATH_DEFINITIONS
+}
+
+function isCountPerActorMath(math: string | undefined): math is CountPerActorMathType {
+    return !!math && math in COUNT_PER_ACTOR_MATH_DEFINITIONS
+}
+
+function useMathSelectorOptions({
+    math,
+    index,
+    mathAvailability,
+    onMathSelect,
+}: MathSelectorProps): LemonSelectOptions<string> {
     const { needsUpgradeForGroups, canStartUsingGroups, staticMathDefinitions, staticActorsOnlyMathDefinitions } =
         useValues(mathsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const [propertyMathTypeShown, setPropertyMathTypeShown] = useState<PropertyMathType>(PropertyMathType.Average)
+    const [propertyMathTypeShown, setPropertyMathTypeShown] = useState<PropertyMathType>(
+        isPropertyValueMath(math) ? math : PropertyMathType.Average
+    )
     const [countPerActorMathTypeShown, setCountPerActorMathTypeShown] = useState<CountPerActorMathType>(
-        CountPerActorMathType.Average
+        isCountPerActorMath(math) ? math : CountPerActorMathType.Average
     )
 
     const options: LemonSelectOption<string>[] = Object.entries(
@@ -508,14 +519,9 @@ function useMathSelectorOptions(
     ]
 }
 
-function MathSelector({
-    math,
-    mathGroupTypeIndex,
-    mathAvailability,
-    index,
-    onMathSelect,
-}: MathSelectorProps): JSX.Element {
-    const options = useMathSelectorOptions(index, mathAvailability, onMathSelect)
+function MathSelector(props: MathSelectorProps): JSX.Element {
+    const options = useMathSelectorOptions(props)
+    const { math, mathGroupTypeIndex, index, onMathSelect } = props
 
     const mathType = apiValueToMathType(math, mathGroupTypeIndex)
 


### PR DESCRIPTION
## Changes

Quick fix for this:
<img width="717" alt="Screenshot 2022-11-08 at 15 03 16" src="https://user-images.githubusercontent.com/4550621/200584997-717bd738-ab8d-4f0b-b212-54859bf7f17d.png">

This selector is likely to change with https://github.com/PostHog/posthog/pull/12444 (and count per group), so not adding a test for this.