### PR TITLE
fix: refactor ingestion logic

### DIFF
--- a/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
@@ -3,9 +3,8 @@ import './IngestionWizard.scss'
 
 import { VerificationPanel } from 'scenes/ingestion/v2/panels/VerificationPanel'
 import { InstructionsPanel } from 'scenes/ingestion/v2/panels/InstructionsPanel'
-import { MOBILE, BACKEND, WEB, BOOKMARKLET, THIRD_PARTY } from 'scenes/ingestion/v2/constants'
 import { useValues, useActions } from 'kea'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2, INGESTION_VIEWS } from 'scenes/ingestion/v2/ingestionLogic'
 import { FrameworkPanel } from 'scenes/ingestion/v2/panels/FrameworkPanel'
 import { PlatformPanel } from 'scenes/ingestion/v2/panels/PlatformPanel'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -24,8 +23,7 @@ import { InviteTeamPanel } from './panels/InviteTeamPanel'
 import { TeamInvitedPanel } from './panels/TeamInvitedPanel'
 
 export function IngestionWizardV2(): JSX.Element {
-    const { platform, framework, verify, addBilling, technical, hasInvitedMembers } = useValues(ingestionLogic)
-    const { isInviteModalShown } = useValues(inviteLogic)
+    const { currentView, platform } = useValues(ingestionLogicV2)
     const { reportIngestionLandingSeen } = useActions(eventUsageLogic)
 
     useEffect(() => {
@@ -34,85 +32,25 @@ export function IngestionWizardV2(): JSX.Element {
         }
     }, [platform])
 
-    if (addBilling) {
-        return (
-            <IngestionContainer>
-                <BillingPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (hasInvitedMembers && !isInviteModalShown && !technical) {
-        return (
-            <IngestionContainer>
-                <TeamInvitedPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (!platform && !verify && !technical) {
-        return (
-            <IngestionContainer>
-                <InviteTeamPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (!platform && !verify && technical) {
-        return (
-            <IngestionContainer>
-                <PlatformPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (verify) {
-        return (
-            <IngestionContainer>
-                <VerificationPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (framework || platform === WEB) {
-        return (
-            <IngestionContainer>
-                <InstructionsPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (platform === MOBILE || platform === BACKEND) {
-        return (
-            <IngestionContainer>
-                <FrameworkPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (platform === BOOKMARKLET) {
-        return (
-            <IngestionContainer>
-                <BookmarkletPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (platform === THIRD_PARTY) {
-        return (
-            <IngestionContainer>
-                <ThirdPartyPanel />
-            </IngestionContainer>
-        )
-    }
-
-    return <></>
+    return (
+        <IngestionContainer>
+            {currentView === INGESTION_VIEWS.BILLING && <BillingPanel />}
+            {currentView === INGESTION_VIEWS.INVITE_TEAM && <InviteTeamPanel />}
+            {currentView === INGESTION_VIEWS.POST_INVITE_TEAM && <TeamInvitedPanel />}
+            {currentView === INGESTION_VIEWS.CHOOSE_PLATFORM && <PlatformPanel />}
+            {currentView === INGESTION_VIEWS.CHOOSE_FRAMEWORK && <FrameworkPanel />}
+            {currentView === INGESTION_VIEWS.WEB_INSTRUCTIONS && <InstructionsPanel />}
+            {currentView === INGESTION_VIEWS.VERIFICATION && <VerificationPanel />}
+            {currentView === INGESTION_VIEWS.BOOKMARKLET && <BookmarkletPanel />}
+            {currentView === INGESTION_VIEWS.CHOOSE_THIRD_PARTY && <ThirdPartyPanel />}
+        </IngestionContainer>
+    )
 }
 
 function IngestionContainer({ children }: { children: React.ReactNode }): JSX.Element {
     const { isInviteModalShown } = useValues(inviteLogic)
     const { hideInviteModal } = useActions(inviteLogic)
-    const { isSmallScreen } = useValues(ingestionLogic)
+    const { isSmallScreen } = useValues(ingestionLogicV2)
 
     return (
         <div className="flex h-full flex-col">

--- a/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
@@ -36,7 +36,7 @@ export function IngestionWizardV2(): JSX.Element {
         <IngestionContainer>
             {currentView === INGESTION_VIEWS.BILLING && <BillingPanel />}
             {currentView === INGESTION_VIEWS.INVITE_TEAM && <InviteTeamPanel />}
-            {currentView === INGESTION_VIEWS.POST_INVITE_TEAM && <TeamInvitedPanel />}
+            {currentView === INGESTION_VIEWS.TEAM_INVITED && <TeamInvitedPanel />}
             {currentView === INGESTION_VIEWS.CHOOSE_PLATFORM && <PlatformPanel />}
             {currentView === INGESTION_VIEWS.CHOOSE_FRAMEWORK && <FrameworkPanel />}
             {currentView === INGESTION_VIEWS.WEB_INSTRUCTIONS && <InstructionsPanel />}
@@ -50,7 +50,8 @@ export function IngestionWizardV2(): JSX.Element {
 function IngestionContainer({ children }: { children: React.ReactNode }): JSX.Element {
     const { isInviteModalShown } = useValues(inviteLogic)
     const { hideInviteModal } = useActions(inviteLogic)
-    const { isSmallScreen } = useValues(ingestionLogicV2)
+    const { isSmallScreen, hasInvitedMembers } = useValues(ingestionLogicV2)
+    const { next } = useActions(ingestionLogicV2)
 
     return (
         <div className="flex h-full flex-col">
@@ -61,7 +62,15 @@ function IngestionContainer({ children }: { children: React.ReactNode }): JSX.El
                     <SitePopover />
                 </div>
             </div>
-            <InviteModal isOpen={isInviteModalShown} onClose={hideInviteModal} />
+            <InviteModal
+                isOpen={isInviteModalShown}
+                onClose={() => {
+                    hideInviteModal()
+                    if (hasInvitedMembers) {
+                        next({ isTechnicalUser: false })
+                    }
+                }}
+            />
             <div className="flex h-full">
                 {!isSmallScreen && <Sidebar />}
                 {/* <div className="IngestionContainer" */}

--- a/frontend/src/scenes/ingestion/v2/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/v2/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { ingestionLogic } from './ingestionLogic'
+import { ingestionLogicV2 } from './ingestionLogic'
 import { useActions, useValues } from 'kea'
 import './IngestionWizard.scss'
 import { InviteMembersButton } from '~/layout/navigation/TopBar/SitePopover'
@@ -11,8 +11,8 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 const HELP_UTM_TAGS = '?utm_medium=in-product-onboarding&utm_campaign=help-button-sidebar'
 
 export function Sidebar(): JSX.Element {
-    const { currentStep, sidebarSteps } = useValues(ingestionLogic)
-    const { sidebarStepClick } = useActions(ingestionLogic)
+    const { currentStep, sidebarSteps } = useValues(ingestionLogicV2)
+    const { sidebarStepClick } = useActions(ingestionLogicV2)
     const { reportIngestionHelpClicked, reportIngestionSidebarButtonClicked } = useActions(eventUsageLogic)
 
     const currentIndex = sidebarSteps.findIndex((x) => x === currentStep)

--- a/frontend/src/scenes/ingestion/v2/constants.tsx
+++ b/frontend/src/scenes/ingestion/v2/constants.tsx
@@ -7,11 +7,11 @@ export const FRAMEWORK = 'FRAMEWORK'
 export const INSTRUCTIONS = 'INSTRUCTIONS'
 export const VERIFICATION = 'VERIFICATION'
 
-export const WEB = 'Web'
-export const MOBILE = 'Mobile'
-export const BACKEND = 'Backend'
-export const THIRD_PARTY = 'Import events from a third party'
-export const BOOKMARKLET = 'Just exploring?'
+export const WEB = 'web'
+export const MOBILE = 'mobile'
+export const BACKEND = 'backend'
+export const THIRD_PARTY = 'third-party'
+export const BOOKMARKLET = 'just-exploring'
 export const platforms: PlatformType[] = [WEB, MOBILE, BACKEND]
 
 export const NODEJS = 'NODEJS'
@@ -90,7 +90,7 @@ export const thirdPartySources: ThirdPartySource[] = [
         labels: ['beta'],
         icon: (
             <img
-                style={{ height: 48, width: 48 }}
+                style={{ height: 36, width: 36 }}
                 src={'https://raw.githubusercontent.com/PostHog/posthog-redshift-import-plugin/main/logo.png'}
             />
         ),

--- a/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
@@ -37,7 +37,7 @@ export enum INGESTION_STEPS_WITHOUT_BILLING {
 export enum INGESTION_VIEWS {
     BILLING = 'billing',
     INVITE_TEAM = 'invite-team',
-    POST_INVITE_TEAM = 'post-invite-team',
+    TEAM_INVITED = 'post-invite-team',
     CHOOSE_PLATFORM = 'choose-platform',
     VERIFICATION = 'verification',
     WEB_INSTRUCTIONS = 'web-instructions',
@@ -49,7 +49,7 @@ export enum INGESTION_VIEWS {
 export const INGESTION_VIEW_TO_STEP = {
     [INGESTION_VIEWS.BILLING]: INGESTION_STEPS.BILLING,
     [INGESTION_VIEWS.INVITE_TEAM]: INGESTION_STEPS.START,
-    [INGESTION_VIEWS.POST_INVITE_TEAM]: INGESTION_STEPS.START,
+    [INGESTION_VIEWS.TEAM_INVITED]: INGESTION_STEPS.START,
     [INGESTION_VIEWS.CHOOSE_PLATFORM]: INGESTION_STEPS.PLATFORM,
     [INGESTION_VIEWS.VERIFICATION]: INGESTION_STEPS.VERIFY,
     [INGESTION_VIEWS.WEB_INSTRUCTIONS]: INGESTION_STEPS.CONNECT_PRODUCT,
@@ -58,28 +58,85 @@ export const INGESTION_VIEW_TO_STEP = {
     [INGESTION_VIEWS.CHOOSE_THIRD_PARTY]: INGESTION_STEPS.CONNECT_PRODUCT,
 }
 
-const stringToPlatformType = (
-    platform: string | null,
-    allowed: string[] = ['mobile', 'web', 'backend', 'just-exploring', 'third-party']
-): PlatformType | null => {
-    if (!platform || !allowed.includes(platform)) {
-        return null
+export type IngestionState = {
+    platform: PlatformType
+    framework: Framework
+    readyToVerify: boolean
+    showBilling: boolean
+    hasInvitedMembers: boolean | null
+    isTechnicalUser: boolean | null
+}
+
+const viewToState = (view: string, props: IngestionState): IngestionState => {
+    switch (view) {
+        case INGESTION_VIEWS.INVITE_TEAM:
+            return {
+                isTechnicalUser: null,
+                hasInvitedMembers: null,
+                platform: null,
+                framework: null,
+                readyToVerify: false,
+                showBilling: false,
+            }
+        case INGESTION_VIEWS.TEAM_INVITED:
+            return {
+                isTechnicalUser: false,
+                hasInvitedMembers: true,
+                platform: null,
+                framework: null,
+                readyToVerify: false,
+                showBilling: false,
+            }
+        case INGESTION_VIEWS.BILLING:
+            return {
+                isTechnicalUser: null,
+                hasInvitedMembers: null,
+                platform: props.platform,
+                framework: props.framework,
+                readyToVerify: false,
+                showBilling: true,
+            }
+        case INGESTION_VIEWS.VERIFICATION:
+            return {
+                isTechnicalUser: true,
+                hasInvitedMembers: null,
+                platform: props.platform,
+                framework: props.framework,
+                readyToVerify: true,
+                showBilling: false,
+            }
+        case INGESTION_VIEWS.CHOOSE_PLATFORM:
+            return {
+                isTechnicalUser: true,
+                hasInvitedMembers: null,
+                platform: null,
+                framework: null,
+                readyToVerify: false,
+                showBilling: false,
+            }
+
+        case INGESTION_VIEWS.CHOOSE_FRAMEWORK:
+            return {
+                isTechnicalUser: true,
+                hasInvitedMembers: null,
+                platform: props.platform,
+                framework: null,
+                readyToVerify: false,
+                showBilling: false,
+            }
     }
-    return platform === 'mobile'
-        ? MOBILE
-        : platform === 'web'
-        ? WEB
-        : platform === 'backend'
-        ? BACKEND
-        : platform === 'just-exploring'
-        ? BOOKMARKLET
-        : platform === 'third-party'
-        ? THIRD_PARTY
-        : null
+    return {
+        isTechnicalUser: null,
+        hasInvitedMembers: null,
+        platform: null,
+        framework: null,
+        readyToVerify: false,
+        showBilling: false,
+    }
 }
 
 export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
-    path(['scenes', 'ingestion', 'ingestionLogic']),
+    path(['scenes', 'ingestion', 'ingestionLogicV2']),
     connect({
         values: [
             featureFlagLogic,
@@ -96,33 +153,20 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         actions: [teamLogic, ['updateCurrentTeamSuccess'], inviteLogic, ['inviteTeamMembersSuccess']],
     }),
     actions({
-        setTechnical: (technical: boolean) => ({ technical }),
-        setHasInvitedMembers: (hasInvitedMembers: boolean) => ({ hasInvitedMembers }),
-        setPlatform: (platform: PlatformType) => ({ platform }),
-        setFramework: (framework: Framework) => ({ framework: framework as Framework }),
-        setVerify: (verify: boolean) => ({ verify }),
-        setAddBilling: (addBilling: boolean) => ({ addBilling }),
         setState: ({
-            technical,
+            isTechnicalUser,
             hasInvitedMembers,
             platform,
             framework,
-            verify,
-            addBilling,
-        }: {
-            technical: boolean | null
-            hasInvitedMembers: boolean | null
-            platform: PlatformType
-            framework: string | null
-            verify: boolean
-            addBilling: boolean
-        }) => ({
-            technical,
+            readyToVerify,
+            showBilling,
+        }: IngestionState) => ({
+            isTechnicalUser,
             hasInvitedMembers,
             platform,
             framework,
-            verify,
-            addBilling,
+            readyToVerify,
+            showBilling,
         }),
         setActiveTab: (tab: string) => ({ tab }),
         setInstructionsModal: (isOpen: boolean) => ({ isOpen }),
@@ -131,61 +175,49 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         completeOnboarding: true,
         setCurrentStep: (currentStep: string) => ({ currentStep }),
         sidebarStepClick: (step: string) => ({ step }),
+        next: (props: Partial<IngestionState>) => props,
         onBack: true,
+        goToView: (view: INGESTION_VIEWS) => ({ view }),
         setSidebarSteps: (steps: string[]) => ({ steps }),
     }),
     windowValues({
         isSmallScreen: (window: Window) => window.innerWidth < getBreakpoint('md'),
     }),
     reducers({
-        technical: [
+        isTechnicalUser: [
             null as null | boolean,
             {
-                setTechnical: (_, { technical }) => technical,
-                setState: (_, { technical }) => technical,
+                setState: (_, { isTechnicalUser }) => isTechnicalUser,
             },
         ],
         hasInvitedMembers: [
             null as null | boolean,
             {
-                setHasInvitedMembers: (_, { hasInvitedMembers }) => hasInvitedMembers,
                 setState: (_, { hasInvitedMembers }) => hasInvitedMembers,
             },
         ],
         platform: [
             null as null | PlatformType,
             {
-                setPlatform: (_, { platform }) => platform,
                 setState: (_, { platform }) => platform,
             },
         ],
         framework: [
             null as null | Framework,
             {
-                setFramework: (_, { framework }) => framework as Framework,
                 setState: (_, { framework }) => (framework ? (framework.toUpperCase() as Framework) : null),
             },
         ],
-        verify: [
+        readyToVerify: [
             false,
             {
-                setPlatform: () => false,
-                setFramework: () => false,
-                setAddBilling: () => false,
-                setTechnical: () => false,
-                setVerify: (_, { verify }) => verify,
-                setState: (_, { verify }) => verify,
+                setState: (_, { readyToVerify }) => readyToVerify,
             },
         ],
-        addBilling: [
+        showBilling: [
             false,
             {
-                setPlatform: () => false,
-                setFramework: () => false,
-                setVerify: () => false,
-                setTechnical: () => false,
-                setAddBilling: (_, { addBilling }) => addBilling,
-                setState: (_, { addBilling }) => addBilling,
+                setState: (_, { showBilling }) => showBilling,
             },
         ],
         activeTab: [
@@ -221,52 +253,53 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         ],
     }),
     selectors(() => ({
+        currentState: [
+            (s) => [s.platform, s.framework, s.readyToVerify, s.showBilling, s.isTechnicalUser, s.hasInvitedMembers],
+            (platform, framework, readyToVerify, showBilling, isTechnicalUser, hasInvitedMembers) => ({
+                platform,
+                framework,
+                readyToVerify,
+                showBilling,
+                isTechnicalUser,
+                hasInvitedMembers,
+            }),
+        ],
         currentView: [
-            (s) => [
-                s.technical,
-                s.platform,
-                s.framework,
-                s.verify,
-                s.addBilling,
-                s.hasInvitedMembers,
-                s.isInviteModalShown,
-            ],
-            (technical, platform, framework, verify, addBilling, hasInvitedMembers, isInviteModalShown) => {
-                if (addBilling) {
+            (s) => [s.currentState],
+            ({ isTechnicalUser, platform, framework, readyToVerify, showBilling, hasInvitedMembers }) => {
+                if (showBilling) {
                     return INGESTION_VIEWS.BILLING
                 }
-
-                if (hasInvitedMembers && !isInviteModalShown && !technical) {
-                    return INGESTION_VIEWS.POST_INVITE_TEAM
-                }
-
-                if (!platform && !verify && !technical) {
-                    return INGESTION_VIEWS.INVITE_TEAM
-                }
-
-                if (!platform && !verify && technical) {
-                    return INGESTION_VIEWS.CHOOSE_PLATFORM
-                }
-
-                if (verify) {
+                if (readyToVerify) {
                     return INGESTION_VIEWS.VERIFICATION
                 }
 
-                if (framework || platform === WEB) {
-                    return INGESTION_VIEWS.WEB_INSTRUCTIONS
+                if (isTechnicalUser) {
+                    if (!platform) {
+                        return INGESTION_VIEWS.CHOOSE_PLATFORM
+                    }
+                    if (framework || platform === WEB) {
+                        return INGESTION_VIEWS.WEB_INSTRUCTIONS
+                    }
+                    if (platform === MOBILE || platform === BACKEND) {
+                        return INGESTION_VIEWS.CHOOSE_FRAMEWORK
+                    }
+                    if (platform === THIRD_PARTY) {
+                        return INGESTION_VIEWS.CHOOSE_THIRD_PARTY
+                    }
+                    // could be null, so we check that it's set to false
+                } else if (isTechnicalUser === false) {
+                    if (hasInvitedMembers) {
+                        return INGESTION_VIEWS.TEAM_INVITED
+                    }
+                    if (!platform && !readyToVerify) {
+                        return INGESTION_VIEWS.INVITE_TEAM
+                    }
+                    if (platform === BOOKMARKLET) {
+                        return INGESTION_VIEWS.BOOKMARKLET
+                    }
                 }
 
-                if (platform === MOBILE || platform === BACKEND) {
-                    return INGESTION_VIEWS.CHOOSE_FRAMEWORK
-                }
-
-                if (platform === BOOKMARKLET) {
-                    return INGESTION_VIEWS.BOOKMARKLET
-                }
-
-                if (platform === THIRD_PARTY) {
-                    return INGESTION_VIEWS.CHOOSE_THIRD_PARTY
-                }
                 return INGESTION_VIEWS.INVITE_TEAM
             },
         ],
@@ -314,85 +347,40 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
     })),
 
     actionToUrl(({ values }) => ({
-        setTechnical: () => getUrl(values),
-        setHasInvitedMembers: () => getUrl(values),
-        setPlatform: () => getUrl(values),
-        setFramework: () => getUrl(values),
-        setVerify: () => getUrl(values),
-        setAddBilling: () => getUrl(values),
         setState: () => getUrl(values),
         updateCurrentTeamSuccess: () => {
-            const isBillingPage = router.values.location.pathname == '/ingestion/billing'
-            const isVerifyPage = !values.showBillingStep && router.values.location.pathname == '/ingestion/verify'
-            if (isBillingPage || isVerifyPage) {
+            if (router.values.location.pathname.includes('/ingestion')) {
                 return urls.events()
             }
         },
     })),
 
     urlToAction(({ actions }) => ({
-        '/ingestion': () =>
+        '/ingestion': () => actions.goToView(INGESTION_VIEWS.INVITE_TEAM),
+        '/ingestion/invites-sent': () => actions.goToView(INGESTION_VIEWS.TEAM_INVITED),
+        '/ingestion/billing': () => actions.goToView(INGESTION_VIEWS.BILLING),
+        '/ingestion/verify': () => actions.goToView(INGESTION_VIEWS.VERIFICATION),
+        '/ingestion/platform': () => actions.goToView(INGESTION_VIEWS.CHOOSE_FRAMEWORK),
+        '/ingestion(/:platform)(/:framework)': (pathParams, searchParams) => {
+            const platform = pathParams.platform || searchParams.platform || null
+            const framework = pathParams.framework || searchParams.framework || null
             actions.setState({
-                technical: null,
+                isTechnicalUser: true,
                 hasInvitedMembers: null,
-                platform: null,
-                framework: null,
-                verify: false,
-                addBilling: false,
-            }),
-        '/ingestion/invites-sent': () =>
-            actions.setState({
-                technical: false,
-                hasInvitedMembers: true,
-                platform: null,
-                framework: null,
-                verify: false,
-                addBilling: false,
-            }),
-        '/ingestion/billing': (_: any, { platform, framework }) => {
-            actions.setState({
-                technical: null,
-                hasInvitedMembers: null,
-                platform: stringToPlatformType(platform),
-                framework,
-                verify: false,
-                addBilling: false,
-            })
-        },
-        '/ingestion/verify': (_: any, { platform, framework }) => {
-            actions.setState({
-                technical: true,
-                hasInvitedMembers: null,
-                platform: stringToPlatformType(platform),
+                platform: platform,
                 framework: framework,
-                verify: false,
-                addBilling: false,
+                readyToVerify: false,
+                showBilling: false,
             })
-        },
-        '/ingestion/api': (_: any, { platform }) => {
-            actions.setState({
-                technical: true,
-                hasInvitedMembers: null,
-                platform: stringToPlatformType(platform, ['web', 'mobile', 'backend']),
-                framework: API,
-                verify: false,
-                addBilling: false,
-            })
-        },
-        '/ingestion(/:platform)(/:framework)': ({ platform, framework }) => {
-            if (platform && framework) {
-                actions.setState({
-                    technical: true,
-                    hasInvitedMembers: null,
-                    platform: stringToPlatformType(platform),
-                    framework,
-                    verify: false,
-                    addBilling: false,
-                })
-            }
         },
     })),
     listeners(({ actions, values }) => ({
+        next: (props) => {
+            actions.setState({ ...values.currentState, ...props } as IngestionState)
+        },
+        goToView: ({ view }) => {
+            actions.setState(viewToState(view, values.currentState as IngestionState))
+        },
         completeOnboarding: () => {
             teamLogic.actions.updateCurrentTeam({
                 completed_snippet_onboarding: true,
@@ -410,80 +398,53 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         sidebarStepClick: ({ step }) => {
             switch (step) {
                 case INGESTION_STEPS.START:
-                    actions.setTechnical(false)
+                    actions.goToView(INGESTION_VIEWS.INVITE_TEAM)
                     return
                 case INGESTION_STEPS.PLATFORM:
-                    actions.setPlatform(null)
+                    actions.goToView(INGESTION_VIEWS.CHOOSE_PLATFORM)
                     return
                 case INGESTION_STEPS.CONNECT_PRODUCT:
-                    if (values.platform) {
-                        actions.setVerify(false)
-                        actions.setPlatform(values.platform)
-                    }
+                    actions.goToView(INGESTION_VIEWS.CHOOSE_FRAMEWORK)
                     return
                 case INGESTION_STEPS.VERIFY:
-                    if (values.platform) {
-                        actions.setVerify(true)
-                    }
+                    actions.goToView(INGESTION_VIEWS.VERIFICATION)
                     return
                 case INGESTION_STEPS.BILLING:
-                    if (values.platform) {
-                        actions.setAddBilling(true)
-                    }
+                    actions.goToView(INGESTION_VIEWS.BILLING)
                     return
                 default:
                     return
             }
         },
         onBack: () => {
-            switch (values.currentStep) {
-                case INGESTION_STEPS.BILLING:
-                    actions.setState({
-                        technical: values.technical,
-                        hasInvitedMembers: values.hasInvitedMembers,
-                        platform: values.platform,
-                        framework: values.framework,
-                        verify: true,
-                        addBilling: false,
-                    })
-                    return
-                case INGESTION_STEPS.VERIFY:
-                    actions.setState({
-                        technical: values.technical,
-                        hasInvitedMembers: values.hasInvitedMembers,
-                        platform: values.platform,
-                        framework: null,
-                        verify: false,
-                        addBilling: false,
-                    })
-                    return
-                case INGESTION_STEPS.CONNECT_PRODUCT:
-                    actions.setState({
-                        technical: values.technical,
-                        hasInvitedMembers: values.hasInvitedMembers,
-                        platform: null,
-                        framework: null,
-                        verify: false,
-                        addBilling: false,
-                    })
-                    return
-                case INGESTION_STEPS.PLATFORM:
-                    actions.setState({
-                        technical: null,
-                        hasInvitedMembers: null,
-                        platform: null,
-                        framework: null,
-                        verify: false,
-                        addBilling: false,
-                    })
-                    return
+            switch (values.currentView) {
+                case INGESTION_VIEWS.BILLING:
+                    return actions.goToView(INGESTION_VIEWS.VERIFICATION)
+                case INGESTION_VIEWS.TEAM_INVITED:
+                    return actions.goToView(INGESTION_VIEWS.INVITE_TEAM)
+                case INGESTION_VIEWS.CHOOSE_PLATFORM:
+                    return actions.goToView(INGESTION_VIEWS.INVITE_TEAM)
+                case INGESTION_VIEWS.VERIFICATION:
+                    return actions.goToView(INGESTION_VIEWS.CHOOSE_FRAMEWORK)
+                case INGESTION_VIEWS.WEB_INSTRUCTIONS:
+                    return actions.goToView(INGESTION_VIEWS.CHOOSE_PLATFORM)
+                case INGESTION_VIEWS.CHOOSE_FRAMEWORK:
+                    return actions.goToView(INGESTION_VIEWS.CHOOSE_PLATFORM)
+                case INGESTION_VIEWS.BOOKMARKLET:
+                    if (values.hasInvitedMembers) {
+                        return actions.goToView(INGESTION_VIEWS.TEAM_INVITED)
+                    } else {
+                        return actions.goToView(INGESTION_VIEWS.INVITE_TEAM)
+                    }
+                case INGESTION_VIEWS.CHOOSE_THIRD_PARTY:
+                    return actions.goToView(INGESTION_VIEWS.CHOOSE_PLATFORM)
                 default:
-                    return
+                    return actions.goToView(INGESTION_VIEWS.INVITE_TEAM)
             }
         },
         inviteTeamMembersSuccess: () => {
             if (router.values.location.pathname.includes('/ingestion')) {
-                actions.setHasInvitedMembers(true)
+                actions.setState({ ...values.currentState, hasInvitedMembers: true } as IngestionState)
             }
         },
     })),
@@ -493,12 +454,12 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
             actions.setSidebarSteps(Object.values(steps))
         },
         billing: (billing: BillingType) => {
-            if (billing?.plan && values.addBilling) {
+            if (billing?.plan && values.showBilling) {
                 actions.setCurrentStep(INGESTION_STEPS.DONE)
             }
         },
         currentTeam: (currentTeam: TeamType) => {
-            if (currentTeam?.ingested_event && values.verify && !values.showBillingStep) {
+            if (currentTeam?.ingested_event && values.readyToVerify && !values.showBillingStep) {
                 actions.setCurrentStep(INGESTION_STEPS.DONE)
             }
         },
@@ -506,65 +467,66 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
 ])
 
 function getUrl(values: ingestionLogicV2Type['values']): string | [string, Record<string, undefined | string>] {
-    const { technical, platform, framework, verify, addBilling, hasInvitedMembers } = values
+    const { isTechnicalUser, platform, framework, readyToVerify, showBilling, hasInvitedMembers } = values
 
     let url = '/ingestion'
 
-    if (addBilling) {
+    if (showBilling) {
         return url + '/billing'
     }
 
-    if (verify) {
-        url += '/verify'
-        return [
-            url,
-            {
-                platform: stringToPlatformType(platform) as string,
-                framework: framework?.toLowerCase() || undefined,
-            },
-        ]
-    }
+    if (isTechnicalUser) {
+        if (readyToVerify) {
+            url += '/verify'
+            return [
+                url,
+                {
+                    platform: platform || undefined,
+                    framework: framework?.toLowerCase() || undefined,
+                },
+            ]
+        }
+        if (framework === API) {
+            url += '/api'
+            return [
+                url,
+                {
+                    platform: platform || undefined,
+                },
+            ]
+        }
 
-    if (framework === API) {
-        url += '/api'
-        return [
-            url,
-            {
-                platform: stringToPlatformType(platform, ['web', 'mobile', 'backend']) as string,
-            },
-        ]
-    }
+        if (platform === MOBILE) {
+            url += '/mobile'
+        }
 
-    if (platform === MOBILE) {
-        url += '/mobile'
-    }
+        if (platform === WEB) {
+            url += '/web'
+        }
 
-    if (platform === WEB) {
-        url += '/web'
-    }
+        if (platform === BACKEND) {
+            url += '/backend'
+        }
 
-    if (platform === BACKEND) {
-        url += '/backend'
-    }
+        if (platform === BOOKMARKLET) {
+            url += '/just-exploring'
+        }
 
-    if (platform === BOOKMARKLET) {
-        url += '/just-exploring'
-    }
+        if (platform === THIRD_PARTY) {
+            url += '/third-party'
+        }
 
-    if (platform === THIRD_PARTY) {
-        url += '/third-party'
-    }
+        if (!platform) {
+            url += '/platform'
+        }
 
-    if (technical && !platform) {
-        url += '/platform'
-    }
-
-    if (!technical && !platform && hasInvitedMembers) {
-        url += '/invites-sent'
-    }
-
-    if (framework) {
-        url += `/${framework.toLowerCase()}`
+        if (framework) {
+            url += `/${framework.toLowerCase()}`
+        }
+    } else {
+        if (!platform && isTechnicalUser && hasInvitedMembers) {
+            url += '/invites-sent'
+        }
     }
 
     return url

--- a/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
@@ -289,14 +289,14 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
                     }
                     // could be null, so we check that it's set to false
                 } else if (isTechnicalUser === false) {
+                    if (platform === BOOKMARKLET) {
+                        return INGESTION_VIEWS.BOOKMARKLET
+                    }
                     if (hasInvitedMembers) {
                         return INGESTION_VIEWS.TEAM_INVITED
                     }
                     if (!platform && !readyToVerify) {
                         return INGESTION_VIEWS.INVITE_TEAM
-                    }
-                    if (platform === BOOKMARKLET) {
-                        return INGESTION_VIEWS.BOOKMARKLET
                     }
                 }
 

--- a/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogic.ts
@@ -436,6 +436,11 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
                     } else {
                         return actions.goToView(INGESTION_VIEWS.INVITE_TEAM)
                     }
+                // If they're on the InviteTeam step, but on the Team Invited panel,
+                // we still want them to be able to go back to the previous step.
+                // So this resets the state for that panel so they can go back.
+                case INGESTION_VIEWS.INVITE_TEAM:
+                    return actions.goToView(INGESTION_VIEWS.INVITE_TEAM)
                 case INGESTION_VIEWS.CHOOSE_THIRD_PARTY:
                     return actions.goToView(INGESTION_VIEWS.CHOOSE_PLATFORM)
                 default:

--- a/frontend/src/scenes/ingestion/v2/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/BillingPanel.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { CardContainer } from 'scenes/ingestion/v2/CardContainer'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogic'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -16,7 +16,7 @@ import { urls } from 'scenes/urls'
 import { BillingHero } from 'scenes/billing/v2/BillingHero'
 
 export function BillingPanel(): JSX.Element {
-    const { completeOnboarding } = useActions(ingestionLogic)
+    const { completeOnboarding } = useActions(ingestionLogicV2)
     const { reportIngestionContinueWithoutBilling } = useActions(eventUsageLogic)
     const { billing, billingVersion } = useValues(billingLogic)
     const { billing: billingV2 } = useValues(billingLogicV2)

--- a/frontend/src/scenes/ingestion/v2/panels/FrameworkPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/FrameworkPanel.tsx
@@ -1,14 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { CardContainer } from 'scenes/ingestion/v2/CardContainer'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogic'
 import { API, mobileFrameworks, BACKEND, webFrameworks } from 'scenes/ingestion/v2/constants'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function FrameworkPanel(): JSX.Element {
-    const { setFramework } = useActions(ingestionLogic)
-    const { platform } = useValues(ingestionLogic)
+    const { setFramework } = useActions(ingestionLogicV2)
+    const { platform } = useValues(ingestionLogicV2)
     const frameworks = platform === BACKEND ? webFrameworks : mobileFrameworks
 
     return (

--- a/frontend/src/scenes/ingestion/v2/panels/FrameworkPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/FrameworkPanel.tsx
@@ -7,7 +7,7 @@ import './Panels.scss'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function FrameworkPanel(): JSX.Element {
-    const { setFramework } = useActions(ingestionLogicV2)
+    const { next } = useActions(ingestionLogicV2)
     const { platform } = useValues(ingestionLogicV2)
     const frameworks = platform === BACKEND ? webFrameworks : mobileFrameworks
 
@@ -30,7 +30,7 @@ export function FrameworkPanel(): JSX.Element {
                             size="large"
                             center
                             className="mb-2"
-                            onClick={() => setFramework(item)}
+                            onClick={() => next({ framework: item })}
                         >
                             {frameworks[item]}
                         </LemonButton>
@@ -42,7 +42,7 @@ export function FrameworkPanel(): JSX.Element {
                         size="large"
                         center
                         className="mb-2"
-                        onClick={() => setFramework(API)}
+                        onClick={() => next({ framework: API })}
                     >
                         Other
                     </LemonButton>

--- a/frontend/src/scenes/ingestion/v2/panels/InstructionsPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/InstructionsPanel.tsx
@@ -15,7 +15,7 @@ import {
 } from 'scenes/ingestion/v2/frameworks'
 import { API, MOBILE, BACKEND, WEB } from '../constants'
 import { useValues } from 'kea'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogic'
 import { WebInstructions } from '../frameworks/WebInstructions'
 import { Link } from '@posthog/lemon-ui'
 
@@ -34,7 +34,7 @@ const frameworksSnippet: Record<string, React.ComponentType> = {
 }
 
 export function InstructionsPanel(): JSX.Element {
-    const { platform, framework, frameworkString } = useValues(ingestionLogic)
+    const { platform, framework, frameworkString } = useValues(ingestionLogicV2)
 
     if (platform !== WEB && !framework) {
         return <></>

--- a/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
@@ -9,9 +9,9 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
 
 export function InviteTeamPanel(): JSX.Element {
-    const { setTechnical, setPlatform } = useActions(ingestionLogicV2)
+    const { next } = useActions(ingestionLogicV2)
     const { showInviteModal } = useActions(inviteLogic)
-    const { reportInviteMembersButtonClicked } = useActions(eventUsageLogic)
+    const { reportInviteMembersButtonClicked, reportIngestionTryWithBookmarkletClicked } = useActions(eventUsageLogic)
 
     return (
         <div>
@@ -24,7 +24,7 @@ export function InviteTeamPanel(): JSX.Element {
             <LemonDivider thick dashed className="my-6" />
             <div className="flex flex-col mb-6">
                 <LemonButton
-                    onClick={() => setTechnical(true)}
+                    onClick={() => next({ isTechnicalUser: true })}
                     fullWidth
                     size="large"
                     className="mb-4"
@@ -40,7 +40,6 @@ export function InviteTeamPanel(): JSX.Element {
                 </LemonButton>
                 <LemonButton
                     onClick={() => {
-                        setTechnical(false)
                         showInviteModal()
                         reportInviteMembersButtonClicked()
                     }}
@@ -59,8 +58,8 @@ export function InviteTeamPanel(): JSX.Element {
                 </LemonButton>
                 <LemonButton
                     onClick={() => {
-                        setTechnical(false)
-                        setPlatform(BOOKMARKLET)
+                        reportIngestionTryWithBookmarkletClicked()
+                        next({ isTechnicalUser: false, platform: BOOKMARKLET })
                     }}
                     center
                     fullWidth

--- a/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
@@ -1,5 +1,5 @@
 import { useActions } from 'kea'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogic'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { LemonDivider } from 'lib/components/LemonDivider'
@@ -9,7 +9,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
 
 export function InviteTeamPanel(): JSX.Element {
-    const { setTechnical, setPlatform } = useActions(ingestionLogic)
+    const { setTechnical, setPlatform } = useActions(ingestionLogicV2)
     const { showInviteModal } = useActions(inviteLogic)
     const { reportInviteMembersButtonClicked } = useActions(eventUsageLogic)
 

--- a/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
@@ -3,14 +3,14 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
-import { ingestionLogic, INGESTION_STEPS } from '../ingestionLogic'
+import { ingestionLogicV2, INGESTION_STEPS } from '../ingestionLogic'
 import './Panels.scss'
 import { IconArrowLeft } from 'lib/components/icons'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function PanelFooter(): JSX.Element {
-    const { platform } = useValues(ingestionLogic)
-    const { setPlatform, setVerify } = useActions(ingestionLogic)
+    const { platform } = useValues(ingestionLogicV2)
+    const { setPlatform, setVerify } = useActions(ingestionLogicV2)
     const { reportIngestionTryWithBookmarkletClicked } = useActions(eventUsageLogic)
 
     return (
@@ -61,8 +61,8 @@ export function PanelFooter(): JSX.Element {
 }
 
 export function PanelHeader(): JSX.Element | null {
-    const { isSmallScreen, previousStep, currentStep } = useValues(ingestionLogic)
-    const { onBack } = useActions(ingestionLogic)
+    const { isSmallScreen, previousStep, currentStep } = useValues(ingestionLogicV2)
+    const { onBack } = useActions(ingestionLogicV2)
 
     // no back buttons on the first screen
     if (currentStep === INGESTION_STEPS.START) {

--- a/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
@@ -30,18 +30,26 @@ export function PanelFooter(): JSX.Element {
 }
 
 export function PanelHeader(): JSX.Element | null {
-    const { isSmallScreen, previousStep, currentStep } = useValues(ingestionLogicV2)
+    const { isSmallScreen, previousStep, currentStep, hasInvitedMembers } = useValues(ingestionLogicV2)
     const { onBack } = useActions(ingestionLogicV2)
 
-    // no back buttons on the first screen
-    if (currentStep === INGESTION_STEPS.START) {
+    // no back buttons on the Getting Started step
+    // but only if it's not the MembersInvited panel
+    // (since they'd want to be able to go back from there)
+    if (currentStep === INGESTION_STEPS.START && !hasInvitedMembers) {
         return null
     }
 
     return (
         <div className="flex items-center mb-2" data-attr="wizard-step-counter">
             <LemonButton type="tertiary" status="primary" onClick={onBack} icon={<IconArrowLeft />} size="small">
-                {isSmallScreen ? '' : previousStep}
+                {isSmallScreen
+                    ? ''
+                    : // If we're on the MembersInvited panel, they "go back" to
+                    // the Get Started step, even though it's technically the same step
+                    currentStep === INGESTION_STEPS.START && hasInvitedMembers
+                    ? currentStep
+                    : previousStep}
             </LemonButton>
         </div>
     )

--- a/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
@@ -1,61 +1,30 @@
 import { useActions, useValues } from 'kea'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonDivider } from 'lib/components/LemonDivider'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { BOOKMARKLET } from '../constants'
 import { ingestionLogicV2, INGESTION_STEPS } from '../ingestionLogic'
 import './Panels.scss'
 import { IconArrowLeft } from 'lib/components/icons'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function PanelFooter(): JSX.Element {
-    const { platform } = useValues(ingestionLogicV2)
-    const { setPlatform, setVerify } = useActions(ingestionLogicV2)
-    const { reportIngestionTryWithBookmarkletClicked } = useActions(eventUsageLogic)
+    const { next } = useActions(ingestionLogicV2)
 
     return (
         <div className="panel-footer">
             <LemonDivider thick dashed className="my-6" />
-            {platform === BOOKMARKLET ? (
-                <div>
-                    <LemonButton
-                        type="primary"
-                        size="large"
-                        fullWidth
-                        center
-                        onClick={() => {
-                            reportIngestionTryWithBookmarkletClicked()
-                            setVerify(true)
-                        }}
-                    >
-                        Try PostHog with the exploration bookmarklet
-                    </LemonButton>
-                    <LemonButton
-                        className="mt-2"
-                        size="large"
-                        fullWidth
-                        center
-                        type="secondary"
-                        onClick={() => setPlatform(null)}
-                    >
-                        Back to setup
-                    </LemonButton>
-                </div>
-            ) : (
-                <div>
-                    <LemonButton
-                        type="primary"
-                        size="large"
-                        fullWidth
-                        center
-                        className="mb-2"
-                        onClick={() => setVerify(true)}
-                    >
-                        Continue
-                    </LemonButton>
-                    <IngestionInviteMembersButton />
-                </div>
-            )}
+            <div>
+                <LemonButton
+                    type="primary"
+                    size="large"
+                    fullWidth
+                    center
+                    className="mb-2"
+                    onClick={() => next({ readyToVerify: true })}
+                >
+                    Continue
+                </LemonButton>
+                <IngestionInviteMembersButton />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/ingestion/v2/panels/PlatformPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/PlatformPanel.tsx
@@ -7,7 +7,7 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function PlatformPanel(): JSX.Element {
-    const { setPlatform } = useActions(ingestionLogicV2)
+    const { next } = useActions(ingestionLogicV2)
 
     return (
         <div>
@@ -26,20 +26,20 @@ export function PlatformPanel(): JSX.Element {
                         size="large"
                         type="primary"
                         className="mb-2"
-                        onClick={() => setPlatform(platform)}
+                        onClick={() => next({ platform })}
                     >
                         {platform}
                     </LemonButton>
                 ))}
                 <LemonButton
-                    onClick={() => setPlatform(THIRD_PARTY)}
+                    onClick={() => next({ platform: THIRD_PARTY })}
                     fullWidth
                     center
                     size="large"
                     className="mb-2"
                     type="primary"
                 >
-                    {THIRD_PARTY}
+                    Import events from a third party
                 </LemonButton>
                 <IngestionInviteMembersButton />
             </div>

--- a/frontend/src/scenes/ingestion/v2/panels/PlatformPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/PlatformPanel.tsx
@@ -1,5 +1,5 @@
 import { useActions } from 'kea'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogic'
 import { THIRD_PARTY, platforms } from '../constants'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
@@ -7,7 +7,7 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function PlatformPanel(): JSX.Element {
-    const { setPlatform } = useActions(ingestionLogic)
+    const { setPlatform } = useActions(ingestionLogicV2)
 
     return (
         <div>

--- a/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
@@ -8,8 +8,9 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
 
 export function TeamInvitedPanel(): JSX.Element {
-    const { completeOnboarding, setTechnical, setPlatform } = useActions(ingestionLogicV2)
-    const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
+    const { completeOnboarding, next } = useActions(ingestionLogicV2)
+    const { reportIngestionContinueWithoutVerifying, reportIngestionTryWithBookmarkletClicked } =
+        useActions(eventUsageLogic)
 
     return (
         <div>
@@ -21,8 +22,8 @@ export function TeamInvitedPanel(): JSX.Element {
             <div className="flex flex-col mb-6">
                 <LemonButton
                     onClick={() => {
-                        setTechnical(false)
-                        setPlatform(BOOKMARKLET)
+                        reportIngestionTryWithBookmarkletClicked()
+                        next({ isTechnicalUser: false, platform: BOOKMARKLET })
                     }}
                     fullWidth
                     size="large"

--- a/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
@@ -1,5 +1,5 @@
 import { useActions } from 'kea'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogic'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { LemonDivider } from 'lib/components/LemonDivider'
@@ -8,7 +8,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
 
 export function TeamInvitedPanel(): JSX.Element {
-    const { completeOnboarding, setTechnical, setPlatform } = useActions(ingestionLogic)
+    const { completeOnboarding, setTechnical, setPlatform } = useActions(ingestionLogicV2)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
     return (

--- a/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
@@ -1,7 +1,7 @@
 import { useValues, useActions } from 'kea'
 import { LemonButton } from 'lib/components/LemonButton'
 import { CardContainer } from '../CardContainer'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogic'
 import './Panels.scss'
 import { LemonModal } from 'lib/components/LemonModal'
 import { thirdPartySources, ThirdPartySourceType } from '../constants'
@@ -16,7 +16,7 @@ import { Link } from 'lib/components/Link'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export function ThirdPartyPanel(): JSX.Element {
-    const { setInstructionsModal, setThirdPartySource, openThirdPartyPluginModal } = useActions(ingestionLogic)
+    const { setInstructionsModal, setThirdPartySource, openThirdPartyPluginModal } = useActions(ingestionLogicV2)
     const { filteredUninstalledPlugins, installedPlugins } = useValues(pluginsLogic)
     const { installPlugin } = useActions(pluginsLogic)
     const {
@@ -134,8 +134,8 @@ export function ThirdPartyPanel(): JSX.Element {
 }
 
 export function IntegrationInstructionsModal(): JSX.Element {
-    const { instructionsModalOpen, thirdPartyIntegrationSource, thirdPartyPluginSource } = useValues(ingestionLogic)
-    const { setInstructionsModal } = useActions(ingestionLogic)
+    const { instructionsModalOpen, thirdPartyIntegrationSource, thirdPartyPluginSource } = useValues(ingestionLogicV2)
+    const { setInstructionsModal } = useActions(ingestionLogicV2)
     const { currentTeam } = useValues(teamLogic)
 
     return (

--- a/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
@@ -28,7 +28,7 @@ export function ThirdPartyPanel(): JSX.Element {
     return (
         <CardContainer showFooter>
             <div className="px-6">
-                <h1 className="ingestion-title">Set up apps</h1>
+                <h1 className="ingestion-title pb-4">Set up apps</h1>
                 {thirdPartySources.map((source, idx) => {
                     const installedThirdPartyPlugin = installedPlugins?.find((plugin: PluginTypeWithConfig) =>
                         plugin.name.includes(source.name)
@@ -44,7 +44,7 @@ export function ThirdPartyPanel(): JSX.Element {
                         >
                             <div className="flex items-center justify-between gap-2">
                                 <div className="flex items-center">
-                                    {source.icon}
+                                    <div className="w-8 h-8">{source.icon}</div>
                                     <div className="ml-2">
                                         <h3 className="mb-0 flex align-center font-semibold text-base">
                                             {source.name} Import

--- a/frontend/src/scenes/ingestion/v2/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/VerificationPanel.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useInterval } from 'lib/hooks/useInterval'
 import { CardContainer } from '../CardContainer'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { Spinner } from 'lib/components/Spinner/Spinner'
 import { LemonButton } from 'lib/components/LemonButton'
@@ -13,8 +13,8 @@ import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 export function VerificationPanel(): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { setAddBilling, completeOnboarding } = useActions(ingestionLogic)
-    const { showBillingStep } = useValues(ingestionLogic)
+    const { setAddBilling, completeOnboarding } = useActions(ingestionLogicV2)
+    const { showBillingStep } = useValues(ingestionLogicV2)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
     useInterval(() => {

--- a/frontend/src/scenes/ingestion/v2/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/VerificationPanel.tsx
@@ -13,7 +13,7 @@ import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 export function VerificationPanel(): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { setAddBilling, completeOnboarding } = useActions(ingestionLogicV2)
+    const { next, completeOnboarding } = useActions(ingestionLogicV2)
     const { showBillingStep } = useValues(ingestionLogicV2)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
@@ -26,7 +26,7 @@ export function VerificationPanel(): JSX.Element {
     return (
         <CardContainer>
             <div className="text-center">
-                {currentTeam?.ingested_event ? (
+                {!currentTeam?.ingested_event ? (
                     <>
                         <div className="ingestion-listening-for-events">
                             <Spinner className="text-4xl" />
@@ -43,7 +43,7 @@ export function VerificationPanel(): JSX.Element {
                                 type="tertiary"
                                 onClick={() => {
                                     if (showBillingStep) {
-                                        setAddBilling(true)
+                                        next({ showBilling: true })
                                     } else {
                                         completeOnboarding()
                                     }
@@ -67,7 +67,7 @@ export function VerificationPanel(): JSX.Element {
                                 type="primary"
                                 onClick={() => {
                                     if (showBillingStep) {
-                                        setAddBilling(true)
+                                        next({ showBilling: true })
                                     } else {
                                         completeOnboarding()
                                     }

--- a/frontend/src/scenes/organization/Settings/inviteLogic.ts
+++ b/frontend/src/scenes/organization/Settings/inviteLogic.ts
@@ -7,7 +7,6 @@ import type { inviteLogicType } from './inviteLogicType'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { router } from 'kea-router'
 import { lemonToast } from 'lib/components/lemonToast'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
 
 /** State of a single invite row (with input data) in bulk invite creation. */
 export interface InviteRowState {
@@ -32,7 +31,7 @@ export const inviteLogic = kea<inviteLogicType>({
     },
     connect: {
         values: [preflightLogic, ['preflight']],
-        actions: [router, ['locationChanged'], ingestionLogic, ['setHasInvitedMembers']],
+        actions: [router, ['locationChanged']],
     },
     reducers: () => ({
         isInviteModalShown: [
@@ -124,10 +123,6 @@ export const inviteLogic = kea<inviteLogicType>({
 
             organizationLogic.actions.loadCurrentOrganization()
             actions.loadInvites()
-
-            if (router.values.location.pathname.includes('/ingestion')) {
-                ingestionLogic.actions.setHasInvitedMembers(true)
-            }
 
             if (values.preflight?.email_service_available) {
                 actions.hideInviteModal()


### PR DESCRIPTION
## Problem
The ingestion logic is not pretty, we want it to be pretty

## Changes
- the new `test` logic is called `ingestionLogicV2`
- `ingestionLogic` now works as a state machine, it maps views to a state and viceversa
- the `currentView` to show in the ingestion flow is now calculated in `ingestionLogic`
- sidebar steps are directly mapped to the `currentView`
- `ingestionLogic.actions.setState` now takes an object, so it's more explicit to declare what's the state
- fixed a circular dependency between `ingestionLogic` and `inviteLogic`
- there is now a `next` function to move from one view to another, which takes states changes
- fixed a bug in `test/VerificationPanel` where the check would never show that users have ingested events
- fixed a 1000 small things in the logic and the ingestion flow

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- We don't have tests for the ingestion flow, we should add them asap
