### PR TITLE
feat(recordings): derived names for session recording playlists

### DIFF
--- a/ee/api/session_recording_playlist.py
+++ b/ee/api/session_recording_playlist.py
@@ -72,7 +72,6 @@ class SessionRecordingPlaylistSerializer(serializers.ModelSerializer):
         read_only_fields = [
             "id",
             "short_id",
-            "derived_name",
             "team",
             "created_at",
             "created_by",

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -155,7 +155,7 @@
             }
             &:not(:disabled):active {
                 color: var(--#{$status}-dark, var(--primary-dark));
-                .LemonIcon {
+                .LemonButton__icon {
                     color: var(--#{$status}-dark, var(--primary-dark));
                 }
             }

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -3,7 +3,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { useActions, useValues } from 'kea'
 import { urls } from 'scenes/urls'
 import { SceneExport } from 'scenes/sceneTypes'
-import { sessionRecordingsListLogic } from 'scenes/session-recordings/playlist/sessionRecordingsListLogic'
 import { SessionRecordingsPlaylist } from './playlist/SessionRecordingsPlaylist'
 import { AlertMessage } from 'lib/components/AlertMessage'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -22,12 +21,9 @@ import { openSessionRecordingSettingsDialog } from './settings/SessionRecordingS
 export function SessionsRecordings(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { tab } = useValues(sessionRecordingsLogic)
+    const { tab, newPlaylistLoading } = useValues(sessionRecordingsLogic)
+    const { saveNewPlaylist } = useActions(sessionRecordingsLogic)
     const showRecordingPlaylists = !!featureFlags[FEATURE_FLAGS.RECORDING_PLAYLISTS]
-    const listLogic = sessionRecordingsListLogic({ key: 'recents', updateSearchParams: true })
-    const { filters, newPlaylistLoading } = useValues(listLogic)
-    const { saveNewPlaylist } = useActions(listLogic)
-
     const recentRecordings = <SessionRecordingsPlaylist logicKey="recents" updateSearchParams />
 
     const recordingsDisabled = currentTeam && !currentTeam?.session_recording_opt_in
@@ -58,11 +54,7 @@ export function SessionsRecordings(): JSX.Element {
                                 >
                                     <LemonButton
                                         type="primary"
-                                        onClick={() =>
-                                            saveNewPlaylist({
-                                                filters: tab === SessionRecordingsTabs.Recent ? filters : undefined,
-                                            })
-                                        }
+                                        onClick={() => saveNewPlaylist()}
                                         loading={newPlaylistLoading}
                                         data-attr="save-recordings-playlist-button"
                                         icon={<IconPlus />}

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -22,16 +22,13 @@ import { openSessionRecordingSettingsDialog } from './settings/SessionRecordingS
 export function SessionsRecordings(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { tab, newPlaylistLoading } = useValues(sessionRecordingsLogic)
-    const { saveNewPlaylist } = useActions(sessionRecordingsLogic)
+    const { tab } = useValues(sessionRecordingsLogic)
     const showRecordingPlaylists = !!featureFlags[FEATURE_FLAGS.RECORDING_PLAYLISTS]
-    const { filters } = useValues(sessionRecordingsListLogic({ key: 'recents', updateSearchParams: true }))
+    const listLogic = sessionRecordingsListLogic({ key: 'recents', updateSearchParams: true })
+    const { filters, newPlaylistLoading } = useValues(listLogic)
+    const { saveNewPlaylist } = useActions(listLogic)
 
-    const recentRecordings = (
-        <>
-            <SessionRecordingsPlaylist logicKey="recents" updateSearchParams />
-        </>
-    )
+    const recentRecordings = <SessionRecordingsPlaylist logicKey="recents" updateSearchParams />
 
     const recordingsDisabled = currentTeam && !currentTeam?.session_recording_opt_in
 

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useActions, useValues } from 'kea'
-import { deleteWithUndo, range } from '~/lib/utils'
+import { range } from '~/lib/utils'
 import { RecordingDurationFilter, RecordingFilters, SessionRecordingsTabs, SessionRecordingType } from '~/types'
 import {
     defaultPageviewPropertyEntityFilter,
@@ -28,9 +28,9 @@ import { sessionRecordingsPlaylistLogic } from './sessionRecordingsPlaylistLogic
 import { NotFound } from 'lib/components/NotFound'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
 import { More } from 'lib/components/LemonButton/More'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { router } from 'kea-router'
+import { deletePlaylistWithUndo } from './playlistUtils'
 
 export const scene: SceneExport = {
     component: SessionRecordingsPlaylistScene,
@@ -41,7 +41,6 @@ export const scene: SceneExport = {
 }
 
 export function SessionRecordingsPlaylistScene(): JSX.Element {
-    const { currentTeamId } = useValues(teamLogic)
     const { playlist, playlistLoading, hasChanges, derivedName } = useValues(sessionRecordingsPlaylistLogic)
     const { updatePlaylist, setFilters, saveChanges, duplicatePlaylist } = useActions(sessionRecordingsPlaylistLogic)
 
@@ -118,15 +117,10 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
                                     <LemonButton
                                         status="danger"
                                         onClick={() =>
-                                            deleteWithUndo({
-                                                object: playlist,
-                                                idField: 'short_id',
-                                                endpoint: `projects/${currentTeamId}/session_recording_playlists`,
-                                                callback: () => {
-                                                    router.actions.replace(
-                                                        urls.sessionRecordings(SessionRecordingsTabs.Playlists)
-                                                    )
-                                                },
+                                            deletePlaylistWithUndo(playlist, () => {
+                                                router.actions.replace(
+                                                    urls.sessionRecordings(SessionRecordingsTabs.Playlists)
+                                                )
                                             })
                                         }
                                         fullWidth

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -42,7 +42,7 @@ export const scene: SceneExport = {
 
 export function SessionRecordingsPlaylistScene(): JSX.Element {
     const { currentTeamId } = useValues(teamLogic)
-    const { playlist, playlistLoading, hasChanges } = useValues(sessionRecordingsPlaylistLogic)
+    const { playlist, playlistLoading, hasChanges, derivedName } = useValues(sessionRecordingsPlaylistLogic)
     const { updatePlaylist, setFilters, saveChanges, duplicatePlaylist } = useActions(sessionRecordingsPlaylistLogic)
 
     if (!playlist && playlistLoading) {
@@ -81,7 +81,7 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
                     <EditableField
                         name="name"
                         value={playlist.name || ''}
-                        placeholder={'Untitled Playlist'}
+                        placeholder={derivedName}
                         onSave={(value) => updatePlaylist({ name: value })}
                         saveOnBlur={true}
                         maxLength={400}

--- a/frontend/src/scenes/session-recordings/playlist/playlistUtils.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistUtils.test.ts
@@ -1,0 +1,169 @@
+import { CohortType, FilterLogicalOperator, PropertyOperator } from '~/types'
+import { summarizePlaylistFilters } from 'scenes/session-recordings/playlist/playlistUtils'
+
+describe('summarizePlaylistFilters()', () => {
+    const cohortIdsMapped: Partial<Record<CohortType['id'], CohortType>> = {
+        1: {
+            id: 1,
+            name: 'New Yorkers',
+            filters: { properties: { id: '1', type: FilterLogicalOperator.Or, values: [] } },
+            groups: [],
+        },
+    }
+
+    it('summarizes a playlist with four events and an action', () => {
+        expect(
+            summarizePlaylistFilters(
+                {
+                    events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            order: 0,
+                        },
+                        {
+                            id: '$rageclick',
+                            name: '$rageclick',
+                            order: 1,
+                        },
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            order: 4,
+                        },
+                        {
+                            id: '$autocapture',
+                            name: '$autocapture',
+                            order: 5,
+                        },
+                    ],
+                    actions: [
+                        {
+                            id: 1,
+                            name: 'Random action',
+                            order: 2,
+                        },
+                    ],
+                },
+                cohortIdsMapped
+            )
+        ).toEqual('Pageview & Rageclick & Random action & Pageview & Autocapture')
+    })
+
+    it('summarizes a playlist with one event, one PH person property and one custom property', () => {
+        expect(
+            summarizePlaylistFilters(
+                {
+                    events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            order: 0,
+                        },
+                    ],
+                    properties: [
+                        {
+                            key: '$initial_browser',
+                            type: 'person',
+                            operator: PropertyOperator.Exact,
+                            value: 'Chrome',
+                        },
+                        {
+                            key: 'custom_property',
+                            type: 'person',
+                            operator: PropertyOperator.IContains,
+                            value: 'blah',
+                        },
+                    ],
+                },
+                cohortIdsMapped
+            )
+        ).toEqual('Pageview, on Initial Browser = Chrome & custom_property ∋ blah')
+    })
+
+    it('summarizes a playlist with one event and one cohort', () => {
+        expect(
+            summarizePlaylistFilters(
+                {
+                    events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            order: 0,
+                        },
+                    ],
+                    properties: [
+                        {
+                            key: 'id',
+                            type: 'cohort',
+                            value: 1,
+                        },
+                    ],
+                },
+                cohortIdsMapped
+            )
+        ).toEqual('Pageview, on cohorts: New Yorkers')
+    })
+
+    it('summarizes a playlist with one property', () => {
+        expect(
+            summarizePlaylistFilters(
+                {
+                    properties: [
+                        {
+                            key: 'id',
+                            type: 'cohort',
+                            value: 1,
+                        },
+                    ],
+                },
+                cohortIdsMapped
+            )
+        ).toEqual('cohorts: New Yorkers')
+    })
+
+    it('all together', () => {
+        expect(
+            summarizePlaylistFilters(
+                {
+                    events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            order: 0,
+                        },
+                    ],
+                    actions: [
+                        {
+                            id: 1,
+                            name: 'Random action',
+                            order: 2,
+                        },
+                    ],
+                    properties: [
+                        {
+                            key: '$initial_browser',
+                            type: 'person',
+                            operator: PropertyOperator.Exact,
+                            value: 'Chrome',
+                        },
+                        {
+                            key: 'custom_property',
+                            type: 'person',
+                            operator: PropertyOperator.IContains,
+                            value: 'blah',
+                        },
+                        {
+                            key: 'id',
+                            type: 'cohort',
+                            value: 1,
+                        },
+                    ],
+                },
+                cohortIdsMapped
+            )
+        ).toEqual(
+            'Pageview & Random action, on Initial Browser = Chrome & custom_property ∋ blah & cohorts: New Yorkers'
+        )
+    })
+})

--- a/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
@@ -1,0 +1,57 @@
+import { PropertyOperator, RecordingFilters } from '~/types'
+import { cohortsModelType } from '~/models/cohortsModelType'
+import { toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
+import { getDisplayNameFromEntityFilter } from 'scenes/insights/utils'
+import { convertPropertyGroupToProperties, genericOperatorMap } from 'lib/utils'
+import { getKeyMapping } from 'lib/components/PropertyKeyInfo'
+
+function getOperatorSymbol(operator: PropertyOperator | null): string {
+    if (!operator) {
+        return '?'
+    }
+    if (genericOperatorMap?.[operator]) {
+        return genericOperatorMap[operator].slice(0, 1)
+    }
+    return String(operator)
+}
+
+export function summarizePlaylistFilters(
+    filters: Partial<RecordingFilters>,
+    cohortsById: cohortsModelType['values']['cohortsById']
+): string {
+    let summary: string
+    const localFilters = toLocalFilters(filters)
+
+    summary = localFilters
+        .map((localFilter) => {
+            return getDisplayNameFromEntityFilter(localFilter)
+        })
+        .join(' & ')
+
+    const properties = convertPropertyGroupToProperties(filters.properties)
+    if (properties && (properties.length ?? 0) > 0) {
+        const propertiesSummary = properties
+            .map((property) => {
+                if (property.type === 'person') {
+                    return `${getKeyMapping(property.key, 'event')?.label || property.key} ${getOperatorSymbol(
+                        property.operator
+                    )} ${property.value}`
+                }
+                if (property.type === 'cohort') {
+                    const cohortId = Number(property.value)
+                    return `cohorts: ${
+                        property.value === 'all'
+                            ? 'all users'
+                            : cohortId in cohortsById
+                            ? cohortsById[cohortId]?.name
+                            : `ID ${cohortId}`
+                    }`
+                }
+            })
+            .filter((property) => !!property)
+            .join(' & ')
+        summary += `${summary ? ', on ' : ''}${propertiesSummary}`
+    }
+
+    return summary
+}

--- a/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
@@ -11,6 +11,7 @@ import { PLAYLIST_LIMIT_REACHED_MESSAGE } from '../sessionRecordingsLogic'
 import { lemonToast } from '@posthog/lemon-ui'
 import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
+import { DEFAULT_RECORDING_FILTERS } from './sessionRecordingsListLogic'
 
 function getOperatorSymbol(operator: PropertyOperator | null): string {
     if (!operator) {
@@ -68,6 +69,7 @@ export async function createPlaylist(
     redirect = true
 ): Promise<SessionRecordingPlaylistType | null> {
     try {
+        playlist.filters = playlist.filters || DEFAULT_RECORDING_FILTERS
         const res = await api.recordings.createPlaylist(playlist)
         if (redirect) {
             router.actions.push(urls.sessionRecordingPlaylist(res.short_id))

--- a/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
@@ -18,7 +18,7 @@ function getOperatorSymbol(operator: PropertyOperator | null): string {
 export function summarizePlaylistFilters(
     filters: Partial<RecordingFilters>,
     cohortsById: cohortsModelType['values']['cohortsById']
-): string {
+): string | null {
     let summary: string
     const localFilters = toLocalFilters(filters)
 
@@ -53,5 +53,5 @@ export function summarizePlaylistFilters(
         summary += `${summary ? ', on ' : ''}${propertiesSummary}`
     }
 
-    return summary
+    return summary.trim() || null
 }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -6,7 +6,6 @@ import {
     PropertyOperator,
     RecordingFilters,
     SessionRecordingId,
-    SessionRecordingPlaylistType,
     SessionRecordingPropertiesType,
     SessionRecordingsResponse,
     SessionRecordingsTabs,
@@ -21,8 +20,6 @@ import { dayjs } from 'lib/dayjs'
 import { loaders } from 'kea-loaders'
 import { urls } from 'scenes/urls'
 import { cohortsModel } from '~/models/cohortsModel'
-import { createPlaylist } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
-import { summarizePlaylistFilters } from 'scenes/session-recordings/playlist/playlistUtils'
 
 export type PersonUUID = string
 interface Params {
@@ -128,7 +125,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         }),
         loadNext: true,
         loadPrev: true,
-        saveNewPlaylist: (playlist: Partial<SessionRecordingPlaylistType>) => ({ playlist }),
     }),
     loaders(({ props, values, actions }) => ({
         sessionRecordingsResponse: [
@@ -182,17 +178,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
 
                     breakpoint()
                     return response
-                },
-            },
-        ],
-        newPlaylist: [
-            null as SessionRecordingPlaylistType | null,
-            {
-                saveNewPlaylist: async ({ playlist }) => {
-                    return await createPlaylist({
-                        ...playlist,
-                        derived_name: summarizePlaylistFilters(playlist.filters || {}, values.cohortsById),
-                    })
                 },
             },
         ],
@@ -263,12 +248,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         },
         getSessionRecordingsSuccess: () => {
             actions.getSessionRecordingsProperties({})
-        },
-        saveNewPlaylistSuccess: async ({ newPlaylist }) => {
-            if (!newPlaylist) {
-                return
-            }
-            router.actions.push(urls.sessionRecordingPlaylist(newPlaylist.short_id))
         },
     })),
     selectors({

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -15,11 +15,9 @@ import type { sessionRecordingsListLogicType } from './sessionRecordingsListLogi
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import equal from 'fast-deep-equal'
-import { teamLogic } from '../../teamLogic'
 import { dayjs } from 'lib/dayjs'
 import { loaders } from 'kea-loaders'
 import { urls } from 'scenes/urls'
-import { cohortsModel } from '~/models/cohortsModel'
 
 export type PersonUUID = string
 interface Params {
@@ -109,7 +107,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
     props({} as SessionRecordingListLogicProps),
     key((props) => `${props.key}-${props.updateSearchParams ?? '-with-search'}`),
     connect({
-        values: [teamLogic, ['currentTeamId'], cohortsModel, ['cohortsById']],
         actions: [
             eventUsageLogic,
             ['reportRecordingsListFetched', 'reportRecordingsListPropertiesFetched', 'reportRecordingsListFilterAdded'],

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1,14 +1,34 @@
-import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { Breadcrumb, RecordingFilters, SessionRecordingPlaylistType, SessionRecordingsTabs } from '~/types'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
-
 import type { sessionRecordingsPlaylistLogicType } from './sessionRecordingsPlaylistLogicType'
 import { urls } from 'scenes/urls'
 import equal from 'fast-deep-equal'
 import { lemonToast } from '@posthog/lemon-ui'
 import { beforeUnload, router } from 'kea-router'
-import { createPlaylist } from '../sessionRecordingsLogic'
+import { cohortsModel } from '~/models/cohortsModel'
+import { openBillingPopupModal } from 'scenes/billing/v2/BillingPopup'
+import { PLAYLIST_LIMIT_REACHED_MESSAGE } from 'scenes/session-recordings/sessionRecordingsLogic'
+import { summarizePlaylistFilters } from 'scenes/session-recordings/playlist/playlistUtils'
+
+export async function createPlaylist(
+    playlist: Partial<SessionRecordingPlaylistType>
+): Promise<SessionRecordingPlaylistType | null> {
+    try {
+        return await api.recordings.createPlaylist(playlist)
+    } catch (e: any) {
+        if (e.status === 403) {
+            openBillingPopupModal({
+                title: `Upgrade now to unlock unlimited playlists`,
+                description: PLAYLIST_LIMIT_REACHED_MESSAGE,
+            })
+        } else {
+            throw e
+        }
+    }
+    return null
+}
 
 export interface SessionRecordingsPlaylistLogicProps {
     shortId: string
@@ -18,13 +38,16 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
     path((key) => ['scenes', 'session-recordings', 'playlist', 'sessionRecordingsPlaylistLogic', key]),
     props({} as SessionRecordingsPlaylistLogicProps),
     key((props) => props.shortId),
+    connect({
+        values: [cohortsModel, ['cohortsById']],
+    }),
     actions({
         loadPlaylist: true,
         setFilters: (filters: RecordingFilters | null) => ({ filters }),
         saveChanges: true,
         duplicatePlaylist: true,
     }),
-    loaders(({ props }) => ({
+    loaders(({ props, values }) => ({
         playlist: [
             null as SessionRecordingPlaylistType | null,
             {
@@ -34,7 +57,10 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
 
                 updatePlaylist: async (playlist: Partial<SessionRecordingPlaylistType>, breakpoint) => {
                     await breakpoint(100)
-                    const response = api.recordings.updatePlaylist(props.shortId, playlist)
+                    const response = api.recordings.updatePlaylist(props.shortId, {
+                        ...playlist,
+                        derived_name: values.derivedName, // Makes sure derived name is kept up to date
+                    })
                     breakpoint()
 
                     lemonToast.success('Playlist updated successfully')
@@ -67,6 +93,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
 
             const { id, short_id, ...playlist } = values.playlist
             playlist.name = playlist.name ? playlist.name + ' (copy)' : ''
+            playlist.derived_name = playlist.derived_name ? playlist.derived_name + ' (copy)' : ''
 
             const newPlaylist = await createPlaylist(playlist)
             if (!newPlaylist) {
@@ -94,7 +121,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                     path: urls.sessionRecordings(SessionRecordingsTabs.Playlists),
                 },
                 {
-                    name: playlist?.name || 'Untitled Playlist',
+                    name: playlist?.name || playlist?.derived_name || 'Untitled Playlist',
                     path: urls.sessionRecordingPlaylist(playlist?.short_id || ''),
                 },
             ],
@@ -102,6 +129,10 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         hasChanges: [
             (s) => [s.playlist, s.filters],
             (playlist, filters): boolean => !equal(playlist?.filters, filters),
+        ],
+        derivedName: [
+            (s) => [s.filters, s.cohortsById],
+            (filters, cohortsById) => summarizePlaylistFilters(filters || {}, cohortsById).slice(0, 400),
         ],
     })),
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -132,7 +132,8 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         ],
         derivedName: [
             (s) => [s.filters, s.cohortsById],
-            (filters, cohortsById) => summarizePlaylistFilters(filters || {}, cohortsById).slice(0, 400),
+            (filters, cohortsById) =>
+                summarizePlaylistFilters(filters || {}, cohortsById)?.slice(0, 400) || '(Untitled)',
         ],
     })),
 

--- a/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylists.tsx
+++ b/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylists.tsx
@@ -11,6 +11,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { membersLogic } from 'scenes/organization/Settings/membersLogic'
 import { TZLabel } from '@posthog/apps-common'
 import { SavedSessionRecordingPlaylistsEmptyState } from 'scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylistsEmptyState'
+import clsx from 'clsx'
 
 export type SavedSessionRecordingPlaylistsProps = {
     tab: SessionRecordingsTabs.Playlists
@@ -44,8 +45,11 @@ export function SavedSessionRecordingPlaylists({ tab }: SavedSessionRecordingPla
             render: function Render(name, { short_id, derived_name, description }) {
                 return (
                     <>
-                        <Link className="font-semibold" to={urls.sessionRecordingPlaylist(short_id)}>
-                            {name || derived_name || 'Untitled'}
+                        <Link
+                            className={clsx('font-semibold', !name && 'italic')}
+                            to={urls.sessionRecordingPlaylist(short_id)}
+                        >
+                            {name || derived_name || '(Untitled)'}
                         </Link>
                         {description ? <div className="truncate">{description}</div> : null}
                     </>

--- a/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylists.tsx
+++ b/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylists.tsx
@@ -40,11 +40,11 @@ export function SavedSessionRecordingPlaylists({ tab }: SavedSessionRecordingPla
         {
             title: 'Name',
             dataIndex: 'name',
-            render: function Render(name, { short_id, description }) {
+            render: function Render(name, { short_id, derived_name, description }) {
                 return (
                     <>
                         <Link className="font-semibold" to={urls.sessionRecordingPlaylist(short_id)}>
-                            {name || 'Untitled'}
+                            {name || derived_name || 'Untitled'}
                         </Link>
                         {description ? <div className="truncate">{description}</div> : null}
                     </>

--- a/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylistsEmptyState.tsx
+++ b/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylistsEmptyState.tsx
@@ -1,10 +1,12 @@
 import { LemonButton } from 'lib/components/LemonButton'
 import { IconPlus } from 'lib/components/icons'
-import { sessionRecordingsListLogic } from 'scenes/session-recordings/playlist/sessionRecordingsListLogic'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
+import { SessionRecordingsTabs } from '~/types'
+import { savedSessionRecordingPlaylistsLogic } from './savedSessionRecordingPlaylistsLogic'
 
-export function SavedSessionRecordingPlaylistsEmptyState(): JSX.Element {
-    const { saveNewPlaylist } = useActions(sessionRecordingsListLogic({ key: 'recents', updateSearchParams: true }))
+export function SavedSessionRecordingPlaylistsEmptyState({ tab }: { tab: SessionRecordingsTabs }): JSX.Element {
+    const { newPlaylistLoading } = useValues(savedSessionRecordingPlaylistsLogic({ tab }))
+    const { createPlaylist } = useActions(savedSessionRecordingPlaylistsLogic({ tab }))
 
     return (
         <div className="flex items-center justify-center">
@@ -16,8 +18,9 @@ export function SavedSessionRecordingPlaylistsEmptyState(): JSX.Element {
                     type="primary"
                     data-attr="add-session-playlist-button-empty-state"
                     icon={<IconPlus />}
+                    loading={newPlaylistLoading}
                     onClick={() => {
-                        saveNewPlaylist({})
+                        createPlaylist()
                     }}
                 >
                     New Playlist

--- a/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylistsEmptyState.tsx
+++ b/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylistsEmptyState.tsx
@@ -1,10 +1,10 @@
 import { LemonButton } from 'lib/components/LemonButton'
 import { IconPlus } from 'lib/components/icons'
+import { sessionRecordingsListLogic } from 'scenes/session-recordings/playlist/sessionRecordingsListLogic'
 import { useActions } from 'kea'
-import { sessionRecordingsLogic } from 'scenes/session-recordings/sessionRecordingsLogic'
 
 export function SavedSessionRecordingPlaylistsEmptyState(): JSX.Element {
-    const { saveNewPlaylist } = useActions(sessionRecordingsLogic)
+    const { saveNewPlaylist } = useActions(sessionRecordingsListLogic({ key: 'recents', updateSearchParams: true }))
 
     return (
         <div className="flex items-center justify-center">


### PR DESCRIPTION
## Problem

Adding recording playlists without names will quickly flood the new saved playlists view with "Untitled" items that give users little context about the playlist.

## Changes

This PR adds derived names for playlists which brings it up to par with insight derived names.

Also moved `createNewPlaylist` from `sessionRecordingsLogic` to `sessionRecordingPlaylistLogic` which probably makes more sense.

https://user-images.githubusercontent.com/13460330/201178964-904f6b97-fc72-46d6-b316-35f06f91d54e.mov


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Add exhaustive tests for new summarizePlaylistFilters util