### PR TITLE
fix(style): fix saved insights icon spacing

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -242,7 +242,7 @@ export function SavedInsights(): JSX.Element {
                                 )}
                             </Link>
                             <div
-                                className={'ml-32 w-fit cursor-pointer'}
+                                className={'ml-1 w-fit cursor-pointer'}
                                 onClick={() => updateFavoritedInsight(insight, !insight.favorited)}
                             >
                                 {insight.favorited ? (


### PR DESCRIPTION
## Problem

Spacing between the name and icon of saved insights is missing. Somehow there was a `ml-32` utility class that doesn't exit. 

## Changes

I'm replacing with `ml-1` to add some spacing.

#### before
<img width="323" alt="Screenshot 2022-11-18 at 16 07 34" src="https://user-images.githubusercontent.com/1851359/202737062-95b1338d-89ea-4cda-be27-bd373811a97e.png">

#### after
<img width="355" alt="Screenshot 2022-11-18 at 16 07 20" src="https://user-images.githubusercontent.com/1851359/202737057-d42c3f7a-e174-4015-8731-fe9a132b82df.png">