### PR TITLE
feat(ingestion): use bounded LRU cache for teams

### DIFF
--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -55,11 +55,11 @@ describe('TeamManager()', () => {
             // expect(team!.__fetch_event_uuid).toEqual('uuid1')
             expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
 
+            // 2min have passed i.e. the cache should have expired
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:02:06Z').getTime())
 
             team = await teamManager.fetchTeam(2)
             expect(team!.name).toEqual('Updated Name!')
-            // expect(team!.__fetch_event_uuid).toEqual('uuid3')
 
             expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
         })
@@ -114,7 +114,7 @@ describe('TeamManager()', () => {
                     number: 4,
                     numeric_prop: 5,
                 })
-                teamManager.teamCache.clear()
+                teamManager.teamCache.reset()
 
                 const eventDefinitions = await hub.db.fetchEventDefinitions()
 


### PR DESCRIPTION
## Problem

While working on #12303 I noticed our team cache is completely unbounded! I immediately connected this fact with the OOMs we've seen on ingestion pods. While we only care about values no older than 2min, we never get rid of the old values.

This lines up with the metrics, which show that memory grows over time, rather than spike during a period of time, indicating a cache that doesn't clear:

<img width="1098" alt="Screenshot 2022-11-17 at 10 27 51" src="https://user-images.githubusercontent.com/38760734/202461002-dc23f6b2-2c76-42ce-80a6-4fb8f328b4c0.png">

(note that there were no deploys during the period shown above)

## Changes

We already use `lru-cache` in the `TeamManager` class, so let's use it more to prevent unbounded memory growth. Put some arbitrary value for max number of teams but happy to make that configurable.

## How did you test this code?

Existing tests for the cache cover it
