### PR TITLE
style(flake8): enable C403

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,7 +18,6 @@ ignore=
     B024, # ClickhouseFunnelBase is an abstract base class, but it has no abstract methods. Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
     C400, # Unnecessary generator - rewrite as a list comprehension
     C401, # Unnecessary generator - rewrite as a set comprehension.
-    C403, # Unnecessary list comprehension - rewrite as a set comprehension.
     C405, # Unnecessary list literal - rewrite as a set literal.
     C407, # Unnecessary list comprehension - 'any' can take a generator.
     C408, # Unnecessary dict call - rewrite as a literal.

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -29,7 +29,7 @@ class EnterpriseColumnOptimizer(FOSSColumnOptimizer):
             columns_to_query = columns_to_query.union(
                 self.columns_to_query(
                     "events",
-                    set([property for property in used_properties if property[2] == group_type_index]),
+                    {property for property in used_properties if property[2] == group_type_index},
                     f"group{group_type_index}_properties",
                 )
             )

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -323,7 +323,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p2.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p2.uuid]), {r[0] for r in res})
 
     def test_can_handle_many_performed_multiple_filters(self):
         p1 = _create_person(
@@ -400,7 +400,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p1.uuid, p2.uuid, p3.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p1.uuid, p2.uuid, p3.uuid]), {r[0] for r in res})
 
     def test_performed_event_zero_times_(self):
         filter = Filter(
@@ -764,7 +764,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
-        self.assertEqual(set([p1.uuid, p2.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p1.uuid, p2.uuid]), {r[0] for r in res})
 
     @snapshot_clickhouse_queries
     def test_person_props_only(self):
@@ -2218,7 +2218,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p1.uuid, p2.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p1.uuid, p2.uuid]), {r[0] for r in res})
 
     @snapshot_clickhouse_queries
     def test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts(self):

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -704,7 +704,7 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
 def _get_secret_fields_for_plugin(plugin: Plugin) -> Set[str]:
     # A set of keys for config fields that have secret = true
-    secret_fields = set([field["key"] for field in plugin.config_schema if "secret" in field and field["secret"]])
+    secret_fields = {field["key"] for field in plugin.config_schema if "secret" in field and field["secret"]}
     return secret_fields
 
 

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -31,7 +31,7 @@ class TaggedItemSerializerMixin(serializers.Serializer):
             return
 
         # Normalize and dedupe tags
-        deduped_tags = list(set([tagify(t) for t in tags]))
+        deduped_tags = list({tagify(t) for t in tags})
         tagged_item_objects = []
 
         # Create tags

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -192,7 +192,7 @@ def subscription_saved(sender, instance, created, raw, using, **kwargs):
 
 
 def to_rrule_weekdays(weekday: Subscription.SubscriptionByWeekDay):
-    return set([RRULE_WEEKDAY_MAP.get(x) for x in weekday])
+    return {RRULE_WEEKDAY_MAP.get(x) for x in weekday}
 
 
 def get_unsubscribe_token(subscription: Subscription, email: str) -> str:

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -113,7 +113,7 @@ class ActorBaseQuery:
         """
         params = {"team_id": self._team.pk, "session_ids": list(session_ids)}
         raw_result = sync_execute(query, params)
-        return set([row[0] for row in raw_result])
+        return {row[0] for row in raw_result}
 
     def add_matched_recordings_to_serialized_actors(
         self, serialized_actors: Union[List[SerializedGroup], List[SerializedPerson]], raw_result

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -161,7 +161,7 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
             send_first_ingestion_reminder_emails()
             self.assertEqual(MessagingRecord.objects.all().count(), 2)
             self.assertEqual(
-                set([record[0] for record in MessagingRecord.objects.all().values_list("email_hash")]),
+                {record[0] for record in MessagingRecord.objects.all().values_list("email_hash")},
                 set(
                     [get_email_hash("in_range_user_not_admin@posthog.com"), get_email_hash("in_range_user@posthog.com")]
                 ),
@@ -187,7 +187,7 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
             send_second_ingestion_reminder_emails()
             self.assertEqual(MessagingRecord.objects.all().count(), 2)
             self.assertEqual(
-                set([record[0] for record in MessagingRecord.objects.all().values_list("email_hash")]),
+                {record[0] for record in MessagingRecord.objects.all().values_list("email_hash")},
                 set(
                     [get_email_hash("in_range_user_not_admin@posthog.com"), get_email_hash("in_range_user@posthog.com")]
                 ),

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1372,7 +1372,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             )
             res = cursor.fetchall()
             self.assertEqual(len(res), 2)
-            self.assertEqual(set([var[0] for var in res]), set(["other_id"]))
+            self.assertEqual({var[0] for var in res}, set(["other_id"]))
 
     def test_retrieving_hash_key_overrides(self):
 
@@ -1412,7 +1412,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             )
             res = cursor.fetchall()
             self.assertEqual(len(res), 3)
-            self.assertEqual(set([var[0] for var in res]), set([hash_key]))
+            self.assertEqual({var[0] for var in res}, set([hash_key]))
 
     def test_entire_flow_with_hash_key_override(self):
         # get feature flags for 'other_id', with an override for 'example_id'

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -409,7 +409,7 @@ def get_frontend_apps(team_id: int) -> Dict[int, Dict[str, Any]]:
     for p in plugin_configs:
         config = p["pluginconfig__config"] or {}
         config_schema = p["config_schema"] or {}
-        secret_fields = set([field["key"] for field in config_schema if "secret" in field and field["secret"]])
+        secret_fields = {field["key"] for field in config_schema if "secret" in field and field["secret"]}
         for key in secret_fields:
             if key in config:
                 config[key] = "** SECRET FIELD **"


### PR DESCRIPTION
## Problem

> C403-404: Unnecessary list comprehension - rewrite as a <set/dict> comprehension.
> It’s unnecessary to use a list comprehension inside a call to set or dict, since there are equivalent comprehensions for these types.
> 

## Changes
Fix all occurrences and enable lint rule

## How did you test this code?
Tested locally + CI