### PR TITLE
fix(saml): let the idp choose the auth context

### DIFF
--- a/ee/settings.py
+++ b/ee/settings.py
@@ -23,7 +23,8 @@ AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
 # SAML base attributes
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = SITE_URL
 SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
-    "wantAttributeStatement": False  # AttributeStatement is optional in the specification
+    "wantAttributeStatement": False,  # AttributeStatement is optional in the specification
+    "requestedAuthnContext": False,  # do not explicitly request a password login, also allow multifactor and others
 }
 # Attributes below are required for the SAML integration from social_core to work properly
 SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = ""


### PR DESCRIPTION
## Problem

From a [support thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1668559163550179?thread_ts=1665636804.114259&cid=C01GLBKHKQT).

Logging in with Azure AD gives the following error:

```
AADSTS75011: Authentication method 'X509, MultiFactor' by which the user authenticated with the service doesn't match requested authentication method 'Password, ProtectedTransport'.
```

but only if the user is already logged in elsewhere (e.g. log in somewhere else with Azure AD, then log in to PostHog with the same Azure AD in the same browser). 

It appears we are demanding the user log in via password, but the Azure AD server wants to log in via "MultiFactor".

There's a parameter `requestedAuthnContext` that restrict what type of authentication takes place on the IdP before the SAML assertion is issued.

By default [it is set to](https://github.com/onelogin/python3-saml/blob/ba572e24fd3028c0e38c8f9dcd02af46ddcc0870/src/onelogin/saml2/authn_request.py#L96-L107) `"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"`.

## Changes

This removes the `requestedAuthnContext` parameter. Now the SAML provider chooses how the user authenticates.
 
## How did you test this code?

I didn't really :)... but this seems to be the right parameter in the right place.