### PR TITLE
fix(trends-tooltip): Fix column titles being out of sync with data

### DIFF
--- a/frontend/src/lib/components/LemonTable/types.ts
+++ b/frontend/src/lib/components/LemonTable/types.ts
@@ -17,7 +17,7 @@ export type TableCellRenderResult =
 
 export interface LemonTableColumn<T extends Record<string, any>, D extends keyof T | undefined> {
     title?: string | React.ReactNode
-    key?: string | number
+    key?: string
     dataIndex?: D
     render?: (dataValue: D extends keyof T ? T[D] : undefined, record: T, recordIndex: number) => TableCellRenderResult
     /** Sorting function. Set to `true` if using manual pagination, in which case you'll also have to provide `sorting` on the table. */

--- a/frontend/src/lib/components/LemonTable/types.ts
+++ b/frontend/src/lib/components/LemonTable/types.ts
@@ -17,7 +17,7 @@ export type TableCellRenderResult =
 
 export interface LemonTableColumn<T extends Record<string, any>, D extends keyof T | undefined> {
     title?: string | React.ReactNode
-    key?: string
+    key?: string | number
     dataIndex?: D
     render?: (dataValue: D extends keyof T ? T[D] : undefined, record: T, recordIndex: number) => TableCellRenderResult
     /** Sorting function. Set to `true` if using manual pagination, in which case you'll also have to provide `sorting` on the table. */

--- a/frontend/src/lib/components/ResizableTable/TableConfig.tsx
+++ b/frontend/src/lib/components/ResizableTable/TableConfig.tsx
@@ -31,7 +31,7 @@ const DragHandle = sortableHandle(() => (
 
 interface TableConfigProps {
     immutableColumns?: string[] //the titles of the columns that are always displayed
-    defaultColumns: string[] // the titles of the set of columns to show when there is no user choice
+    defaultColumns: string[] // the keys of the set of columns to show when there is no user choice
 }
 
 export function LemonTableConfig(props: TableConfigProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -172,7 +172,6 @@ export function InsightTooltip({
                     },
                 })
             })
-            console.log(truncatedCols)
             dataColumns.sort(
                 (a, b) =>
                     (truncatedCols[a.key as number]?.action?.order || 0) -

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -46,15 +46,27 @@ function renderDatumToTableCell(
     datumMathProperty: string | undefined,
     datumValue: number | undefined,
     formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction,
-    renderCount: (value: number) => React.ReactNode
-): ReactNode {
+    renderCount: (value: number) => React.ReactNode,
+    /** Optional hexadecimal color string.
+     * Usually the color is shown on the datum row level, but in case of breakdowns where there are multiple columns,
+     * we need to show the color separately for each cell.
+     */
+    color?: string
+): JSX.Element {
     // Value can be undefined if the datum's series doesn't have ANY value for the breakdown value being rendered
-    return datumValue !== undefined ? (
+    return (
         <div className="series-data-cell">
-            {formatAggregationValue(datumMathProperty, datumValue, renderCount, formatPropertyValueForDisplay)}
+            {
+                color && (
+                    <span className="mr-2" style={{ color }}>
+                        ●
+                    </span>
+                ) /* eslint-disable-line react/forbid-dom-props */
+            }
+            {datumValue !== undefined
+                ? formatAggregationValue(datumMathProperty, datumValue, renderCount, formatPropertyValueForDisplay)
+                : '–'}
         </div>
-    ) : (
-        '–'
     )
 }
 
@@ -104,6 +116,7 @@ export function InsightTooltip({
     const rightTitle: ReactNode | null = getTooltipTitle(seriesData, altRightTitle, date) || null
 
     if (itemizeEntitiesAsColumns) {
+        hideColorCol = true
         const dataSource = invertDataSource(seriesData)
         const columns: LemonTableColumns<InvertedSeriesDatum> = [
             {
@@ -121,12 +134,14 @@ export function InsightTooltip({
 
         if (numDataPoints > 0) {
             const indexOfLongestSeries = dataSource.findIndex((ds) => ds?.seriesData?.length === numDataPoints)
-            const truncatedCols = dataSource?.[indexOfLongestSeries !== -1 ? indexOfLongestSeries : 0].seriesData
-                .slice(0, colCutoff)
-                .sort((a, b) => a.datasetIndex - b.datasetIndex)
+            const truncatedCols = dataSource?.[indexOfLongestSeries !== -1 ? indexOfLongestSeries : 0].seriesData.slice(
+                0,
+                colCutoff
+            )
+            const dataColumns: LemonTableColumn<InvertedSeriesDatum, keyof InvertedSeriesDatum | undefined>[] = []
             truncatedCols.forEach((seriesColumn, colIdx) => {
-                columns.push({
-                    key: `series-column-data-${colIdx}`,
+                dataColumns.push({
+                    key: colIdx,
                     className: 'datum-counts-column',
                     align: 'right',
                     title:
@@ -146,15 +161,24 @@ export function InsightTooltip({
                                 colIdx
                             )),
                     render: function renderSeriesColumnData(_, datum) {
+                        const seriesColumnData = datum.seriesData?.[colIdx]
                         return renderDatumToTableCell(
-                            datum.seriesData?.[colIdx]?.action?.math_property,
-                            datum.seriesData?.[colIdx]?.count,
+                            seriesColumnData?.action?.math_property,
+                            seriesColumnData?.count,
                             formatPropertyValueForDisplay,
-                            renderCount
+                            renderCount,
+                            seriesColumnData.color
                         )
                     },
                 })
             })
+            console.log(truncatedCols)
+            dataColumns.sort(
+                (a, b) =>
+                    (truncatedCols[a.key as number]?.action?.order || 0) -
+                    (truncatedCols[b.key as number]?.action?.order || 0)
+            )
+            columns.push(...dataColumns)
         }
 
         return (

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -141,7 +141,7 @@ export function InsightTooltip({
             const dataColumns: LemonTableColumn<InvertedSeriesDatum, keyof InvertedSeriesDatum | undefined>[] = []
             truncatedCols.forEach((seriesColumn, colIdx) => {
                 dataColumns.push({
-                    key: colIdx,
+                    key: colIdx.toString(),
                     className: 'datum-counts-column',
                     align: 'right',
                     title:
@@ -174,8 +174,8 @@ export function InsightTooltip({
             })
             dataColumns.sort(
                 (a, b) =>
-                    (truncatedCols[a.key as number]?.action?.order || 0) -
-                    (truncatedCols[b.key as number]?.action?.order || 0)
+                    (truncatedCols[parseInt(a.key as string)]?.action?.order || 0) -
+                    (truncatedCols[parseInt(b.key as string)]?.action?.order || 0)
             )
             columns.push(...dataColumns)
         }


### PR DESCRIPTION
## Problem

In the trends tooltip, we ordered column _titles_ correctly, but it was possible for column data to be used out-of-order, which resulted in tooltips being wrong under certain conditions, like so:

<img width="737" alt="Before" src="https://user-images.githubusercontent.com/4550621/201968292-16190eec-ff29-4c9a-824e-c0d220a3a604.png">

Additionally, color-coding was on the row level, which is confusing and not very useful when each series is represented by a separate cell.

## Changes

The columns are now in sync. And each cell is color-coded in an intuitive way.

<img width="738" alt="After" src="https://user-images.githubusercontent.com/4550621/201968297-744bae23-2e4d-4e71-930a-4972fdc1770d.png">
