### PR TITLE
style(flake8): enable C405

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,7 +18,6 @@ ignore=
     B024, # ClickhouseFunnelBase is an abstract base class, but it has no abstract methods. Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
     C400, # Unnecessary generator - rewrite as a list comprehension
     C401, # Unnecessary generator - rewrite as a set comprehension.
-    C405, # Unnecessary list literal - rewrite as a set literal.
     C407, # Unnecessary list comprehension - 'any' can take a generator.
     C408, # Unnecessary dict call - rewrite as a literal.
     C413, # Unnecessary list call around sorted()

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -323,7 +323,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p2.uuid]), {r[0] for r in res})
+        self.assertEqual({p2.uuid}, {r[0] for r in res})
 
     def test_can_handle_many_performed_multiple_filters(self):
         p1 = _create_person(
@@ -400,7 +400,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p1.uuid, p2.uuid, p3.uuid]), {r[0] for r in res})
+        self.assertEqual({p1.uuid, p2.uuid, p3.uuid}, {r[0] for r in res})
 
     def test_performed_event_zero_times_(self):
         filter = Filter(
@@ -764,7 +764,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
-        self.assertEqual(set([p1.uuid, p2.uuid]), {r[0] for r in res})
+        self.assertEqual({p1.uuid, p2.uuid}, {r[0] for r in res})
 
     @snapshot_clickhouse_queries
     def test_person_props_only(self):
@@ -2218,7 +2218,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p1.uuid, p2.uuid]), {r[0] for r in res})
+        self.assertEqual({p1.uuid, p2.uuid}, {r[0] for r in res})
 
     @snapshot_clickhouse_queries
     def test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts(self):

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -117,9 +117,16 @@ class ExperimentSerializer(serializers.ModelSerializer):
         has_start_date = validated_data.get("start_date") is not None
         feature_flag = instance.feature_flag
 
-        expected_keys = set(
-            ["name", "description", "start_date", "end_date", "filters", "parameters", "archived", "secondary_metrics"]
-        )
+        expected_keys = {
+            "name",
+            "description",
+            "start_date",
+            "end_date",
+            "filters",
+            "parameters",
+            "archived",
+            "secondary_metrics",
+        }
         given_keys = set(validated_data.keys())
         extra_keys = given_keys - expected_keys
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -232,7 +232,7 @@ class LegacyCohortViewSet(CohortViewSet):
 def will_create_loops(cohort: Cohort) -> bool:
     # Loops can only be formed when trying to update a Cohort, not when creating one
     team_id = cohort.team_id
-    cohorts_seen = set([cohort.pk])
+    cohorts_seen = {cohort.pk}
     cohorts_queue = [property.value for property in cohort.properties.flat if property.type == "cohort"]
     while cohorts_queue:
         current_cohort_id = cohorts_queue.pop()

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -170,7 +170,7 @@ class TestPasswordResetAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content.decode(), "")
 
-        self.assertSetEqual({",".join(outmail.to) for outmail in mail.outbox}, set([self.CONFIG_EMAIL]))
+        self.assertSetEqual({",".join(outmail.to) for outmail in mail.outbox}, {self.CONFIG_EMAIL})
 
         self.assertEqual(mail.outbox[0].subject, "Reset your PostHog password")
         self.assertEqual(mail.outbox[0].body, "")  # no plain-text version support yet
@@ -211,7 +211,7 @@ class TestPasswordResetAPI(APIBaseTest):
             response = self.client.post("/api/reset/", {"email": self.CONFIG_EMAIL})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        self.assertSetEqual({",".join(outmail.to) for outmail in mail.outbox}, set([self.CONFIG_EMAIL]))
+        self.assertSetEqual({",".join(outmail.to) for outmail in mail.outbox}, {self.CONFIG_EMAIL})
 
         html_message = mail.outbox[0].alternatives[0][0]  # type: ignore
         self.validate_basic_html(

--- a/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
+++ b/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
@@ -67,7 +67,7 @@ def materialize_session_and_window_id(database):
         # expected mat_{property_name}. However, that would only happen if the customer manually
         # materialized the column or renamed the column, and then ran the 0004_...  async migration
         # before this migration runs.
-        possible_old_column_names = set(["mat_" + property_name])
+        possible_old_column_names = {"mat_" + property_name}
         current_materialized_column_name = materialized_columns.get(property_name, None)
         if current_materialized_column_name != property_name:
             possible_old_column_names.add(current_materialized_column_name)

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -162,9 +162,7 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
             self.assertEqual(MessagingRecord.objects.all().count(), 2)
             self.assertEqual(
                 {record[0] for record in MessagingRecord.objects.all().values_list("email_hash")},
-                set(
-                    [get_email_hash("in_range_user_not_admin@posthog.com"), get_email_hash("in_range_user@posthog.com")]
-                ),
+                {get_email_hash("in_range_user_not_admin@posthog.com"), get_email_hash("in_range_user@posthog.com")},
             )
 
             send_first_ingestion_reminder_emails()
@@ -188,9 +186,7 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
             self.assertEqual(MessagingRecord.objects.all().count(), 2)
             self.assertEqual(
                 {record[0] for record in MessagingRecord.objects.all().values_list("email_hash")},
-                set(
-                    [get_email_hash("in_range_user_not_admin@posthog.com"), get_email_hash("in_range_user@posthog.com")]
-                ),
+                {get_email_hash("in_range_user_not_admin@posthog.com"), get_email_hash("in_range_user@posthog.com")},
             )
 
             send_second_ingestion_reminder_emails()

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1372,7 +1372,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             )
             res = cursor.fetchall()
             self.assertEqual(len(res), 2)
-            self.assertEqual({var[0] for var in res}, set(["other_id"]))
+            self.assertEqual({var[0] for var in res}, {"other_id"})
 
     def test_retrieving_hash_key_overrides(self):
 
@@ -1412,7 +1412,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             )
             res = cursor.fetchall()
             self.assertEqual(len(res), 3)
-            self.assertEqual({var[0] for var in res}, set([hash_key]))
+            self.assertEqual({var[0] for var in res}, {hash_key})
 
     def test_entire_flow_with_hash_key_override(self):
         # get feature flags for 'other_id', with an override for 'example_id'

--- a/posthog/test/test_migration_0259.py
+++ b/posthog/test/test_migration_0259.py
@@ -60,26 +60,24 @@ class RecordingDomainMigrationTestCase(TestMigrations):
         # CASE 2:
         self.assertEqual(
             set(Team.objects.get(name="t2").recording_domains),
-            set(
-                [
-                    "https://example.com",
-                    "https://www.example2.com",
-                    "http://localhost:8000",
-                    "http://localhost:9000",
-                ]
-            ),
+            {
+                "https://example.com",
+                "https://www.example2.com",
+                "http://localhost:8000",
+                "http://localhost:9000",
+            },
         )
 
         # CASE 3:
         self.assertEqual(
             set(Team.objects.get(name="t3").recording_domains),
-            set(["https://*.example.com", "https://*.app.example.com"]),
+            {"https://*.example.com", "https://*.app.example.com"},
         )
 
         # CASE 4:
         self.assertEqual(
             set(Team.objects.get(name="t4").recording_domains),
-            set(["https://test.example.com"]),
+            {"https://test.example.com"},
         )
 
     def tearDown(self):


### PR DESCRIPTION
## Problem
> C405-406: Unnecessary <list/tuple> literal - rewrite as a <set/dict> literal.
It’s unnecessary to use a list or tuple literal within a call to set or dict. For example:

## Changes

Fix occurrences & enable lint rule

## How did you test this code?
CI is ✅ 