### PR TITLE
ci: Restore stale PRs bot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
     stale:
         # Only unleash the stale bot on PostHog/posthog, as there's no POSTHOG_BOT_GITHUB_TOKEN token on forks
-        if: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+        if: ${{ github.repository == 'PostHog/posthog' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/stale@v4


### PR DESCRIPTION
## Problem

I just realized I accidentally disabled the stale PRs bot three months ago via #11289.
Today we have FIFTY open PRs older than a month – so not doing very well on the "[reducing work in progress](https://posthog.com/handbook/engineering/development-process#2-sizing-a-task-and-reducing-wip)" front. We need more narrative closure.

## Changes

This fixes the ruthless automated overlord.