### PR TITLE
chore(events): only join on person_id

### DIFF
--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -107,8 +107,8 @@
          created_at
   FROM events
   where team_id = 2
-    AND timestamp > '2022-11-16 10:27:44.423249'
-    AND timestamp < '2022-11-17 10:27:49.423273'
+    AND timestamp > '2020-01-19 20:00:00.000000'
+    AND timestamp < '2020-01-20 20:00:05.000000'
     AND person_id = '00000000-0000-4000-8000-000000000001'
   ORDER BY timestamp DESC
   LIMIT 101
@@ -127,7 +127,7 @@
          created_at
   FROM events
   where team_id = 2
-    AND timestamp < '2022-11-17 10:27:49.437129'
+    AND timestamp < '2020-01-20 20:00:05.000000'
     AND person_id = '00000000-0000-4000-8000-000000000001'
   ORDER BY timestamp DESC
   LIMIT 101

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -133,3 +133,42 @@
   LIMIT 101
   '
 ---
+# name: TestEvents.test_filter_by_person_for_person_on_events_enabled.2
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT uuid,
+         event,
+         properties,
+         timestamp,
+         team_id,
+         distinct_id,
+         elements_chain,
+         created_at
+  FROM events
+  where team_id = 2
+    AND timestamp > '2020-01-19 20:00:00.000000'
+    AND timestamp < '2020-01-20 20:00:05.000000'
+    AND person_id = '00000000-0000-4000-8000-000000000002'
+  ORDER BY timestamp DESC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_filter_by_person_for_person_on_events_enabled.3
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT uuid,
+         event,
+         properties,
+         timestamp,
+         team_id,
+         distinct_id,
+         elements_chain,
+         created_at
+  FROM events
+  where team_id = 2
+    AND timestamp < '2020-01-20 20:00:05.000000'
+    AND person_id = '00000000-0000-4000-8000-000000000002'
+  ORDER BY timestamp DESC
+  LIMIT 101
+  '
+---

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -94,3 +94,42 @@
   LIMIT 10
   '
 ---
+# name: TestEvents.test_filter_by_person_for_person_on_events_enabled
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT uuid,
+         event,
+         properties,
+         timestamp,
+         team_id,
+         distinct_id,
+         elements_chain,
+         created_at
+  FROM events
+  where team_id = 2
+    AND timestamp > '2022-11-16 10:27:44.423249'
+    AND timestamp < '2022-11-17 10:27:49.423273'
+    AND person_id = '00000000-0000-4000-8000-000000000001'
+  ORDER BY timestamp DESC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_filter_by_person_for_person_on_events_enabled.1
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT uuid,
+         event,
+         properties,
+         timestamp,
+         team_id,
+         distinct_id,
+         elements_chain,
+         created_at
+  FROM events
+  where team_id = 2
+    AND timestamp < '2022-11-17 10:27:49.437129'
+    AND person_id = '00000000-0000-4000-8000-000000000001'
+  ORDER BY timestamp DESC
+  LIMIT 101
+  '
+---

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -153,6 +153,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(response["results"]), 2)
 
     @mock.patch("posthog.models.team.Team.actor_on_events_querying_enabled", return_value=True)
+    @freeze_time("2020-01-20 20:00:00")
     def test_filter_by_person_for_person_on_events_enabled(self, mock_actor_on_events_querying_enabled):
         """
         Check the difference in functionality between

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -227,7 +227,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(response["results"]), 1)
 
     def test_filter_by_nonexisting_person(self):
-        response = self.client.get(f"/api/projects/{self.team.pk}/events/?person_id=5555555555")
+        response = self.client.get(f"/api/projects/{self.team.id}/events/?person_id=5555555555")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["results"]), 0)
 

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -152,6 +152,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/events/?person_id={person.uuid}").json()
         self.assertEqual(len(response["results"]), 2)
 
+    @snapshot_clickhouse_queries
     @mock.patch("posthog.models.team.Team.actor_on_events_querying_enabled", return_value=True)
     @freeze_time("2020-01-20 20:00:00")
     def test_filter_by_person_for_person_on_events_enabled(self, mock_actor_on_events_querying_enabled):
@@ -214,11 +215,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         flush_persons_and_events()
 
-        call_endpoint = lambda self: self.client.get(
-            f"/api/projects/{self.team.pk}/events/?person_id={initial_person.uuid}"
-        ).json()
-        response = snapshot_clickhouse_queries(call_endpoint)(self)
-
+        response = self.client.get(f"/api/projects/{self.team.pk}/events/?person_id={initial_person.uuid}").json()
         self.assertEqual(len(response["results"]), 3)
 
         response = self.client.get(

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -33,10 +33,14 @@ def determine_event_conditions(
             result += "AND timestamp < %(before)s"
             params.update({"before": timestamp})
         elif k == "person_id":
-            result += """AND distinct_id IN (%(distinct_ids)s)"""
-            person = get_pk_or_uuid(Person.objects.all(), v).first()
-            distinct_ids = person.distinct_ids if person is not None else []
-            params.update({"distinct_ids": list(map(str, distinct_ids))})
+            if team.actor_on_events_querying_enabled:
+                result += "AND person_id = %(person_id)s"
+                params.update({"person_id": v})
+            else:
+                result += """AND distinct_id IN (%(distinct_ids)s)"""
+                person = get_pk_or_uuid(Person.objects.all(), v).first()
+                distinct_ids = person.distinct_ids if person is not None else []
+                params.update({"distinct_ids": list(map(str, distinct_ids))})
         elif k == "distinct_id":
             result += "AND distinct_id = %(distinct_id)s"
             params.update({"distinct_id": v})

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -177,7 +177,7 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
 
         event = {
             **event,
-            "person_id": event.get("person_id", person_id),  # Allow overriding person_id
+            "person_id": event.get("person_id") or person_id,  # Allow overriding person_id
             "person_properties": {**person_properties, **event.get("person_properties", {})},
             "person_created_at": person_created_at,
         }

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -176,10 +176,11 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
                 person_created_at = datetime64_default_timestamp
 
         event = {
-            **event,
-            "person_properties": {**person_properties, **event.get("person_properties", {})},
             "person_id": person_id,
+            "person_properties": {**person_properties, **event.get("person_properties", {})},
             "person_created_at": person_created_at,
+            # NOTE: we put this last allowing us to override all properties
+            **event,
         }
 
         # Populate group properties as well

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -177,8 +177,8 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
 
         event = {
             **event,
-            "person_id": event.get("person_id") or person_id,  # Allow overriding person_id
             "person_properties": {**person_properties, **event.get("person_properties", {})},
+            "person_id": event.get("person_id") or person_id,  # Allow overriding person_id
             "person_created_at": person_created_at,
         }
 

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -176,11 +176,10 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
                 person_created_at = datetime64_default_timestamp
 
         event = {
-            "person_id": person_id,
+            **event,
+            "person_id": event.get("person_id", person_id),  # Allow overriding person_id
             "person_properties": {**person_properties, **event.get("person_properties", {})},
             "person_created_at": person_created_at,
-            # NOTE: we put this last allowing us to override all properties
-            **event,
         }
 
         # Populate group properties as well

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -596,11 +596,13 @@ def snapshot_clickhouse_queries(fn):
     @wraps(fn)
     def wrapped(self, *args, **kwargs):
         with self.capture_select_queries() as queries:
-            fn(self, *args, **kwargs)
+            result = fn(self, *args, **kwargs)
 
         for query in queries:
             if "FROM system.columns" not in query:
                 self.assertQueryMatchesSnapshot(query)
+
+        return result
 
     return wrapped
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -596,13 +596,11 @@ def snapshot_clickhouse_queries(fn):
     @wraps(fn)
     def wrapped(self, *args, **kwargs):
         with self.capture_select_queries() as queries:
-            result = fn(self, *args, **kwargs)
+            fn(self, *args, **kwargs)
 
         for query in queries:
             if "FROM system.columns" not in query:
                 self.assertQueryMatchesSnapshot(query)
-
-        return result
 
     return wrapped
 


### PR DESCRIPTION
## Problem

We use person on events for insights which uses the `person_id` on the events to handle attribution. Previously we would join across `person_distinct_id2` then onto `person`.

The events list on the persons page however was still using `person_distinct_id2` and `person` to generate the list. This updates to just use `person_id` to do the join thereby maintaining consistency with insight querying.

While handling support hero people have been confused that they can see events on the persons events list, but then somehow the people do not appear in insights. See for example:

1. https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667849627634539
2. https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667942045649409

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
