### PR TITLE
fix: Recording sharing modal buttons and configure button

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -34,13 +34,15 @@ export function SessionsRecordings(): JSX.Element {
                 title={<div>Session Recordings</div>}
                 buttons={
                     <>
-                        <LemonButton
-                            type="secondary"
-                            icon={<IconSettings />}
-                            onClick={() => openSessionRecordingSettingsDialog()}
-                        >
-                            Configure
-                        </LemonButton>
+                        {!recordingsDisabled && (
+                            <LemonButton
+                                type="secondary"
+                                icon={<IconSettings />}
+                                onClick={() => openSessionRecordingSettingsDialog()}
+                            >
+                                Configure
+                            </LemonButton>
+                        )}
 
                         {showRecordingPlaylists ? (
                             <>

--- a/frontend/src/scenes/session-recordings/player/share/PlayerShare.tsx
+++ b/frontend/src/scenes/session-recordings/player/share/PlayerShare.tsx
@@ -22,7 +22,6 @@ export function ShareRecording(props: PlayerShareLogicProps): JSX.Element {
             </p>
             <LemonButton
                 type="secondary"
-                status="primary-alt"
                 fullWidth
                 center
                 sideIcon={<IconCopy />}
@@ -57,5 +56,9 @@ export function openPlayerShareDialog({ seconds, id }: PlayerShareLogicProps): v
         title: 'Share recording',
         content: <ShareRecording seconds={seconds} id={id} />,
         width: 600,
+        primaryButton: {
+            children: 'Close',
+            type: 'secondary',
+        },
     })
 }


### PR DESCRIPTION
## Problem

@annikaschmid pointed out that some of the buttons aren't so clear on the Recording share modal and also that we have double configure buttons when the disabled recordings alert shows.

## Changes

|Before|After|
|----|----|
|<img width="376" alt="Screenshot 2022-11-14 at 16 01 49" src="https://user-images.githubusercontent.com/2536520/201693272-8d609e29-f4af-464a-b8f5-5eca08a320d5.png">|<img width="609" alt="Screenshot 2022-11-14 at 15 59 43" src="https://user-images.githubusercontent.com/2536520/201692984-c093d09e-70f0-477f-9ee8-fb90f4a50699.png">|
|<img width="643" alt="Screenshot 2022-11-14 at 16 01 56" src="https://user-images.githubusercontent.com/2536520/201693283-68e3613a-540d-4a30-8727-7a723117afcb.png">|<img width="650" alt="Screenshot 2022-11-14 at 15 59 48" src="https://user-images.githubusercontent.com/2536520/201692990-face2d76-097a-4459-9afb-41c5b8f5e419.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
