### PR TITLE
chore(persons-modal): Make missing persons message more informative

### DIFF
--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -14,7 +14,7 @@ import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { triggerExport } from 'lib/components/ExportButton/exporter'
 import { ExporterFormat } from '~/types'
 import clsx from 'clsx'
-import { AlertMessage } from 'lib/components/AlertMessage'
+import { MissingPersonsAlert } from 'scenes/trends/persons-modal/PersonsModal'
 import { Noun } from '~/models/groupsModel'
 
 export function RetentionModal({
@@ -67,17 +67,7 @@ export function RetentionModal({
             title={results[selectedRow] ? dayjs(results[selectedRow].date).format('MMMM D, YYYY') : ''}
         >
             {actors && !!actors.missing_persons && (
-                <AlertMessage type="info" className="mb-2">
-                    {actors.missing_persons}{' '}
-                    {actors.missing_persons > 1
-                        ? `${aggregationTargetLabel.plural} are`
-                        : `${aggregationTargetLabel.singular} is`}{' '}
-                    not shown because they've been merged with those listed, or deleted.{' '}
-                    <a href="https://posthog.com/docs/how-posthog-works/queries#insights-counting-unique-persons">
-                        Read more here for when this can happen
-                    </a>
-                    .
-                </AlertMessage>
+                <MissingPersonsAlert actorLabel={aggregationTargetLabel} missingActorsCount={actors.missing_persons} />
             )}
             <div className="min-h-20">
                 {actorsLoading ? (

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -72,7 +72,7 @@ export function RetentionModal({
                     {actors.missing_persons > 1
                         ? `${aggregationTargetLabel.plural} are`
                         : `${aggregationTargetLabel.singular} is`}{' '}
-                    not shown because they've been lost.{' '}
+                    not shown because they've been merged with those listed, or deleted.{' '}
                     <a href="https://posthog.com/docs/how-posthog-works/queries#insights-counting-unique-persons">
                         Read more here for when this can happen
                     </a>

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -8,7 +8,7 @@ import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { GroupActorHeader, groupDisplayId } from 'scenes/persons/GroupActorHeader'
 import { IconPlayCircle, IconUnfoldLess, IconUnfoldMore } from 'lib/components/icons'
 import { triggerExport } from 'lib/components/ExportButton/exporter'
-import { LemonButton, LemonDivider, LemonInput, LemonModal, LemonSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonInput, LemonModal, LemonSelect, Link } from '@posthog/lemon-ui'
 import { asDisplay, PersonHeader } from 'scenes/persons/PersonHeader'
 import ReactDOM from 'react-dom'
 import { Spinner } from 'lib/components/Spinner/Spinner'
@@ -18,6 +18,7 @@ import { Skeleton, Tabs } from 'antd'
 import { SessionPlayerModal } from 'scenes/session-recordings/player/modal/SessionPlayerModal'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { AlertMessage } from 'lib/components/AlertMessage'
+import { Noun } from '~/models/groupsModel'
 
 export interface PersonsModalProps {
     onAfterClose?: () => void
@@ -68,15 +69,7 @@ function PersonsModal({ url: _url, urlsIndex, urls, title, onAfterClose }: Perso
                 </LemonModal.Header>
                 <div className="px-6 py-2">
                     {actorsResponse && !!missingActorsCount && (
-                        <AlertMessage type="info" className="mb-2">
-                            {missingActorsCount}{' '}
-                            {missingActorsCount > 1 ? `${actorLabel.plural} are` : `${actorLabel.singular} is`} not
-                            shown because they've been lost.{' '}
-                            <a href="https://posthog.com/docs/how-posthog-works/queries#insights-counting-unique-persons">
-                                Read more here for when this can happen
-                            </a>
-                            .
-                        </AlertMessage>
+                        <MissingPersonsAlert actorLabel={actorLabel} missingActorsCount={missingActorsCount} />
                     )}
                     <LemonInput
                         type="search"
@@ -324,6 +317,24 @@ export function ActorRow({ actor, onOpenRecording }: ActorRowProps): JSX.Element
                 </div>
             ) : null}
         </div>
+    )
+}
+
+export function MissingPersonsAlert({
+    actorLabel,
+    missingActorsCount,
+}: {
+    actorLabel: Noun
+    missingActorsCount: number
+}): JSX.Element {
+    return (
+        <AlertMessage type="info" className="mb-2">
+            {missingActorsCount} {missingActorsCount > 1 ? `${actorLabel.plural} are` : `${actorLabel.singular} is`} not
+            shown because they've been merged with those listed, or deleted.{' '}
+            <Link to="https://posthog.com/docs/how-posthog-works/queries#insights-counting-unique-persons">
+                Learn more.
+            </Link>
+        </AlertMessage>
     )
 }
 


### PR DESCRIPTION
## Problem

This message is much too scary:

<img width="618" alt="before" src="https://user-images.githubusercontent.com/4550621/201739778-5c5665cd-1541-40ef-92a6-dfe6c869d5e8.png">

"Losing" persons sounds irresponsible, but that's not something we actually do. When some _appear_ missing, it's due to legitimate conditions.

## Changes

Updated the wording based on [Tiina's suggestion](https://posthog.slack.com/archives/C0113360FFV/p1668092557356879?thread_ts=1668092470.551439&cid=C0113360FFV):

<img width="615" alt="after" src="https://user-images.githubusercontent.com/4550621/201739931-8284b506-0717-4059-95ad-aa45b047bcd6.png">

