### PR TITLE
fix(signup): rename the test logic

### DIFF
--- a/frontend/src/scenes/authentication/signup/signupForm/control/SignupForm.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/control/SignupForm.tsx
@@ -3,7 +3,7 @@ import { Link } from 'lib/components/Link'
 import { SocialLoginButtons } from 'lib/components/SocialLoginButton'
 import { useValues } from 'kea'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { signupLogic } from './signupLogic'
+import { signupControlLogic } from './signupControlLogic'
 import { userLogic } from '../../../../userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { Form } from 'kea-forms'
@@ -16,7 +16,7 @@ import SignupRoleSelect from 'lib/components/SignupRoleSelect'
 
 export const scene: SceneExport = {
     component: SignupForm,
-    logic: signupLogic,
+    logic: signupControlLogic,
 }
 
 const UTM_TAGS = 'utm_campaign=in-product&utm_tag=signup-header'
@@ -24,7 +24,7 @@ const UTM_TAGS = 'utm_campaign=in-product&utm_tag=signup-header'
 export function SignupForm(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
     const { user } = useValues(userLogic)
-    const { isSignupSubmitting, signupManualErrors, signup } = useValues(signupLogic)
+    const { isSignupSubmitting, signupManualErrors, signup } = useValues(signupControlLogic)
     const emailInputRef = useRef<HTMLInputElement | null>(null)
 
     useEffect(() => {
@@ -51,7 +51,7 @@ export function SignupForm(): JSX.Element | null {
                     {signupManualErrors.generic?.detail || 'Could not complete your signup. Please try again.'}
                 </AlertMessage>
             )}
-            <Form logic={signupLogic} formKey={'signup'} className="space-y-4" enableFormOnSubmit>
+            <Form logic={signupControlLogic} formKey={'signup'} className="space-y-4" enableFormOnSubmit>
                 <RegionSelect />
                 <Field name="email" label="Email">
                     <LemonInput

--- a/frontend/src/scenes/authentication/signup/signupForm/control/signupControlLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/control/signupControlLogic.ts
@@ -3,7 +3,7 @@ import { urlToAction } from 'kea-router'
 import { forms } from 'kea-forms'
 import api from 'lib/api'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import type { signupLogicType } from './signupLogicType'
+import type { signupControlLogicType } from './signupControlLogicType'
 
 export interface AccountResponse {
     success: boolean
@@ -21,8 +21,8 @@ export interface SignupForm {
     role_at_organization?: string
 }
 
-export const signupLogic = kea<signupLogicType>([
-    path(['scenes', 'authentication', 'signupLogic']),
+export const signupControlLogic = kea<signupControlLogicType>([
+    path(['scenes', 'authentication', 'signupControlLogic']),
     connect({
         values: [preflightLogic, ['preflight']],
     }),

--- a/frontend/src/scenes/authentication/signup/signupForm/test/SignupForm.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/SignupForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'lib/components/Link'
 import { useActions, useValues } from 'kea'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { signupLogicTest } from './signupLogicTest'
+import { signupTestLogic } from './signupTestLogic'
 import { userLogic } from '../../../../userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -14,14 +14,14 @@ import { SignupPanel2 } from './panels/SignupPanel2'
 
 export const scene: SceneExport = {
     component: SignupForm,
-    logic: signupLogicTest,
+    logic: signupTestLogic,
 }
 
 export function SignupForm(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
     const { user } = useValues(userLogic)
-    const { isSignupPanel2Submitting, signupPanel2ManualErrors, panel } = useValues(signupLogicTest)
-    const { setPanel } = useActions(signupLogicTest)
+    const { isSignupPanel2Submitting, signupPanel2ManualErrors, panel } = useValues(signupTestLogic)
+    const { setPanel } = useActions(signupTestLogic)
     const [showSpinner, setShowSpinner] = useState(true)
 
     useEffect(() => {

--- a/frontend/src/scenes/authentication/signup/signupForm/test/SignupForm.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/SignupForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'lib/components/Link'
 import { useActions, useValues } from 'kea'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { signupLogic } from './signupLogic'
+import { signupLogicTest } from './signupLogicTest'
 import { userLogic } from '../../../../userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -14,14 +14,14 @@ import { SignupPanel2 } from './panels/SignupPanel2'
 
 export const scene: SceneExport = {
     component: SignupForm,
-    logic: signupLogic,
+    logic: signupLogicTest,
 }
 
 export function SignupForm(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
     const { user } = useValues(userLogic)
-    const { isSignupPanel2Submitting, signupPanel2ManualErrors, panel } = useValues(signupLogic)
-    const { setPanel } = useActions(signupLogic)
+    const { isSignupPanel2Submitting, signupPanel2ManualErrors, panel } = useValues(signupLogicTest)
+    const { setPanel } = useActions(signupLogicTest)
     const [showSpinner, setShowSpinner] = useState(true)
 
     useEffect(() => {

--- a/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel1.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel1.tsx
@@ -6,11 +6,11 @@ import { Field } from 'lib/forms/Field'
 import PasswordStrength from 'lib/components/PasswordStrength'
 import { SocialLoginButtons } from 'lib/components/SocialLoginButton'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { signupLogic } from '../signupLogic'
+import { signupLogicTest } from '../signupLogicTest'
 
 export function SignupPanel1(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
-    const { isSignupPanel1Submitting, signupPanel1 } = useValues(signupLogic)
+    const { isSignupPanel1Submitting, signupPanel1 } = useValues(signupLogicTest)
     const emailInputRef = useRef<HTMLInputElement | null>(null)
 
     useEffect(() => {
@@ -20,7 +20,7 @@ export function SignupPanel1(): JSX.Element | null {
 
     return (
         <div className="space-y-4 Signup__panel__1">
-            <Form logic={signupLogic} formKey={'signupPanel1'} className="space-y-4" enableFormOnSubmit>
+            <Form logic={signupLogicTest} formKey={'signupPanel1'} className="space-y-4" enableFormOnSubmit>
                 <Field name="email" label="Email">
                     <LemonInput
                         className="ph-ignore-input"

--- a/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel1.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel1.tsx
@@ -6,11 +6,11 @@ import { Field } from 'lib/forms/Field'
 import PasswordStrength from 'lib/components/PasswordStrength'
 import { SocialLoginButtons } from 'lib/components/SocialLoginButton'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { signupLogicTest } from '../signupLogicTest'
+import { signupTestLogic } from '../signupTestLogic'
 
 export function SignupPanel1(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
-    const { isSignupPanel1Submitting, signupPanel1 } = useValues(signupLogicTest)
+    const { isSignupPanel1Submitting, signupPanel1 } = useValues(signupTestLogic)
     const emailInputRef = useRef<HTMLInputElement | null>(null)
 
     useEffect(() => {
@@ -20,7 +20,7 @@ export function SignupPanel1(): JSX.Element | null {
 
     return (
         <div className="space-y-4 Signup__panel__1">
-            <Form logic={signupLogicTest} formKey={'signupPanel1'} className="space-y-4" enableFormOnSubmit>
+            <Form logic={signupTestLogic} formKey={'signupPanel1'} className="space-y-4" enableFormOnSubmit>
                 <Field name="email" label="Email">
                     <LemonInput
                         className="ph-ignore-input"

--- a/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel2.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel2.tsx
@@ -4,17 +4,17 @@ import { Form } from 'kea-forms'
 import SignupRoleSelect from 'lib/components/SignupRoleSelect'
 import { Field } from 'lib/forms/Field'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { signupLogic } from '../signupLogic'
+import { signupLogicTest } from '../signupLogicTest'
 
 const UTM_TAGS = 'utm_campaign=in-product&utm_tag=signup-header'
 
 export function SignupPanel2(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
-    const { isSignupPanel2Submitting } = useValues(signupLogic)
+    const { isSignupPanel2Submitting } = useValues(signupLogicTest)
 
     return (
         <div className="space-y-4 Signup__panel__2">
-            <Form logic={signupLogic} formKey={'signupPanel2'} className="space-y-4" enableFormOnSubmit>
+            <Form logic={signupLogicTest} formKey={'signupPanel2'} className="space-y-4" enableFormOnSubmit>
                 <Field name="first_name" label="Your name">
                     <LemonInput
                         className="ph-ignore-input"

--- a/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel2.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/panels/SignupPanel2.tsx
@@ -4,17 +4,17 @@ import { Form } from 'kea-forms'
 import SignupRoleSelect from 'lib/components/SignupRoleSelect'
 import { Field } from 'lib/forms/Field'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { signupLogicTest } from '../signupLogicTest'
+import { signupTestLogic } from '../signupTestLogic'
 
 const UTM_TAGS = 'utm_campaign=in-product&utm_tag=signup-header'
 
 export function SignupPanel2(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
-    const { isSignupPanel2Submitting } = useValues(signupLogicTest)
+    const { isSignupPanel2Submitting } = useValues(signupTestLogic)
 
     return (
         <div className="space-y-4 Signup__panel__2">
-            <Form logic={signupLogicTest} formKey={'signupPanel2'} className="space-y-4" enableFormOnSubmit>
+            <Form logic={signupTestLogic} formKey={'signupPanel2'} className="space-y-4" enableFormOnSubmit>
                 <Field name="first_name" label="Your name">
                     <LemonInput
                         className="ph-ignore-input"

--- a/frontend/src/scenes/authentication/signup/signupForm/test/signupLogicTest.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/signupLogicTest.ts
@@ -5,8 +5,6 @@ import api from 'lib/api'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import type { signupLogicTestType } from './signupLogicTestType'
 
-import type { signupLogicTestType } from './signupLogicType'
-
 export interface AccountResponse {
     success: boolean
     redirect_url?: string

--- a/frontend/src/scenes/authentication/signup/signupForm/test/signupLogicTest.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/signupLogicTest.ts
@@ -3,7 +3,9 @@ import { urlToAction } from 'kea-router'
 import { forms } from 'kea-forms'
 import api from 'lib/api'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import type { signupLogicType } from './signupLogicType'
+import type { signupLogicTestType } from './signupLogicTestType'
+
+import type { signupLogicTestType } from './signupLogicType'
 
 export interface AccountResponse {
     success: boolean
@@ -24,8 +26,8 @@ export interface SignupForm {
 export const emailRegex: RegExp =
     /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
 
-export const signupLogic = kea<signupLogicType>([
-    path(['scenes', 'authentication', 'signupLogic']),
+export const signupLogicTest = kea<signupLogicTestType>([
+    path(['scenes', 'authentication', 'signupLogicTest']),
     connect({
         values: [preflightLogic, ['preflight']],
     }),

--- a/frontend/src/scenes/authentication/signup/signupForm/test/signupTestLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/test/signupTestLogic.ts
@@ -3,7 +3,7 @@ import { urlToAction } from 'kea-router'
 import { forms } from 'kea-forms'
 import api from 'lib/api'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import type { signupLogicTestType } from './signupLogicTestType'
+import type { signupTestLogicType } from './signupTestLogicType'
 
 export interface AccountResponse {
     success: boolean
@@ -24,8 +24,8 @@ export interface SignupForm {
 export const emailRegex: RegExp =
     /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
 
-export const signupLogicTest = kea<signupLogicTestType>([
-    path(['scenes', 'authentication', 'signupLogicTest']),
+export const signupTestLogic = kea<signupTestLogicType>([
+    path(['scenes', 'authentication', 'signupTestLogic']),
     connect({
         values: [preflightLogic, ['preflight']],
     }),


### PR DESCRIPTION
## Problem

When we launched the onboarding experiment, we found that having the same logic name for both versions caused problems. I haven't see the same situation happening here, but having the same logic name for both versions (control and test) is making me nervous, so I wanted to change it. 

## Changes

In the `test` version, the logic is now called `signupLogicTest`.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
