### PR TITLE
feat: permission return on feature flag

### DIFF
--- a/ee/api/test/test_feature_flag_role_access.py
+++ b/ee/api/test/test_feature_flag_role_access.py
@@ -81,9 +81,7 @@ class TestFeatureFlagRoleAccessAPI(APILicensedTest):
 
         # Should only have viewing privileges
         response_flags = self.client.get(f"/api/projects/@current/feature_flags")
-        self.assertEqual(
-            response_flags.json()["results"][0]["permission"], Organization.FeatureFlagsAccessLevel.CAN_ONLY_VIEW
-        )
+        self.assertEqual(response_flags.json()["results"][0]["can_edit"], False)
 
         # Add role membership and feature flag access level
         self.client.post(
@@ -97,6 +95,4 @@ class TestFeatureFlagRoleAccessAPI(APILicensedTest):
 
         # Should now have edit privileges
         response_flags = self.client.get(f"/api/projects/@current/feature_flags")
-        self.assertEqual(
-            response_flags.json()["results"][0]["permission"], Organization.FeatureFlagsAccessLevel.CAN_ALWAYS_EDIT
-        )
+        self.assertEqual(response_flags.json()["results"][0]["can_edit"], True)

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -741,7 +741,8 @@ class TestExperimentCRUD(APILicensedTest):
             format="json",
         ).json()
 
-        with self.assertNumQueries(7):
+        # TODO: Make sure permission bool doesn't cause n + 1
+        with self.assertNumQueries(10):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             result = response.json()

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -36,7 +36,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         allow_blank=True,
         help_text="contains the description for the flag (field name `name` is kept for backwards-compatibility)",
     )
-    permission = serializers.SerializerMethodField()
+    can_edit = serializers.SerializerMethodField()
 
     class Meta:
         model = FeatureFlag
@@ -55,10 +55,10 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
             "experiment_set",
             "rollback_conditions",
             "performed_rollback",
-            "permission",
+            "can_edit",
         ]
 
-    def get_permission(self, feature_flag: FeatureFlag) -> Organization.FeatureFlagsAccessLevel:
+    def get_can_edit(self, feature_flag: FeatureFlag) -> Organization.FeatureFlagsAccessLevel:
         # TODO: make sure this isn't n+1
         try:
             from ee.models.feature_flag_role_access import FeatureFlagRoleAccess
@@ -73,17 +73,13 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
             )
             final_level = max(role_level, org_level)
             if final_level == Organization.FeatureFlagsAccessLevel.DEFAULT_VIEW_ALLOW_EDIT_BASED_ON_ROLE:
-                ff_access = FeatureFlagRoleAccess.objects.filter(
+                can_edit = FeatureFlagRoleAccess.objects.filter(
                     feature_flag__id=feature_flag.pk,
                     role__id__in=[membership.role.pk for membership in all_role_memberships],
                 ).exists()
-                return (
-                    Organization.FeatureFlagsAccessLevel.CAN_ALWAYS_EDIT
-                    if ff_access
-                    else Organization.FeatureFlagsAccessLevel.CAN_ONLY_VIEW
-                )
+                return can_edit
             else:
-                return final_level
+                return final_level == Organization.FeatureFlagsAccessLevel.CAN_ALWAYS_EDIT
 
     # Simple flags are ones that only have rollout_percentage
     #  That means server side libraries are able to gate these flags without calling to the server

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -58,7 +58,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
             "can_edit",
         ]
 
-    def get_can_edit(self, feature_flag: FeatureFlag) -> Organization.FeatureFlagsAccessLevel:
+    def get_can_edit(self, feature_flag: FeatureFlag) -> bool:
         # TODO: make sure this isn't n+1
         try:
             from ee.models.feature_flag_role_access import FeatureFlagRoleAccess


### PR DESCRIPTION
## Problem

- Need a way to denote whether a flag should be viewable or editable
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add a calculate field on the featureflag serializer that does logic to check if requester can view or edit based on organization level and role memberships

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
