### PR TITLE
spike: calling other views so we can hide them

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -326,9 +326,10 @@ export const insightLogic = kea<insightLogicType>([
                             isLifecycleFilter(filters)
                         ) {
                             response = await api.get(
-                                `api/projects/${currentTeamId}/insights/trend/?${toParams(
-                                    filterTrendsClientSideParams(params)
-                                )}`,
+                                `api/projects/${currentTeamId}/query/q?${toParams({
+                                    ...filterTrendsClientSideParams(params),
+                                    type: 'legacy_trends',
+                                })}`,
                                 cache.abortController.signal
                             )
                         } else if (isRetentionFilter(filters)) {

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -28,6 +28,7 @@ from . import (
     plugin_log_entry,
     prompt,
     property_definition,
+    queries,
     sharing,
     site_app,
     team,
@@ -142,6 +143,8 @@ projects_router.register(r"cohorts", CohortViewSet, "project_cohorts", ["team_id
 projects_router.register(r"persons", PersonViewSet, "project_persons", ["team_id"])
 projects_router.register(r"elements", ElementViewSet, "project_elements", ["team_id"])
 projects_router.register(r"session_recordings", SessionRecordingViewSet, "project_session_recordings", ["team_id"])
+
+projects_router.register(r"query", queries.QueryViewSet, "project_query", ["team_id"])
 
 if EE_AVAILABLE:
     from ee.clickhouse.views.experiments import ClickhouseExperimentsViewSet

--- a/posthog/api/queries.py
+++ b/posthog/api/queries.py
@@ -1,0 +1,22 @@
+from rest_framework import response, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+
+from posthog.api.insight import InsightViewSet
+from posthog.api.routing import StructuredViewSetMixin
+from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
+
+
+class QueryViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
+    permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
+
+    @action(url_path="q", methods=["GET"], detail=False)
+    def query(self, request, *args, **kwargs) -> response.Response:
+        query_type = request.query_params.get("type")
+        if query_type == "legacy_trends":
+            insight_trend_view = InsightViewSet.as_view({"get": "trend"})
+            view_response = insight_trend_view(request._request, *args, **kwargs)
+            return response.Response(view_response.data, status=view_response.status_code)
+        else:
+            raise ValidationError(detail=f"{query_type} is not a valid query type")

--- a/posthog/api/test/test_queries.py
+++ b/posthog/api/test/test_queries.py
@@ -1,0 +1,24 @@
+import freezegun
+from rest_framework import status
+
+from posthog.test.base import APIBaseTest
+
+
+class TestPropertyDefinitionAPI(APIBaseTest):
+    @freezegun.freeze_time("2021-01-01T12:00:00Z")
+    def test_legacy_trends_query(self) -> None:
+        query_params = "&".join(["type=legacy_trends", "filters={'insight'='trends'}"])
+        response = self.client.get(f"/api/projects/{self.team.id}/query/q?{query_params}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.json() == {
+            "is_cached": False,
+            "last_refresh": "2021-01-01T12:00:00Z",
+            "next": None,
+            "result": [],
+            "timezone": "UTC",
+        }
+
+    def test_unknown_query_type(self) -> None:
+        query_params = "&".join(["type=next_episode", "filters={'not':'known'}"])
+        response = self.client.get(f"/api/projects/{self.team.id}/query/q?{query_params}")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/984817/201951790-4eced091-d313-4232-8afb-d0dee9ec42c9.png)

We want to add a new flexible query endpoint so we can start to add a more unified approach to querying and presenting data

We don't want to have to deprecate the existing API endpoints until we're sure we can

We want to compare results between old and new query mechanisms before rolling them out to users

## Changes

* adds an endpoint that checks the type of the inbound request
* creates the appropriate DRF viewset
* and uses that to return the existing "legacy" response
* as a spike supports only insight trends editing

![legacy_q](https://user-images.githubusercontent.com/984817/201952550-3b8b6399-8917-42e6-b3c7-2cde6671aa46.gif)

## How did you test this code?

* adding minimal developer tests
* 👀