### PR TITLE
fix: Broken link in transactional emails

### DIFF
--- a/posthog/templates/email/second_ingestion_reminder.html
+++ b/posthog/templates/email/second_ingestion_reminder.html
@@ -5,7 +5,7 @@
     <p>
         If you're having trouble getting started, you can
         <a
-            href="https://posthog.com/signup/self-host/get-in-touch?{{ utm_tags }}#demo"
+            href="https://posthog.com/book-a-demo?{{ utm_tags }}#demo"
             target="_blank"
         >
             <strong>book a demo with our customer success team</strong>


### PR DESCRIPTION
## Problem

A customer reported via feedback that the customer success link in the onboarding emails were broken. Turns out they were right!

@simfish85 Can you confirm that we're now sending people the right link?

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
