### PR TITLE
feat(ingestion): add metric for web events with $active_feature_flags missing

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -167,6 +167,7 @@ def _ensure_web_feature_flags_in_properties(
 ):
     """If the event comes from web, ensure that it contains property $active_feature_flags."""
     if event["properties"].get("$lib") == "web" and "$active_feature_flags" not in event["properties"]:
+        statsd.incr("active_feature_flags_missing")
         flags, _ = get_active_feature_flags(team_id=ingestion_context.team_id, distinct_id=distinct_id)
         event["properties"]["$active_feature_flags"] = list(flags.keys())
         for k, v in flags.items():


### PR DESCRIPTION
Would like to know how useful this code path still is