### PR TITLE
feat(capture): make endpoint return 503 on produce errors

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -296,7 +296,9 @@ def get_event(request):
                 ),
             )
 
-    if ingestion_context and str(ingestion_context.team_id) in settings.ACK_EVENTS_PRODUCED_FOR_TEAMS:
+    if (
+        ingestion_context and str(ingestion_context.team_id) in settings.ACK_EVENTS_PRODUCED_FOR_TEAMS
+    ) or "*" in settings.ACK_EVENTS_PRODUCED_FOR_TEAMS:
         # If the request is for a team we've enabled acks for, return HTTP
         # status codes accordingly. Ultimately we'll roll this out everywhere
         # but to allow for testing what effect this has we only do it for a

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -306,7 +306,7 @@ def get_event(request):
                 request,
                 generate_exception_response(
                     "capture",
-                    "Unable to store event. Please try again. If you are the owner of this app you can check the logs for further details.",
+                    "Unable to store some events. Please try again. If you are the owner of this app you can check the logs for further details.",
                     code="server_error",
                     type="server_error",
                     status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -296,22 +296,27 @@ def get_event(request):
                 ),
             )
 
-    for future in futures:
-        try:
-            future.get(timeout=10)
-        except KafkaError:
-            # TODO: distinguish between retriable errors and non-retriable
-            # errors, and set Retry-After header accordingly.
-            return cors_response(
-                request,
-                generate_exception_response(
-                    "capture",
-                    "Unable to store some events. Please try again. If you are the owner of this app you can check the logs for further details.",
-                    code="server_error",
-                    type="server_error",
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                ),
-            )
+    if ingestion_context and str(ingestion_context.team_id) in settings.ACK_EVENTS_PRODUCED_FOR_TEAMS:
+        # If the request is for a team we've enabled acks for, return HTTP
+        # status codes accordingly. Ultimately we'll roll this out everywhere
+        # but to allow for testing what effect this has we only do it for a
+        # subset of requests.
+        for future in futures:
+            try:
+                future.get(timeout=1)
+            except KafkaError:
+                # TODO: distinguish between retriable errors and non-retriable
+                # errors, and set Retry-After header accordingly.
+                return cors_response(
+                    request,
+                    generate_exception_response(
+                        "capture",
+                        "Unable to store some events. Please try again. If you are the owner of this app you can check the logs for further details.",
+                        code="server_error",
+                        type="server_error",
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    ),
+                )
 
     statsd.incr("posthog_cloud_raw_endpoint_success", tags={"endpoint": "capture"})
     return cors_response(request, JsonResponse({"status": 1}))

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 import re
 from datetime import datetime
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 from dateutil import parser
@@ -10,6 +10,8 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
+from kafka.errors import KafkaError
+from kafka.producer.future import FutureRecordMetadata
 from rest_framework import status
 from sentry_sdk import configure_scope
 from sentry_sdk.api import capture_exception
@@ -57,13 +59,14 @@ def parse_kafka_event_data(
     }
 
 
-def log_event(data: Dict, event_name: str, partition_key: Optional[str]) -> None:
+def log_event(data: Dict, event_name: str, partition_key: Optional[str]):
     logger.debug("logging_event", event_name=event_name, kafka_topic=KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC)
 
     # TODO: Handle Kafka being unavailable with exponential backoff retries
     try:
-        KafkaProducer().produce(topic=KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC, data=data, key=partition_key)
+        future = KafkaProducer().produce(topic=KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC, data=data, key=partition_key)
         statsd.incr("posthog_cloud_plugin_server_ingestion")
+        return future
     except Exception as e:
         statsd.incr("capture_endpoint_log_event_error")
         print(f"Failed to produce event to Kafka topic {KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC} with error:", e)
@@ -251,6 +254,8 @@ def get_event(request):
             request, generate_exception_response("capture", f"Invalid payload: {e}", code="invalid_payload")
         )
 
+    futures: List[FutureRecordMetadata] = []
+
     for event, event_uuid, distinct_id in processed_events:
         if send_events_to_dead_letter_queue:
             kafka_event = parse_kafka_event_data(
@@ -274,10 +279,29 @@ def get_event(request):
             continue
 
         try:
-            capture_internal(event, distinct_id, ip, site_url, now, sent_at, ingestion_context.team_id, event_uuid)  # type: ignore
+            futures.append(
+                capture_internal(event, distinct_id, ip, site_url, now, sent_at, ingestion_context.team_id, event_uuid)  # type: ignore
+            )
         except Exception as e:
             capture_exception(e, {"data": data})
             statsd.incr("posthog_cloud_raw_endpoint_failure", tags={"endpoint": "capture"})
+            return cors_response(
+                request,
+                generate_exception_response(
+                    "capture",
+                    "Unable to store event. Please try again. If you are the owner of this app you can check the logs for further details.",
+                    code="server_error",
+                    type="server_error",
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                ),
+            )
+
+    for future in futures:
+        try:
+            future.get(timeout=10)
+        except KafkaError:
+            # TODO: distinguish between retriable errors and non-retriable
+            # errors, and set Retry-After header accordingly.
             return cors_response(
                 request,
                 generate_exception_response(
@@ -330,7 +354,7 @@ def parse_event(event, distinct_id, ingestion_context):
     return event
 
 
-def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, event_uuid=None) -> None:
+def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, event_uuid=None):
     if event_uuid is None:
         event_uuid = UUIDT()
 
@@ -354,4 +378,4 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
     if candidate_partition_key not in settings.EVENT_PARTITION_KEYS_TO_OVERRIDE:
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
 
-    log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
+    return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -15,6 +15,9 @@ import lzstring
 from django.test.client import Client
 from django.utils import timezone
 from freezegun import freeze_time
+from kafka.errors import KafkaError
+from kafka.producer.future import FutureProduceResult, FutureRecordMetadata
+from kafka.structs import TopicPartition
 from rest_framework import status
 
 from posthog.api.capture import get_distinct_id
@@ -122,6 +125,34 @@ class TestCapture(BaseTest):
             },
             self._to_arguments(kafka_produce),
         )
+
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_capture_events_503_on_kafka_produce_errors(self, kafka_produce):
+        produce_future = FutureProduceResult(topic_partition=TopicPartition(KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC, 1))
+        future = FutureRecordMetadata(
+            produce_future=produce_future,
+            relative_offset=0,
+            timestamp_ms=0,
+            checksum=0,
+            serialized_key_size=0,
+            serialized_value_size=0,
+            serialized_header_size=0,
+        )
+        future.failure(KafkaError("Failed to produce"))
+        kafka_produce.return_value = future
+        data = {
+            "event": "$autocapture",
+            "properties": {
+                "distinct_id": 2,
+                "token": self.team.api_token,
+                "$elements": [
+                    {"tag_name": "a", "nth_child": 1, "nth_of_type": 2, "attr__class": "btn btn-sm"},
+                    {"tag_name": "div", "nth_child": 1, "nth_of_type": 2, "$el_text": "💻"},
+                ],
+            },
+        }
+        response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost")
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_capture_event_ip(self, kafka_produce):

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -157,6 +157,10 @@ class TestCapture(BaseTest):
             response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost")
             self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
 
+        with override_settings(ACK_EVENTS_PRODUCED_FOR_TEAMS=["*"]):
+            response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost")
+            self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
         with override_settings(ACK_EVENTS_PRODUCED_FOR_TEAMS=[]):
             response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost")
             self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import kafka.errors
 from kafka import KafkaConsumer as KC
 from kafka import KafkaProducer as KP
-from kafka.producer.future import FutureProduceResult, RecordMetadata
+from kafka.producer.future import FutureProduceResult, FutureRecordMetadata, RecordMetadata
 from kafka.structs import TopicPartition
 from statshog.defaults.django import statsd
 from structlog import get_logger
@@ -33,7 +33,15 @@ class KafkaProducerForTests:
         pass
 
     def send(self, topic: str, value: Any, key: Any = None, headers: Optional[List[Tuple[str, bytes]]] = None):
-        return FutureProduceResult(topic_partition=TopicPartition(topic, 1))
+        return FutureRecordMetadata(
+            produce_future=FutureProduceResult(topic_partition=TopicPartition(topic, 1)),
+            relative_offset=0,
+            timestamp_ms=0,
+            checksum=0,
+            serialized_key_size=0,
+            serialized_value_size=0,
+            serialized_header_size=0,
+        )
 
     def flush(self):
         return

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -126,6 +126,7 @@ class _KafkaProducer:
         future = self.producer.send(topic, value=b, key=key, headers=encoded_headers)
         # Record if the send request was successful or not
         future.add_callback(self.on_send_success).add_errback(lambda exc: self.on_send_failure(topic=topic, exc=exc))
+        return future
 
     def close(self):
         self.producer.flush()

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -257,3 +257,5 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
         ),
     )
 )
+
+ACK_EVENTS_PRODUCED_FOR_TEAMS = get_list(os.getenv("ACK_EVENTS_PRODUCED_FOR_TEAMS", ""))


### PR DESCRIPTION
At the moment we are swallowing errors. This change should make it such
that when e.g. we have issues with Kafka, the client is informed that
there is an issue, and we can also use HTTP error rates to monitor and
alert, rather than looking at Kafka specific metrics.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
