### PR TITLE
fix(project-settings): Handle null `correlation_config` gracefully

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -8,6 +8,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import {
     AvailableFeature,
+    CorrelationConfigType,
     FunnelCorrelation,
     FunnelCorrelationResultsType,
     FunnelCorrelationType,
@@ -16,7 +17,6 @@ import {
     InsightLogicProps,
     InsightShortId,
     InsightType,
-    TeamType,
 } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -140,7 +140,7 @@ const funnelResults = [
 
 describe('funnelLogic', () => {
     let logic: ReturnType<typeof funnelLogic.build>
-    let correlationConfig: TeamType['correlation_config'] = {}
+    let correlationConfig: CorrelationConfigType = {}
 
     beforeEach(() => {
         useAvailableFeatures([AvailableFeature.CORRELATION_ANALYSIS, AvailableFeature.GROUP_ANALYTICS])

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -32,9 +32,9 @@ import {
     PropertyFilter,
     PropertyOperator,
     StepOrderValue,
-    TeamType,
     TrendResult,
     FunnelsFilterType,
+    CorrelationConfigType,
 } from '~/types'
 import { BIN_COUNT_AUTO, FunnelLayout } from 'lib/constants'
 
@@ -1454,7 +1454,7 @@ export const funnelLogic = kea<funnelLogicType>({
 })
 
 const appendToCorrelationConfig = (
-    configKey: keyof TeamType['correlation_config'],
+    configKey: keyof CorrelationConfigType,
     currentValue: string[],
     configValue: string
 ): void => {

--- a/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
+++ b/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
@@ -57,7 +57,7 @@ export function CorrelationConfig(): JSX.Element {
                         </h3>
                         <PersonPropertySelect
                             onChange={(properties) => handleChange(properties)}
-                            selectedProperties={currentTeam.correlation_config.excluded_person_property_names || []}
+                            selectedProperties={funnelCorrelationConfig.excluded_person_property_names || []}
                             addText="Add exclusion"
                         />
                     </div>
@@ -68,7 +68,7 @@ export function CorrelationConfig(): JSX.Element {
                         </h3>
                         <EventSelect
                             onChange={(excludedEvents) => handleChange(undefined, excludedEvents)}
-                            selectedEvents={currentTeam.correlation_config.excluded_event_names || []}
+                            selectedEvents={funnelCorrelationConfig.excluded_event_names || []}
                             addElement={
                                 <LemonButton size="small" type="secondary" icon={<IconPlus />}>
                                     Add exclusion
@@ -85,7 +85,7 @@ export function CorrelationConfig(): JSX.Element {
                             <LemonSelectMultiple
                                 mode="multiple-custom"
                                 onChange={(properties) => handleChange(undefined, undefined, properties)}
-                                value={currentTeam.correlation_config.excluded_event_property_names || []}
+                                value={funnelCorrelationConfig.excluded_event_property_names || []}
                             />
                         </div>
                     </div>

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -1,7 +1,7 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import api from 'lib/api'
 import type { teamLogicType } from './teamLogicType'
-import { TeamType } from '~/types'
+import { CorrelationConfigType, TeamType } from '~/types'
 import { userLogic } from './userLogic'
 import { identifierToHuman, isUserLoggedIn, resolveWebhookService } from 'lib/utils'
 import { organizationLogic } from './organizationLogic'
@@ -128,7 +128,7 @@ export const teamLogic = kea<teamLogicType>([
         ],
         funnelCorrelationConfig: [
             (selectors) => [selectors.currentTeam],
-            (currentTeam): Partial<TeamType['correlation_config']> => {
+            (currentTeam): CorrelationConfigType => {
                 return currentTeam?.correlation_config || {}
             },
         ],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -244,6 +244,12 @@ export interface TeamBasicType {
     effective_membership_level: OrganizationMembershipLevel | null
 }
 
+export interface CorrelationConfigType {
+    excluded_person_property_names?: string[]
+    excluded_event_property_names?: string[]
+    excluded_event_names?: string[]
+}
+
 export interface TeamType extends TeamBasicType {
     created_at: string
     updated_at: string
@@ -261,14 +267,12 @@ export interface TeamType extends TeamBasicType {
     has_group_types: boolean
     primary_dashboard: number // Dashboard shown on the project homepage
     live_events_columns: string[] | null // Custom columns shown on the Live Events page
-
-    // Uses to exclude person properties from correlation analysis results, for
-    // example can be used to exclude properties that have trivial causation
-    correlation_config: {
-        excluded_person_property_names?: string[]
-        excluded_event_property_names?: string[]
-        excluded_event_names?: string[]
-    }
+    /** Used to exclude person properties from correlation analysis results.
+     *
+     * For example can be used to exclude properties that have trivial causation.
+     * This field should have a default value of `{}`, but it IS nullable and can be `null` in some cases.
+     */
+    correlation_config: CorrelationConfigType | null
 }
 
 export interface ActionType {


### PR DESCRIPTION
## Problem

`correlation_config` is a nullable column on `posthog_team`, but it wasn't typed as such in the frontend, so [a customer was unable to open project settings](https://posthog.slack.com/archives/C02MHBYHS05/p1668538551965599) with this error:

<img width="1393" alt="image" src="https://user-images.githubusercontent.com/4550621/202014493-50ca4559-8003-48a9-a607-bad982eea1df.png">

## Changes

This fixes the problem by aligning `TeamType` with reality.