### PR TITLE
fix: edit queries should be cacheable

### DIFF
--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1754,6 +1754,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
     @patch("posthog.decorators.get_safe_cache")
     def test_including_query_id_does_not_affect_cache_key(self, patched_get_safe_cache) -> None:
+        """
+        regression test, by introducing a query_id we were changing the cache key
+        so, if you made the same query twice, the second one would not be cached, only because the query id had changed
+        """
         self._get_insight_with_client_query_id("b3ef3987-b8e7-4339-b9b8-fa2b65606692")
         self._get_insight_with_client_query_id("00000000-b8e7-4339-b9b8-fa2b65606692")
 

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -100,7 +100,6 @@ class ClientQueryIdMixin(BaseParamMixin):
     def client_query_id(self) -> Optional[str]:
         return self._data.get(CLIENT_QUERY_ID, None)
 
-    @include_dict
     def client_query_id_to_dict(self):
         return {"client_query_id": self.client_query_id} if self.client_query_id else {}
 

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -100,9 +100,6 @@ class ClientQueryIdMixin(BaseParamMixin):
     def client_query_id(self) -> Optional[str]:
         return self._data.get(CLIENT_QUERY_ID, None)
 
-    def client_query_id_to_dict(self):
-        return {"client_query_id": self.client_query_id} if self.client_query_id else {}
-
 
 class FilterTestAccountsMixin(BaseParamMixin):
     @cached_property

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -32,6 +32,7 @@ class TestFilter(BaseTest):
                 "actions": [],
                 "date_from": "2020-01-01T20:00:00Z",
                 "search": "query",
+                "client_query_id": "123",
             }
         )
         self.assertCountEqual(


### PR DESCRIPTION
## Problem

including client query id in the filters hash meant that editing insights would not hit the cache

## Changes

removes client_query_id from the candidates for inclusion in the filters hash

## How did you test this code?

adding a developer test
clicking around in the UI and seeing we still cancel things and we start using the cache