### PR TITLE
fix: 0007 test to not re-use distinct id after person deletion

### DIFF
--- a/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
@@ -80,9 +80,9 @@ class Test0007PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
                 "TRUNCATE TABLE sharded_events",
                 "TRUNCATE TABLE person",
                 "TRUNCATE TABLE person_distinct_id",
-                "DROP TABLE IF EXISTS tmp_person_0006",
-                "DROP TABLE IF EXISTS tmp_person_distinct_id2_0006",
-                "DROP TABLE IF EXISTS tmp_groups_0006",
+                "DROP TABLE IF EXISTS tmp_person_0007",
+                "DROP TABLE IF EXISTS tmp_person_distinct_id2_0007",
+                "DROP TABLE IF EXISTS tmp_groups_0007",
                 "DROP DICTIONARY IF EXISTS person_dict",
                 "DROP DICTIONARY IF EXISTS person_distinct_id2_dict",
                 "DROP DICTIONARY IF EXISTS groups_dict",
@@ -207,13 +207,14 @@ class Test0007PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         )
 
     def test_deleted_data_persons(self):
-        create_event(event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview")
+        distinct_id = "not-reused-id"  # distinct ID re-use isn't supported after person deletion
+        create_event(event_uuid=uuid1, team=self.team, distinct_id=distinct_id, event="$pageview")
         person = Person.objects.create(
             team_id=self.team.pk,
-            distinct_ids=["1"],
+            distinct_ids=[distinct_id],
             properties={"$some_prop": "something", "$another_prop": "something"},
         )
-        create_person_distinct_id(self.team.pk, "1", str(person.uuid))
+        create_person_distinct_id(self.team.pk, distinct_id, str(person.uuid))
         delete_person(person)
 
         # the mutation will run as noted by person_properties becoming '{}' instead of ''
@@ -223,7 +224,12 @@ class Test0007PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         events = query_events()
         self.assertEqual(len(events), 1)
         self.assertDictContainsSubset(
-            {"distinct_id": "1", "person_id": ZERO_UUID, "person_properties": "{}", "person_created_at": ZERO_DATE},
+            {
+                "distinct_id": distinct_id,
+                "person_id": ZERO_UUID,
+                "person_properties": "{}",
+                "person_created_at": ZERO_DATE,
+            },
             events[0],
         )
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Some 0007 tests were failing if running all of the tests, but each test individually worked fine, so the data somehow got into a bad state.

https://github.com/PostHog/posthog/pull/12475 broke this test, but that PR is doing the reasonable thing. If we're deleting persons we should delete distinct Ids too. 

We haven't yet solved the distinct id re-use after person deletion problem, so fixed the tests here by not re-using the distinct id.

We should not re-use uuids and distinct ids across tests to avoid this in the future as that makes it difficult to debug + that doesn't really add anything value to the test.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
