### PR TITLE
feat(jobs): add metric to count job enqueue attempts

### DIFF
--- a/plugin-server/src/worker/vm/extensions/jobs.ts
+++ b/plugin-server/src/worker/vm/extensions/jobs.ts
@@ -47,6 +47,7 @@ export function createJobs(server: Hub, pluginConfig: PluginConfig): Jobs {
                 pluginConfigId: pluginConfig.id,
                 pluginConfigTeam: pluginConfig.team_id,
             }
+            server.statsd?.increment('job_enqueue_attempt')
             await server.enqueuePluginJob(job)
         } catch (e) {
             await pluginConfig.vm?.createLogEntry(


### PR DESCRIPTION
We have committed to processing 99.999% of jobs. In order to calculate how we're doing on that regard, we need to have a tally on how many jobs we tried to even enqueue anywhere in the first place