### PR TITLE
fix: signupPanel2ManualErrors might be undefined

### DIFF
--- a/frontend/src/scenes/authentication/signup/signupForm/test/SignupForm.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/SignupForm.tsx
@@ -52,7 +52,7 @@ export function SignupForm(): JSX.Element | null {
                     </Link>
                 </div>
             )}
-            {!isSignupPanel2Submitting && signupPanel2ManualErrors.generic && (
+            {!isSignupPanel2Submitting && signupPanel2ManualErrors?.generic && (
                 <AlertMessage type="error">
                     {signupPanel2ManualErrors.generic?.detail || 'Could not complete your signup. Please try again.'}
                 </AlertMessage>


### PR DESCRIPTION
## Problem

See: https://sentry.io/organizations/posthog/issues/3746422437/?project=1899813&referrer=slack

## Changes

Be forgiving of signupPanel2ManualErrors being undefined.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually set it to undefined and made sure that, with the fix, no errors occurred.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
