### PR TITLE
fix(trends): Ignore NaNs in formula results, with Sentry reporting

### DIFF
--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -72,7 +72,9 @@ class TrendsFormula:
             additional_values: Dict[str, Any] = {"label": self._label(filter, item)}
             if is_aggregate:
                 additional_values["data"] = []
-                additional_values["aggregated_value"] = item[1][0]
+                additional_values["aggregated_value"] = (
+                    0.0 if math.isnan(item[1][0]) and not math.isinf(item[1][0]) else item[1][0]
+                )
             else:
                 additional_values["data"] = [
                     round(number, 2) if not math.isnan(number) and not math.isinf(number) else 0.0 for number in item[1]


### PR DESCRIPTION
## Problem

See this internal slack thread https://posthog.slack.com/archives/C045L1VEG87/p1667267842286539

and this sentry error: https://sentry.io/organizations/posthog/issues/3141575499/?project=1899813&query=is%3Aunresolved&referrer=issue-stream

This error `Out of range float values are not JSON compliant` always seems to be associated with `aggregated_value: nan` in a formula response

_Really_ we should fix whatever is causing the NaN. But when this error throws it blocks access to an entire dashboard.

In the meantime lets not explode when there is a NaN

## How did you test this code?

I didn't 🙈 
