### PR TITLE
feat(signup): include signup role select on confirm org screen

### DIFF
--- a/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
+++ b/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
@@ -10,6 +10,7 @@ import { AnimatedCollapsible } from 'lib/components/AnimatedCollapsible'
 import { urls } from 'scenes/urls'
 import { Form } from 'kea-forms'
 import { BridgePage } from 'lib/components/BridgePage/BridgePage'
+import SignupRoleSelect from 'lib/components/SignupRoleSelect'
 
 export const scene: SceneExport = {
     component: ConfirmOrganization,
@@ -74,6 +75,8 @@ export function ConfirmOrganization(): JSX.Element {
                 >
                     <LemonInput className="ph-ignore-input" placeholder="Hogflix Movies" />
                 </Field>
+
+                <SignupRoleSelect />
 
                 <LemonButton
                     htmlType="submit"


### PR DESCRIPTION
## Problem

the role select was included on other signup forms except for this one, because we have no e2e tests for the social login and I wasn't aware of this form 😬 We should do that, but this will allow people to use social login for now while we figure out how to do e2e tests for the social login.

## Changes

The signup form for confirming org after social login now has the role field. 
<img width="437" alt="image" src="https://user-images.githubusercontent.com/18598166/202862700-8c7cbd4e-0e43-4db1-be66-20b85475b229.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
