### PR TITLE
feat: Display free trial if you are on it

### DIFF
--- a/frontend/src/lib/components/BillingAlertsV2.tsx
+++ b/frontend/src/lib/components/BillingAlertsV2.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { billingLogic } from 'scenes/billing/v2/billingLogic'
 import { urls } from 'scenes/urls'
 import { AlertMessage } from './AlertMessage'
@@ -9,6 +9,7 @@ export function BillingAlertsV2(): JSX.Element | null {
     const { billingAlert, billingVersion } = useValues(billingLogic)
     const { reportBillingAlertShown } = useActions(billingLogic)
     const { currentLocation } = useValues(router)
+    const [alertHidden, setAlertHidden] = useState(false)
 
     const showAlert = billingAlert && billingVersion !== 'v2'
 
@@ -18,16 +19,18 @@ export function BillingAlertsV2(): JSX.Element | null {
         }
     }, [showAlert])
 
-    if (!billingAlert || billingVersion !== 'v2') {
+    if (!billingAlert || billingVersion !== 'v2' || alertHidden) {
         return null
     }
 
     const showButton = currentLocation.pathname !== urls.organizationBilling()
+
     return (
         <div className="my-4">
             <AlertMessage
                 type={billingAlert.status}
                 action={showButton ? { to: urls.organizationBilling(), children: 'Manage billing' } : undefined}
+                onClose={billingAlert.status !== 'error' ? () => setAlertHidden(true) : undefined}
             >
                 <b>{billingAlert.title}</b>
                 <br />

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -70,6 +70,11 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
 
     return (
         <div ref={ref}>
+            {billing?.free_trial_until ? (
+                <AlertMessage type="success" className="mb-2">
+                    You are currently on a free trial until <b>{billing.free_trial_until.format('LL')}</b>
+                </AlertMessage>
+            ) : null}
             {!billing && !billingLoading ? (
                 <div className="space-y-4">
                     <AlertMessage type="error">

--- a/frontend/src/scenes/billing/v2/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/billingLogic.ts
@@ -34,6 +34,8 @@ const parseBillingResponse = (data: Partial<BillingV2Type>): BillingV2Type => {
         })
     }
 
+    data.free_trial_until = data.free_trial_until ? dayjs(data.free_trial_until) : undefined
+
     return data as BillingV2Type
 }
 
@@ -94,9 +96,10 @@ export const billingLogic = kea<billingLogicType>([
         billingAlert: [
             (s) => [s.billing, s.preflight],
             (billing, preflight): BillingAlertConfig | undefined => {
-                if (!billing || !preflight?.cloud) {
+                if (!billing || !preflight?.cloud || (billing.free_trial_until && billing.free_trial_until < dayjs())) {
                     return
                 }
+
                 const productOverLimit = billing.products.find((x) => {
                     return x.percentage_usage > 1
                 })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -866,6 +866,7 @@ export interface BillingProductV2Type {
 export interface BillingV2Type {
     customer_id: string
     has_active_subscription: boolean
+    free_trial_until?: Dayjs
     stripe_portal_url?: string
     deactivated?: boolean
     current_total_amount_usd?: string


### PR DESCRIPTION
## Problem

We added a mode for doing free trials for unsubscribed customers but it currently has no frontend reference.

## Changes

* Adds a small banner on the billing page if it is enabled
* Adds warning message banner if in the last 3 days of the trial
* Makes banner dismissable if the status is not error (red)

#### Standard page

<img width="984" alt="Screenshot 2022-11-14 at 13 01 17" src="https://user-images.githubusercontent.com/2536520/201655240-32199e50-b7c3-4fd5-8b5b-8f4f02e686cd.png">

#### Billing page
<img width="993" alt="Screenshot 2022-11-14 at 13 01 12" src="https://user-images.githubusercontent.com/2536520/201655229-406aeb81-b0bf-4e2f-b652-d6824196f3b1.png">




👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
