### PR TITLE
chore: tailwind style hiding

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -79,7 +79,7 @@ function ValueDisplay({
     const valueComponent = (
         <span
             className={clsx(
-                'relative hidden inline-flex items-center flex flex-row flex-nowrap w-fit break-all',
+                'relative inline-flex items-center flex flex-row flex-nowrap w-fit break-all',
                 canEdit ? 'editable ph-no-capture' : 'ph-no-capture'
             )}
             onClick={() => canEdit && textBasedTypes.includes(valueType) && setEditing(true)}

--- a/frontend/src/scenes/authentication/Login.scss
+++ b/frontend/src/scenes/authentication/Login.scss
@@ -5,7 +5,7 @@
     transition: max-height 0.8s ease-in-out;
     max-height: 1000px;
 
-    &.hidden {
+    &.zero-height {
         max-height: 0;
         margin: 0 !important;
     }

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -112,7 +112,7 @@ export function Login(): JSX.Element {
                             }}
                         />
                     </Field>
-                    <div className={clsx('PasswordWrapper', isPasswordHidden && 'hidden')}>
+                    <div className={clsx('PasswordWrapper', isPasswordHidden && 'zero-height')}>
                         <Field name="password" label="Password">
                             <LemonInput
                                 type="password"

--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -6,12 +6,6 @@
     }
 
     .dashboard-items-action-refresh-text {
-        visibility: visible;
-
-        &.hidden {
-            visibility: hidden;
-        }
-
         &.completed {
             position: absolute;
             left: 30px;

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -97,10 +97,12 @@ export function DashboardReloadAction(): JSX.Element {
                 <span className="dashboard-items-action-icon">
                     {itemsLoading ? <LoadingOutlined /> : <ReloadOutlined />}
                 </span>
-                <span className={clsx('dashboard-items-action-refresh-text', { hidden: itemsLoading })}>
+                <span className={clsx('dashboard-items-action-refresh-text', itemsLoading && 'invisible')}>
                     <LastRefreshText />
                 </span>
-                <span className={clsx('dashboard-items-action-refresh-text', 'completed', { hidden: !itemsLoading })}>
+                <span
+                    className={clsx('dashboard-items-action-refresh-text', 'completed', !itemsLoading && 'invisible')}
+                >
                     Refreshed {refreshMetrics.completed} out of {refreshMetrics.total}
                 </span>
             </Dropdown.Button>

--- a/frontend/src/scenes/funnels/Funnel.scss
+++ b/frontend/src/scenes/funnels/Funnel.scss
@@ -7,8 +7,4 @@
             display: none;
         }
     }
-
-    .select-option-hidden {
-        display: none;
-    }
 }

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -243,12 +243,8 @@ function AverageTimeInspector({
 
     return (
         <div ref={wrapperRef}>
-            <span
-                ref={infoTextRef}
-                className="text-muted-alt"
-                style={{ paddingRight: 4, display: 'inline-block', visibility: infoTextVisible ? undefined : 'hidden' }}
-            >
-                Average time:
+            <span ref={infoTextRef} className={clsx('inline-block text-muted-alt', !infoTextVisible && 'invisible')}>
+                Average time:{' '}
             </span>
             <ValueInspectorButton
                 innerRef={buttonRef}

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -535,10 +535,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                         completed step
                                     </div>
                                 </div>
-                                <div
-                                    className="step-stat"
-                                    style={stepIndex === 0 ? { visibility: 'hidden' } : undefined}
-                                >
+                                <div className={clsx('step-stat', stepIndex === 0 && 'invisible')}>
                                     <div className="center-flex">
                                         <ValueInspectorButton
                                             onClick={() => openPersonsModalForStep({ step, converted: false })}

--- a/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
@@ -88,7 +88,7 @@ export function FunnelBinsPicker({ disabled }: { disabled?: boolean }): JSX.Elem
                     }
                     return (
                         <Select.Option
-                            className={clsx({ 'select-option-hidden': !option.display })}
+                            className={clsx({ hidden: !option.display })}
                             key={option.value}
                             value={option.value}
                             label={

--- a/frontend/src/scenes/persons/PersonsTable.tsx
+++ b/frontend/src/scenes/persons/PersonsTable.tsx
@@ -45,7 +45,7 @@ export function PersonsTable({
             key: 'id',
             render: function Render(_, person: PersonType) {
                 return (
-                    <div style={{ overflow: 'hidden' }}>
+                    <div className={'overflow-hidden'}>
                         {person.distinct_ids.length && (
                             <CopyToClipboardInline
                                 explicitValue={person.distinct_ids[0]}

--- a/frontend/src/scenes/plugins/Plugins.scss
+++ b/frontend/src/scenes/plugins/Plugins.scss
@@ -47,9 +47,6 @@
             cursor: move;
         }
         .arrow {
-            &.hide {
-                visibility: hidden;
-            }
             color: #888;
             height: 19px;
         }

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -32,6 +32,7 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { PluginsAccessLevel } from 'lib/constants'
 import { urls } from 'scenes/urls'
 import { SuccessRateBadge } from './SuccessRateBadge'
+import clsx from 'clsx'
 
 export function PluginAboutButton({ url, disabled = false }: { url: string; disabled?: boolean }): JSX.Element {
     return (
@@ -108,7 +109,7 @@ export function PluginCard({
                 <Row align="middle" className="plugin-card-row">
                     {typeof order === 'number' && typeof maxOrder === 'number' ? (
                         <DragColumn>
-                            <div className={`arrow${order === 1 ? ' hide' : ''}`}>
+                            <div className={clsx('arrow', order === 1 && 'invisible')}>
                                 <DownOutlined />
                             </div>
                             <div>
@@ -116,7 +117,7 @@ export function PluginCard({
                                     {order}
                                 </Tag>
                             </div>
-                            <div className={`arrow${order === maxOrder ? ' hide' : ''}`}>
+                            <div className={clsx('arrow', order === maxOrder && 'invisible')}>
                                 <DownOutlined />
                             </div>
                         </DragColumn>

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -864,3 +864,11 @@
 .z-auto {
     z-index: auto;
 }
+
+.invisible {
+    visibility: hidden;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Problem

we had to revert #12830  in https://github.com/PostHog/posthog/pull/12843 because that PR added tailwind `hidden` but we had used `hidden` to mean different things in different places. 

## Changes

removes or replaces those uses with tailwind css

so we can un-revert #12830 

## How did you test this code?

👀 
