### PR TITLE
fix(recordings): hide inspector picker on widescreen view

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerController.tsx
@@ -15,9 +15,15 @@ import { PlayerInspectorPicker } from './PlayerInspector'
 
 interface PlayerControllerProps extends SessionRecordingPlayerProps {
     isDetail: boolean
+    hideInspectorPicker?: boolean
 }
 
-export function PlayerController({ sessionRecordingId, playerKey, isDetail }: PlayerControllerProps): JSX.Element {
+export function PlayerController({
+    sessionRecordingId,
+    playerKey,
+    isDetail,
+    hideInspectorPicker = false,
+}: PlayerControllerProps): JSX.Element {
     const { togglePlayPause, setSpeed, setSkipInactivitySetting, setIsFullScreen } = useActions(
         sessionRecordingPlayerLogic({ sessionRecordingId, playerKey })
     )
@@ -33,7 +39,7 @@ export function PlayerController({ sessionRecordingId, playerKey, isDetail }: Pl
             </div>
             <div className="flex justify-between items-center h-8 gap-2">
                 <div className="flex items-center gap-2 flex-1">
-                    {!isFullScreen && (
+                    {!hideInspectorPicker && !isFullScreen && (
                         <PlayerInspectorPicker sessionRecordingId={sessionRecordingId} playerKey={playerKey} />
                     )}
                 </div>

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -97,7 +97,12 @@ export function SessionRecordingPlayer({
                     <PlayerFrame sessionRecordingId={sessionRecordingId} ref={frame} playerKey={playerKey} />
                 </div>
                 <LemonDivider className="my-0" />
-                <PlayerController sessionRecordingId={sessionRecordingId} playerKey={playerKey} isDetail={isDetail} />
+                <PlayerController
+                    sessionRecordingId={sessionRecordingId}
+                    playerKey={playerKey}
+                    isDetail={isDetail}
+                    hideInspectorPicker={size !== 'small'}
+                />
             </div>
             {!isFullScreen && (
                 <div className="SessionRecordingPlayer__inspector">

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
@@ -39,7 +39,7 @@ export function SessionRecordingPlaylistItem({
             : recording.person?.properties || {}
 
     const propertyIcons = (
-        <div className="flex flex-row flex-nowrap shrink-0 gap-1 h-6">
+        <div className="flex flex-row flex-nowrap shrink-0 gap-1 h-6 ph-no-capture">
             {!recordingPropertiesLoading ? (
                 iconPropertyKeys.map((property) => {
                     const value =


### PR DESCRIPTION
## Problem

Inspector picker (events + console) was still showing up at the bottom of the player in the new wide screen view.

![Screen Shot 2022-11-10 at 11 50 05 AM](https://user-images.githubusercontent.com/13460330/201156743-9334f9a1-171f-43fd-88ed-f815f8561c74.png)


## Changes

+ small change to add ph no capture to property icons in playlist items

![Screen Shot 2022-11-10 at 11 48 56 AM](https://user-images.githubusercontent.com/13460330/201156491-d4c60b0c-7ab7-4208-9d47-a72d84d8a2d7.png)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally
