### PR TITLE
fix: Disable strict JSON, so that insights with NaNs don't crash

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -200,6 +200,7 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "STRICT_JSON": False,
 }
 if DEBUG:
     REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"].append("rest_framework.renderers.BrowsableAPIRenderer")  # type: ignore


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/11887.

## Changes

This just makes is to that requests with NaNs or infinites don't crash at the server level. It's not necessary to throw an error for the whole dashboard when that happens, and it's much easier to debug if the data actually is returned.