### PR TITLE
feat: Only show window identifiers if we have multiple windows

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -29,6 +29,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
         currentWindowIndex,
         recordingStartTime,
         sessionPlayerMetaDataLoading,
+        windowIds,
     } = useValues(playerMetaLogic({ sessionRecordingId, playerKey }))
 
     const { isFullScreen, isMetadataExpanded } = useValues(playerSettingsLogic)
@@ -176,7 +177,10 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                 ) : (
                     <>
                         <IconWindow value={currentWindowIndex + 1} className="text-muted-alt" />
-                        {!isSmallPlayer && <div className="text-muted-alt">Window {currentWindowIndex + 1}</div>}
+                        {windowIds.length > 1 && !isSmallPlayer ? (
+                            <div className="text-muted-alt">Window {currentWindowIndex + 1}</div>
+                        ) : null}
+
                         {lastPageviewEvent?.properties?.['$current_url'] && (
                             <span className="flex items-center gap-2 truncate">
                                 <span>·</span>

--- a/frontend/src/scenes/session-recordings/player/list/PlayerFilter.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerFilter.tsx
@@ -68,31 +68,33 @@ export function PlayerFilter({
                 )}
             </div>
 
-            <div className="flex items-center gap-2 flex-wrap">
-                <LemonSelect
-                    data-attr="player-window-select"
-                    value={windowIdFilter ?? undefined}
-                    onChange={(val) => setWindowIdFilter(val as WindowOption)}
-                    options={[
-                        {
-                            value: RecordingWindowFilter.All,
-                            label: 'All windows',
-                            icon: <IconWindow value="A" className="text-muted" />,
-                        },
-                        ...windowIds.map((windowId, index) => ({
-                            value: windowId,
-                            label: `Window ${index + 1}`,
-                            icon: <IconWindow value={index + 1} className="text-muted" />,
-                        })),
-                    ]}
-                />
-                <Tooltip
-                    title="Each recording window translates to a distinct browser tab or window."
-                    className="text-base text-muted-alt mr-2"
-                >
-                    <IconInfo />
-                </Tooltip>
-            </div>
+            {windowIds.length > 1 ? (
+                <div className="flex items-center gap-2 flex-wrap">
+                    <LemonSelect
+                        data-attr="player-window-select"
+                        value={windowIdFilter ?? undefined}
+                        onChange={(val) => setWindowIdFilter(val as WindowOption)}
+                        options={[
+                            {
+                                value: RecordingWindowFilter.All,
+                                label: 'All windows',
+                                icon: <IconWindow value="A" className="text-muted" />,
+                            },
+                            ...windowIds.map((windowId, index) => ({
+                                value: windowId,
+                                label: `Window ${index + 1}`,
+                                icon: <IconWindow value={index + 1} className="text-muted" />,
+                            })),
+                        ]}
+                    />
+                    <Tooltip
+                        title="Each recording window translates to a distinct browser tab or window."
+                        className="text-base text-muted-alt mr-2"
+                    >
+                        <IconInfo />
+                    </Tooltip>
+                </div>
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -60,7 +60,7 @@ export function PlayerList<T extends Record<string, any>>({
     const { data, showPositionFinder, isCurrent, isDirectionUp, expandedRows } = useValues(logic)
     const { setRenderedRows, setList, scrollTo, disablePositionFinder, handleRowClick, expandRow, collapseRow } =
         useActions(logic)
-    const { sessionEventsDataLoading, sessionPlayerMetaDataLoading } = useValues(
+    const { sessionEventsDataLoading, sessionPlayerMetaDataLoading, windowIds } = useValues(
         sessionRecordingDataLogic({ sessionRecordingId, playerKey })
     )
     const { currentTeam } = useValues(teamLogic)
@@ -224,6 +224,9 @@ export function PlayerList<T extends Record<string, any>>({
                                                 optionsDetermined={optionsDetermined ?? []}
                                                 expandedDetermined={expandedDetermined}
                                                 loading={sessionEventsDataLoading}
+                                                windowNumber={
+                                                    windowIds.indexOf(record.playerPosition.windowId) + 1 || undefined
+                                                }
                                             />
                                         )
                                     }}

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -225,7 +225,10 @@ export function PlayerList<T extends Record<string, any>>({
                                                 expandedDetermined={expandedDetermined}
                                                 loading={sessionEventsDataLoading}
                                                 windowNumber={
-                                                    windowIds.indexOf(record.playerPosition.windowId) + 1 || undefined
+                                                    windowIds.length > 1
+                                                        ? windowIds.indexOf(record.playerPosition.windowId) + 1 ||
+                                                          undefined
+                                                        : undefined
                                                 }
                                             />
                                         )

--- a/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
@@ -81,7 +81,7 @@ function PlayerListRowRaw<T extends Record<string, any>>({
                 <div
                     className={clsx(
                         'PlayerList__item__content__header',
-                        'cursor-pointer shrink-0 flex gap-3 items-start justify-between p-2',
+                        'cursor-pointer shrink-0 flex gap-1 items-start justify-between p-2',
                         {
                             'text-warning-dark bg-warning-highlight': statusDetermined === RowStatus.Warning,
                             'text-danger-dark bg-danger-highlight': statusDetermined === RowStatus.Error,
@@ -91,31 +91,29 @@ function PlayerListRowRaw<T extends Record<string, any>>({
                         !isExpanded && 'h-10'
                     )}
                 >
-                    <div className="flex flex-row items-center gap-1">
-                        {!!expandable ? (
-                            <LemonButton
-                                noPadding
-                                disabled={!!loading}
-                                className="shrink-0"
-                                icon={expandedDetermined ? <IconUnfoldLess /> : <IconUnfoldMore />}
-                                size="small"
-                                active={!!expandedDetermined}
-                                status="stealth"
-                                onClick={(event) => {
-                                    event.stopPropagation()
-                                    if (expandedDetermined) {
-                                        expandable?.onRowCollapse?.(record, recordIndex)
-                                    } else {
-                                        expandable?.onRowExpand?.(record, recordIndex)
-                                    }
-                                }}
-                                title={expandedDetermined ? 'Show less' : 'Show more'}
-                            />
-                        ) : (
-                            <LemonButton size="small" />
-                        )}
-                        {windowNumber ? <IconWindow value={windowNumber} className="text-muted shrink-0" /> : null}
-                    </div>
+                    {!!expandable ? (
+                        <LemonButton
+                            noPadding
+                            disabled={!!loading}
+                            className="shrink-0"
+                            icon={expandedDetermined ? <IconUnfoldLess /> : <IconUnfoldMore />}
+                            size="small"
+                            active={!!expandedDetermined}
+                            status="stealth"
+                            onClick={(event) => {
+                                event.stopPropagation()
+                                if (expandedDetermined) {
+                                    expandable?.onRowCollapse?.(record, recordIndex)
+                                } else {
+                                    expandable?.onRowExpand?.(record, recordIndex)
+                                }
+                            }}
+                            title={expandedDetermined ? 'Show less' : 'Show more'}
+                        />
+                    ) : (
+                        <LemonButton size="small" />
+                    )}
+                    {windowNumber ? <IconWindow value={windowNumber} className="text-muted shrink-0 mr-1" /> : null}
                     <div className={clsx('grow h-full', !isExpanded && 'overflow-hidden')}>{contentDetermined}</div>
                     <div className="flex shrink-0 flex-row gap-3 items-center leading-6">
                         {sideContentDetermined}

--- a/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
@@ -35,6 +35,7 @@ export interface PlayerListRowProps<T extends Record<string, any>> {
     sideContentDetermined: ReactElement | null | undefined
     onClick: (record: T) => void
     optionsDetermined: ListRowOptions<T>
+    windowNumber?: number | null
     /** Used to pause any interactions while player list is still loading **/
     loading?: boolean
 }
@@ -54,6 +55,7 @@ function PlayerListRowRaw<T extends Record<string, any>>({
     optionsDetermined,
     onClick,
     loading,
+    windowNumber,
 }: PlayerListRowProps<T>): JSX.Element {
     const [sections, allOptions] = useMemo(() => boxToSections(optionsDetermined), [optionsDetermined])
     const isExpanded = expandable && expandedDetermined
@@ -89,12 +91,12 @@ function PlayerListRowRaw<T extends Record<string, any>>({
                         !isExpanded && 'h-10'
                     )}
                 >
-                    <div className="flex flex-row items-center">
+                    <div className="flex flex-row items-center gap-1">
                         {!!expandable ? (
                             <LemonButton
                                 noPadding
                                 disabled={!!loading}
-                                className="shrink-0 mr-1"
+                                className="shrink-0"
                                 icon={expandedDetermined ? <IconUnfoldLess /> : <IconUnfoldMore />}
                                 size="small"
                                 active={!!expandedDetermined}
@@ -112,9 +114,7 @@ function PlayerListRowRaw<T extends Record<string, any>>({
                         ) : (
                             <LemonButton size="small" />
                         )}
-                        <div>
-                            <IconWindow value="1" className="text-muted shrink-0" />
-                        </div>
+                        {windowNumber ? <IconWindow value={windowNumber} className="text-muted shrink-0" /> : null}
                     </div>
                     <div className={clsx('grow h-full', !isExpanded && 'overflow-hidden')}>{contentDetermined}</div>
                     <div className="flex shrink-0 flex-row gap-3 items-center leading-6">

--- a/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
@@ -17,7 +17,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>({
     connect: ({ sessionRecordingId, playerKey }: SessionRecordingPlayerLogicProps) => ({
         values: [
             sessionRecordingDataLogic({ sessionRecordingId }),
-            ['sessionPlayerData', 'sessionEventsData', 'sessionPlayerMetaDataLoading'],
+            ['sessionPlayerData', 'sessionEventsData', 'sessionPlayerMetaDataLoading', 'windowIds'],
             sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }),
             ['currentPlayerPosition', 'scale', 'currentPlayerTime'],
         ],
@@ -64,12 +64,6 @@ export const playerMetaLogic = kea<playerMetaLogicType>({
             (sessionPlayerData) => {
                 const startTimeFromMeta = sessionPlayerData?.metadata?.segments[0]?.startTimeEpochMs
                 return startTimeFromMeta ?? null
-            },
-        ],
-        windowIds: [
-            (selectors) => [selectors.sessionPlayerData],
-            (sessionPlayerData) => {
-                return Object.keys(sessionPlayerData?.metadata?.startAndEndTimesByWindowId) ?? []
             },
         ],
         currentWindowIndex: [

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -432,6 +432,12 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 }
             },
         ],
+        windowIds: [
+            (s) => [s.sessionPlayerData],
+            (sessionPlayerData) => {
+                return Object.keys(sessionPlayerData?.metadata?.startAndEndTimesByWindowId) ?? []
+            },
+        ],
     }),
     afterMount(({ props, actions }) => {
         if (props.sessionRecordingId) {


### PR DESCRIPTION
## Problem

We always show the windows selectors and identifiers despite most recordings not having multiple windows...

## Changes

* Only show window identifiers if we actually have multiple windows in the recording
* Otherwise hides them and the controls related to them
* Also fixes the window icon in events - we were previously always showing 1 🙈 

**With multiple windows**
<img width="848" alt="Screenshot 2022-11-17 at 10 42 42" src="https://user-images.githubusercontent.com/2536520/202411890-9d185206-1d31-4036-98b8-a966539b8842.png">

**Without multiple windows**
<img width="844" alt="Screenshot 2022-11-17 at 10 42 50" src="https://user-images.githubusercontent.com/2536520/202411899-06dfa5bc-3de0-4d64-ab3d-954b2709479a.png">

 
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
