### PR TITLE
chore(insights): Track all `aggregated_value`s being NaN or Infinity

### DIFF
--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -56,6 +56,7 @@ from posthog.queries.trends.sql import (
 from posthog.queries.trends.util import (
     COUNT_PER_ACTOR_MATH_FUNCTIONS,
     PROPERTY_MATH_FUNCTIONS,
+    ensure_value_is_json_serializable,
     enumerate_time_range,
     get_active_user_params,
     parse_response,
@@ -457,6 +458,7 @@ class TrendsBreakdown:
         def _parse(result: List) -> List:
             parsed_results = []
             for stats in result:
+                aggregated_value = ensure_value_is_json_serializable(stats[0])
                 result_descriptors = self._breakdown_result_descriptors(stats[1], filter, entity)
                 filter_params = filter.to_params()
                 extra_params = {
@@ -467,7 +469,7 @@ class TrendsBreakdown:
                 }
                 parsed_params: Dict[str, str] = encode_get_request_params({**filter_params, **extra_params})
                 parsed_result = {
-                    "aggregated_value": stats[0],
+                    "aggregated_value": aggregated_value,
                     "filter": filter_params,
                     "persons": {
                         "filter": extra_params,

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -1,8 +1,9 @@
 import math
 from itertools import accumulate
+from string import ascii_uppercase
 from typing import Any, Dict, List
 
-from sentry_sdk import capture_exception, push_scope
+from sentry_sdk import push_scope
 
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.client import sync_execute
@@ -10,12 +11,12 @@ from posthog.constants import NON_TIME_SERIES_DISPLAY_TYPES, TRENDS_CUMULATIVE
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.breakdown_props import get_breakdown_cohort_name
-from posthog.queries.trends.util import parse_response
+from posthog.queries.trends.util import ensure_value_is_json_serializable, parse_response
 
 
 class TrendsFormula:
     def _run_formula_query(self, filter: Filter, team: Team):
-        letters = [chr(65 + i) for i in range(0, len(filter.entities))]
+        letters = [ascii_uppercase[i] for i in range(0, len(filter.entities))]
         queries = []
         params: Dict[str, Any] = {}
         for idx, entity in enumerate(filter.entities):
@@ -68,30 +69,26 @@ class TrendsFormula:
                 [" CROSS JOIN ({}) as sub_{}".format(query, letters[i + 1]) for i, query in enumerate(queries[1:])]
             ),
         )
-        result = sync_execute(sql, params)
-        response = []
-        for item in result:
-            additional_values: Dict[str, Any] = {"label": self._label(filter, item)}
-            if is_aggregate:
-                additional_values["data"] = []
-                additional_values["aggregated_value"] = (
-                    0.0 if math.isnan(item[1][0]) and not math.isinf(item[1][0]) else item[1][0]
-                )
-
-                if math.isnan(item[1][0]) or math.isinf(item[1][0]):
-                    with push_scope() as scope:
-                        scope.set_context("filter", filter.to_dict())
-                        scope.set_context("query", {"sql": sql, "params": params})
-                        scope.set_tag("team", team)
-                        capture_exception(Exception("Formula had aggregated_value of NaN or Inf"))
-            else:
-                additional_values["data"] = [
-                    round(number, 2) if not math.isnan(number) and not math.isinf(number) else 0.0 for number in item[1]
-                ]
-                if filter.display == TRENDS_CUMULATIVE:
-                    additional_values["data"] = list(accumulate(additional_values["data"]))
-            additional_values["count"] = float(sum(additional_values["data"]))
-            response.append(parse_response(item, filter, additional_values=additional_values))
+        with push_scope() as scope:
+            scope.set_context("filter", filter.to_dict())
+            scope.set_tag("team", team)
+            scope.set_context("query", {"sql": sql, "params": params})
+            result = sync_execute(sql, params)
+            response = []
+            for item in result:
+                additional_values: Dict[str, Any] = {"label": self._label(filter, item)}
+                if is_aggregate:
+                    additional_values["data"] = []
+                    additional_values["aggregated_value"] = ensure_value_is_json_serializable(item[1][0])
+                else:
+                    additional_values["data"] = [
+                        round(number, 2) if not math.isnan(number) and not math.isinf(number) else 0.0
+                        for number in item[1]
+                    ]
+                    if filter.display == TRENDS_CUMULATIVE:
+                        additional_values["data"] = list(accumulate(additional_values["data"]))
+                additional_values["count"] = float(sum(additional_values["data"]))
+                response.append(parse_response(item, filter, additional_values=additional_values))
         return response
 
     def _label(self, filter: Filter, item: List) -> str:

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -28,6 +28,7 @@ from posthog.queries.trends.trends_event_query import TrendsEventQuery
 from posthog.queries.trends.util import (
     COUNT_PER_ACTOR_MATH_FUNCTIONS,
     PROPERTY_MATH_FUNCTIONS,
+    ensure_value_is_json_serializable,
     enumerate_time_range,
     parse_response,
     process_math,
@@ -163,6 +164,7 @@ class TrendsTotalVolume:
 
     def _parse_aggregate_volume_result(self, filter: Filter, entity: Entity, team_id: int) -> Callable:
         def _parse(result: List) -> List:
+            aggregated_value = ensure_value_is_json_serializable(result[0][0]) if result and len(result) else 0
             seconds_in_interval = TIME_IN_SECONDS[filter.interval]
             time_range = enumerate_time_range(filter, seconds_in_interval)
             filter_params = filter.to_params()
@@ -176,7 +178,7 @@ class TrendsTotalVolume:
 
             return [
                 {
-                    "aggregated_value": result[0][0] if result and len(result) else 0,
+                    "aggregated_value": aggregated_value,
                     "days": time_range,
                     "filter": filter_params,
                     "persons": {


### PR DESCRIPTION
## Changes

Follow-up to #12799. Now we know where the NaNs are (`aggregated_value`), but it's still not obvious what causes them. For some reason I can only reproduce this issue when a _dashboard_ is refreshed, and not on its individual insights, so here I propose adding some better tracking for this type of problems.