### PR TITLE
ci(plugin-server): make function test output less confusing

### DIFF
--- a/plugin-server/.eslintrc.js
+++ b/plugin-server/.eslintrc.js
@@ -18,6 +18,9 @@ module.exports = {
             'error',
             {
                 ignoreRestSiblings: true,
+                argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
+                caughtErrorsIgnorePattern: '^_',
             },
         ],
         '@typescript-eslint/prefer-ts-expect-error': 'error',

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -17,7 +17,9 @@ export BUFFER_CONVERSION_SECONDS=2 # Make sure we don't have to wait for the def
 export KAFKA_MAX_MESSAGE_BATCH_SIZE=0
 export APP_METRICS_GATHERED_FOR_ALL=true
 
-./node_modules/.bin/c8 --reporter html node dist/index.js &
+LOG_FILE=$(mktemp)
+
+./node_modules/.bin/c8 --reporter html node dist/index.js > $LOG_FILE 2>&1 &
 SERVER_PID=$!
 
 until curl http://localhost:6738/_ready; do
@@ -33,5 +35,11 @@ set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
+
+if [ $exit_code -ne 0 ]; then
+    echo '::group::Plugin Server logs'
+    cat $LOG_FILE
+    echo '::endgroup::'
+fi
 
 exit $exit_code

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -25,10 +25,12 @@ echo '::group::Starting plugin server'
 SERVER_PID=$!
 
 until curl http://localhost:6738/_ready; do
-    echo 'Waiting for plugin-server to be ready...'
     echo ''
+    echo 'Waiting for plugin-server to be ready...'
     sleep 1
 done
+
+echo ''
 
 echo '::endgroup::'
 

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -25,8 +25,8 @@ echo '::group::Starting plugin server'
 SERVER_PID=$!
 
 until curl http://localhost:6738/_ready; do
-    echo ''
     echo 'Waiting for plugin-server to be ready...'
+    echo ''
     sleep 1
 done
 

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -33,7 +33,7 @@ done
 echo '::endgroup::'
 
 set +e
-yarn functional_tests --maxConcurrency=10
+yarn functional_tests --maxConcurrency=10 --verbose
 exit_code=$?
 set -e
 

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -19,6 +19,8 @@ export APP_METRICS_GATHERED_FOR_ALL=true
 
 LOG_FILE=$(mktemp)
 
+echo '::group::Starting plugin server'
+
 ./node_modules/.bin/c8 --reporter html node dist/index.js > $LOG_FILE 2>&1 &
 SERVER_PID=$!
 
@@ -27,6 +29,8 @@ until curl http://localhost:6738/_ready; do
     echo 'Waiting for plugin-server to be ready...'
     sleep 1
 done
+
+echo '::endgroup::'
 
 set +e
 yarn functional_tests --maxConcurrency=10

--- a/plugin-server/functional_tests/e2e.test.ts
+++ b/plugin-server/functional_tests/e2e.test.ts
@@ -23,7 +23,6 @@ import {
     fetchSessionRecordingsEvents,
     reloadAction,
 } from './api'
-// import { beforeAll, afterAll, test, expect } from 'vitest'
 
 let producer: Producer
 let clickHouseClient: ClickHouse
@@ -974,8 +973,7 @@ test.concurrent(`webhooks: fires slack webhook`, async () => {
             $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: 'text' }],
         })
 
-        for (const attempt in Array.from(Array(20).keys())) {
-            console.debug(`Attempt ${attempt} to check webhook was called`)
+        for (const _ in Array.from(Array(20).keys())) {
             if (webHookCalledWith) {
                 break
             }


### PR DESCRIPTION
Redirect logs to file, output only on test failure. The output looks something like this on success:

```
$ jest --config ./jest.config.functional.js --maxConcurrency=10 --verbose
  console.error
    {"level":"ERROR","timestamp":"2022-11-17T18:12:22.767Z","logger":"kafkajs","message":"[Connection] Response Metadata(key: 3, version: 6)","broker":"kafka:9092","clientId":"kafkajs","error":"There is no leader for this topic-partition as we are in the middle of a leadership election","correlationId":1,"size":78}

      at node_modules/kafkajs/src/loggers/console.js:15:22
      at node_modules/kafkajs/src/loggers/index.js:16:3
      at Connection.logError (node_modules/kafkajs/src/network/connection.js:111:7)
      at Connection.send (node_modules/kafkajs/src/network/connection.js:444:14)
      at Broker.[private:Broker:sendRequest] (node_modules/kafkajs/src/broker/index.js:904:14)
      at Broker.metadata (node_modules/kafkajs/src/broker/index.js:177:12)

  console.info
    {"level":"INFO","timestamp":"2022-11-17T18:12:22.872Z","logger":"kafkajs","message":"[Consumer] Starting","groupId":"jobs-consumer-test"}

      at node_modules/kafkajs/src/loggers/console.js:13:22

  console.info
    {"level":"INFO","timestamp":"2022-11-17T18:12:22.959Z","logger":"kafkajs","message":"[ConsumerGroup] Consumer has joined the group","groupId":"jobs-consumer-test","memberId":"kafkajs-d5fa8103-b883-4688-97a6-3c4c5a7a0f8b","leaderId":"kafkajs-d5fa8103-b883-4688-97a6-3c4c5a7a0f8b","isLeader":true,"memberAssignment":{"jobs_dlq":[0]},"groupProtocol":"RoundRobinAssigner","duration":37}

      at node_modules/kafkajs/src/loggers/console.js:13:22

  console.info
    {"level":"INFO","timestamp":"2022-11-17T18:13:05.940Z","logger":"kafkajs","message":"[Runner] consumer not running, exiting","groupId":"jobs-consumer-test","memberId":"kafkajs-d5fa8103-b883-4688-97a6-3c4c5a7a0f8b"}

      at node_modules/kafkajs/src/loggers/console.js:13:22

  console.info
    {"level":"INFO","timestamp":"2022-11-17T18:13:05.958Z","logger":"kafkajs","message":"[Consumer] Stopped","groupId":"jobs-consumer-test"}

      at node_modules/kafkajs/src/loggers/console.js:13:22

PASS functional_tests/e2e.test.ts (44.392 s)
  ✓ plugin method tests: event captured, processed, ingested (6926 ms)
  ✓ plugin method tests: correct $autocapture properties included in onEvent calls (436 ms)
  ✓ session recording ingestion: snapshot captured, processed, ingested
  ✓ event ingestion: can set and update group properties (557 ms)
  ✓ event ingestion: can $set and update person properties
  ✓ event ingestion: can $set_once person properties but not update (1 ms)
  ✓ event ingestion: anonymous event recieves same person_id if $identify happenes shortly after
  ✓ exports: exporting events on ingestion (10523 ms)
  ✓ exports: exporting $autocapture events on ingestion (78 ms)
  ✓ exports: historical exports (852 ms)
  ✓ exports: historical exports v2 (5346 ms)
  ✓ plugin jobs: can call runNow from onEvent
  ✓ plugin jobs: can call runNow from processEvent
  ✓ plugin jobs: runEveryMinute is executed (16015 ms)
  ✓ webhooks: fires slack webhook
  ✓ jobs-consumer: handles empty messages
  ✓ jobs-consumer: handles invalid JSON

PASS functional_tests/definitions.test.ts (11.88 s)
  ✓ event ingestion: definition for string property %p (5432 ms)
  ✓ event ingestion: definition for number property as number 2
  ✓ event ingestion: definition for number property as number 2.1234 (112 ms)
  ✓ event ingestion: definition for number property as number "2"
  ✓ event ingestion: definition for number property as number "2.1234" (108 ms)
  ✓ event ingestion: definition for date/datetime property should be datetime "01/01/2020 00:00:00" (24 ms)
  ✓ event ingestion: definition for date/datetime property should be datetime "01-01-2020 00:00:00" (107 ms)
  ✓ event ingestion: definition for date/datetime property should be datetime "2020/01/01 00:00:00" (4 ms)
  ✓ event ingestion: definition for date/datetime property should be datetime "2020-01-01T00:00:00Z" (105 ms)
  ✓ event ingestion: definition for date/datetime property should be datetime "2020-01-01 00:00:00" (1 ms)
  ✓ event ingestion: definition for date/datetime property should be datetime "2020-01-01" (5056 ms)
  ✓ event ingestion: definition for boolean property true (1 ms)
  ✓ event ingestion: definition for boolean property "true" (104 ms)
  ✓ event ingestion: utm properties should always be strings
  ✓ event ingestion: utm properties should always be strings (101 ms)

Test Suites: 2 passed, 2 total
Tests:       32 passed, 32 total
Snapshots:   0 total
Time:        56.387 s
Ran all test suites.
```

And will print the plugin-server logs on failure.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
