### PR TITLE
feat(charts): improve value chart ux for many breakdown values

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -15,7 +15,7 @@ import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 
 type DataSet = any
 
-export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): JSX.Element | null {
+export function ActionsHorizontalBar({ inCardView, showPersonsModal = true }: ChartParams): JSX.Element | null {
     const [data, setData] = useState<DataSet[] | null>(null)
     const [total, setTotal] = useState(0)
     const { insightProps, insight, hiddenLegendKeys } = useValues(insightLogic)
@@ -83,6 +83,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
             hiddenLegendKeys={hiddenLegendKeys}
             showPersonsModal={showPersonsModal}
             filters={insight.filters}
+            inCardView={inCardView}
             onClick={
                 !showPersonsModal || (isTrendsFilter(insight.filters) && insight.filters.formula)
                     ? undefined


### PR DESCRIPTION
## Problem

This PR aims to improve the UX for value charts when there are many breakdown values. Right now we're hiding every n-th label from display, which is confusing if the labels still align with the bars.

The chart can be displayed in following situations:
1. When creating a new insight or exploring data via the new insight interface `/insights/new`
2. When editing an existing insight (same as above, but we don't show the load more button - this is probably a bug/unwanted) `/insights/xxx`
3. On a dashboard `/dashboard/xxx`
4. As a shared link `/shared/xxx`

I investigated various ways this could be improved with the existing Charts.js library and found the best way is to use it's `beforeFit` callback, where it has calculated the number of labels it wants to display and only display as many bars.

For (1 and 2) the proposed change will only make a difference when the browser window is smaller than the default height of the insights card. However the "load more" will not work any more, as we're displaying only as many bars as we have space for. Ideally we'd adjust the height of the InsightsCard based on the number of bars in this case (there is nothing else below it when creating/editing an Insight). I'd also add the "load more button to the "edit insight page". After some initial investigation I found that this is not as straight-forward as I'd like it to be and it could take quite a while to implement it (let me know if you see a way to do this easily). Thus leading to following options:

1. Removing the "load more" button from the `/insights/new` page.
2. Keeping the existing "skip" logic for the `/insights/new` page.
3. Re-sizing the `<InsightsCard />` / canvas appropriately as explained above. **This is now implemented in this PR as well.**

For 3 and 4 the UX gets notably better and is probably what the user wants. For some cases a "load more" button could also be useful on the exports page.

![Group_2](https://user-images.githubusercontent.com/1851359/202495141-deb47d7e-1b0e-4d25-9e27-fe96b1f6c5ce.png)


## Considered Options

1. Display all labels, no matter what. Easy, but doesn't help much as well.
5. Display only a handful of bars and aggregate the rest in a "other" bar. Challenging: Displaying the rest is more challenging than expected, since we're too late in the Charts.js lifecycle (as far as I investigated - we're in undocumented API territory here) to swap out the data and it would be quite hacky to trigger a React state update from within the Charts.js lifecycle.
6. Auto-adjust the height of the insights card. This will only work for the insights editor, not on a dashboard.
7. Add a help text that the user should probably use the table viz instead.