### PR TITLE
fix: Disallow closing project/org deletion modal with ongoing deletion

### DIFF
--- a/frontend/src/scenes/organization/Settings/DangerZone.tsx
+++ b/frontend/src/scenes/organization/Settings/DangerZone.tsx
@@ -21,7 +21,7 @@ export function DeleteOrganizationModal({
     return (
         <LemonModal
             title="Delete the entire organization?"
-            onClose={() => setIsOpen(false)}
+            onClose={!isDeletionInProgress ? () => setIsOpen(false) : undefined}
             footer={
                 <>
                     <LemonButton disabled={isDeletionInProgress} type="secondary" onClick={() => setIsOpen(false)}>

--- a/frontend/src/scenes/project/Settings/DangerZone.tsx
+++ b/frontend/src/scenes/project/Settings/DangerZone.tsx
@@ -21,7 +21,7 @@ export function DeleteProjectModal({
     return (
         <LemonModal
             title="Delete the project and its data?"
-            onClose={() => setIsOpen(false)}
+            onClose={!isDeletionInProgress ? () => setIsOpen(false) : undefined}
             footer={
                 <>
                     <LemonButton disabled={isDeletionInProgress} type="secondary" onClick={() => setIsOpen(false)}>


### PR DESCRIPTION
## Changes

Small UX fix for project/org deletion. The close button shouldn't be available when deletion is in progress.