### PR TITLE
fix(cohort): ensure cohorts based on latest person version

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -13,8 +13,13 @@
      WHERE team_id = 2
        AND id IN
          (SELECT id
-          FROM person
-          WHERE team_id = 2
+          FROM
+            (SELECT *
+             FROM person
+             WHERE team_id = 2
+             ORDER BY version DESC
+             LIMIT 1 BY id) AS person
+          WHERE True
             AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))
                   AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$another_prop'), '^"|"$', '')))))) )
      GROUP BY id

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -18,7 +18,7 @@
              FROM person
              WHERE team_id = 2
              ORDER BY version DESC
-             LIMIT 1 BY id) AS person
+             LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
           WHERE True
             AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))
                   AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$another_prop'), '^"|"$', '')))))) )

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -268,8 +268,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -362,8 +367,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -456,8 +466,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -550,8 +565,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -742,8 +762,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Positive'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -836,8 +861,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Positive'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -930,8 +960,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Negative'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -1024,8 +1059,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['Negative'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -478,8 +478,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -623,8 +628,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
@@ -766,8 +776,13 @@
                           WHERE team_id = 2
                             AND id IN
                               (SELECT id
-                               FROM person
-                               WHERE team_id = 2
+                               FROM
+                                 (SELECT *
+                                  FROM person
+                                  WHERE team_id = 2
+                                  ORDER BY version DESC
+                                  LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                               WHERE True
                                  AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -335,8 +335,13 @@
      WHERE team_id = 2
        AND id IN
          (SELECT id
-          FROM person
-          WHERE team_id = 2
+          FROM
+            (SELECT *
+             FROM person
+             WHERE team_id = 2
+             ORDER BY version DESC
+             LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+          WHERE True
             AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -138,8 +138,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND ((replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '') ILIKE '%test%')) )
         GROUP BY id
         HAVING max(is_deleted) = 0

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -34,8 +34,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
@@ -110,8 +115,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
@@ -152,8 +162,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
@@ -352,8 +367,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
@@ -474,8 +494,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
@@ -495,8 +520,13 @@
   WHERE team_id = 2
     AND id IN
       (SELECT id
-       FROM person
-       WHERE team_id = 2
+       FROM
+         (SELECT *
+          FROM person
+          WHERE team_id = 2
+          ORDER BY version DESC
+          LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+       WHERE True
          AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))
                OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))
               OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
@@ -562,8 +592,13 @@
   WHERE team_id = 2
     AND id IN
       (SELECT id
-       FROM person
-       WHERE team_id = 2
+       FROM
+         (SELECT *
+          FROM person
+          WHERE team_id = 2
+          ORDER BY version DESC
+          LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+       WHERE True
          AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))
               OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
   GROUP BY id

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -49,8 +49,13 @@
      WHERE team_id = 2
        AND id IN
          (SELECT id
-          FROM person
-          WHERE team_id = 2
+          FROM
+            (SELECT *
+             FROM person
+             WHERE team_id = 2
+             ORDER BY version DESC
+             LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+          WHERE True
             AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
@@ -101,8 +106,13 @@
             WHERE team_id = 2
               AND id IN
                 (SELECT id
-                 FROM person
-                 WHERE team_id = 2
+                 FROM
+                   (SELECT *
+                    FROM person
+                    WHERE team_id = 2
+                    ORDER BY version DESC
+                    LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                 WHERE True
                    AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
@@ -176,8 +186,13 @@
             WHERE team_id = 2
               AND id IN
                 (SELECT id
-                 FROM person
-                 WHERE team_id = 2
+                 FROM
+                   (SELECT *
+                    FROM person
+                    WHERE team_id = 2
+                    ORDER BY version DESC
+                    LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                 WHERE True
                    AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
@@ -302,8 +317,13 @@
      WHERE team_id = 2
        AND id IN
          (SELECT id
-          FROM person
-          WHERE team_id = 2
+          FROM
+            (SELECT *
+             FROM person
+             WHERE team_id = 2
+             ORDER BY version DESC
+             LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+          WHERE True
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -20,10 +20,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND (   person."pmat_email" ILIKE %(v_0)s)
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -40,10 +51,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -60,10 +82,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_2)s), '^"|"$', '')))
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_2)s), '^"|"$', '')))
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -95,10 +128,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND (   person."pmat_email" ILIKE %(v_0)s)
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -115,10 +159,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -135,10 +190,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -155,10 +221,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND (   person."pmat_email" ILIKE %(v_0)s)
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -175,10 +252,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND (   person."pmat_email" ILIKE %(v_0)s)
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -195,10 +283,21 @@
               FROM person
               WHERE team_id = %(team_id)s
               AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
+                  SELECT id FROM (
+                      SELECT *
+                      FROM person
+                      
+                      WHERE team_id = %(team_id)s
+                      ORDER BY version DESC
+                      LIMIT 1 BY id
+                      -- NOTE: by default asterisk doesn't include materialized
+                      -- columns. I don't know how optimised this is e.g. if the
+                      -- stream returned by this subquery will include literally
+                      -- everything of if it will be optimised to only include
+                      -- those columns that are actually used in the outer query.
+                      SETTINGS asterisk_include_materialized_columns=1
+                  ) AS person
+                  WHERE True AND (   person."pmat_email" ILIKE %(v_0)s)
               )
               GROUP BY id
               HAVING max(is_deleted) = 0

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -224,8 +224,13 @@
            WHERE team_id = 2
              AND id IN
                (SELECT id
-                FROM person
-                WHERE team_id = 2
+                FROM
+                  (SELECT *
+                   FROM person
+                   WHERE team_id = 2
+                   ORDER BY version DESC
+                   LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                WHERE True
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
@@ -260,8 +265,13 @@
            WHERE team_id = 2
              AND id IN
                (SELECT id
-                FROM person
-                WHERE team_id = 2
+                FROM
+                  (SELECT *
+                   FROM person
+                   WHERE team_id = 2
+                   ORDER BY version DESC
+                   LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                WHERE True
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
@@ -324,8 +334,13 @@
            WHERE team_id = 2
              AND id IN
                (SELECT id
-                FROM person
-                WHERE team_id = 2
+                FROM
+                  (SELECT *
+                   FROM person
+                   WHERE team_id = 2
+                   ORDER BY version DESC
+                   LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                WHERE True
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
@@ -360,8 +375,13 @@
            WHERE team_id = 2
              AND id IN
                (SELECT id
-                FROM person
-                WHERE team_id = 2
+                FROM
+                  (SELECT *
+                   FROM person
+                   WHERE team_id = 2
+                   ORDER BY version DESC
+                   LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                WHERE True
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
@@ -420,8 +440,13 @@
            WHERE team_id = 2
              AND id IN
                (SELECT id
-                FROM person
-                WHERE team_id = 2
+                FROM
+                  (SELECT *
+                   FROM person
+                   WHERE team_id = 2
+                   ORDER BY version DESC
+                   LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                WHERE True
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
@@ -456,8 +481,13 @@
            WHERE team_id = 2
              AND id IN
                (SELECT id
-                FROM person
-                WHERE team_id = 2
+                FROM
+                  (SELECT *
+                   FROM person
+                   WHERE team_id = 2
+                   ORDER BY version DESC
+                   LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                WHERE True
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -499,8 +499,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
                     AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
         GROUP BY id
@@ -576,8 +581,13 @@
                     WHERE team_id = 2
                       AND id IN
                         (SELECT id
-                         FROM person
-                         WHERE team_id = 2
+                         FROM
+                           (SELECT *
+                            FROM person
+                            WHERE team_id = 2
+                            ORDER BY version DESC
+                            LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                         WHERE True
                            AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
                                 AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
                     GROUP BY id
@@ -631,8 +641,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
                     AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
         GROUP BY id

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -32,8 +32,13 @@
   WHERE team_id = 2
     AND id IN
       (SELECT id
-       FROM person
-       WHERE team_id = 2
+       FROM
+         (SELECT *
+          FROM person
+          WHERE team_id = 2
+          ORDER BY version DESC
+          LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+       WHERE True
          AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'some_prop'), '^"|"$', ''))) )
   GROUP BY id
   HAVING max(is_deleted) = 0

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -39,8 +39,13 @@
                                    WHERE team_id = 2
                                      AND id IN
                                        (SELECT id
-                                        FROM person
-                                        WHERE team_id = 2
+                                        FROM
+                                          (SELECT *
+                                           FROM person
+                                           WHERE team_id = 2
+                                           ORDER BY version DESC
+                                           LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                                        WHERE True
                                           AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%')) )
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
@@ -288,8 +293,13 @@
                              WHERE team_id = 2
                                AND id IN
                                  (SELECT id
-                                  FROM person
-                                  WHERE team_id = 2
+                                  FROM
+                                    (SELECT *
+                                     FROM person
+                                     WHERE team_id = 2
+                                     ORDER BY version DESC
+                                     LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                                  WHERE True
                                     AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
                                           AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
                                          OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
@@ -404,8 +414,13 @@
                              WHERE team_id = 2
                                AND id IN
                                  (SELECT id
-                                  FROM person
-                                  WHERE team_id = 2
+                                  FROM
+                                    (SELECT *
+                                     FROM person
+                                     WHERE team_id = 2
+                                     ORDER BY version DESC
+                                     LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                                  WHERE True
                                     AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
                                           AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
                                          OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
@@ -524,8 +539,13 @@
                              WHERE team_id = 2
                                AND id IN
                                  (SELECT id
-                                  FROM person
-                                  WHERE team_id = 2
+                                  FROM
+                                    (SELECT *
+                                     FROM person
+                                     WHERE team_id = 2
+                                     ORDER BY version DESC
+                                     LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                                  WHERE True
                                     AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
                                           AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
                                          OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
@@ -644,8 +664,13 @@
                              WHERE team_id = 2
                                AND id IN
                                  (SELECT id
-                                  FROM person
-                                  WHERE team_id = 2
+                                  FROM
+                                    (SELECT *
+                                     FROM person
+                                     WHERE team_id = 2
+                                     ORDER BY version DESC
+                                     LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                                  WHERE True
                                     AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
                                           AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
                                          OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,7 +102,7 @@ class PersonQuery:
                     ORDER BY version DESC
                     LIMIT 1 BY id
                 )
-                {person_filters}
+                WHERE True AND {person_filters}
             )
             GROUP BY id
             HAVING max(is_deleted) = 0

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,7 +102,7 @@ class PersonQuery:
                     ORDER BY version DESC
                     LIMIT 1 BY id
                 ) AS person
-                WHERE {person_filters}
+                WHERE True {person_filters}
             )
             GROUP BY id
             HAVING max(is_deleted) = 0

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -101,7 +101,7 @@ class PersonQuery:
                     WHERE team_id = %(team_id)s
                     ORDER BY version DESC
                     LIMIT 1 BY id
-                )
+                ) AS person
                 WHERE True AND {person_filters}
             )
             GROUP BY id

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -94,9 +94,14 @@ class PersonQuery:
             FROM person
             WHERE team_id = %(team_id)s
             AND id IN (
-                SELECT id FROM person
-                {cohort_query}
-                WHERE team_id = %(team_id)s
+                SELECT id FROM (
+                    SELECT *
+                    FROM person
+                    {cohort_query}
+                    WHERE team_id = %(team_id)s
+                    ORDER BY version DESC
+                    LIMIT 1 BY id
+                )
                 {person_filters}
             )
             GROUP BY id

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -101,6 +101,12 @@ class PersonQuery:
                     WHERE team_id = %(team_id)s
                     ORDER BY version DESC
                     LIMIT 1 BY id
+                    -- NOTE: by default asterisk doesn't include materialized
+                    -- columns. I don't know how optimised this is e.g. if the
+                    -- stream returned by this subquery will include literally
+                    -- everything of if it will be optimised to only include
+                    -- those columns that are actually used in the outer query.
+                    SETTINGS asterisk_include_materialized_columns=1
                 ) AS person
                 WHERE True {person_filters}
             )

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,7 +102,7 @@ class PersonQuery:
                     ORDER BY version DESC
                     LIMIT 1 BY id
                 ) AS person
-                WHERE True AND {person_filters}
+                WHERE {person_filters}
             )
             GROUP BY id
             HAVING max(is_deleted) = 0

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -538,8 +538,13 @@
               WHERE team_id = 2
                 AND id IN
                   (SELECT id
-                   FROM person
-                   WHERE team_id = 2
+                   FROM
+                     (SELECT *
+                      FROM person
+                      WHERE team_id = 2
+                      ORDER BY version DESC
+                      LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                   WHERE True
                      AND (has(['person1'], person."pmat_name")) )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -616,8 +621,13 @@
               WHERE team_id = 2
                 AND id IN
                   (SELECT id
-                   FROM person
-                   WHERE team_id = 2
+                   FROM
+                     (SELECT *
+                      FROM person
+                      WHERE team_id = 2
+                      ORDER BY version DESC
+                      LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                   WHERE True
                      AND (has(['person1'], person."pmat_name")) )
               GROUP BY id
               HAVING max(is_deleted) = 0

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -269,8 +269,13 @@
                      WHERE team_id = 2
                        AND id IN
                          (SELECT id
-                          FROM person
-                          WHERE team_id = 2
+                          FROM
+                            (SELECT *
+                             FROM person
+                             WHERE team_id = 2
+                             ORDER BY version DESC
+                             LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                          WHERE True
                             AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                      GROUP BY id
                      HAVING max(is_deleted) = 0
@@ -354,8 +359,13 @@
                                  WHERE team_id = 2
                                    AND id IN
                                      (SELECT id
-                                      FROM person
-                                      WHERE team_id = 2
+                                      FROM
+                                        (SELECT *
+                                         FROM person
+                                         WHERE team_id = 2
+                                         ORDER BY version DESC
+                                         LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                                      WHERE True
                                         AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
@@ -412,8 +422,13 @@
               WHERE team_id = 2
                 AND id IN
                   (SELECT id
-                   FROM person
-                   WHERE team_id = 2
+                   FROM
+                     (SELECT *
+                      FROM person
+                      WHERE team_id = 2
+                      ORDER BY version DESC
+                      LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                   WHERE True
                      AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -460,8 +475,13 @@
               WHERE team_id = 2
                 AND id IN
                   (SELECT id
-                   FROM person
-                   WHERE team_id = 2
+                   FROM
+                     (SELECT *
+                      FROM person
+                      WHERE team_id = 2
+                      ORDER BY version DESC
+                      LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                   WHERE True
                      AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
@@ -1146,8 +1166,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
                      OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
         GROUP BY id
@@ -1211,8 +1236,13 @@
               WHERE team_id = 2
                 AND id IN
                   (SELECT id
-                   FROM person
-                   WHERE team_id = 2
+                   FROM
+                     (SELECT *
+                      FROM person
+                      WHERE team_id = 2
+                      ORDER BY version DESC
+                      LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                   WHERE True
                      AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
                            OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
               GROUP BY id
@@ -1258,8 +1288,13 @@
         WHERE team_id = 2
           AND id IN
             (SELECT id
-             FROM person
-             WHERE team_id = 2
+             FROM
+               (SELECT *
+                FROM person
+                WHERE team_id = 2
+                ORDER BY version DESC
+                LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+             WHERE True
                AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
                       AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
                     AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
@@ -1324,8 +1359,13 @@
               WHERE team_id = 2
                 AND id IN
                   (SELECT id
-                   FROM person
-                   WHERE team_id = 2
+                   FROM
+                     (SELECT *
+                      FROM person
+                      WHERE team_id = 2
+                      ORDER BY version DESC
+                      LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                   WHERE True
                      AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
                             AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
                           AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
@@ -1413,8 +1453,13 @@
               WHERE team_id = 2
                 AND id IN
                   (SELECT id
-                   FROM person
-                   WHERE team_id = 2
+                   FROM
+                     (SELECT *
+                      FROM person
+                      WHERE team_id = 2
+                      ORDER BY version DESC
+                      LIMIT 1 BY id SETTINGS asterisk_include_materialized_columns=1) AS person
+                   WHERE True
                      AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))) )
               GROUP BY id
               HAVING max(is_deleted) = 0


### PR DESCRIPTION
I'm not sure if this is a proper fix but this was triggered by
https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667923610913149

This change is more broad than just Cohorts. Its across all things that do filters on the persons table.

Essentially before we were filtering on persons based on applied filters, then taking the max.

Now we are getting the latest person, then filtering, then getting the max version as well. The last max version
is redundant but I've kept this in to limit how much is being changed at once.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I wasn't sure what to do here, as the issue here relies on ClickHouse _NOT_ doing a merge which is something I wasn't sure how to test.

Maybe in tests we could just use a plain MergeTree to ensure that our querying is correct? Given that it should only be considered an optimisation.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
