### PR TITLE
chore: allow elements limit to be set from URL

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -1,5 +1,6 @@
 from rest_framework import authentication, request, response, serializers, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 
 from posthog.api.routing import StructuredViewSetMixin
@@ -53,7 +54,10 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         date_to, date_to_params = query_date_range.date_to
         date_params.update(date_from_params)
         date_params.update(date_to_params)
-        limit = request.GET.get("limit", 100)
+        try:
+            limit = int(request.GET.get("limit", 100))
+        except ValueError:
+            raise ValidationError("Limit must be an integer")
 
         prop_filters, prop_filter_params = parse_prop_grouped_clauses(
             team_id=self.team.pk, property_group=filter.property_groups

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -53,13 +53,19 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         date_to, date_to_params = query_date_range.date_to
         date_params.update(date_from_params)
         date_params.update(date_to_params)
+        limit = request.GET.get("limit", 100)
 
         prop_filters, prop_filter_params = parse_prop_grouped_clauses(
             team_id=self.team.pk, property_group=filter.property_groups
         )
         result = sync_execute(
-            GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters),
-            {"team_id": self.team.pk, "timezone": self.team.timezone, **prop_filter_params, **date_params},
+            GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters, limit=limit),
+            {
+                "team_id": self.team.pk,
+                "timezone": self.team.timezone,
+                **prop_filter_params,
+                **date_params,
+            },
         )
         return response.Response(
             [

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -11,7 +11,7 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _
 
 
 class TestElement(ClickhouseTestMixin, APIBaseTest):
-    def test_element_automatic_order(self):
+    def test_element_automatic_order(self) -> None:
         elements = [
             Element(tag_name="a", href="https://posthog.com/about", text="click here"),
             Element(tag_name="span"),
@@ -23,7 +23,7 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(elements[1].order, 1)
         self.assertEqual(elements[2].order, 2)
 
-    def test_event_property_values(self):
+    def test_event_property_values(self) -> None:
         _create_event(
             team=self.team,
             distinct_id="test",
@@ -41,7 +41,7 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response[0]["name"], "click here")
         self.assertEqual(len(response), 1)
 
-    def test_element_stats(self):
+    def test_element_stats(self) -> None:
         elements = [
             Element(tag_name="a", href="https://posthog.com/about", text="click here", order=0),
             Element(tag_name="div", href="https://posthog.com/about", text="click here", order=1),
@@ -81,8 +81,8 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
             elements=[Element(tag_name="img")],
         )
 
-        with self.assertNumQueries(6):
-            # Django session, PostHog user, PostHog team, PostHog org membership
+        with self.assertNumQueries(7):
+            # Django session, PostHog user, ee license, PostHog team, PostHog org membership
             # then 2 for inserting person in test setup
             response = self.client.get("/api/element/stats/").json()
         self.assertEqual(response[0]["count"], 2)
@@ -95,7 +95,7 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
         ).json()
         self.assertEqual(len(response), 1)
 
-    def test_element_stats_clamps_date_from_to_start_of_day(self):
+    def test_element_stats_clamps_date_from_to_start_of_day(self) -> None:
         event_start = "2012-01-14T03:21:34.000Z"
         query_time = "2012-01-14T08:21:34.000Z"
 
@@ -133,3 +133,42 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
             response_json = response.json()
             self.assertEqual(response_json[0]["count"], 2)
             self.assertEqual(response_json[0]["elements"][0]["tag_name"], "a")
+
+    def test_element_stats_obeys_limit_parameter(self) -> None:
+        _create_event(
+            team=self.team,
+            elements=[
+                Element(tag_name="a", href="https://posthog.com/event-1", text="event 1", order=0),
+                Element(tag_name="div", href="https://posthog.com/event-1", text="event 1", order=1),
+            ],
+            event="$autocapture",
+            distinct_id="test",
+            properties={"$current_url": "http://example.com/demo"},
+        )
+
+        _create_event(
+            team=self.team,
+            elements=[
+                Element(tag_name="a", href="https://posthog.com/event-2", text="event 2", order=0),
+                Element(tag_name="div", href="https://posthog.com/event-2", text="event 2", order=1),
+            ],
+            event="$autocapture",
+            distinct_id="test",
+            properties={"$current_url": "http://example.com/demo"},
+        )
+
+        response = self.client.get(f"/api/element/stats/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_json = response.json()
+        assert len(response_json) == 2  # there are 2 events
+        assert [e["count"] for e in response_json] == [1, 1]  # each of 1 click
+        assert [len(e["elements"]) for e in response_json] == [2, 2]  # each click has a chain of 2 selectors
+
+        response = self.client.get(f"/api/element/stats/?limit=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_json = response.json()
+        assert len(response_json) == 1  # there is now 1 events
+        assert [e["count"] for e in response_json] == [1]  # of 1 click
+        assert [len(e["elements"]) for e in response_json] == [2]  # with a chain of 2 selectors

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -81,8 +81,8 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
             elements=[Element(tag_name="img")],
         )
 
-        with self.assertNumQueries(7):
-            # Django session, PostHog user, ee license, PostHog team, PostHog org membership
+        with self.assertNumQueries(6):
+            # Django session, PostHog user, PostHog team, PostHog org membership
             # then 2 for inserting person in test setup
             response = self.client.get("/api/element/stats/").json()
         self.assertEqual(response[0]["count"], 2)

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -172,3 +172,7 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
         assert len(response_json) == 1  # there is now 1 events
         assert [e["count"] for e in response_json] == [1]  # of 1 click
         assert [len(e["elements"]) for e in response_json] == [2]  # with a chain of 2 selectors
+
+    def test_element_stats_does_not_allow_non_numeric_limit(self) -> None:
+        response = self.client.get(f"/api/element/stats/?limit=not-a-number")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/posthog/models/element/sql.py
+++ b/posthog/models/element/sql.py
@@ -11,7 +11,7 @@ WHERE
     {query}
 GROUP BY elements_chain
 ORDER BY count DESC
-LIMIT 100;
+LIMIT {limit};
 """
 
 GET_VALUES = """


### PR DESCRIPTION
## Problem

When debugging why the heatmap doesn't show expected events I find myself wanting to manually grab more than the default limit of 100 results

## Changes

Adds a limit parameter to the end point

## How did you test this code?

added a developer test