### PR TITLE
style(project-settings): Fix "htttp" typo

### DIFF
--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -231,9 +231,9 @@ export function ProjectSettings(): JSX.Element {
                             Make your <Link to={urls.insightNew({ insight: InsightType.PATHS })}>Paths</Link> clearer by
                             aliasing one or multiple URLs.{' '}
                             <i>
-                                Example: <code>htttp://client1.mydomain.com/accounts</code> and{' '}
-                                <code>htttp://tenant2.mydomain.com/accounts</code> can become a single{' '}
-                                <code>accounts</code> path.
+                                Example: <code>http://tenant-one.mydomain.com/accounts</code> and{' '}
+                                <code>http://tenant-two.mydomain.com/accounts</code> can become a single{' '}
+                                <code>/accounts</code> path.
                             </i>
                         </p>
                         <p>


### PR DESCRIPTION
## Changes

Tiny fix for an example in settings where we used an "htttp://" (triple "t") URL (+ made those example URLs a bit nicer).