### PR TITLE
fix: multiply by none

### DIFF
--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -443,7 +443,9 @@ class TrendsBreakdown:
         if self.filter.breakdown_type == "session":
             # if session duration breakdown, we want ordering based on the time buckets, not the value
             return (-1, "")
-        return (value.get("count", value.get("aggregated_value", 0)) * -1, value.get("label"))  # reverse it
+
+        count_or_aggregated_value = value.get("count", value.get("aggregated_value", 0) or 0)
+        return count_or_aggregated_value * -1, value.get("label")  # reverse it
 
     def _parse_single_aggregate_result(
         self, filter: Filter, entity: Entity, additional_values: Dict[str, Any]

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -444,7 +444,7 @@ class TrendsBreakdown:
             # if session duration breakdown, we want ordering based on the time buckets, not the value
             return (-1, "")
 
-        count_or_aggregated_value = value.get("count", value.get("aggregated_value", 0) or 0)
+        count_or_aggregated_value = value.get("count", value.get("aggregated_value") or 0)
         return count_or_aggregated_value * -1, value.get("label")  # reverse it
 
     def _parse_single_aggregate_result(


### PR DESCRIPTION
## Problem

When changing a working trends line graph to a value graph I got an error.

Sentry showed we're multiplying None by -1 

https://sentry.io/organizations/posthog/issues/3738882372/?query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h

## Changes

guards against that value being None

## How did you test this code?

I didn't 🙈 