### PR TITLE
feat(insights): refactor insightLogic loadResults

### DIFF
--- a/frontend/src/lib/api.mock.ts
+++ b/frontend/src/lib/api.mock.ts
@@ -23,7 +23,7 @@ export const MOCK_TEAM_UUID: TeamType['uuid'] = 'TEAM_UUID'
 export const MOCK_ORGANIZATION_ID: OrganizationType['id'] = 'ABCD'
 
 type APIMockReturnType = {
-    [K in keyof Pick<typeof apiReal, 'create' | 'get' | 'update' | 'delete'>]: jest.Mock<
+    [K in keyof Pick<typeof apiReal, 'create' | 'createRaw' | 'get' | 'getRaw' | 'update' | 'delete'>]: jest.Mock<
         ReturnType<typeof apiReal[K]>,
         Parameters<typeof apiReal[K]>
     >

--- a/frontend/src/lib/api.mock.ts
+++ b/frontend/src/lib/api.mock.ts
@@ -23,10 +23,10 @@ export const MOCK_TEAM_UUID: TeamType['uuid'] = 'TEAM_UUID'
 export const MOCK_ORGANIZATION_ID: OrganizationType['id'] = 'ABCD'
 
 type APIMockReturnType = {
-    [K in keyof Pick<typeof apiReal, 'create' | 'createRaw' | 'get' | 'getRaw' | 'update' | 'delete'>]: jest.Mock<
-        ReturnType<typeof apiReal[K]>,
-        Parameters<typeof apiReal[K]>
-    >
+    [K in keyof Pick<
+        typeof apiReal,
+        'create' | 'createResponse' | 'get' | 'getResponse' | 'update' | 'delete'
+    >]: jest.Mock<ReturnType<typeof apiReal[K]>, Parameters<typeof apiReal[K]>>
 }
 
 export const api = apiReal as any as APIMockReturnType

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,7 +56,7 @@ export interface CountedPaginatedResponse<T> extends PaginatedResponse<T> {
 
 export interface ApiMethodOptions {
     signal?: AbortSignal
-    includeResponseReference?: boolean
+    returnFetchResponse?: boolean
 }
 
 const CSRF_COOKIE_NAME = 'posthog_csrftoken'
@@ -76,13 +76,9 @@ export function getCookie(name: string): string | null {
     return cookieValue
 }
 
-async function getJSONOrThrow(response: Response, options?: ApiMethodOptions): Promise<any> {
+export async function getJSONOrThrow(response: Response): Promise<any> {
     try {
-        const json = await response.json()
-        if (options?.includeResponseReference) {
-            json._response = response
-        }
-        return json
+        return await response.json()
     } catch (e) {
         return { statusText: response.statusText }
     }
@@ -906,7 +902,7 @@ const api = {
 
     async get(url: string, options?: ApiMethodOptions): Promise<any> {
         const res = await api.getRaw(url, options)
-        return await getJSONOrThrow(res, options)
+        return await getJSONOrThrow(res)
     },
 
     async getRaw(url: string, options?: ApiMethodOptions): Promise<Response> {
@@ -922,7 +918,7 @@ const api = {
 
         if (!response.ok) {
             reportError('GET', url, response, startTime)
-            const data = await getJSONOrThrow(response, options)
+            const data = await getJSONOrThrow(response)
             throw { status: response.status, ...data }
         }
         return response
@@ -945,16 +941,21 @@ const api = {
 
         if (!response.ok) {
             reportError('PATCH', url, response, startTime)
-            const jsonData = await getJSONOrThrow(response, options)
+            const jsonData = await getJSONOrThrow(response)
             if (Array.isArray(jsonData)) {
                 throw jsonData
             }
             throw { status: response.status, ...jsonData }
         }
-        return await getJSONOrThrow(response, options)
+        return await getJSONOrThrow(response)
     },
 
     async create(url: string, data?: any, options?: ApiMethodOptions): Promise<any> {
+        const res = await api.createRaw(url, data, options)
+        return await getJSONOrThrow(res)
+    },
+
+    async createRaw(url: string, data?: any, options?: ApiMethodOptions): Promise<any> {
         url = normalizeUrl(url)
         ensureProjectIdNotInvalid(url)
         const isFormData = data instanceof FormData
@@ -971,13 +972,13 @@ const api = {
 
         if (!response.ok) {
             reportError('POST', url, response, startTime)
-            const jsonData = await getJSONOrThrow(response, options)
+            const jsonData = await getJSONOrThrow(response)
             if (Array.isArray(jsonData)) {
                 throw jsonData
             }
             throw { status: response.status, ...jsonData }
         }
-        return await getJSONOrThrow(response, options)
+        return response
     },
 
     async delete(url: string): Promise<any> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -954,7 +954,7 @@ const api = {
         return await getJSONOrThrow(res)
     },
 
-    async createRaw(url: string, data?: any, options?: ApiMethodOptions): Promise<any> {
+    async createRaw(url: string, data?: any, options?: ApiMethodOptions): Promise<Response> {
         url = normalizeUrl(url)
         ensureProjectIdNotInvalid(url)
         const isFormData = data instanceof FormData

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -363,8 +363,8 @@ class ApiRequest {
         return await api.get(this.assembleFullUrl(), options)
     }
 
-    public async getRaw(options?: ApiMethodOptions): Promise<Response> {
-        return await api.getRaw(this.assembleFullUrl(), options)
+    public async getResponse(options?: ApiMethodOptions): Promise<Response> {
+        return await api.getResponse(this.assembleFullUrl(), options)
     }
 
     public async update(options?: { data: any }): Promise<any> {
@@ -900,11 +900,11 @@ const api = {
     },
 
     async get(url: string, options?: ApiMethodOptions): Promise<any> {
-        const res = await api.getRaw(url, options)
+        const res = await api.getResponse(url, options)
         return await getJSONOrThrow(res)
     },
 
-    async getRaw(url: string, options?: ApiMethodOptions): Promise<Response> {
+    async getResponse(url: string, options?: ApiMethodOptions): Promise<Response> {
         url = normalizeUrl(url)
         ensureProjectIdNotInvalid(url)
         let response
@@ -950,11 +950,11 @@ const api = {
     },
 
     async create(url: string, data?: any, options?: ApiMethodOptions): Promise<any> {
-        const res = await api.createRaw(url, data, options)
+        const res = await api.createResponse(url, data, options)
         return await getJSONOrThrow(res)
     },
 
-    async createRaw(url: string, data?: any, options?: ApiMethodOptions): Promise<Response> {
+    async createResponse(url: string, data?: any, options?: ApiMethodOptions): Promise<Response> {
         url = normalizeUrl(url)
         ensureProjectIdNotInvalid(url)
         const isFormData = data instanceof FormData

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,7 +56,6 @@ export interface CountedPaginatedResponse<T> extends PaginatedResponse<T> {
 
 export interface ApiMethodOptions {
     signal?: AbortSignal
-    returnFetchResponse?: boolean
 }
 
 const CSRF_COOKIE_NAME = 'posthog_csrftoken'

--- a/frontend/src/lib/components/ExportButton/exporter.tsx
+++ b/frontend/src/lib/components/ExportButton/exporter.tsx
@@ -14,8 +14,8 @@ const MAX_CSV_POLL = 60
 
 async function downloadExportedAsset(asset: ExportedAssetType): Promise<void> {
     const downloadUrl = api.exports.determineExportUrl(asset.id)
-    const res = await api.getRaw(downloadUrl)
-    const blobObject = await res.blob()
+    const response = await api.getResponse(downloadUrl)
+    const blobObject = await response.blob()
     const blob = window.URL.createObjectURL(blobObject)
     const anchor = document.createElement('a')
     anchor.style.display = 'none'

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1,5 +1,5 @@
 import { isBreakpoint, kea } from 'kea'
-import api from 'lib/api'
+import api, { getJSONOrThrow } from 'lib/api'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { router } from 'kea-router'
 import { clearDOMTextSelection, isUserLoggedIn, toParams, uuid } from 'lib/utils'
@@ -139,7 +139,9 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     try {
                         // :TODO: Send dashboardQueryId forward as well if refreshing
                         const apiUrl = values.apiUrl(refresh)
-                        const dashboard: DashboardType = await api.get(apiUrl, { includeResponseReference: true })
+                        const dashboardRaw: Response = await api.getRaw(apiUrl)
+                        const dashboard: DashboardType = await getJSONOrThrow(dashboardRaw)
+
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
                         const lastRefresh = sortDates(dashboard.tiles.map((tile) => tile.last_refresh))
 
@@ -868,9 +870,8 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 try {
                     breakpoint()
 
-                    const refreshedInsight: InsightModel = await api.get(apiUrl, {
-                        includeResponseReference: true,
-                    })
+                    const refreshedInsightRaw: Response = await api.getRaw(apiUrl)
+                    const refreshedInsight: InsightModel = await getJSONOrThrow(refreshedInsightRaw)
                     breakpoint()
                     // reload the cached results inside the insight's logic
                     if (insight.filters.insight) {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -139,8 +139,8 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     try {
                         // :TODO: Send dashboardQueryId forward as well if refreshing
                         const apiUrl = values.apiUrl(refresh)
-                        const dashboardRaw: Response = await api.getResponse(apiUrl)
-                        const dashboard: DashboardType = await getJSONOrThrow(dashboardRaw)
+                        const dashboardResponse: Response = await api.getResponse(apiUrl)
+                        const dashboard: DashboardType = await getJSONOrThrow(dashboardResponse)
 
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
                         const lastRefresh = sortDates(dashboard.tiles.map((tile) => tile.last_refresh))
@@ -151,7 +151,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             action,
                             dashboard_query_id: dashboardQueryId,
                             time_to_see_data_ms: Math.floor(performance.now() - refreshStartTime),
-                            api_response_bytes: getResponseBytes(dashboard),
+                            api_response_bytes: getResponseBytes(dashboardResponse),
                             insights_fetched: dashboard.tiles.length,
                             insights_fetched_cached: dashboard.tiles.reduce(
                                 (acc, curr) => acc + (curr.is_cached ? 1 : 0),
@@ -870,8 +870,8 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 try {
                     breakpoint()
 
-                    const refreshedInsightRaw: Response = await api.getResponse(apiUrl)
-                    const refreshedInsight: InsightModel = await getJSONOrThrow(refreshedInsightRaw)
+                    const refreshedInsightResponse: Response = await api.getResponse(apiUrl)
+                    const refreshedInsight: InsightModel = await getJSONOrThrow(refreshedInsightResponse)
                     breakpoint()
                     // reload the cached results inside the insight's logic
                     if (insight.filters.insight) {
@@ -900,7 +900,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                         query_id: queryId,
                         status: 'success',
                         time_to_see_data_ms: Math.floor(performance.now() - queryStartTime),
-                        api_response_bytes: getResponseBytes(refreshedInsight),
+                        api_response_bytes: getResponseBytes(refreshedInsightResponse),
                         insights_fetched: 1,
                         insights_fetched_cached: 0,
                         api_url: apiUrl,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -139,7 +139,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     try {
                         // :TODO: Send dashboardQueryId forward as well if refreshing
                         const apiUrl = values.apiUrl(refresh)
-                        const dashboardRaw: Response = await api.getRaw(apiUrl)
+                        const dashboardRaw: Response = await api.getResponse(apiUrl)
                         const dashboard: DashboardType = await getJSONOrThrow(dashboardRaw)
 
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
@@ -870,7 +870,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 try {
                     breakpoint()
 
-                    const refreshedInsightRaw: Response = await api.getRaw(apiUrl)
+                    const refreshedInsightRaw: Response = await api.getResponse(apiUrl)
                     const refreshedInsight: InsightModel = await getJSONOrThrow(refreshedInsightRaw)
                     breakpoint()
                     // reload the cached results inside the insight's logic

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -452,7 +452,7 @@ describe('funnelLogic', () => {
     })
 
     it("load results, don't send breakdown if old visualisation is shown", async () => {
-        jest.spyOn(api, 'create')
+        jest.spyOn(api, 'createRaw')
         await initFunnelLogic()
 
         // wait for clickhouse features to be enabled, otherwise this won't call "loadResults"
@@ -483,7 +483,7 @@ describe('funnelLogic', () => {
                 }),
             })
 
-        expect(api.create).toHaveBeenNthCalledWith(
+        expect(api.createRaw).toHaveBeenNthCalledWith(
             2,
             `api/projects/${MOCK_TEAM_ID}/insights/funnel/`,
             expect.objectContaining({

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -452,7 +452,7 @@ describe('funnelLogic', () => {
     })
 
     it("load results, don't send breakdown if old visualisation is shown", async () => {
-        jest.spyOn(api, 'createRaw')
+        jest.spyOn(api, 'createResponse')
         await initFunnelLogic()
 
         // wait for clickhouse features to be enabled, otherwise this won't call "loadResults"
@@ -483,7 +483,7 @@ describe('funnelLogic', () => {
                 }),
             })
 
-        expect(api.createRaw).toHaveBeenNthCalledWith(
+        expect(api.createResponse).toHaveBeenNthCalledWith(
             2,
             `api/projects/${MOCK_TEAM_ID}/insights/funnel/`,
             expect.objectContaining({

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -311,15 +311,6 @@ export const insightLogic = kea<insightLogicType>([
                     let apiUrl: string = ''
                     const { currentTeamId } = values
 
-                    async function executeInsightRequest(
-                        apiMethod: any,
-                        url: string,
-                        ...args: any[]
-                    ): Promise<[any, string]> {
-                        const response = await apiMethod(url, ...args)
-                        return [response, url]
-                    }
-
                     const methodOptions: ApiMethodOptions = {
                         signal: cache.abortController.signal,
                         includeResponseReference: true,
@@ -334,44 +325,27 @@ export const insightLogic = kea<insightLogicType>([
                         ) {
                             // Instead of making a search for filters, reload the insight via its id if possible.
                             // This makes sure we update the insight's cache key if we get new default filters.
-                            ;[response, apiUrl] = await executeInsightRequest(
-                                api.get,
-                                `api/projects/${currentTeamId}/insights/${values.savedInsight.id}/?refresh=true`,
-                                methodOptions
-                            )
+                            apiUrl = `api/projects/${currentTeamId}/insights/${values.savedInsight.id}/?refresh=true`
+                            response = await api.get(apiUrl, methodOptions)
                         } else if (
                             isTrendsFilter(filters) ||
                             isStickinessFilter(filters) ||
                             isLifecycleFilter(filters)
                         ) {
-                            ;[response, apiUrl] = await executeInsightRequest(
-                                api.get,
-                                `api/projects/${currentTeamId}/insights/trend/?${toParams(
-                                    filterTrendsClientSideParams(params)
-                                )}`,
-                                methodOptions
-                            )
+                            apiUrl = `api/projects/${currentTeamId}/insights/trend/?${toParams(
+                                filterTrendsClientSideParams(params)
+                            )}`
+                            response = api.get(apiUrl, methodOptions)
                         } else if (isRetentionFilter(filters)) {
-                            ;[response, apiUrl] = await executeInsightRequest(
-                                api.get,
-                                `api/projects/${currentTeamId}/insights/retention/?${toParams(params)}`,
-                                methodOptions
-                            )
+                            apiUrl = `api/projects/${currentTeamId}/insights/retention/?${toParams(params)}`
+                            response = await api.get(apiUrl, methodOptions)
                         } else if (isFunnelsFilter(filters)) {
                             const { refresh, ...bodyParams } = params
-                            ;[response, apiUrl] = await executeInsightRequest(
-                                api.create,
-                                `api/projects/${currentTeamId}/insights/funnel/${refresh ? '?refresh=true' : ''}`,
-                                bodyParams,
-                                methodOptions
-                            )
+                            apiUrl = `api/projects/${currentTeamId}/insights/funnel/${refresh ? '?refresh=true' : ''}`
+                            response = await api.create(apiUrl, bodyParams, methodOptions)
                         } else if (isPathsFilter(filters)) {
-                            ;[response, apiUrl] = await executeInsightRequest(
-                                api.create,
-                                `api/projects/${currentTeamId}/insights/path`,
-                                params,
-                                methodOptions
-                            )
+                            apiUrl = `api/projects/${currentTeamId}/insights/path`
+                            response = await api.create(apiUrl, params, methodOptions)
                         } else {
                             throw new Error(`Cannot load insight of type ${insight}`)
                         }

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -335,17 +335,17 @@ export const insightLogic = kea<insightLogicType>([
                             apiUrl = `api/projects/${currentTeamId}/insights/trend/?${toParams(
                                 filterTrendsClientSideParams(params)
                             )}`
-                            rawResponse = api.getResponse(apiUrl, methodOptions)
+                            rawResponse = await api.getResponse(apiUrl, methodOptions)
                         } else if (isRetentionFilter(filters)) {
                             apiUrl = `api/projects/${currentTeamId}/insights/retention/?${toParams(params)}`
                             rawResponse = await api.getResponse(apiUrl, methodOptions)
                         } else if (isFunnelsFilter(filters)) {
                             const { refresh, ...bodyParams } = params
                             apiUrl = `api/projects/${currentTeamId}/insights/funnel/${refresh ? '?refresh=true' : ''}`
-                            rawResponse = await api.createRaw(apiUrl, bodyParams, methodOptions)
+                            rawResponse = await api.createResponse(apiUrl, bodyParams, methodOptions)
                         } else if (isPathsFilter(filters)) {
                             apiUrl = `api/projects/${currentTeamId}/insights/path`
-                            rawResponse = await api.createRaw(apiUrl, params, methodOptions)
+                            rawResponse = await api.createResponse(apiUrl, params, methodOptions)
                         } else {
                             throw new Error(`Cannot load insight of type ${insight}`)
                         }

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -307,7 +307,7 @@ export const insightLogic = kea<insightLogicType>([
                         dashboardsModel.actions.updateDashboardRefreshStatus(dashboardItemId, true, null)
                     }
 
-                    let rawResponse: any
+                    let fetchResponse: any
                     let response: any
                     let apiUrl: string = ''
                     const { currentTeamId } = values
@@ -326,7 +326,7 @@ export const insightLogic = kea<insightLogicType>([
                             // Instead of making a search for filters, reload the insight via its id if possible.
                             // This makes sure we update the insight's cache key if we get new default filters.
                             apiUrl = `api/projects/${currentTeamId}/insights/${values.savedInsight.id}/?refresh=true`
-                            rawResponse = await api.getResponse(apiUrl, methodOptions)
+                            fetchResponse = await api.getResponse(apiUrl, methodOptions)
                         } else if (
                             isTrendsFilter(filters) ||
                             isStickinessFilter(filters) ||
@@ -335,21 +335,21 @@ export const insightLogic = kea<insightLogicType>([
                             apiUrl = `api/projects/${currentTeamId}/insights/trend/?${toParams(
                                 filterTrendsClientSideParams(params)
                             )}`
-                            rawResponse = await api.getResponse(apiUrl, methodOptions)
+                            fetchResponse = await api.getResponse(apiUrl, methodOptions)
                         } else if (isRetentionFilter(filters)) {
                             apiUrl = `api/projects/${currentTeamId}/insights/retention/?${toParams(params)}`
-                            rawResponse = await api.getResponse(apiUrl, methodOptions)
+                            fetchResponse = await api.getResponse(apiUrl, methodOptions)
                         } else if (isFunnelsFilter(filters)) {
                             const { refresh, ...bodyParams } = params
                             apiUrl = `api/projects/${currentTeamId}/insights/funnel/${refresh ? '?refresh=true' : ''}`
-                            rawResponse = await api.createResponse(apiUrl, bodyParams, methodOptions)
+                            fetchResponse = await api.createResponse(apiUrl, bodyParams, methodOptions)
                         } else if (isPathsFilter(filters)) {
                             apiUrl = `api/projects/${currentTeamId}/insights/path`
-                            rawResponse = await api.createResponse(apiUrl, params, methodOptions)
+                            fetchResponse = await api.createResponse(apiUrl, params, methodOptions)
                         } else {
                             throw new Error(`Cannot load insight of type ${insight}`)
                         }
-                        response = await getJSONOrThrow(rawResponse)
+                        response = await getJSONOrThrow(fetchResponse)
                     } catch (e: any) {
                         if (e.name === 'AbortError' || e.message?.name === 'AbortError') {
                             actions.abortQuery({
@@ -393,7 +393,7 @@ export const insightLogic = kea<insightLogicType>([
                         lastRefresh: response.last_refresh,
                         response: {
                             cached: response?.is_cached,
-                            apiResponseBytes: getResponseBytes(rawResponse),
+                            apiResponseBytes: getResponseBytes(fetchResponse),
                             apiUrl,
                         },
                     })

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -326,7 +326,7 @@ export const insightLogic = kea<insightLogicType>([
                             // Instead of making a search for filters, reload the insight via its id if possible.
                             // This makes sure we update the insight's cache key if we get new default filters.
                             apiUrl = `api/projects/${currentTeamId}/insights/${values.savedInsight.id}/?refresh=true`
-                            rawResponse = await api.getRaw(apiUrl, methodOptions)
+                            rawResponse = await api.getResponse(apiUrl, methodOptions)
                         } else if (
                             isTrendsFilter(filters) ||
                             isStickinessFilter(filters) ||
@@ -335,10 +335,10 @@ export const insightLogic = kea<insightLogicType>([
                             apiUrl = `api/projects/${currentTeamId}/insights/trend/?${toParams(
                                 filterTrendsClientSideParams(params)
                             )}`
-                            rawResponse = api.getRaw(apiUrl, methodOptions)
+                            rawResponse = api.getResponse(apiUrl, methodOptions)
                         } else if (isRetentionFilter(filters)) {
                             apiUrl = `api/projects/${currentTeamId}/insights/retention/?${toParams(params)}`
-                            rawResponse = await api.getRaw(apiUrl, methodOptions)
+                            rawResponse = await api.getResponse(apiUrl, methodOptions)
                         } else if (isFunnelsFilter(filters)) {
                             const { refresh, ...bodyParams } = params
                             apiUrl = `api/projects/${currentTeamId}/insights/funnel/${refresh ? '?refresh=true' : ''}`

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -389,5 +389,5 @@ export function sortDates(dates: Array<string | null>): Array<string | null> {
 
 // Gets content-length header from an api call with { includeResponseReference: true } for observability purposes
 export function getResponseBytes(apiResponse: any): number {
-    return parseInt((apiResponse as any)?._response?.headers?.get?.('Content-Length') ?? 0)
+    return parseInt((apiResponse as any)?.headers?.get?.('Content-Length') ?? 0)
 }

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -387,7 +387,7 @@ export function sortDates(dates: Array<string | null>): Array<string | null> {
     return dates.sort((a, b) => (dayjs(a).isAfter(dayjs(b)) ? 1 : -1))
 }
 
-// Gets content-length header from an api call with { includeResponseReference: true } for observability purposes
-export function getResponseBytes(apiResponse: any): number {
-    return parseInt((apiResponse as any)?.headers?.get?.('Content-Length') ?? 0)
+// Gets content-length header from a fetch Response
+export function getResponseBytes(apiResponse: Response): number {
+    return parseInt(apiResponse.headers.get('Content-Length') ?? '0')
 }


### PR DESCRIPTION
## Problem

PR #12838 introduced what I'd consider several quality regressions. This PR tries to clean them up by making implicit things explicit:

- Under certain conditions, a `_response` key was added to API results, which contained the original `Response` from `fetch`. This is dangerous, since we have no idea where the API results themselves end up. They could be serialized as JSON and stored in a database (together with whatever can be serialized from the Response object). They could be compared with something, and deemed "not the same", etc. Adding magic _untyped_ values on objects is a no no.
- The code to get the length of a response was hard to trace. (Set a param in one place, call a function somewhere else, that assumes a untyped var is set on a third thing)
- The `apiURL` going in and out of `executeInsightRequest` in `insightLogic` felt like too much misdirection. We're just returning the same argument given to the function (again through an `any`), so refactored that.

## Changes

Just a refactor of all of that. Get the response directly and use it when needed.

## How did you test this code?

Things loaded locally. Tests pass.