### PR TITLE
feat(insights): reoganize chart filter options

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -1,6 +1,5 @@
 import { useActions, useValues } from 'kea'
 import { chartFilterLogic } from './chartFilterLogic'
-import { LineChartOutlined, OrderedListOutlined } from '@ant-design/icons'
 import {
     IconShowChart,
     IconCumulativeChart,
@@ -11,10 +10,9 @@ import {
     IconPublic,
 } from 'lib/components/icons'
 
-import { ChartDisplayType, FilterType, FunnelVizType, InsightType } from '~/types'
+import { ChartDisplayType, FilterType, FunnelVizType } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { Tooltip } from '../Tooltip'
-import { LemonTag } from '../LemonTag/LemonTag'
 import { LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 import { isRetentionFilter, isStickinessFilter, isTrendsFilter } from 'scenes/insights/sharedUtils'
 
@@ -64,90 +62,68 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
         )
     }
 
-    const options: LemonSelectOptions<ChartDisplayType | FunnelVizType> =
-        filters.insight === InsightType.FUNNELS
-            ? [
-                  { value: FunnelVizType.Steps, label: <Label icon={<OrderedListOutlined />}>Steps</Label> },
-                  {
-                      value: FunnelVizType.Trends,
-                      label: (
-                          <Label icon={<LineChartOutlined />}>
-                              Trends
-                              <LemonTag
-                                  type="warning"
-                                  className="uppercase"
-                                  style={{ marginLeft: 6, lineHeight: '1.4em' }}
-                              >
-                                  BETA
-                              </LemonTag>
-                          </Label>
-                      ),
-                  },
-              ]
-            : [
-                  {
-                      title: 'Time Series',
-                      options: [
-                          {
-                              value: ChartDisplayType.ActionsLineGraph,
-                              label: <Label icon={<IconShowChart />}>Line</Label>,
-                          },
-                          {
-                              value: ChartDisplayType.ActionsLineGraphCumulative,
-                              label: <Label icon={<IconCumulativeChart />}>Cumulative</Label>,
-                              disabled: cumulativeDisabled,
-                          },
-                          {
-                              value: ChartDisplayType.ActionsBar,
-                              label: <Label icon={<IconBarChart />}>Bar</Label>,
-                              disabled: barDisabled,
-                          },
-                      ],
-                  },
-                  {
-                      title: 'Value',
-                      options: [
-                          {
-                              value: ChartDisplayType.BoldNumber,
-                              label: (
-                                  <Label
-                                      icon={<Icon123 />}
-                                      tooltip="Big and bold. Only works with one series at a time."
-                                  >
-                                      Number
-                                  </Label>
-                              ),
-                              disabled: boldNumberDisabled,
-                          },
-                          {
-                              value: ChartDisplayType.ActionsPie,
-                              label: <Label icon={<IconPieChart />}>Pie</Label>,
-                              disabled: pieDisabled,
-                          },
-                          {
-                              value: ChartDisplayType.ActionsBarValue,
-                              label: <Label icon={<IconBarChart className="rotate-90" />}>Bar</Label>,
-                              disabled: barValueDisabled,
-                          },
-                          {
-                              value: ChartDisplayType.ActionsTable,
-                              label: <Label icon={<IconTableChart fontSize="14" />}>Table</Label>,
-                          },
-                          {
-                              value: ChartDisplayType.WorldMap,
-                              label: (
-                                  <Label
-                                      icon={<IconPublic />}
-                                      tooltip="Visualize data by country. Only works with one series at a time."
-                                  >
-                                      World Map
-                                  </Label>
-                              ),
-                              disabled: worldMapDisabled,
-                          },
-                      ],
-                  },
-              ]
+    const options: LemonSelectOptions<ChartDisplayType | FunnelVizType> = [
+        {
+            title: 'Time Series',
+            options: [
+                {
+                    value: ChartDisplayType.ActionsLineGraph,
+                    label: <Label icon={<IconShowChart />}>Line</Label>,
+                },
+                {
+                    value: ChartDisplayType.ActionsLineGraphCumulative,
+                    label: <Label icon={<IconCumulativeChart />}>Cumulative</Label>,
+                    disabled: cumulativeDisabled,
+                },
+                {
+                    value: ChartDisplayType.ActionsBar,
+                    label: <Label icon={<IconBarChart />}>Bar</Label>,
+                    disabled: barDisabled,
+                },
+            ],
+        },
+        {
+            title: 'Value',
+            options: [
+                {
+                    value: ChartDisplayType.BoldNumber,
+                    label: (
+                        <Label icon={<Icon123 />} tooltip="Big and bold. Only works with one series at a time.">
+                            Number
+                        </Label>
+                    ),
+                    disabled: boldNumberDisabled,
+                },
+                {
+                    value: ChartDisplayType.ActionsPie,
+                    label: <Label icon={<IconPieChart />}>Pie</Label>,
+                    disabled: pieDisabled,
+                },
+                {
+                    value: ChartDisplayType.ActionsBarValue,
+                    label: <Label icon={<IconBarChart className="rotate-90" />}>Bar</Label>,
+                    disabled: barValueDisabled,
+                },
+                {
+                    value: ChartDisplayType.ActionsTable,
+                    label: <Label icon={<IconTableChart fontSize="14" />}>Table</Label>,
+                },
+                {
+                    value: ChartDisplayType.WorldMap,
+                    label: (
+                        <Label
+                            icon={<IconPublic />}
+                            tooltip="Visualize data by country. Only works with one series at a time."
+                        >
+                            World Map
+                        </Label>
+                    ),
+                    disabled: worldMapDisabled,
+                },
+            ],
+        },
+    ]
+
     return (
         <LemonSelect
             key="2"

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -1,15 +1,16 @@
 import { useActions, useValues } from 'kea'
 import { chartFilterLogic } from './chartFilterLogic'
+import { LineChartOutlined, OrderedListOutlined } from '@ant-design/icons'
 import {
-    AreaChartOutlined,
-    BarChartOutlined,
-    LineChartOutlined,
-    OrderedListOutlined,
-    PieChartOutlined,
-    GlobalOutlined,
-    TableOutlined,
-    NumberOutlined,
-} from '@ant-design/icons'
+    IconShowChart,
+    IconCumulativeChart,
+    IconBarChart,
+    Icon123,
+    IconPieChart,
+    IconTableChart,
+    IconPublic,
+} from 'lib/components/icons'
+
 import { ChartDisplayType, FilterType, FunnelVizType, InsightType } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { Tooltip } from '../Tooltip'
@@ -56,8 +57,8 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
     }): JSX.Element {
         return (
             <Tooltip title={tooltip} placement="left">
-                <div className="w-full">
-                    {icon} {children}
+                <div className="flex items-center">
+                    {icon}&nbsp;{children}
                 </div>
             </Tooltip>
         )
@@ -85,41 +86,32 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
               ]
             : [
                   {
-                      title: 'Line Chart',
+                      title: 'Time Series',
                       options: [
                           {
                               value: ChartDisplayType.ActionsLineGraph,
-                              label: <Label icon={<LineChartOutlined />}>Linear</Label>,
+                              label: <Label icon={<IconShowChart />}>Line</Label>,
                           },
                           {
                               value: ChartDisplayType.ActionsLineGraphCumulative,
-                              label: <Label icon={<AreaChartOutlined />}>Cumulative</Label>,
+                              label: <Label icon={<IconCumulativeChart />}>Cumulative</Label>,
                               disabled: cumulativeDisabled,
                           },
-                      ],
-                  },
-                  {
-                      title: 'Bar Chart',
-                      options: [
                           {
                               value: ChartDisplayType.ActionsBar,
-                              label: <Label icon={<BarChartOutlined />}>Time</Label>,
+                              label: <Label icon={<IconBarChart />}>Bar</Label>,
                               disabled: barDisabled,
-                          },
-                          {
-                              value: ChartDisplayType.ActionsBarValue,
-                              label: <Label icon={<BarChartOutlined />}>Value</Label>,
-                              disabled: barValueDisabled,
                           },
                       ],
                   },
                   {
+                      title: 'Value',
                       options: [
                           {
                               value: ChartDisplayType.BoldNumber,
                               label: (
                                   <Label
-                                      icon={<NumberOutlined />}
+                                      icon={<Icon123 />}
                                       tooltip="Big and bold. Only works with one series at a time."
                                   >
                                       Number
@@ -128,19 +120,24 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
                               disabled: boldNumberDisabled,
                           },
                           {
-                              value: ChartDisplayType.ActionsTable,
-                              label: <Label icon={<TableOutlined />}>Table</Label>,
+                              value: ChartDisplayType.ActionsPie,
+                              label: <Label icon={<IconPieChart />}>Pie</Label>,
+                              disabled: pieDisabled,
                           },
                           {
-                              value: ChartDisplayType.ActionsPie,
-                              label: <Label icon={<PieChartOutlined />}>Pie</Label>,
-                              disabled: pieDisabled,
+                              value: ChartDisplayType.ActionsBarValue,
+                              label: <Label icon={<IconBarChart className="rotate-90" />}>Bar</Label>,
+                              disabled: barValueDisabled,
+                          },
+                          {
+                              value: ChartDisplayType.ActionsTable,
+                              label: <Label icon={<IconTableChart fontSize="14" />}>Table</Label>,
                           },
                           {
                               value: ChartDisplayType.WorldMap,
                               label: (
                                   <Label
-                                      icon={<GlobalOutlined />}
+                                      icon={<IconPublic />}
                                       tooltip="Visualize data by country. Only works with one series at a time."
                                   >
                                       World Map

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -552,11 +552,79 @@ export function IconFlag(props: SvgIconProps): JSX.Element {
     )
 }
 
+/** Material Design Show Chart icon. */
+export function IconShowChart(props: SvgIconProps): JSX.Element {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99l1.5 1.5z" fill="currentColor" />
+        </SvgIcon>
+    )
+}
+
+export function IconCumulativeChart(props: SvgIconProps): JSX.Element {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path
+                d="M20.8805 7.97408C15.0614 18.7809 6.51281 19.5979 2.71265 18.4578L3.28734 16.5422C6.15384 17.4021 13.7386 17.0191 19.1195 7.02588L20.8805 7.97408Z"
+                fill="currentColor"
+            />
+        </SvgIcon>
+    )
+}
+
 /** Material Design Bar Chart icon. */
 export function IconBarChart(props: SvgIconProps): JSX.Element {
     return (
         <SvgIcon fill="none" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
             <path d="m5 9.2h3v9.8h-3zm5.6-4.2h2.8v14h-2.8zm5.6 8h2.8v6h-2.8z" fill="currentColor" />
+        </SvgIcon>
+    )
+}
+
+/** Material Design Pie Chart icon. */
+export function IconPieChart(props: SvgIconProps): JSX.Element {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm7.93 9H13V4.07c3.61.45 6.48 3.32 6.93 6.93zM4 12c0-4.07 3.06-7.44 7-7.93v15.86c-3.94-.49-7-3.86-7-7.93zm9 7.93V13h6.93c-.45 3.61-3.32 6.48-6.93 6.93z"
+                fill="currentColor"
+            />
+        </SvgIcon>
+    )
+}
+
+/** Material Design Table Chart icon. */
+export function IconTableChart(props: SvgIconProps): JSX.Element {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path
+                d="M20 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 2v3H5V5h15zm-5 14h-5v-9h5v9zM5 10h3v9H5v-9zm12 9v-9h3v9h-3z"
+                fill="currentColor"
+            />
+        </SvgIcon>
+    )
+}
+
+/** Material Design 123 icon. */
+export function Icon123(props: SvgIconProps): JSX.Element {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path
+                d="M7,15H5.5v-4.5H4V9h3V15z M13.5,13.5h-3v-1h2c0.55,0,1-0.45,1-1V10c0-0.55-0.45-1-1-1H9v1.5h3v1h-2c-0.55,0-1,0.45-1,1V15 h4.5V13.5z M19.5,14v-4c0-0.55-0.45-1-1-1H15v1.5h3v1h-2v1h2v1h-3V15h3.5C19.05,15,19.5,14.55,19.5,14z"
+                fill="currentColor"
+            />
+        </SvgIcon>
+    )
+}
+
+/** Material Public icon. */
+export function IconPublic(props: SvgIconProps): JSX.Element {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-.61.08-1.21.21-1.78L8.99 15v1c0 1.1.9 2 2 2v1.93C7.06 19.43 4 16.07 4 12zm13.89 5.4c-.26-.81-1-1.4-1.9-1.4h-1v-3c0-.55-.45-1-1-1h-6v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41C17.92 5.77 20 8.65 20 12c0 2.08-.81 3.98-2.11 5.4z"
+                fill="currentColor"
+            />
         </SvgIcon>
     )
 }


### PR DESCRIPTION
## Problem

I was having a hard time understanding the different chart options, especially how the "Time" and "Value" Chart are different.

## Changes

- Re-organizing the chart filter options into "Time Series" and "Value" categories and using the chart type as name.
- Replacing the existing Antd-Icons with Material icons and adding a custom icon for cumulative.
- Removing leftover code from trends beta.

![Group_1](https://user-images.githubusercontent.com/1851359/202219316-457a976d-81e4-488c-838f-30d9244d41a9.png)

## Discussion

> ## Changes
> 
> - I'm proposing to re-organize the chart filter options into "Time" and "Value" as primary category and then simply using the type as name (see screenshot).
> - I've changed the icon for the "Bold Number" chart into something I found more fitting. It  would be great to have a horizontal bar chart icon for the "Value" Chart as well.
> 
> *Before*
> <img width="338" alt="before" src="https://user-images.githubusercontent.com/1851359/201982558-af11d532-947d-491c-b042-dfdb20123ffd.png">
> 
> *After*
> <img width="221" alt="after1" src="https://user-images.githubusercontent.com/1851359/201983212-5ee1658c-3600-4dd3-9deb-626f08517e8c.png">
> <img width="217" alt="after2" src="https://user-images.githubusercontent.com/1851359/201983210-5f032f50-45ab-4959-bbbd-15bf728232f2.png">
> <img width="217" alt="after3" src="https://user-images.githubusercontent.com/1851359/201983208-6c1c1af8-35ce-4f71-839a-7f002f3c59a4.png">
> 
> ## Request for comments
> 
> - Please let me know if I'm misunderstanding/missing something about the charts that doesn't make this categorization work.
> - Also let me know what you think of this? Are the categories more/less clear for you? Option 1/2/3?
> - Probably would be great to get some real user feedback as well, if we want to continue with this.