### PR TITLE
chore: report cache hit and miss for the cached_function_decorator

### DIFF
--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict, List, TypeVar, Union, cast
@@ -7,6 +8,7 @@ from django.core.cache import cache
 from django.utils.timezone import now
 from rest_framework.request import Request
 from rest_framework.viewsets import GenericViewSet
+from statshog.defaults.django import statsd
 
 from posthog.models import DashboardTile, User
 from posthog.models.filters.utils import get_filter
@@ -29,6 +31,8 @@ ResultPackage = Union[Dict[str, Any], List[Dict[str, Any]]]
 T = TypeVar("T", bound=ResultPackage)
 U = TypeVar("U", bound=GenericViewSet)
 
+path_tag_pattern = re.compile(r"/api/projects/\d+")
+
 
 def cached_function(f: Callable[[U, Request], T]) -> Callable[[U, Request], T]:
     @wraps(f)
@@ -44,9 +48,20 @@ def cached_function(f: Callable[[U, Request], T]) -> Callable[[U, Request], T]:
         # return cached result when possible
         if not should_refresh(request):
             cached_result_package = get_safe_cache(cache_key)
+
+            # ignore the bare exception warning. we never want this to fail
+            # noinspection PyBroadException
+            try:
+                path = path_tag_pattern.sub("", request.path)
+            except:
+                path = "unknown"
+
             if cached_result_package and cached_result_package.get("result"):
                 cached_result_package["is_cached"] = True
+                statsd.incr("posthog_cached_function_cache_hit", tags={"path": path})
                 return cached_result_package
+            else:
+                statsd.incr("posthog_cached_function_cache_miss", tags={"path": path})
 
         # call function being wrapped
         fresh_result_package = cast(T, f(self, request))


### PR DESCRIPTION
## Problem

We report cache hit and miss to statsd for saved insights but not unsaved insights

The `cached_function` decorator is used in more than one place.

## Changes

Adds a statsd incr to the `cached_function` decorator. Tags it by reduced path.

## How did you test this code?

running locally and seeing you can still load insights