### PR TITLE
fix: Buffer non-merging identify and alias events

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -56,7 +56,7 @@ export async function emitToBufferStep(
 
 /** Returns whether the event should be delayed using the event buffer mechanism.
  *
- * Why? Non-anonymous non-$identify events with no existing person matching their distinct ID are sent to a buffer.
+ * Why? Non-anonymous not merging events with no existing person matching their distinct ID are sent to a buffer.
  * This is so that we can better handle the case where one client uses a fresh distinct ID before another client
  * has managed to send the $identify event aliasing an existing anonymous distinct ID to the fresh distinct ID.
  *
@@ -89,7 +89,9 @@ export function shouldSendEventToBuffer(
     // we don't want to buffer these to make group properties available asap
     // identify and alias are identical and could merge the person - the sooner we update the person_id the better
     const isIdentifyingEvent =
-        event.event == '$groupidentify' || event.event == '$identify' || event.event == `$create_alias`
+        event.event == '$groupidentify' ||
+        (event.event == '$identify' && !!event.properties && !!event.properties['$anon_distinct_id']) ||
+        (event.event == `$create_alias` && !!event.properties && !!event.properties['alias'])
 
     const isAnonymousEvent =
         event.properties && event.properties['$device_id'] && event.distinct_id === event.properties['$device_id']

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -163,20 +163,22 @@ describe('shouldSendEventToBuffer()', () => {
         expect(result).toEqual(false)
     })
 
-    it('returns false for $identify events for non-existing users', () => {
+    it('returns false for merging $identify events for non-existing users', () => {
         const event = {
             ...pluginEvent,
             event: '$identify',
+            properties: { $anon_distinct_id: 'some-id' },
         }
 
         const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
         expect(result).toEqual(false)
     })
 
-    it('returns false for $identify events for new users', () => {
+    it('returns false for merging $identify events for new users', () => {
         const event = {
             ...pluginEvent,
             event: '$identify',
+            properties: { $anon_distinct_id: 'some-id' },
         }
         const person = {
             ...existingPerson,
@@ -187,10 +189,31 @@ describe('shouldSendEventToBuffer()', () => {
         expect(result).toEqual(false)
     })
 
-    it('returns false for $create_alias events', () => {
+    it('returns true for non merging $identify events', () => {
+        const event = {
+            ...pluginEvent,
+            event: '$identify',
+        }
+
+        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+        expect(result).toEqual(true)
+    })
+
+    it('returns true for non merging $create_alias events', () => {
         const event = {
             ...pluginEvent,
             event: '$create_alias',
+        }
+
+        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+        expect(result).toEqual(true)
+    })
+
+    it('returns false for merging $create_alias events', () => {
+        const event = {
+            ...pluginEvent,
+            event: '$create_alias',
+            properties: { alias: 'some-id' },
         }
 
         const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

`$identify` events are often used to set person properties, those can come from backend too.
If the `$identify` event isn't doing a merge, we should treat it the same way as `$set` events, i.e. buffer if it's a backend event.

Related thread: https://posthog.slack.com/archives/C0374DA782U/p1668685482832439

## Changes

Made alias also work the same way as identify distinguishing between merging vs non-merging usage of both of these events.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

added tests