### PR TITLE
chore(plugin-server): use distinct_id as the Kafka key

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -13,8 +13,13 @@
      WHERE team_id = 2
        AND id IN
          (SELECT id
-          FROM person
-          WHERE team_id = 2
+          FROM
+            (SELECT *
+             FROM person
+             WHERE team_id = 2
+             ORDER BY version DESC
+             LIMIT 1 BY id) AS person
+          WHERE True
             AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))
                   AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$another_prop'), '^"|"$', '')))))) )
      GROUP BY id

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -40,7 +40,7 @@ export async function emitToBufferStep(
             topic: KAFKA_BUFFER,
             messages: [
                 {
-                    key: event.team_id.toString(),
+                    key: event.distinct_id,
                     value: JSON.stringify(event),
                     headers: { processEventAt: processEventAt.toString(), eventId: event.uuid },
                 },

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,7 +102,7 @@ class PersonQuery:
                     ORDER BY version DESC
                     LIMIT 1 BY id
                 )
-                {person_filters}
+                WHERE True AND {person_filters}
             )
             GROUP BY id
             HAVING max(is_deleted) = 0

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,7 +102,7 @@ class PersonQuery:
                     ORDER BY version DESC
                     LIMIT 1 BY id
                 ) AS person
-                WHERE {person_filters}
+                WHERE True {person_filters}
             )
             GROUP BY id
             HAVING max(is_deleted) = 0

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -101,7 +101,7 @@ class PersonQuery:
                     WHERE team_id = %(team_id)s
                     ORDER BY version DESC
                     LIMIT 1 BY id
-                )
+                ) AS person
                 WHERE True AND {person_filters}
             )
             GROUP BY id

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -94,9 +94,14 @@ class PersonQuery:
             FROM person
             WHERE team_id = %(team_id)s
             AND id IN (
-                SELECT id FROM person
-                {cohort_query}
-                WHERE team_id = %(team_id)s
+                SELECT id FROM (
+                    SELECT *
+                    FROM person
+                    {cohort_query}
+                    WHERE team_id = %(team_id)s
+                    ORDER BY version DESC
+                    LIMIT 1 BY id
+                )
                 {person_filters}
             )
             GROUP BY id

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -101,6 +101,12 @@ class PersonQuery:
                     WHERE team_id = %(team_id)s
                     ORDER BY version DESC
                     LIMIT 1 BY id
+                    -- NOTE: by default asterisk doesn't include materialized
+                    -- columns. I don't know how optimised this is e.g. if the
+                    -- stream returned by this subquery will include literally
+                    -- everything of if it will be optimised to only include
+                    -- those columns that are actually used in the outer query.
+                    SETTINGS asterisk_include_materialized_columns=1
                 ) AS person
                 WHERE True {person_filters}
             )

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,7 +102,7 @@ class PersonQuery:
                     ORDER BY version DESC
                     LIMIT 1 BY id
                 ) AS person
-                WHERE True AND {person_filters}
+                WHERE {person_filters}
             )
             GROUP BY id
             HAVING max(is_deleted) = 0


### PR DESCRIPTION
This might cause a bit more flapping on the buffer consmer due to the
timestamps being more aligned but we'll see.

It atleast means users can't easily send loads of events to the same
partition without being obviously bad.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
