### PR TITLE
chore(admin): Replace direct password change form with reset link

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -66,14 +66,14 @@ def send_member_join(invitee_uuid: str, organization_id: str) -> None:
 @app.task(max_retries=1)
 def send_password_reset(user_id: int) -> None:
     user = User.objects.get(pk=user_id)
-    token = default_token_generator.make_token(user)
+    password_reset_token = default_token_generator.make_token(user)
     message = EmailMessage(
         campaign_key=f"password-reset-{user.uuid}-{timezone.now().timestamp()}",
         subject=f"Reset your PostHog password",
         template_name="password_reset",
         template_context={
             "preheader": "Please follow the link inside to reset your password.",
-            "link": f"/reset/{user.uuid}/{token}",
+            "link": f"/reset/{user.uuid}/{password_reset_token}",
             "cloud": is_cloud(),
             "site_url": settings.SITE_URL,
             "social_providers": list(user.social_auth.values_list("provider", flat=True)),

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -54,7 +54,9 @@ else:
 
 # The admin interface is disabled on self-hosted instances, as its misuse can be unsafe
 admin_urlpatterns = (
-    [path("admin/", include("loginas.urls")), path("admin/", admin.site.urls)] if is_cloud() or settings.DEMO else []
+    [path("admin/", include("loginas.urls")), path("admin/", admin.site.urls)]
+    if is_cloud() or settings.DEMO or settings.DEBUG
+    else []
 )
 
 


### PR DESCRIPTION
## Problem

I've seen two Cloud users this week with password problems (ZEN-916, ZEN-944), claiming they're not getting the password reset email. I'm not sure why that'd be, though those requests do seem legitimate.
However, there's no tooling in the admin interface currently to send those links manually. There's only an option to change a user's password directly, but I'd strongly prefer not to send a new password over email (i.e. plain text – especially given that then there's no way to force such a user to change that password ASAP).

## Changes

This adds the password reset link to the admin interface, and removes the direct password change page (since it's strictly worse – subpar security-wise and equivalent in terms of functionality).

<img width="401" alt="pass" src="https://user-images.githubusercontent.com/4550621/202523227-d9e77444-a119-454b-b665-ca009317ffab.png">
