### PR TITLE
fix: Don't send billing usage for v1 licenses

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -222,10 +222,10 @@ def send_report_to_billing_service(organization: Organization, report: Dict) -> 
     from ee.settings import BILLING_SERVICE_URL
 
     license = License.objects.first_valid()
-    token = build_billing_token(license, organization) if license else None
+    if not license or not license.is_v2_license:
+        return
 
-    if not license:
-        return None
+    token = build_billing_token(license, organization) if license else None
 
     headers = {}
     if token:

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -225,7 +225,7 @@ def send_report_to_billing_service(organization: Organization, report: Dict) -> 
     if not license or not license.is_v2_license:
         return
 
-    token = build_billing_token(license, organization) if license else None
+    token = build_billing_token(license, organization)
 
     headers = {}
     if token:


### PR DESCRIPTION
## Problem

We have some errors from usage reports trying to talk to the billing service with a v1 license.

## Changes

* Don't report to billing for v1 licenses (posthog tracking still happens)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
