### PR TITLE
fix: check filter type before reading display

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
@@ -1,6 +1,7 @@
 import { kea } from 'kea'
 import { ChartDisplayType, FilterType } from '~/types'
 import type { insightsTableLogicType } from './insightsTableLogicType'
+import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 
 export type CalcColumnState = 'total' | 'average' | 'median'
 
@@ -27,7 +28,7 @@ export const insightsTableLogic = kea<insightsTableLogicType>({
         showTotalCount: [
             () => [(_, props) => props.filters],
             (filters: Partial<FilterType>) => {
-                if (filters.display == ChartDisplayType.ActionsTable) {
+                if (isTrendsFilter(filters) && filters.display == ChartDisplayType.ActionsTable) {
                     return true
                 }
                 return (


### PR DESCRIPTION
## Problem

follow #12683, `insightTableLogic` needs to check if filters are trends

## Changes

checks

## How did you test this code?

👀