### PR TITLE
chore(time-to-see-data): Make ClickHouse query tagging thread-safe

### DIFF
--- a/ee/clickhouse/test/test_client.py
+++ b/ee/clickhouse/test/test_client.py
@@ -142,10 +142,12 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         Note I'm not really testing much complexity, I trust that those will
         come out as failures in other tests.
         """
+        from posthog.clickhouse.query_tagging import tag_queries
+
         # First add in the request information that should be added to the sql.
         # We check this to make sure it is not removed by the comment stripping
         with self.capture_select_queries() as sqls:
-            client._request_information = {"kind": "request", "id": "1"}
+            tag_queries(kind="request", id="1")
             sync_execute(
                 query="""
                     -- this request returns 1

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -182,16 +182,16 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
 # Set up clickhouse query instrumentation
 @task_prerun.connect
 def set_up_instrumentation(task_id, task, **kwargs):
-    from posthog import client
+    from posthog.clickhouse.query_tagging import tag_queries
 
-    client._request_information = {"kind": "celery", "id": task.name}
+    tag_queries(kind="celery", id=task.name)
 
 
 @task_postrun.connect
 def teardown_instrumentation(task_id, task, **kwargs):
-    from posthog import client
+    from posthog.clickhouse.query_tagging import reset_query_tags
 
-    client._request_information = None
+    reset_query_tags()
 
 
 @app.task(ignore_result=True)

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -1,0 +1,23 @@
+# This module is responsible for adding tags/metadata to outgoing clickhouse queries in a thread-safe manner
+
+import threading
+
+thread_local_storage = threading.local()
+
+
+def get_query_tags():
+    try:
+        return thread_local_storage.query_tags
+    except AttributeError:
+        return {}
+
+
+def tag_queries(**kwargs):
+    try:
+        thread_local_storage.query_tags.update(kwargs)
+    except AttributeError:
+        thread_local_storage.query_tags = kwargs
+
+
+def reset_query_tags():
+    thread_local_storage.query_tags = {}

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -514,7 +514,7 @@ def _annotate_tagged_query(query, args):
     # Annotate the query with information on the request/task
     if len(tags) > 0:
         user_id = f" user_id:{tags['user_id']}" if "user_id" in tags else ""
-        query = f"/*{user_id} {tags['kind']}:{tags.get('id', '').replace('/', '_')} */ {query}"
+        query = f"/*{user_id} {tags.get('kind')}:{tags.get('id', '').replace('/', '_')} */ {query}"
 
     return query, tags
 

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -512,7 +512,7 @@ def _annotate_tagged_query(query, args):
     if isinstance(args, dict) and "team_id" in args:
         tags["team_id"] = args["team_id"]
     # Annotate the query with information on the request/task
-    if len(tags) > 0:
+    if "kind" in tags:
         user_id = f" user_id:{tags['user_id']}" if "user_id" in tags else ""
         query = f"/*{user_id} {tags.get('kind')}:{tags.get('id', '').replace('/', '_')} */ {query}"
 

--- a/posthog/management/commands/backfill_persons_and_groups_on_events.py
+++ b/posthog/management/commands/backfill_persons_and_groups_on_events.py
@@ -6,7 +6,7 @@ import structlog
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from posthog import client
+from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries
 from posthog.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.group.sql import GROUPS_TABLE
@@ -150,11 +150,11 @@ def run_backfill(options):
     print_and_execute_query(PERSON_DISTINCT_IDS_DICTIONARY_SQL, "PERSON_DISTINCT_IDS_DICTIONARY_SQL", dry_run)
     print_and_execute_query(PERSONS_DICTIONARY_SQL, "PERSONS_DICTIONARY_SQL", dry_run)
 
-    client._request_information = {"kind": "backfill", "id": backfill_query_id}
+    tag_queries(kind="backfill", id=backfill_query_id)
     print_and_execute_query(
         BACKFILL_SQL, "BACKFILL_SQL", dry_run, 0, {"team_id": options["team_id"], "id": backfill_query_id}
     )
-    client._request_information = None
+    reset_query_tags()
 
     if dry_run or settings.TEST:
         return

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -10,6 +10,7 @@ from django.urls.base import resolve
 from django.utils.cache import add_never_cache_headers
 
 from posthog.api.decide import get_decide
+from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries
 from posthog.internal_metrics import incr
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Team, User
 
@@ -159,18 +160,17 @@ class CHQueries:
         If monkey-patch has not been run in for this process (assuming multiple preforked processes),
         then do it now.
         """
-        from posthog import client
-
         route = resolve(request.path)
         route_id = f"{route.route} ({route.func.__name__})"
-        client._request_information = {"user_id": request.user.pk, "kind": "request", "id": request.path}
+
+        tag_queries(user_id=request.user.pk, kind="request", id=request.path)
 
         response: HttpResponse = self.get_response(request)
 
         if "api/" in request.path and "capture" not in request.path:
             incr("http_api_request_response", tags={"id": route_id, "status_code": response.status_code})
 
-        client._request_information = None
+        reset_query_tags()
 
         return response
 


### PR DESCRIPTION
## Problem

1. I want to add more tags for https://github.com/PostHog/product-internal/pull/385/files
2. Current tagging system isn't thread-safe and adds wrong tags in production

## Changes

Make things thread-safe

## How did you test this code?

ctrl+k and debug ClickHouse queries
