### PR TITLE
chore: switch show details to muted

### DIFF
--- a/frontend/src/lib/components/Cards/Card.tsx
+++ b/frontend/src/lib/components/Cards/Card.tsx
@@ -87,7 +87,7 @@ export function CardMeta({
                                             icon={!areDetailsShown ? <IconSubtitles /> : <IconSubtitlesOff />}
                                             onClick={() => setAreDetailsShown((state) => !state)}
                                             type="tertiary"
-                                            status="primary-alt"
+                                            status="muted"
                                             size={'small'}
                                         >
                                             {showDetailsButtonLabel && `${!areDetailsShown ? 'Show' : 'Hide'} details`}


### PR DESCRIPTION
## Problem

switches show/hide details button to `muted` from `primary-alt`

lifting parts of out #12560

## Changes

### before

<img width="624" alt="Screenshot 2022-11-16 at 15 03 56" src="https://user-images.githubusercontent.com/984817/202216879-e0cda36b-1752-4d9c-a17f-175bece75135.png">

### after

<img width="627" alt="Screenshot 2022-11-16 at 15 02 47" src="https://user-images.githubusercontent.com/984817/202216932-da0690a9-e883-40c2-bfa1-7fcafec2d9bc.png">

## How did you test this code?

👀
