### PR TITLE
fix: Remove demo links from transactional email

### DIFF
--- a/posthog/templates/email/first_ingestion_reminder.html
+++ b/posthog/templates/email/first_ingestion_reminder.html
@@ -26,15 +26,6 @@
 
             <a href="{% absolute_uri '/organization/settings' %}?{{ utm_tags }}" target="_blank"><strong>Invite a colleague who can make changes to your product</strong></a> to set it up for you. PostHog works best with friends anyway!
         </li>
-        <li class="mb">
-            <strong>If you just want to play around:</strong>
-            <a
-                target="_blank"
-                href="https://demo.posthog.com/?{{ utm_tags }}"
-                ><b>Try our demo environment</b></a
-            >
-            to get hands-on with some sample data straight away. All the fun, none of the installation.
-        </li>
     </ul>
 
     <p>


### PR DESCRIPTION
## Problem

@Twixes has removed the demo, so we need to clean up some of the transactional emails even though we're about to switch them over anyway

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
