### PR TITLE
test(clickhouse): stop/start merges for tests

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -73,6 +73,8 @@ def django_db_setup(django_db_setup, django_db_keepdb):
         verify_ssl_cert=settings.CLICKHOUSE_VERIFY,
     )
 
+    sync_execute("SYSTEM STOP MERGES")
+
     if not django_db_keepdb:
         try:
             database.drop_database()
@@ -86,6 +88,8 @@ def django_db_setup(django_db_setup, django_db_keepdb):
     create_clickhouse_tables(table_count)
 
     yield
+
+    sync_execute("SYSTEM START MERGES")
 
     if django_db_keepdb:
         reset_clickhouse_tables()

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -25,7 +25,7 @@ BASE_APP_METRICS_COLUMNS = """
 
 APP_METRICS_DATA_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE sharded_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE TABLE IF NOT EXISTS sharded_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     {BASE_APP_METRICS_COLUMNS}
     {KAFKA_COLUMNS_WITH_PARTITION}
@@ -39,7 +39,7 @@ ORDER BY (team_id, plugin_config_id, job_id, category, toStartOfHour(timestamp),
 
 DISTRIBUTED_APP_METRICS_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE TABLE IF NOT EXISTS app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     {BASE_APP_METRICS_COLUMNS}
     {KAFKA_COLUMNS_WITH_PARTITION}
@@ -50,7 +50,7 @@ ENGINE={Distributed(data_table="sharded_app_metrics", sharding_key="rand()")}
 
 KAFKA_APP_METRICS_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE kafka_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE TABLE IF NOT EXISTS kafka_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     team_id Int64,
     timestamp DateTime64(6, 'UTC'),
@@ -85,7 +85,7 @@ KAFKA_APP_METRICS_DLQ_MV_SQL = lambda: KAFKA_ENGINE_DLQ_MV_BASE_SQL.format(
 
 APP_METRICS_MV_TABLE_SQL = (
     lambda: f"""
-CREATE MATERIALIZED VIEW app_metrics_mv ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE MATERIALIZED VIEW IF NOT EXISTS app_metrics_mv ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 TO {settings.CLICKHOUSE_DATABASE}.sharded_app_metrics
 AS SELECT
 team_id,

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -81,7 +81,7 @@ if TEST:
             created_at = now().strftime("%Y-%m-%d %H:%M:%S.%f")
             timestamp = now().strftime("%Y-%m-%d %H:%M:%S")
             person_inserts.append(
-                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0, {person.version})"
+                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0, {person.version or 0})"
             )
 
         PersonDistinctId.objects.bulk_create(distinct_ids)

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -81,7 +81,7 @@ if TEST:
             created_at = now().strftime("%Y-%m-%d %H:%M:%S.%f")
             timestamp = now().strftime("%Y-%m-%d %H:%M:%S")
             person_inserts.append(
-                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0, 0)"
+                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0, {person.version})"
             )
 
         PersonDistinctId.objects.bulk_create(distinct_ids)


### PR DESCRIPTION
This is so we can test that we are correctly handling ClickHouse
querying and taking into account that there can be e.g.:

 1. duplicate rows
 2. rows for old versions e.g. people that have newer versions by the
    ReplacingMergeTree merge hasn't removed old ones.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
