### PR TITLE
fix: JSsnippet change from user feedback

### DIFF
--- a/frontend/src/lib/components/JSSnippet.tsx
+++ b/frontend/src/lib/components/JSSnippet.tsx
@@ -6,9 +6,9 @@ export function JSSnippet(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
 
     return (
-        <CodeSnippet language={Language.HTML}>{`<script>
+        <CodeSnippet language={Language.HTML}>{`<script defer>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init('${currentTeam?.api_token}',{api_host:'${window.location.origin}'})
-</script>`}</CodeSnippet>
+</script defer>`}</CodeSnippet>
     )
 }


### PR DESCRIPTION
## Problem

PRs > Issues > Slacks, so I did a PR to address the following user feedback about the JS Snippet 

```
Should be <script defer>, I hate when third parties want their JS loaded at the start. Kills loading speed and clients may take it down just because they don’t know how to avoid LCP killers.
https://es.javascript.info/script-async-defer
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
