### PR TITLE
fix: broken link in new action page

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -291,7 +291,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                         />
                                         <small>
                                             <a
-                                                href="https://posthog.com/docs/integrations/message-formatting/"
+                                                href="https://posthog.com/docs/integrate/webhooks/message-formatting"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                             >


### PR DESCRIPTION
## Problem
Broken link in the action creation panel

## Changes
- Adds correct link

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
No need
