### PR TITLE
feat: hide description in card meta if there isn't one

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -248,7 +248,7 @@ function InsightMeta({
                         </h4>
                     </Link>
 
-                    <div className="CardMeta__description">{insight.description || <i>No description</i>}</div>
+                    {!!insight.description && <div className="CardMeta__description">{insight.description}</div>}
                     {insight.tags && insight.tags.length > 0 && <ObjectTags tags={insight.tags} staticOnly />}
                     <UserActivityIndicator at={insight.last_modified_at} by={insight.last_modified_by} />
                 </>


### PR DESCRIPTION
## Problem

If you are on a free plan every card has "no description" in the header because you can't edit it

If you are on a paid plan but trying to fit as many cards on screen as possible every card will have "no description" if you don't add one
 
pulling parts out of #12560 

## Changes

Only show the description if there is one

<img width="1248" alt="Screenshot 2022-11-16 at 15 11 31" src="https://user-images.githubusercontent.com/984817/202219165-898ea4e9-502a-42a7-9760-8e30bd49f542.png">

## How did you test this code?

👀 
