### PR TITLE
feat(onboarding): after inviting team, prompt to use bookmarklet

### DIFF
--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -12,7 +12,7 @@ export const scene: SceneExport = {
 export function IngestionWizard(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
-    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2_EXPERIMENT]) {
+    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2_EXPERIMENT] === 'test') {
         return <IngestionWizardV2 />
     }
 

--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -12,7 +12,7 @@ export const scene: SceneExport = {
 export function IngestionWizard(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
-    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2_EXPERIMENT] === 'test') {
+    if (featureFlags[FEATURE_FLAGS.ONBOARDING_V2_EXPERIMENT]) {
         return <IngestionWizardV2 />
     }
 

--- a/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
@@ -21,9 +21,11 @@ import { HelpButton } from 'lib/components/HelpButton/HelpButton'
 import { BridgePage } from 'lib/components/BridgePage/BridgePage'
 import { PanelHeader } from './panels/PanelComponents'
 import { InviteTeamPanel } from './panels/InviteTeamPanel'
+import { TeamInvitedPanel } from './panels/TeamInvitedPanel'
 
 export function IngestionWizardV2(): JSX.Element {
-    const { platform, framework, verify, addBilling, technical } = useValues(ingestionLogic)
+    const { platform, framework, verify, addBilling, technical, hasInvitedMembers } = useValues(ingestionLogic)
+    const { isInviteModalShown } = useValues(inviteLogic)
     const { reportIngestionLandingSeen } = useActions(eventUsageLogic)
 
     useEffect(() => {
@@ -36,6 +38,14 @@ export function IngestionWizardV2(): JSX.Element {
         return (
             <IngestionContainer>
                 <BillingPanel />
+            </IngestionContainer>
+        )
+    }
+
+    if (hasInvitedMembers && !isInviteModalShown && !technical) {
+        return (
+            <IngestionContainer>
+                <TeamInvitedPanel />
             </IngestionContainer>
         )
     }

--- a/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
@@ -50,18 +50,21 @@ export const ingestionLogic = kea<ingestionLogicType>([
     }),
     actions({
         setTechnical: (technical: boolean) => ({ technical }),
+        setHasInvitedMembers: (hasInvitedMembers: boolean) => ({ hasInvitedMembers }),
         setPlatform: (platform: PlatformType) => ({ platform }),
         setFramework: (framework: Framework) => ({ framework: framework as Framework }),
         setVerify: (verify: boolean) => ({ verify }),
         setAddBilling: (addBilling: boolean) => ({ addBilling }),
         setState: (
             technical: boolean | null,
+            hasInvitedMembers: boolean | null,
             platform: PlatformType,
             framework: string | null,
             verify: boolean,
             addBilling: boolean
         ) => ({
             technical,
+            hasInvitedMembers,
             platform,
             framework,
             verify,
@@ -85,6 +88,13 @@ export const ingestionLogic = kea<ingestionLogicType>([
             null as null | boolean,
             {
                 setTechnical: (_, { technical }) => technical,
+                setState: (_, { technical }) => technical,
+            },
+        ],
+        hasInvitedMembers: [
+            null as null | boolean,
+            {
+                setHasInvitedMembers: (_, { hasInvitedMembers }) => hasInvitedMembers,
                 setState: (_, { technical }) => technical,
             },
         ],
@@ -229,9 +239,10 @@ export const ingestionLogic = kea<ingestionLogicType>([
     })),
 
     urlToAction(({ actions }) => ({
-        '/ingestion': () => actions.setState(null, null, null, false, false),
+        '/ingestion': () => actions.setState(null, null, null, null, false, false),
         '/ingestion/billing': (_: any, { platform, framework }) => {
             actions.setState(
+                null,
                 null,
                 platform === 'mobile'
                     ? MOBILE
@@ -252,6 +263,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
         '/ingestion/verify': (_: any, { platform, framework }) => {
             actions.setState(
                 true,
+                null,
                 platform === 'mobile'
                     ? MOBILE
                     : platform === 'web'
@@ -271,6 +283,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
         '/ingestion/api': (_: any, { platform }) => {
             actions.setState(
                 true,
+                null,
                 platform === 'mobile' ? MOBILE : platform === 'web' ? WEB : platform === 'backend' ? BACKEND : null,
                 API,
                 false,
@@ -280,6 +293,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
         '/ingestion(/:platform)(/:framework)': ({ platform, framework }) => {
             actions.setState(
                 true,
+                null,
                 platform === 'mobile'
                     ? MOBILE
                     : platform === 'web'
@@ -343,16 +357,23 @@ export const ingestionLogic = kea<ingestionLogicType>([
         onBack: () => {
             switch (values.currentStep) {
                 case INGESTION_STEPS.BILLING:
-                    actions.setState(values.technical, values.platform, values.framework, true, false)
+                    actions.setState(
+                        values.technical,
+                        values.hasInvitedMembers,
+                        values.platform,
+                        values.framework,
+                        true,
+                        false
+                    )
                     return
                 case INGESTION_STEPS.VERIFY:
-                    actions.setState(values.technical, values.platform, null, false, false)
+                    actions.setState(values.technical, values.hasInvitedMembers, values.platform, null, false, false)
                     return
                 case INGESTION_STEPS.CONNECT_PRODUCT:
-                    actions.setState(values.technical, null, null, false, false)
+                    actions.setState(values.technical, values.hasInvitedMembers, null, null, false, false)
                     return
                 case INGESTION_STEPS.PLATFORM:
-                    actions.setState(null, null, null, false, false)
+                    actions.setState(null, null, null, null, false, false)
                     return
                 default:
                     return

--- a/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
@@ -95,7 +95,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
             null as null | boolean,
             {
                 setHasInvitedMembers: (_, { hasInvitedMembers }) => hasInvitedMembers,
-                setState: (_, { technical }) => technical,
+                setState: (_, { hasInvitedMembers }) => hasInvitedMembers,
             },
         ],
         platform: [
@@ -224,6 +224,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
 
     actionToUrl(({ values }) => ({
         setTechnical: () => getUrl(values),
+        setHasInvitedMembers: () => getUrl(values),
         setPlatform: () => getUrl(values),
         setFramework: () => getUrl(values),
         setVerify: () => getUrl(values),
@@ -240,6 +241,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
 
     urlToAction(({ actions }) => ({
         '/ingestion': () => actions.setState(null, null, null, null, false, false),
+        '/ingestion/invites-sent': () => actions.setState(false, true, null, null, false, false),
         '/ingestion/billing': (_: any, { platform, framework }) => {
             actions.setState(
                 null,
@@ -399,7 +401,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
 ])
 
 function getUrl(values: ingestionLogicType['values']): string | [string, Record<string, undefined | string>] {
-    const { technical, platform, framework, verify, addBilling } = values
+    const { technical, platform, framework, verify, addBilling, hasInvitedMembers } = values
 
     let url = '/ingestion'
 
@@ -468,6 +470,10 @@ function getUrl(values: ingestionLogicType['values']): string | [string, Record<
 
     if (technical && !platform) {
         url += '/platform'
+    }
+
+    if (!technical && !platform && hasInvitedMembers) {
+        url += '/invites-sent'
     }
 
     if (framework) {

--- a/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
@@ -1,0 +1,59 @@
+import { useActions } from 'kea'
+import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { LemonButton } from 'lib/components/LemonButton'
+import './Panels.scss'
+import { LemonDivider } from 'lib/components/LemonDivider'
+import { IconChevronRight } from 'lib/components/icons'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+
+export function TeamInvitedPanel(): JSX.Element {
+    const { completeOnboarding } = useActions(ingestionLogic)
+    const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
+
+    return (
+        <div>
+            <h1 className="ingestion-title">Help is on the way!</h1>
+            <p className="prompt-text">
+                You can still explore all PostHog has to offer while you wait for your team members to join.
+            </p>
+            <LemonDivider thick dashed className="my-6" />
+            <div className="flex flex-col mb-6">
+                <LemonButton
+                    onClick={() => {
+                        // Import demo data here!
+                    }}
+                    fullWidth
+                    size="large"
+                    className="mb-4"
+                    type="primary"
+                    sideIcon={<IconChevronRight />}
+                >
+                    <div className="mt-4 mb-0">
+                        <p className="mb-2">Explore PostHog with some demo data.</p>
+                        <p className="font-normal text-xs">
+                            Experience all PostHog has to offer without any of the setup.
+                        </p>
+                    </div>
+                </LemonButton>
+                <LemonButton
+                    onClick={() => {
+                        completeOnboarding()
+                        reportIngestionContinueWithoutVerifying()
+                    }}
+                    fullWidth
+                    size="large"
+                    className="mb-4"
+                    type="secondary"
+                    sideIcon={<IconChevronRight />}
+                >
+                    <div className="mt-4 mb-0">
+                        <p className="mb-2">Continue without any events.</p>
+                        <p className="font-normal text-xs">
+                            It might look a little empty in there, but we'll do our best.
+                        </p>
+                    </div>
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
@@ -5,9 +5,10 @@ import './Panels.scss'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { IconChevronRight } from 'lib/components/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { BOOKMARKLET } from '../constants'
 
 export function TeamInvitedPanel(): JSX.Element {
-    const { completeOnboarding } = useActions(ingestionLogic)
+    const { completeOnboarding, setTechnical, setPlatform } = useActions(ingestionLogic)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
     return (
@@ -20,7 +21,8 @@ export function TeamInvitedPanel(): JSX.Element {
             <div className="flex flex-col mb-6">
                 <LemonButton
                     onClick={() => {
-                        // Import demo data here!
+                        setTechnical(false)
+                        setPlatform(BOOKMARKLET)
                     }}
                     fullWidth
                     size="large"
@@ -29,9 +31,9 @@ export function TeamInvitedPanel(): JSX.Element {
                     sideIcon={<IconChevronRight />}
                 >
                     <div className="mt-4 mb-0">
-                        <p className="mb-2">Explore PostHog with some demo data.</p>
+                        <p className="mb-2">Quickly try PostHog with our Bookmarklet.</p>
                         <p className="font-normal text-xs">
-                            Experience all PostHog has to offer without any of the setup.
+                            Create a few events and experience all PostHog has to offer without any of the setup.
                         </p>
                     </div>
                 </LemonButton>

--- a/frontend/src/scenes/organization/Settings/inviteLogic.ts
+++ b/frontend/src/scenes/organization/Settings/inviteLogic.ts
@@ -7,6 +7,7 @@ import type { inviteLogicType } from './inviteLogicType'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { router } from 'kea-router'
 import { lemonToast } from 'lib/components/lemonToast'
+import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
 
 /** State of a single invite row (with input data) in bulk invite creation. */
 export interface InviteRowState {
@@ -31,7 +32,7 @@ export const inviteLogic = kea<inviteLogicType>({
     },
     connect: {
         values: [preflightLogic, ['preflight']],
-        actions: [router, ['locationChanged']],
+        actions: [router, ['locationChanged'], ingestionLogic, ['setHasInvitedMembers']],
     },
     reducers: () => ({
         isInviteModalShown: [
@@ -123,6 +124,10 @@ export const inviteLogic = kea<inviteLogicType>({
 
             organizationLogic.actions.loadCurrentOrganization()
             actions.loadInvites()
+
+            if (router.values.location.pathname.includes('/ingestion')) {
+                ingestionLogic.actions.setHasInvitedMembers(true)
+            }
 
             if (values.preflight?.email_service_available) {
                 actions.hideInviteModal()


### PR DESCRIPTION
## Problem

Fixes #12712. 

We now ask if someone is technical at the beginning of onboarding. If they are not technical, they still should be able to explore PostHog to see if it's the right fit for them before they invite their team, or before their team has time to install it.

## Changes

After someone invites a team member, they are taken to an onboarding screen confirming that they have indeed invited someone, and giving them options for how to explore PostHog while they wait. 

For now, I've given them the option to use the bookmarklet or continue without ingesting any events. In coming days we will replace the bookmarklet with the option to import a demo project with demo data, but this at least gives people a couple options for now until we have that ready.

![Nov-09-2022 14-21-30](https://user-images.githubusercontent.com/18598166/200955588-b9109bf4-76e9-4d50-bbf6-4e722d5a319c.gif)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

There aren't any tests for the onboarding yet. We should add them. For now I just tested this manually by pressing all the buttons. 