### PR TITLE
fix: shared dashboards with text cards

### DIFF
--- a/frontend/src/exporter/index.html
+++ b/frontend/src/exporter/index.html
@@ -19,6 +19,10 @@
             div.innerHTML = "You are using a really old browser. Please upgrade to fully enjoy PostHog!"
             document.body.prepend(div);
         }
+        if (!window.process) {
+            // see https://github.com/remarkjs/react-markdown/issues/339
+            window.process = { cwd: () => '' };
+        }
     </script>
     <div id="root"></div>
   </body>


### PR DESCRIPTION
## Problem

Discovered that you couldn't load shared dashboards if they have text cards.

see https://github.com/remarkjs/react-markdown/issues/339

## Changes

we don't actually need process to do anything... so make it present and useless

## without fix

<img width="1510" alt="Screenshot 2022-11-10 at 21 12 21" src="https://user-images.githubusercontent.com/984817/201207034-21682625-5835-441c-a636-f9cbf03924ac.png">

## with fix 

<img width="1512" alt="Screenshot 2022-11-10 at 21 12 30" src="https://user-images.githubusercontent.com/984817/201207040-7776c527-7963-4857-82ae-d31f2c9d2265.png">

## How did you test this code?

* sharing a dashboard with a text card on and seeing that this change made it possible to visit it
* visiting the unshared dashboard
* exporting the dashboard to PNG
 