### PR TITLE
fix: bootstrap org id for feature flags

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -354,7 +354,9 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     context["posthog_app_context"] = json.dumps(posthog_app_context, default=json_uuid_convert)
 
     if posthog_distinct_id:
-        feature_flags = posthoganalytics.get_all_flags(posthog_distinct_id, only_evaluate_locally=True)
+        feature_flags = posthoganalytics.get_all_flags(
+            posthog_distinct_id, only_evaluate_locally=True, groups={"organization": request.user.organization_id}
+        )
         # don't forcefully set distinctID, as this breaks the link for anonymous users coming from `posthog.com`.
         posthog_bootstrap["featureFlags"] = feature_flags
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -355,8 +355,8 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     if posthog_distinct_id:
         groups = {}
-        if request.user and request.user.is_authenticated:
-            groups = {"organization": str(request.user.organization_id)}
+        if request.user and request.user.is_authenticated and request.user.organization:
+            groups = {"organization": str(request.user.organization.id)}
         feature_flags = posthoganalytics.get_all_flags(posthog_distinct_id, only_evaluate_locally=True, groups=groups)
         # don't forcefully set distinctID, as this breaks the link for anonymous users coming from `posthog.com`.
         posthog_bootstrap["featureFlags"] = feature_flags

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -356,7 +356,7 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     if posthog_distinct_id:
         groups = {}
         if request.user and request.user.is_authenticated:
-            groups = {"organization": request.user.organization_id}
+            groups = {"organization": str(request.user.organization_id)}
         feature_flags = posthoganalytics.get_all_flags(posthog_distinct_id, only_evaluate_locally=True, groups=groups)
         # don't forcefully set distinctID, as this breaks the link for anonymous users coming from `posthog.com`.
         posthog_bootstrap["featureFlags"] = feature_flags

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -354,9 +354,10 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     context["posthog_app_context"] = json.dumps(posthog_app_context, default=json_uuid_convert)
 
     if posthog_distinct_id:
-        feature_flags = posthoganalytics.get_all_flags(
-            posthog_distinct_id, only_evaluate_locally=True, groups={"organization": request.user.organization_id}
-        )
+        groups = {}
+        if request.user and request.user.is_authenticated:
+            groups = {"organization": request.user.organization_id}
+        feature_flags = posthoganalytics.get_all_flags(posthog_distinct_id, only_evaluate_locally=True, groups=groups)
         # don't forcefully set distinctID, as this breaks the link for anonymous users coming from `posthog.com`.
         posthog_bootstrap["featureFlags"] = feature_flags
 


### PR DESCRIPTION
## Problem
We want to boostrap feature flags for an organization

## Changes
- Added org id to the feature flag boostrapping call

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
