### PR TITLE
fix: Don't show 404 error toast on 404 pages

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -142,7 +142,6 @@ export const dashboardLogic = kea<dashboardLogicType>({
                         return dashboard
                     } catch (error: any) {
                         if (error.status === 404) {
-                            lemonToast.error('Dashboard not found')
                             throw new Error('Dashboard not found')
                         }
                         throw error

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -171,7 +171,6 @@ export const insightLogic = kea<insightLogicType>([
                     if (response?.results?.[0]) {
                         return response.results[0]
                     }
-                    lemonToast.error(`Insight "${shortId}" not found`)
                     throw new Error(`Insight "${shortId}" not found`)
                 },
                 updateInsight: async ({ insight, callback }, breakpoint) => {


### PR DESCRIPTION
## Changes

Resolves this point: https://github.com/PostHog/posthog/pull/12704#discussion_r1018098251.
Toasts aren't right for relaying the 404 error message – we've got the whole page for that.