### PR TITLE
feat: 404 from a dashboard should be space hog time

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -142,7 +142,8 @@ export const dashboardLogic = kea<dashboardLogicType>({
                         return dashboard
                     } catch (error: any) {
                         if (error.status === 404) {
-                            return null
+                            lemonToast.error('Dashboard not found')
+                            throw new Error('Dashboard not found')
                         }
                         throw error
                     }


### PR DESCRIPTION
## Problem

If a dashboard did not exist or is in a team you don't have access to we return a 404. But didn't handle it well in the front end.

## Changes

Throw an error and tell the user what is going on

![dashboard-404](https://user-images.githubusercontent.com/984817/200864419-4a65dc7c-ff0a-4ea3-9f12-cfab2fccdc39.gif)

## How did you test this code?

🧐