### PR TITLE
fix(ingestion): rename the ingestion V2 logic

### DIFF
--- a/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
@@ -5,7 +5,7 @@ import { VerificationPanel } from 'scenes/ingestion/v2/panels/VerificationPanel'
 import { InstructionsPanel } from 'scenes/ingestion/v2/panels/InstructionsPanel'
 import { MOBILE, BACKEND, WEB, BOOKMARKLET, THIRD_PARTY } from 'scenes/ingestion/v2/constants'
 import { useValues, useActions } from 'kea'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { FrameworkPanel } from 'scenes/ingestion/v2/panels/FrameworkPanel'
 import { PlatformPanel } from 'scenes/ingestion/v2/panels/PlatformPanel'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -24,7 +24,7 @@ import { InviteTeamPanel } from './panels/InviteTeamPanel'
 import { TeamInvitedPanel } from './panels/TeamInvitedPanel'
 
 export function IngestionWizardV2(): JSX.Element {
-    const { platform, framework, verify, addBilling, technical, hasInvitedMembers } = useValues(ingestionLogic)
+    const { platform, framework, verify, addBilling, technical, hasInvitedMembers } = useValues(ingestionLogicV2)
     const { isInviteModalShown } = useValues(inviteLogic)
     const { reportIngestionLandingSeen } = useActions(eventUsageLogic)
 
@@ -112,7 +112,7 @@ export function IngestionWizardV2(): JSX.Element {
 function IngestionContainer({ children }: { children: React.ReactNode }): JSX.Element {
     const { isInviteModalShown } = useValues(inviteLogic)
     const { hideInviteModal } = useActions(inviteLogic)
-    const { isSmallScreen } = useValues(ingestionLogic)
+    const { isSmallScreen } = useValues(ingestionLogicV2)
 
     return (
         <div className="flex h-full flex-col">

--- a/frontend/src/scenes/ingestion/v2/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/v2/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { ingestionLogic } from './ingestionLogic'
+import { ingestionLogicV2 } from './ingestionLogicV2'
 import { useActions, useValues } from 'kea'
 import './IngestionWizard.scss'
 import { InviteMembersButton } from '~/layout/navigation/TopBar/SitePopover'
@@ -11,8 +11,8 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 const HELP_UTM_TAGS = '?utm_medium=in-product-onboarding&utm_campaign=help-button-sidebar'
 
 export function Sidebar(): JSX.Element {
-    const { currentStep, sidebarSteps } = useValues(ingestionLogic)
-    const { sidebarStepClick } = useActions(ingestionLogic)
+    const { currentStep, sidebarSteps } = useValues(ingestionLogicV2)
+    const { sidebarStepClick } = useActions(ingestionLogicV2)
     const { reportIngestionHelpClicked, reportIngestionSidebarButtonClicked } = useActions(eventUsageLogic)
 
     const currentIndex = sidebarSteps.findIndex((x) => x === currentStep)

--- a/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
@@ -1,7 +1,6 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { Framework, PlatformType } from 'scenes/ingestion/v2/types'
 import { API, MOBILE, BACKEND, WEB, BOOKMARKLET, thirdPartySources, THIRD_PARTY, ThirdPartySource } from './constants'
-import type { ingestionLogicType } from './ingestionLogicType'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { PluginTypeWithConfig } from 'scenes/plugins/types'
@@ -15,6 +14,7 @@ import { billingLogic } from 'scenes/billing/billingLogic'
 import { subscriptions } from 'kea-subscriptions'
 import { BillingType, TeamType } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import type { ingestionLogicV2Type } from './ingestionLogicV2Type'
 
 export enum INGESTION_STEPS {
     START = 'Get started',
@@ -33,7 +33,7 @@ export enum INGESTION_STEPS_WITHOUT_BILLING {
     DONE = 'Done!',
 }
 
-export const ingestionLogic = kea<ingestionLogicType>([
+export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
     path(['scenes', 'ingestion', 'ingestionLogic']),
     connect({
         values: [
@@ -400,7 +400,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
     })),
 ])
 
-function getUrl(values: ingestionLogicType['values']): string | [string, Record<string, undefined | string>] {
+function getUrl(values: ingestionLogicV2Type['values']): string | [string, Record<string, undefined | string>] {
     const { technical, platform, framework, verify, addBilling, hasInvitedMembers } = values
 
     let url = '/ingestion'

--- a/frontend/src/scenes/ingestion/v2/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/BillingPanel.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { CardContainer } from 'scenes/ingestion/v2/CardContainer'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -16,7 +16,7 @@ import { urls } from 'scenes/urls'
 import { BillingHero } from 'scenes/billing/v2/BillingHero'
 
 export function BillingPanel(): JSX.Element {
-    const { completeOnboarding } = useActions(ingestionLogic)
+    const { completeOnboarding } = useActions(ingestionLogicV2)
     const { reportIngestionContinueWithoutBilling } = useActions(eventUsageLogic)
     const { billing, billingVersion } = useValues(billingLogic)
     const { billing: billingV2 } = useValues(billingLogicV2)

--- a/frontend/src/scenes/ingestion/v2/panels/FrameworkPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/FrameworkPanel.tsx
@@ -1,14 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { CardContainer } from 'scenes/ingestion/v2/CardContainer'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogicV2'
 import { API, mobileFrameworks, BACKEND, webFrameworks } from 'scenes/ingestion/v2/constants'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function FrameworkPanel(): JSX.Element {
-    const { setFramework } = useActions(ingestionLogic)
-    const { platform } = useValues(ingestionLogic)
+    const { setFramework } = useActions(ingestionLogicV2)
+    const { platform } = useValues(ingestionLogicV2)
     const frameworks = platform === BACKEND ? webFrameworks : mobileFrameworks
 
     return (

--- a/frontend/src/scenes/ingestion/v2/panels/InstructionsPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/InstructionsPanel.tsx
@@ -15,7 +15,7 @@ import {
 } from 'scenes/ingestion/v2/frameworks'
 import { API, MOBILE, BACKEND, WEB } from '../constants'
 import { useValues } from 'kea'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogicV2'
 import { WebInstructions } from '../frameworks/WebInstructions'
 import { Link } from '@posthog/lemon-ui'
 
@@ -34,7 +34,7 @@ const frameworksSnippet: Record<string, React.ComponentType> = {
 }
 
 export function InstructionsPanel(): JSX.Element {
-    const { platform, framework, frameworkString } = useValues(ingestionLogic)
+    const { platform, framework, frameworkString } = useValues(ingestionLogicV2)
 
     if (platform !== WEB && !framework) {
         return <></>

--- a/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
@@ -1,5 +1,5 @@
 import { useActions } from 'kea'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { LemonDivider } from 'lib/components/LemonDivider'
@@ -9,7 +9,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
 
 export function InviteTeamPanel(): JSX.Element {
-    const { setTechnical, setPlatform } = useActions(ingestionLogic)
+    const { setTechnical, setPlatform } = useActions(ingestionLogicV2)
     const { showInviteModal } = useActions(inviteLogic)
     const { reportInviteMembersButtonClicked } = useActions(eventUsageLogic)
 

--- a/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/PanelComponents.tsx
@@ -3,14 +3,14 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
-import { ingestionLogic, INGESTION_STEPS } from '../ingestionLogic'
+import { ingestionLogicV2, INGESTION_STEPS } from '../ingestionLogicV2'
 import './Panels.scss'
 import { IconArrowLeft } from 'lib/components/icons'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function PanelFooter(): JSX.Element {
-    const { platform } = useValues(ingestionLogic)
-    const { setPlatform, setVerify } = useActions(ingestionLogic)
+    const { platform } = useValues(ingestionLogicV2)
+    const { setPlatform, setVerify } = useActions(ingestionLogicV2)
     const { reportIngestionTryWithBookmarkletClicked } = useActions(eventUsageLogic)
 
     return (
@@ -61,8 +61,8 @@ export function PanelFooter(): JSX.Element {
 }
 
 export function PanelHeader(): JSX.Element | null {
-    const { isSmallScreen, previousStep, currentStep } = useValues(ingestionLogic)
-    const { onBack } = useActions(ingestionLogic)
+    const { isSmallScreen, previousStep, currentStep } = useValues(ingestionLogicV2)
+    const { onBack } = useActions(ingestionLogicV2)
 
     // no back buttons on the first screen
     if (currentStep === INGESTION_STEPS.START) {

--- a/frontend/src/scenes/ingestion/v2/panels/PlatformPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/PlatformPanel.tsx
@@ -1,5 +1,5 @@
 import { useActions } from 'kea'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogicV2'
 import { THIRD_PARTY, platforms } from '../constants'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
@@ -7,7 +7,7 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 
 export function PlatformPanel(): JSX.Element {
-    const { setPlatform } = useActions(ingestionLogic)
+    const { setPlatform } = useActions(ingestionLogicV2)
 
     return (
         <div>

--- a/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
@@ -1,5 +1,5 @@
 import { useActions } from 'kea'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { LemonDivider } from 'lib/components/LemonDivider'
@@ -8,7 +8,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BOOKMARKLET } from '../constants'
 
 export function TeamInvitedPanel(): JSX.Element {
-    const { completeOnboarding, setTechnical, setPlatform } = useActions(ingestionLogic)
+    const { completeOnboarding, setTechnical, setPlatform } = useActions(ingestionLogicV2)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
     return (

--- a/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/ThirdPartyPanel.tsx
@@ -1,7 +1,7 @@
 import { useValues, useActions } from 'kea'
 import { LemonButton } from 'lib/components/LemonButton'
 import { CardContainer } from '../CardContainer'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogicV2'
 import './Panels.scss'
 import { LemonModal } from 'lib/components/LemonModal'
 import { thirdPartySources, ThirdPartySourceType } from '../constants'
@@ -16,7 +16,7 @@ import { Link } from 'lib/components/Link'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export function ThirdPartyPanel(): JSX.Element {
-    const { setInstructionsModal, setThirdPartySource, openThirdPartyPluginModal } = useActions(ingestionLogic)
+    const { setInstructionsModal, setThirdPartySource, openThirdPartyPluginModal } = useActions(ingestionLogicV2)
     const { filteredUninstalledPlugins, installedPlugins } = useValues(pluginsLogic)
     const { installPlugin } = useActions(pluginsLogic)
     const {
@@ -133,8 +133,8 @@ export function ThirdPartyPanel(): JSX.Element {
 }
 
 export function IntegrationInstructionsModal(): JSX.Element {
-    const { instructionsModalOpen, thirdPartyIntegrationSource, thirdPartyPluginSource } = useValues(ingestionLogic)
-    const { setInstructionsModal } = useActions(ingestionLogic)
+    const { instructionsModalOpen, thirdPartyIntegrationSource, thirdPartyPluginSource } = useValues(ingestionLogicV2)
+    const { setInstructionsModal } = useActions(ingestionLogicV2)
     const { currentTeam } = useValues(teamLogic)
 
     return (

--- a/frontend/src/scenes/ingestion/v2/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/VerificationPanel.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useInterval } from 'lib/hooks/useInterval'
 import { CardContainer } from '../CardContainer'
-import { ingestionLogic } from '../ingestionLogic'
+import { ingestionLogicV2 } from '../ingestionLogicV2'
 import { teamLogic } from 'scenes/teamLogic'
 import { Spinner } from 'lib/components/Spinner/Spinner'
 import { LemonButton } from 'lib/components/LemonButton'
@@ -13,8 +13,8 @@ import { IngestionInviteMembersButton } from '../IngestionInviteMembersButton'
 export function VerificationPanel(): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { setAddBilling, completeOnboarding } = useActions(ingestionLogic)
-    const { showBillingStep } = useValues(ingestionLogic)
+    const { setAddBilling, completeOnboarding } = useActions(ingestionLogicV2)
+    const { showBillingStep } = useValues(ingestionLogicV2)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
     useInterval(() => {

--- a/frontend/src/scenes/organization/Settings/inviteLogic.ts
+++ b/frontend/src/scenes/organization/Settings/inviteLogic.ts
@@ -7,7 +7,7 @@ import type { inviteLogicType } from './inviteLogicType'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { router } from 'kea-router'
 import { lemonToast } from 'lib/components/lemonToast'
-import { ingestionLogic } from 'scenes/ingestion/v2/ingestionLogic'
+import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 
 /** State of a single invite row (with input data) in bulk invite creation. */
 export interface InviteRowState {
@@ -32,7 +32,7 @@ export const inviteLogic = kea<inviteLogicType>({
     },
     connect: {
         values: [preflightLogic, ['preflight']],
-        actions: [router, ['locationChanged'], ingestionLogic, ['setHasInvitedMembers']],
+        actions: [router, ['locationChanged'], ingestionLogicV2, ['setHasInvitedMembers']],
     },
     reducers: () => ({
         isInviteModalShown: [
@@ -126,7 +126,7 @@ export const inviteLogic = kea<inviteLogicType>({
             actions.loadInvites()
 
             if (router.values.location.pathname.includes('/ingestion')) {
-                ingestionLogic.actions.setHasInvitedMembers(true)
+                ingestionLogicV2.actions.setHasInvitedMembers(true)
             }
 
             if (values.preflight?.email_service_available) {


### PR DESCRIPTION
## Problem

When making the v2 directory for testing changes to the onboarding flow, the logic for that directory was kept with the same naming. I believe this is what is causing issues on production with the new onboarding. Here is my hypothesis for what is happening:

- the page loads before the feature flags do
- the `v1` (aka control) component loads, and brings in `ingestionLogic`
- the feature flags load, and then the `v2` (aka test) component loads, and also brings in a logic called `ingestionLogic`
- when an action is called on `ingestionLogic`, it actually calls that action on the first `ingestionLogic` to load on the page, not the logic that is part of our v2 test

Because I am unable to reproduce this locally (if anyone has any ideas then lmk) I decided to just try this out by shipping to prod. The v2 test is currently turned off, so no one will see these changes, and they shouldn't have any impacts other than allowing me to (dis)prove my hypothesis.

## Changes

The `v2/ingestionLogic` file and component were renamed to `IngestionLogicV2`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
