### PR TITLE
feat: event based prompts

### DIFF
--- a/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.scss
+++ b/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.scss
@@ -48,7 +48,6 @@
     .LemonActionableTooltip__action-buttons {
         display: flex;
         width: 100%;
-        padding: 0 0.5rem;
         flex-direction: column;
         > * + * {
             margin-top: 0.25rem;

--- a/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.scss
+++ b/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.scss
@@ -1,9 +1,15 @@
 .LemonActionableTooltip {
     max-width: var(--in-app-prompts-width);
+    padding: 0.5rem;
+    > * + * {
+        margin-top: 0.5rem;
+    }
     .LemonActionableTooltip__header {
         display: flex;
-        align-items: center;
         justify-content: space-between;
+        > * + * {
+            margin-left: 0.5rem;
+        }
     }
     .LemonActionableTooltip__title {
         font-size: 1.125rem;
@@ -22,7 +28,6 @@
         }
     }
     .LemonActionableTooltip__body {
-        padding: 0.25rem 0.5rem;
         > * + * {
             margin-top: 0.5rem;
         }
@@ -30,27 +35,29 @@
     .LemonActionableTooltip__footer {
         display: flex;
         justify-content: space-between;
-        padding: 0.5rem;
+        margin-top: 1rem;
     }
     .LemonActionableTooltip__url-buttons {
         display: flex;
+        width: 100%;
         flex-direction: column;
         > * + * {
-            margin-top: 0.5rem;
+            margin-top: 0.25rem;
         }
     }
     .LemonActionableTooltip__action-buttons {
         display: flex;
-        justify-content: space-between;
+        width: 100%;
+        padding: 0 0.5rem;
+        flex-direction: column;
         > * + * {
-            margin-left: 0.5rem;
+            margin-top: 0.25rem;
         }
     }
     .LemonActionableTooltip__navigation {
         color: var(--muted);
         display: flex;
         align-items: center;
-        margin-left: 0.5rem;
 
         > * + * {
             margin-left: 0.25rem;

--- a/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.tsx
+++ b/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.tsx
@@ -34,8 +34,8 @@ export const LemonActionableTooltip = ({
     buttons,
     icon,
 }: LemonActionableTooltipProps): JSX.Element | null => {
-    const actionButtons = buttons?.filter((button) => button.action)
-    const urlButtons = buttons?.filter((button) => button.url)
+    const actionButtons = buttons?.filter((button) => button.action) ?? []
+    const urlButtons = buttons?.filter((button) => button.url) ?? []
     return (
         <Popup
             visible={visible}
@@ -45,7 +45,7 @@ export const LemonActionableTooltip = ({
                 <div className="LemonActionableTooltip">
                     <div className="LemonActionableTooltip__header">
                         {maxSteps === 1 && (
-                            <div className="flex space-x-4 pl-2">
+                            <div className="flex space-x-4">
                                 {icon && <div className="LemonActionableTooltip__icon">{icon}</div>}
                                 <div className="LemonActionableTooltip__title">{title ?? ''}</div>
                             </div>
@@ -58,7 +58,7 @@ export const LemonActionableTooltip = ({
                                         onClick={previous}
                                         disabled={step === 0}
                                         size="small"
-                                        status="stealth"
+                                        status="muted"
                                         type="secondary"
                                         icon={<IconChevronLeft />}
                                     />
@@ -70,16 +70,18 @@ export const LemonActionableTooltip = ({
                                         onClick={next}
                                         disabled={step === maxSteps - 1}
                                         size="small"
-                                        status="stealth"
+                                        status="muted"
                                         type="secondary"
                                         icon={<IconChevronRight />}
                                     />
                                 </>
                             )}
                         </div>
-                        <LemonButton size="small" status="stealth" onClick={close}>
-                            <IconClose />
-                        </LemonButton>
+                        <div>
+                            <LemonButton size="small" status="stealth" onClick={close}>
+                                <IconClose />
+                            </LemonButton>
+                        </div>
                     </div>
                     <div className="LemonActionableTooltip__body">
                         {maxSteps > 1 && (
@@ -91,12 +93,12 @@ export const LemonActionableTooltip = ({
                         <div>{text}</div>
                     </div>
                     <div className="LemonActionableTooltip__footer">
-                        {urlButtons && (
+                        {urlButtons.length > 0 && (
                             <div className="LemonActionableTooltip__url-buttons">
                                 {urlButtons.map((button, index) => (
                                     <LemonButton
                                         key={index}
-                                        type="tertiary"
+                                        type="secondary"
                                         icon={<IconOpenInNew />}
                                         onClick={() => window.open(button.url, '_noblank')}
                                         className="max-w-full"
@@ -107,11 +109,11 @@ export const LemonActionableTooltip = ({
                                 ))}
                             </div>
                         )}
-                        {actionButtons && (
+                        {actionButtons.length > 0 && (
                             <div className="LemonActionableTooltip__action-buttons">
                                 {actionButtons.map((button, index) => {
                                     return (
-                                        <LemonButton key={index} type="primary" onClick={button.action}>
+                                        <LemonButton key={index} type="primary" onClick={button.action} fullWidth>
                                             {button.label}
                                         </LemonButton>
                                     )

--- a/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.tsx
+++ b/frontend/src/lib/components/LemonActionableTooltip/LemonActionableTooltip.tsx
@@ -103,6 +103,7 @@ export const LemonActionableTooltip = ({
                                         onClick={() => window.open(button.url, '_noblank')}
                                         className="max-w-full"
                                         fullWidth
+                                        center
                                     >
                                         {button.label}
                                     </LemonButton>
@@ -113,7 +114,13 @@ export const LemonActionableTooltip = ({
                             <div className="LemonActionableTooltip__action-buttons">
                                 {actionButtons.map((button, index) => {
                                     return (
-                                        <LemonButton key={index} type="primary" onClick={button.action} fullWidth>
+                                        <LemonButton
+                                            key={index}
+                                            type="primary"
+                                            onClick={button.action}
+                                            fullWidth
+                                            center
+                                        >
                                             {button.label}
                                         </LemonButton>
                                     )

--- a/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
+++ b/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
@@ -399,7 +399,11 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
             const valid = []
             for (const sequence of values.sequences) {
                 // for now the only valid rule is related to the pathname, can be extended
-                const isMatchingPath = sequence.rule.path.must_match.some((value) => wcmatch(value)(pathname))
+                const { must_match } = sequence.rule.path
+                if (must_match.includes('/*')) {
+                    must_match.push('/**')
+                }
+                const isMatchingPath = must_match.some((value) => wcmatch(value)(pathname))
                 if (isMatchingPath) {
                     if (sequence.rule.path.exclude) {
                         const isMatchingExclusion = sequence.rule.path.exclude.some((value) => wcmatch(value)(pathname))

--- a/posthog/api/prompt.py
+++ b/posthog/api/prompt.py
@@ -75,7 +75,7 @@ def get_active_prompt_sequences(distinct_id: str, team_id: str) -> List[Dict[str
     prompt_keys = set()
     for event in prompt_events:
         prompt = event_properties_to_prompt_sequence(json.loads(event["properties"]))
-        if prompt["key"] not in prompt_keys:
+        if prompt and prompt["key"] not in prompt_keys:
             prompt_keys.add(prompt["key"])
             active_prompts.append(prompt)
 

--- a/posthog/api/prompt.py
+++ b/posthog/api/prompt.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List, Optional
 
 from dateutil import parser
@@ -6,7 +7,79 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from posthog.api.routing import StructuredViewSetMixin
-from posthog.models.prompt import UserPromptSequenceState, get_active_prompt_sequences
+from posthog.client import query_with_columns
+from posthog.models.prompt.constants import prompts_config
+from posthog.models.prompt.prompt import UserPromptSequenceState
+
+SELECT_PROMPT_TRIGGER_SQL = """
+SELECT
+    event,
+    properties,
+    timestamp
+FROM events
+WHERE
+team_id = %(team_id)s
+AND event = 'prompt trigger'
+AND events.distinct_id in [%(distinct_id)s]
+ORDER BY timestamp DESC
+LIMIT 101
+"""
+
+# Take a "prompt trigger" event and build a prompt sequence out of the event parameters
+def event_properties_to_prompt_sequence(properties: Dict) -> Dict[str, Any]:
+    try:
+        if not properties.get("text") or not properties.get("key"):
+            return None
+        sequence: Dict = {
+            "key": properties["key"],
+        }
+        # TODO extend type
+        prompt = {"step": 0, "type": "tooltip", "text": properties["text"]}
+        if properties.get("title"):
+            prompt["title"] = properties["title"]
+        if properties.get("buttons"):
+            buttons = []
+            for button in properties["buttons"]:
+                if not button.get("label") or (not button.get("url") and not button.get("action")):
+                    continue
+                if button.get("url"):
+                    buttons.append(
+                        {
+                            "url": button["url"],
+                            "label": button["label"],
+                        }
+                    )
+                if button.get("action"):
+                    buttons.append(
+                        {
+                            "action": button["action"],
+                            "label": button["label"],
+                        }
+                    )
+            prompt["buttons"] = buttons
+        prompt["placement"] = properties.get("placement", "bottom-start")
+        if properties.get("reference"):
+            prompt["reference"] = properties["reference"]
+        sequence["prompts"] = [prompt]
+        sequence["rule"] = {"path": {"must_match": ["/*"]}}
+        return sequence
+    except Exception:
+        return None
+
+
+# Take the hardcoded "prompts_config" sequences and append event-based sequences
+def get_active_prompt_sequences(distinct_id: str, team_id: str) -> List[Dict[str, Any]]:
+
+    active_prompts = prompts_config
+    prompt_events = query_with_columns(SELECT_PROMPT_TRIGGER_SQL, {"distinct_id": distinct_id, "team_id": team_id})
+    prompt_keys = set()
+    for event in prompt_events:
+        prompt = event_properties_to_prompt_sequence(json.loads(event["properties"]))
+        if prompt["key"] not in prompt_keys:
+            prompt_keys.add(prompt["key"])
+            active_prompts.append(prompt)
+
+    return active_prompts
 
 
 class PromptSequenceStateSerializer(serializers.HyperlinkedModelSerializer):
@@ -27,18 +100,21 @@ class PromptSequenceStateViewSet(StructuredViewSetMixin, viewsets.ViewSet):
         if not request.user.is_authenticated:  # for mypy otherwise check on distict_id below fails
             raise exceptions.NotAuthenticated()
         local_states: List[Dict[str, Any]] = []
+        local_state_keys = set()
         for key in request.data:
-            parsed_state = dict(
-                request.data[key], last_updated_at=parser.isoparse(request.data[key]["last_updated_at"])
-            )
-            local_states.append(parsed_state)
+            if key not in local_state_keys:
+                parsed_state = dict(
+                    request.data[key], last_updated_at=parser.isoparse(request.data[key]["last_updated_at"])
+                )
+                local_states.append(parsed_state)
+                local_state_keys.add(key)
 
         my_prompts: Dict[str, Any] = {"sequences": [], "state": {}}
         states_to_update: List[UserPromptSequenceState] = []
         states_to_create: List[UserPromptSequenceState] = []
 
         saved_states = UserPromptSequenceState.objects.filter(user=request.user)
-        all_sequences = get_active_prompt_sequences()
+        all_sequences = get_active_prompt_sequences(request.user.email, request.user.team.id)
 
         new_states: List[Dict] = []
 

--- a/posthog/api/test/test_prompt.py
+++ b/posthog/api/test/test_prompt.py
@@ -4,7 +4,7 @@ from freezegun.api import freeze_time
 from rest_framework import status
 
 from posthog.models import User
-from posthog.models.prompt import UserPromptSequenceState, prompts_config
+from posthog.models.prompt.prompt import UserPromptSequenceState, prompts_config
 from posthog.test.base import APIBaseTest
 
 

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -30,7 +30,7 @@ from .organization_domain import OrganizationDomain
 from .person import Person, PersonDistinctId
 from .personal_api_key import PersonalAPIKey
 from .plugin import Plugin, PluginAttachment, PluginConfig, PluginSourceFile
-from .prompt import UserPromptSequenceState
+from .prompt.prompt import UserPromptSequenceState
 from .property import Property
 from .property_definition import PropertyDefinition
 from .session_recording_event import SessionRecordingEvent

--- a/posthog/models/prompt/constants.py
+++ b/posthog/models/prompt/constants.py
@@ -1,22 +1,3 @@
-from typing import Any, Dict, List
-
-from django.db import models
-from django.utils import timezone
-
-
-class UserPromptSequenceState(models.Model):
-    class Meta:
-        constraints = [models.UniqueConstraint(fields=["user", "key"], name="unique sequence key for user")]
-
-    user: models.ForeignKey = models.ForeignKey("User", on_delete=models.CASCADE)
-    key: models.CharField = models.CharField(max_length=400)
-
-    last_updated_at: models.DateTimeField = models.DateTimeField(default=timezone.now)
-    step: models.IntegerField = models.IntegerField(default=0)
-    completed: models.BooleanField = models.BooleanField(default=False)
-    dismissed: models.BooleanField = models.BooleanField(default=False)
-
-
 prompts_config = [
     {
         "key": "start-flow",  # sequence key
@@ -126,9 +107,3 @@ prompts_config = [
         "type": "one-off",
     },
 ]
-
-# Return prompts
-def get_active_prompt_sequences() -> List[Dict[str, Any]]:
-
-    # we're running an experiment with a hard coded list of prompts
-    return prompts_config

--- a/posthog/models/prompt/prompt.py
+++ b/posthog/models/prompt/prompt.py
@@ -1,0 +1,15 @@
+from django.db import models
+from django.utils import timezone
+
+
+class UserPromptSequenceState(models.Model):
+    class Meta:
+        constraints = [models.UniqueConstraint(fields=["user", "key"], name="unique sequence key for user")]
+
+    user: models.ForeignKey = models.ForeignKey("User", on_delete=models.CASCADE)
+    key: models.CharField = models.CharField(max_length=400)
+
+    last_updated_at: models.DateTimeField = models.DateTimeField(default=timezone.now)
+    step: models.IntegerField = models.IntegerField(default=0)
+    completed: models.BooleanField = models.BooleanField(default=False)
+    dismissed: models.BooleanField = models.BooleanField(default=False)


### PR DESCRIPTION
## Problem
We are integrating our messaging strategy with an external provider. However, we do not want to use their SDK for in-app messaging, as we don't want to rely on third party cookies.

We can now trigger prompts inside of PostHog by sending a `prompt trigger` event through the API (or any other ingestion), properly formatted (doc on how to format prompts coming soon to these screens).

## Changes
- Search for `prompt trigger` events and build a prompt sequence from each
- Improve `LemonActionableTooltip` interface
- Fix a bug where prompts path rule would not match urls with subpaths (.e.g /hello/world)
- Fix a bug where sequences would be counted twice 

A prompt created from an ingestion event
<img width="957" alt="image" src="https://user-images.githubusercontent.com/7335343/201177363-6c8876b3-b4ba-4edd-8e98-19ad354dba88.png">

## How did you test this code?
- [ ] Need to add tests