### PR TITLE
fix: onboarding v2 as experiment

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -131,7 +131,7 @@ export const FEATURE_FLAGS = {
     AUTO_ROLLBACK_FEATURE_FLAGS: 'auto-rollback-feature-flags', // owner: @EDsCODE
     WEBSITE_ANALYTICS_TEMPLATE: 'website-analytics-template', // owner: @pauldambra
     RECORDING_PLAYLISTS: 'recording-playlists', // owner: #team-recordings
-    ONBOARDING_V2: 'onboarding-v2', // owner: #team-growth
+    ONBOARDING_V2_EXPERIMENT: 'onboarding-v2-experiment', // owner: #team-growth
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/scenes/feature-flags/FeatureFlagAutoRollout.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagAutoRollout.tsx
@@ -39,6 +39,7 @@ export function FeatureFlagAutoRollback({ readOnly }: FeatureFlagAutoRollbackPro
                 )}
             </div>
             {readOnly &&
+                featureFlag.rollback_conditions &&
                 featureFlag.rollback_conditions.map((rollback_condition, index) => (
                     <>
                         {index > 0 && <div className="condition-set-separator">OR</div>}
@@ -75,6 +76,7 @@ export function FeatureFlagAutoRollback({ readOnly }: FeatureFlagAutoRollbackPro
                     </>
                 ))}
             {!readOnly &&
+                featureFlag.rollback_conditions &&
                 featureFlag.rollback_conditions.map((_, index) => (
                     <>
                         {index > 0 && <div className="condition-set-separator">OR</div>}

--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -12,7 +12,7 @@ export const scene: SceneExport = {
 export function IngestionWizard(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
-    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2]) {
+    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2] === 'test') {
         return <IngestionWizardV2 />
     }
 

--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -12,7 +12,7 @@ export const scene: SceneExport = {
 export function IngestionWizard(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
-    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2] === 'test') {
+    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2_EXPERIMENT] === 'test') {
         return <IngestionWizardV2 />
     }
 


### PR DESCRIPTION
## Problem
We want to run onboarding 2.0 as an experiment

## Changes
- Renamed the feature flag and fixed the check
- Added a small fix to the feature flags page which would break in local dev

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Tested the flag locally
