### PR TITLE
fix: Use optimized deletion of Postgres data for projects and orgs

### DIFF
--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -50,8 +50,9 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
             response.json(),
         )
 
+    @patch("posthog.api.organization.delete_bulky_postgres_data")
     @patch("posthoganalytics.capture")
-    def test_delete_second_managed_organization(self, mock_capture):
+    def test_delete_second_managed_organization(self, mock_capture, mock_delete_bulky_postgres_data):
         organization, _, team = Organization.objects.bootstrap(self.user, name="X")
         organization_props = organization.get_analytics_metadata()
         self.assertTrue(Organization.objects.filter(id=organization.id).exists())
@@ -67,6 +68,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
             organization_props,
             groups={"instance": ANY, "organization": str(organization.id)},
         )
+        mock_delete_bulky_postgres_data.assert_called_once_with(team_ids=[team.id])
 
     @patch("posthoganalytics.capture")
     def test_delete_last_organization(self, mock_capture):

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1,9 +1,9 @@
 import json
+from unittest.mock import ANY, MagicMock, patch
 
 from django.core.cache import cache
 from rest_framework import status
 
-from posthog.demo import create_demo_team
 from posthog.models.dashboard import Dashboard
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team import Team
@@ -123,11 +123,13 @@ class TestTeamAPI(APIBaseTest):
         self.assertEqual(response_data["name"], self.team.name)
         self.assertEqual(response_data["test_account_filters"], [{"key": "$current_url", "value": "test"}])
 
-    def test_delete_team_own_second(self):
+    @patch("posthog.api.team.delete_bulky_postgres_data")
+    @patch("posthoganalytics.capture")
+    def test_delete_team_own_second(self, mock_capture: MagicMock, mock_delete_bulky_postgres_data: MagicMock):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        team = create_demo_team(organization=self.organization)
+        team: Team = Team.objects.create_with_data(organization=self.organization)
 
         self.assertEqual(Team.objects.filter(organization=self.organization).count(), 2)
 
@@ -135,6 +137,13 @@ class TestTeamAPI(APIBaseTest):
 
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Team.objects.filter(organization=self.organization).count(), 1)
+        mock_capture.assert_called_once_with(
+            self.user.distinct_id,
+            "team deleted",
+            properties={},
+            groups={"instance": ANY, "organization": str(self.organization.id), "project": str(self.team.uuid)},
+        )
+        mock_delete_bulky_postgres_data.assert_called_once_with(team_ids=[team.pk])
 
     def test_reset_token(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN

--- a/posthog/mixins.py
+++ b/posthog/mixins.py
@@ -1,4 +1,4 @@
-from rest_framework import response, status
+from rest_framework import mixins
 
 from posthog.event_usage import report_user_action
 
@@ -25,7 +25,7 @@ def log_deletion_metadata_to_posthog(func):
     return wrapper
 
 
-class AnalyticsDestroyModelMixin:
+class AnalyticsDestroyModelMixin(mixins.DestroyModelMixin):
     """
     DestroyModelMixin enhancement that provides reporting of when an object is deleted.
 
@@ -35,8 +35,4 @@ class AnalyticsDestroyModelMixin:
 
     @log_deletion_metadata_to_posthog
     def destroy(self, request, *args, **kwargs):
-        instance = self.get_object()  # type: ignore
-
-        instance.delete()
-
-        return response.Response(status=status.HTTP_204_NO_CONTENT)
+        return super().destroy(request, *args, **kwargs)


### PR DESCRIPTION
## Problem

We have this `delete_bulky_postgres_data()` function for optimized deletion of Postgres persons and distinct IDs, but it looks like the project endpoint hasn't been actually using that, because its `delete()` method was overridden in a way which prevented that. I believe this has been behind an issue with project deletion timing out, [reported by a customer](https://posthog.slack.com/archives/C043ZNMAHQX/p1668550594622769).

## Changes

Fixes the culprit – `AnalyticsDestroyModelMixin` class – to use the superclass's `destroy()` method.

## How did you test this code?

Added a test ensuring we call `delete_bulky_postgres_data()` in the API.