### PR TITLE
fix: Update EventBufferNotice.tsx with correct link

### DIFF
--- a/frontend/src/scenes/events/EventBufferNotice.tsx
+++ b/frontend/src/scenes/events/EventBufferNotice.tsx
@@ -21,7 +21,7 @@ export function EventBufferNotice({ additionalInfo, className }: EventBufferNoti
             Note that some events with a never-before-seen distinct ID are deliberately delayed by{' '}
             {pluralize(preflight?.buffer_conversion_seconds, 'second')}
             {additionalInfo}.{' '}
-            <a href="https://posthog.com/docs/integrate/ingest-live-data/#event-ingestion-nuances">
+            <a href="https://posthog.com/docs/integrate/ingest-live-data#event-ingestion-nuances">
                 Learn more about event buffering in PostHog Docs.
             </a>
         </AlertMessage>


### PR DESCRIPTION
## Problem

Addressing a broken link from user feedback. 

```
Link sent me to bottom instead of the section. 
Issue here is the “/” before “#”
https://posthog.com/docs/integrate/ingest-live-data/#event-ingestion-nuances
Should be:
https://posthog.com/docs/integrate/ingest-live-data#event-ingestion-nuances
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
