### PR TITLE
chore(recordings): remove sentry capture error

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1,7 +1,6 @@
 import { KeyboardEvent } from 'react'
 import { actions, connect, events, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import { windowValues } from 'kea-window-values'
-import * as Sentry from '@sentry/react'
 import type { sessionRecordingPlayerLogicType } from './sessionRecordingPlayerLogicType'
 import { Replayer } from 'rrweb'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -648,8 +647,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         afterMount: () => {
             cache.openTime = performance.now()
 
-            cache.errorHandler = (error: ErrorEvent) => {
-                Sentry.captureException(error)
+            cache.errorHandler = () => {
                 actions.incrementErrorCount()
             }
             window.addEventListener('error', cache.errorHandler)


### PR DESCRIPTION
## Problem

We were capturing every error thrown on a page with the session recording player, which is redundant with the exceptions that Sentry automagically captures.

## Changes

Remove explicit Sentry call

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
