### PR TITLE
fix: Links to 3rd party docs

### DIFF
--- a/frontend/src/scenes/ingestion/v1/panels/ThirdPartyPanel.tsx
+++ b/frontend/src/scenes/ingestion/v1/panels/ThirdPartyPanel.tsx
@@ -65,14 +65,13 @@ export function ThirdPartyPanel(): JSX.Element {
                                     <LemonButton
                                         className="mr-2"
                                         type="secondary"
+                                        to={`https://posthog.com${
+                                            source.type === ThirdPartySourceType.Integration
+                                                ? `/docs/integrate/third-party/${source.name.toLowerCase()}`
+                                                : `/integrations/${source.pluginName?.toLowerCase()}`
+                                        }`}
+                                        targetBlank={true}
                                         onClick={() => {
-                                            window.open(
-                                                `https://posthog.com${
-                                                    source.type === ThirdPartySourceType.Integration
-                                                        ? `/docs/integrate/third-party/${source.name}`
-                                                        : `/integrations/${source.pluginName}`
-                                                }`
-                                            )
                                             reportIngestionThirdPartyAboutClicked(source.name)
                                         }}
                                     >
@@ -212,7 +211,13 @@ export function IntegrationInstructionsModal(): JSX.Element {
                                         <p className="text-muted">
                                             <b>
                                                 In order to access the session recordings feature, you'll also have to{' '}
-                                                <Link to="/ingestion/web">integrate posthog js</Link>.
+                                                <Link
+                                                    to="https://posthog.com/docs/integrate/third-party/segment#full-segment-setup-all-features-supported"
+                                                    target="blank"
+                                                >
+                                                    integrate posthog js
+                                                </Link>
+                                                .
                                             </b>
                                         </p>
                                     </div>

--- a/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
@@ -65,14 +65,13 @@ export function ThirdPartyPanel(): JSX.Element {
                                     <LemonButton
                                         className="mr-2"
                                         type="secondary"
+                                        to={`https://posthog.com${
+                                            source.type === ThirdPartySourceType.Integration
+                                                ? `/docs/integrate/third-party/${source.name.toLowerCase()}`
+                                                : `/integrations/${source.pluginName?.toLowerCase()}`
+                                        }`}
+                                        targetBlank={true}
                                         onClick={() => {
-                                            window.open(
-                                                `https://posthog.com${
-                                                    source.type === ThirdPartySourceType.Integration
-                                                        ? `/docs/integrate/third-party/${source.name}`
-                                                        : `/integrations/${source.pluginName}`
-                                                }`
-                                            )
                                             reportIngestionThirdPartyAboutClicked(source.name)
                                         }}
                                     >
@@ -212,7 +211,12 @@ export function IntegrationInstructionsModal(): JSX.Element {
                                         <p className="text-muted">
                                             <b>
                                                 In order to access the session recordings feature, you'll also have to{' '}
-                                                <Link to="/ingestion/web">integrate posthog js</Link>.
+                                                <Link
+                                                    to="https://posthog.com/docs/integrate/third-party/segment#full-segment-setup-all-features-supported"
+                                                    target="blank"
+                                                >
+                                                    integrate posthog js
+                                                </Link>
                                             </b>
                                         </p>
                                     </div>


### PR DESCRIPTION
## Problem

Needs https://github.com/PostHog/posthog.com/pull/4671
The links were using a capitalized url which didn't go anywhere.

## Changes

* Fixes this
* Links Segment info to proper segment docs

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
