### PR TITLE
fix(historical-exports): display selected date range alongside picker

### DIFF
--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -13,6 +13,8 @@ import moment from 'moment'
 import { LemonModal } from 'lib/components/LemonModal'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonCalendarRangeInline } from 'lib/components/LemonCalendarRange/LemonCalendarRangeInline'
+import { dayjs } from 'lib/dayjs'
+import { formatDate, formatDateRange } from 'lib/utils'
 
 // keep in sync with plugin-server's export-historical-events.ts
 export const HISTORICAL_EXPORT_JOB_NAME = 'Export historical events'
@@ -146,6 +148,24 @@ function FieldInput({
                 />
             )
         case 'daterange':
-            return <LemonCalendarRangeInline value={value || null} onChange={onChange} />
+            return (
+                <div className="border rounded p-4">
+                    <div className="pb-4">
+                        <LemonCalendarRangeInline value={value || null} onChange={onChange} />
+                    </div>
+                    <div className="border-t pt-4">
+                        <span className="text-muted">Selected period:</span>{' '}
+                        {value ? (
+                            <span>
+                                {value[0] === value[1]
+                                    ? formatDate(dayjs(value[0]))
+                                    : formatDateRange(dayjs(value[0]), dayjs(value[1]))}
+                            </span>
+                        ) : (
+                            <span className="italic">No period selected.</span>
+                        )}
+                    </div>
+                </div>
+            )
     }
 }


### PR DESCRIPTION
## Problem

Currently it is not clear to the user that they are selecting a range and not a starting point for the export. Context on the selected range also gets lost when selecting a range over multiple months. See https://github.com/PostHog/posthog/issues/12421.

## Changes

Added a text displaying the selected date range below the date picker.

### Before
<img width="556" alt="before" src="https://user-images.githubusercontent.com/1851359/201697448-46a26122-6a45-4067-872e-4ad2a8011aa5.png">

### After
<img width="590" alt="screen2" src="https://user-images.githubusercontent.com/1851359/201697490-e8269663-be51-4410-9c7a-2f10b3724ab2.png">

### Empty & Error State

<img width="585" alt="screen1" src="https://user-images.githubusercontent.com/1851359/201697492-55b9a937-eb67-43db-b375-086ac8486886.png">
<img width="591" alt="screen3" src="https://user-images.githubusercontent.com/1851359/201697479-e0c66ff3-2017-4341-a5e5-7becc871c8c1.png">

## How did you test this code?

Manual testing.
