### PR TITLE
fix(insights): fix breakdown regression

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/Breakdown.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/Breakdown.tsx
@@ -1,16 +1,16 @@
 import { useActions, useValues } from 'kea'
-import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { EditorFilterProps, InsightType } from '~/types'
 import { BreakdownFilter } from 'scenes/insights/filters/BreakdownFilter'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
-export function TrendsBreakdown({ filters, insightProps }: EditorFilterProps): JSX.Element {
-    const { setFilters } = useActions(trendsLogic(insightProps))
+export function Breakdown({ filters }: EditorFilterProps): JSX.Element {
+    const { setFiltersMerge } = useActions(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const useMultiBreakdown =
         filters.insight !== InsightType.TRENDS && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]
 
-    return <BreakdownFilter filters={filters} setFilters={setFilters} useMultiBreakdown={useMultiBreakdown} />
+    return <BreakdownFilter filters={filters} setFilters={setFiltersMerge} useMultiBreakdown={useMultiBreakdown} />
 }

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -11,7 +11,7 @@ import { TrendsSeries, TrendsSeriesLabel } from 'scenes/insights/EditorFilters/T
 import { FEATURE_FLAGS, NON_BREAKDOWN_DISPLAY_TYPES } from 'lib/constants'
 import { GlobalAndOrFilters } from 'scenes/insights/EditorFilters/GlobalAndOrFilters'
 import { TrendsFormula, TrendsFormulaLabel } from 'scenes/insights/EditorFilters/TrendsFormula'
-import { TrendsBreakdown } from 'scenes/insights/EditorFilters/TrendsBreakdown'
+import { Breakdown } from 'scenes/insights/EditorFilters/Breakdown'
 import { LifecycleToggles } from 'scenes/insights/EditorFilters/LifecycleToggles'
 import { LifecycleGlobalFilters } from 'scenes/insights/EditorFilters/LifecycleGlobalFilters'
 import { RetentionSummary } from './RetentionSummary'
@@ -207,7 +207,7 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
                                   give you the event volume for each URL your users have visited.
                               </>
                           ),
-                          component: TrendsBreakdown,
+                          component: Breakdown,
                       }
                     : null,
                 hasAttribution


### PR DESCRIPTION
## Problem

Adding a breakdown on funnel and retention graphs would snap the insight back into a "trend". [Internal thread](https://posthog.slack.com/archives/C02E3BKC78F/p1668541478946949).

Fixes https://github.com/PostHog/posthog/issues/12804

## Changes

Fixes the regression. Funnels stay funnel.

## How did you test this code?

Tested locally.