### PR TITLE
chore(plugin-server): use distinct_id as the Kafka ket

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -40,7 +40,7 @@ export async function emitToBufferStep(
             topic: KAFKA_BUFFER,
             messages: [
                 {
-                    key: event.team_id.toString(),
+                    key: event.distinct_id,
                     value: JSON.stringify(event),
                     headers: { processEventAt: processEventAt.toString(), eventId: event.uuid },
                 },


### PR DESCRIPTION
This might cause a bit more flapping on the buffer consmer due to the
timestamps being more aligned but we'll see.

It atleast means users can't easily send loads of events to the same
partition without being obviously bad.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
