### PR TITLE
test(signup): test social login organization form

### DIFF
--- a/cypress/e2e/signup.js
+++ b/cypress/e2e/signup.js
@@ -50,4 +50,23 @@ describe('Signup', () => {
 
         cy.location('pathname').should('eq', '/ingestion')
     })
+
+    it('Can fill out all the fields on social login', () => {
+        // We can't actually test the social login feature.
+        // But, we can make sure the form exists as it should, and that upon submit
+        // we get the expected error that no social session exists.
+        cy.visit('/logout')
+        cy.location('pathname').should('include', '/login')
+        cy.visit('/organization/confirm-creation?organization_name=&first_name=Test&email=test%40posthog.com')
+
+        cy.get('[name=email]').should('have.value', 'test@posthog.com')
+        cy.get('[name=first_name]').should('have.value', 'Test')
+        cy.get('[name=organization_name]').type('Hogflix SpinOff').should('have.value', 'Hogflix SpinOff')
+        cy.get('[data-attr=signup-role-at-organization]').click()
+        cy.get('.Popup button:first-child').click()
+        cy.get('[data-attr=signup-role-at-organization]').contains('Engineering')
+        cy.get('[type=submit]').click()
+        // if there are other form issues, we'll get errors on the form, not this toast
+        cy.get('.Toastify [data-attr="error-toast"]').contains('Inactive social login session.')
+    })
 })


### PR DESCRIPTION
## Problem

When I made the role field I forgot to put it on one of the forms, but the logic expected it to be there. So people couldn't submit the form. I fixed the bug in #12879 but want to make sure something similar doesn't happen again.

## Changes

It's not really possible to directly test social login, but we can fake it a bit and make sure that the form actually works, and that we get the expected error from the server that there is no social login session. If there is some other problem with the form, we'd instead get errors on the form and it wouldn't submit to the server.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

By running the test 🙃 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
