### PR TITLE
chore(error-boundary): Present more relevant info in case of error

### DIFF
--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -1,10 +1,12 @@
-import { ErrorBoundary as SentryErrorBoundary } from '@sentry/react'
+import { getCurrentHub, ErrorBoundary as SentryErrorBoundary } from '@sentry/react'
 import { HelpButton } from 'lib/components/HelpButton/HelpButton'
 import { IconArrowDropDown } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import './ErrorBoundary.scss'
 
 export function ErrorBoundary({ children }: { children: React.ReactElement }): JSX.Element {
+    const isSentryInitialized = !!getCurrentHub().getClient()
+
     return (
         <SentryErrorBoundary
             fallback={({ error, eventId }) => (
@@ -13,12 +15,18 @@ export function ErrorBoundary({ children }: { children: React.ReactElement }): J
                         <h2>An error has occurred</h2>
                         <pre>
                             <code>
-                                {error.name} (ID {eventId})
-                                <br />
-                                {error.message}
+                                {error.stack || (
+                                    <>
+                                        {error.name}
+                                        <br />
+                                        {error.message}
+                                    </>
+                                )}
                             </code>
                         </pre>
-                        We've registered this event for analysis, but feel free to contact us directly too.
+                        {isSentryInitialized
+                            ? `We've registered this event for analysis (ID ${eventId}), but feel free to contact us directly too.`
+                            : 'Please send over a screenshot of this message, so that we can resolve the issue.'}
                         <HelpButton
                             customComponent={
                                 <LemonButton type="primary" sideIcon={<IconArrowDropDown />}>


### PR DESCRIPTION
## Problem

Multiple times this week I've received screenshots like this one:

<img width="827" alt="before" src="https://user-images.githubusercontent.com/4550621/202704545-1e30631a-a2db-4408-9dab-b97177c9d5a2.png">

There are two issues here:
1. Zero stack trace, so I have to ask the user to send a screenshot from the dev tools console, which is tricky, time-consuming, and error-prone (less technical users don't really know how to find that console).
2. There's a Sentry ID shown, but it's irrelevant if the user is self-hosting, because then they aren't sending those errors to our Sentry anyway.
 
## Changes

The screenshots will now look like this:

###  Sentry initialized
<img width="813" alt="after-sentryful" src="https://user-images.githubusercontent.com/4550621/202705281-c53bfba1-3be2-4d46-b20e-7ff21057a085.png">

### No Sentry
<img width="830" alt="after-sentryless" src="https://user-images.githubusercontent.com/4550621/202705285-4cf12564-92ad-49cf-854d-e69857898b8f.png">


This doesn't look as _clean_, but is vastly more practical, because:
1. There's a full stack trace here, so that an engineer can debug quicker.
2. We no longer say the event has been registered for analysis when it hasn't.

(Unfortunately the stack trace can't make use of source maps because of browser limitations – we could install an extra library to handle this, but it would [expand the size of the bundle](https://bundlephobia.com/package/source-map-support@0.5.16), which makes it not worth it IMO.)