### PR TITLE
fix(signup): hide the entire art wrapper on mobile

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -23,6 +23,12 @@
 
     .BridgePage__art-wrapper {
         margin-right: 60px;
+        display: none;
+
+        @include screen($md) {
+            display: block;
+            visibility: visible;
+        }
     }
 
     .BridgePage__content {


### PR DESCRIPTION
## Problem

The CTA wasn't being hidden on mobile, which caused things to be squished. Now it hides.

## Changes

The CTA now hides on mobile. 

Desktop:

![image](https://user-images.githubusercontent.com/18598166/202754962-d8e392b0-3dbf-4e23-aa5d-1bb988dada38.png)

Mobile:

![image](https://user-images.githubusercontent.com/18598166/202754972-16f8bc05-1ddc-4d08-8485-a199734ad779.png)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
