### PR TITLE
feat(signup): remove self-hosting on the signup page

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -77,19 +77,15 @@ export function BridgePage({
                                 {preflight?.cloud ? (
                                     <span>
                                         {' '}
-                                        You can{' '}
-                                        <Link to="https://posthog.com/docs/self-host">
-                                            <strong>self-host PostHog</strong>
-                                        </Link>{' '}
-                                        or{' '}
+                                        You can use our{' '}
                                         <Link
                                             to={getRegionUrl(preflight?.region === Region.EU ? Region.US : Region.EU)}
                                         >
                                             <strong>
-                                                use our {preflight?.region === Region.EU ? 'US' : 'EU'} cloud
+                                                PostHog Cloud {preflight?.region === Region.EU ? 'US' : 'EU'}
                                             </strong>
                                         </Link>
-                                        .
+                                        {preflight?.region === Region.EU ? ', too' : ' for a GDPR-ready deployment'}.
                                     </span>
                                 ) : (
                                     <span>


### PR DESCRIPTION
## Problem

We want to encourage people to sign up for cloud because it's typically a better experience for them. So, we shouldn't point people toward the option to self-host when signing up.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

**Before:**

![image](https://user-images.githubusercontent.com/18598166/202305647-5ab74040-f97c-41a1-aad0-1dc04164a191.png)

**After, on app.posthog.com/signup:**

![image](https://user-images.githubusercontent.com/18598166/202305433-3f2fc542-32eb-41e9-bbda-9523fb26cb2f.png)

**After, on eu.posthog.com/signup:**

![image](https://user-images.githubusercontent.com/18598166/202305347-d2bcb785-8d99-490c-a5fa-e12fe7d2d4b8.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually.
