### PR TITLE
fix: resize text in text cards

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCard.scss
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.scss
@@ -3,10 +3,6 @@
 }
 
 .TextCard-Body {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-
     ul {
         list-style: disc;
         padding-inline-start: 1.5em;

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -1,5 +1,4 @@
 import './TextCard.scss'
-import { Textfit } from 'react-textfit'
 import { ResizeHandle1D, ResizeHandle2D } from 'lib/components/Cards/handles'
 import clsx from 'clsx'
 import { DashboardTile, DashboardType } from '~/types'
@@ -10,8 +9,9 @@ import { urls } from 'scenes/urls'
 import ReactMarkdown from 'react-markdown'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { CardMeta, Resizeable } from 'lib/components/Cards/Card'
+import useFitText from 'lib/hooks/useFitText'
 
 interface TextCardProps extends React.HTMLAttributes<HTMLDivElement>, Resizeable {
     dashboardId?: string | number
@@ -32,15 +32,21 @@ interface TextCardBodyProps extends Pick<React.HTMLAttributes<HTMLDivElement>, '
 }
 
 export function TextCardBody({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
-    useEffect(() => {
-        window.dispatchEvent(new Event('resize'))
-    }, [style?.height])
+    const { fontSize, ref } = useFitText({
+        maxFontSize: 200,
+        resolution: 5,
+        text,
+    })
 
     return (
-        <div className="TextCard-Body p-2 w-full overflow-y-auto" onClick={() => closeDetails?.()} style={style}>
-            <Textfit mode={'multi'} min={14} max={100}>
-                <ReactMarkdown>{text}</ReactMarkdown>
-            </Textfit>
+        <div
+            ref={ref}
+            className="TextCard-Body p-2 w-full overflow-y-auto"
+            onClick={() => closeDetails?.()}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ ...style, fontSize }}
+        >
+            <ReactMarkdown>{text}</ReactMarkdown>
         </div>
     )
 }

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -26,12 +26,12 @@ interface TextCardProps extends React.HTMLAttributes<HTMLDivElement>, Resizeable
     showEditingControls?: boolean
 }
 
-interface TextCardBodyProps extends Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> {
+interface TextCardBodyProps extends Pick<React.HTMLAttributes<HTMLDivElement>, 'style' | 'className'> {
     text: string
     closeDetails?: () => void
 }
 
-export function TextCardBody({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
+export function TextCardBody({ text, closeDetails, style, className }: TextCardBodyProps): JSX.Element {
     const { fontSize, ref } = useFitText({
         maxFontSize: 200,
         resolution: 5,
@@ -41,7 +41,7 @@ export function TextCardBody({ text, closeDetails, style }: TextCardBodyProps): 
     return (
         <div
             ref={ref}
-            className="TextCard-Body p-2 w-full overflow-y-auto"
+            className={clsx('p-2 w-full overflow-y-auto', className)}
             onClick={() => closeDetails?.()}
             // eslint-disable-next-line react/forbid-dom-props
             style={{ ...style, fontSize }}
@@ -175,6 +175,7 @@ export function TextCardInternal(
                         ? { height: `calc(100% - ${metaPrimaryHeight}px - 2rem /* margins */ - 1px /* border */)` }
                         : undefined
                 }
+                className={'TextCard-Body'}
             />
 
             {showResizeHandles && (

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -41,7 +41,7 @@ export function TextCardBody({ text, closeDetails, style, className }: TextCardB
     return (
         <div
             ref={ref}
-            className={clsx('p-2 w-full overflow-y-auto', className)}
+            className={clsx('TextCard-Body p-2 w-full overflow-y-auto', className)}
             onClick={() => closeDetails?.()}
             // eslint-disable-next-line react/forbid-dom-props
             style={{ ...style, fontSize }}
@@ -175,7 +175,7 @@ export function TextCardInternal(
                         ? { height: `calc(100% - ${metaPrimaryHeight}px - 2rem /* margins */ - 1px /* border */)` }
                         : undefined
                 }
-                className={'TextCard-Body'}
+                className={'absolute'}
             />
 
             {showResizeHandles && (

--- a/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
@@ -137,7 +137,9 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
                 </div>
             </Tabs.TabPane>
             <Tabs.TabPane tab="Preview" key={'preview-card'}>
-                <TextCardBody text={value} />
+                <div className={'relative min-w-16 min-h-8'}>
+                    <TextCardBody text={value} />
+                </div>
             </Tabs.TabPane>
         </Tabs>
     )

--- a/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
@@ -101,11 +101,13 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
         uploadFiles().catch(console.error)
     }, [filesToUpload])
 
+    const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
     return (
         <Tabs>
             <Tabs.TabPane tab="Write" key="write-card" destroyInactiveTabPane={true}>
                 <div ref={dropRef} className={clsx('LemonTextMarkdown flex flex-col p-2 space-y-1 rounded')}>
-                    <LemonTextArea {...editAreaProps} autoFocus value={value} onChange={onChange} />
+                    <LemonTextArea ref={textAreaRef} {...editAreaProps} autoFocus value={value} onChange={onChange} />
                     <div className="text-muted inline-flex items-center space-x-1">
                         <IconMarkdown className={'text-2xl'} />
                         <span>Markdown formatting support</span>
@@ -137,9 +139,15 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
                 </div>
             </Tabs.TabPane>
             <Tabs.TabPane tab="Preview" key={'preview-card'}>
-                <div className={'relative min-w-16 min-h-8'}>
-                    <TextCardBody text={value} />
-                </div>
+                <TextCardBody
+                    text={value}
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{
+                        width: textAreaRef.current?.clientWidth || '200',
+                        height: textAreaRef.current?.clientHeight || '100',
+                        margin: '0 auto',
+                    }}
+                />
             </Tabs.TabPane>
         </Tabs>
     )

--- a/frontend/src/lib/hooks/useFitText.ts
+++ b/frontend/src/lib/hooks/useFitText.ts
@@ -1,0 +1,187 @@
+import { RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import ResizeObserver from 'resize-observer-polyfill'
+
+export interface FitTextProps {
+    maxFontSize?: number
+    minFontSize?: number
+    onFinish?: (fontSize: number) => void
+    onStart?: () => void
+    resolution?: number
+    text?: string
+}
+
+export interface FitTextResult {
+    fontSize: string
+    ref: RefObject<HTMLDivElement>
+}
+
+/** based on https://github.com/saltycrane/use-fit-text **/
+const useFitText = ({
+    text,
+    maxFontSize = 100,
+    minFontSize = 14,
+    onFinish,
+    onStart,
+    resolution = 5,
+}: FitTextProps = {}): FitTextResult => {
+    const initState = useCallback(() => {
+        return {
+            calcKey: 0,
+            fontSize: Math.floor(maxFontSize),
+            fontSizePrev: minFontSize,
+            fontSizeMax: maxFontSize,
+            fontSizeMin: minFontSize,
+            finishedSeeking: false,
+        }
+    }, [maxFontSize, minFontSize])
+
+    const ref = useRef<HTMLDivElement>(null)
+    const isCalculatingRef = useRef(false)
+    const [state, setState] = useState(initState)
+    const { calcKey, fontSize, fontSizeMax, fontSizeMin, fontSizePrev, finishedSeeking } = state
+    const [existingText, setExistingText] = useState(text)
+    const [candidateSizes, setCandidateSizes] = useState<Set<number>>(new Set([]))
+
+    useEffect(() => {
+        if (text !== existingText) {
+            setExistingText(text)
+        }
+    })
+
+    let animationFrameId: number | null = null
+    const [ro] = useState(
+        () =>
+            new ResizeObserver(() => {
+                animationFrameId = window.requestAnimationFrame(() => {
+                    if (isCalculatingRef.current) {
+                        return
+                    }
+                    onStart && onStart()
+                    isCalculatingRef.current = true
+                    // `calcKey` is used in the dependencies array of
+                    // `useLayoutEffect` below. It is incremented so that the font size
+                    // will be recalculated even if the previous state didn't change (e.g.
+                    // when the text fit initially).
+                    setState({
+                        ...initState(),
+                        calcKey: calcKey + 1,
+                    })
+                })
+            })
+    )
+
+    useEffect(() => {
+        if (ref.current) {
+            ro.observe(ref.current)
+        }
+        return () => {
+            animationFrameId && window.cancelAnimationFrame(animationFrameId)
+            ro.disconnect()
+        }
+    }, [animationFrameId, ro])
+
+    // Recalculate when the text changes
+    useEffect(() => {
+        if (calcKey === 0 || isCalculatingRef.current) {
+            return
+        }
+
+        onStart && onStart()
+        setState({
+            ...initState(),
+            calcKey: calcKey + 1,
+        })
+    }, [text])
+
+    useLayoutEffect(() => {
+        // Don't start calculating font size until the `resizeKey` is incremented
+        // above in the `ResizeObserver` callback. This avoids an extra resize
+        // on initialization.
+        if (calcKey === 0 || finishedSeeking) {
+            return
+        }
+
+        const isFinishedSeekingNow = !ref.current || Math.abs(fontSize - fontSizePrev) <= resolution
+        const isOverflow =
+            !!ref.current &&
+            (ref.current.scrollHeight > ref.current.offsetHeight || ref.current.scrollWidth > ref.current.offsetWidth)
+        const isFailed = isOverflow && fontSize === minFontSize
+        const isAsc = fontSize > fontSizePrev
+
+        if (!isOverflow) {
+            // track the found non-overflowing font sizes
+            setCandidateSizes(new Set([...Array.from(candidateSizes).filter((c) => c < fontSize), fontSize]))
+        }
+
+        if (finishedSeeking || isFinishedSeekingNow) {
+            isCalculatingRef.current = false
+            if (isOverflow && !isFailed) {
+                // has finished seeking but is still overflowing
+                // reduces font size to an earlier increment that didn't overflow
+                // or a guess at a candidate.
+                const useEarlierCandidate =
+                    candidateSizes.size > 1 && fontSize === Array.from(candidateSizes)[candidateSizes.size - 1]
+                const adjustedFontSize = useEarlierCandidate
+                    ? candidateSizes[candidateSizes.size - 2]
+                    : fontSize - resolution
+
+                setState({
+                    fontSize: adjustedFontSize,
+                    // reset max and min or you can get stuck flapping
+                    fontSizeMax: Math.min(
+                        adjustedFontSize + resolution,
+                        candidateSizes.size ? Array.from(candidateSizes)[candidateSizes.size - 1] : maxFontSize
+                    ),
+                    fontSizeMin: Math.max(minFontSize, adjustedFontSize - resolution),
+                    fontSizePrev,
+                    calcKey,
+                    finishedSeeking: true,
+                })
+            } else {
+                setState({
+                    fontSize: fontSize,
+                    // reset max and min or you can get stuck flapping
+                    fontSizeMax: fontSizeMax,
+                    fontSizeMin: fontSizeMin,
+                    fontSizePrev,
+                    calcKey,
+                    finishedSeeking: true,
+                })
+            }
+            if (!isCalculatingRef.current && candidateSizes.size) {
+                const candidate = Array.from(candidateSizes)[candidateSizes.size - 1]
+                onFinish?.(candidate)
+            }
+        } else {
+            // Binary search to adjust font size
+            let delta: number
+            let newMax = fontSizeMax
+            let newMin = fontSizeMin
+            if (isOverflow) {
+                delta = isAsc ? fontSizePrev - fontSize : fontSizeMin - fontSize
+                newMax = Math.min(fontSizeMax, fontSize)
+            } else {
+                delta = isAsc ? fontSizeMax - fontSize : fontSizePrev - fontSize
+                newMin = Math.max(fontSizeMin, fontSize)
+            }
+
+            const nextState = {
+                calcKey,
+                fontSize: Math.floor(fontSize + delta / 2),
+                fontSizeMax: newMax,
+                fontSizeMin: newMin,
+                fontSizePrev: fontSize,
+                finishedSeeking: finishedSeeking,
+            }
+
+            setState(nextState)
+        }
+    }, [calcKey, fontSize, fontSizeMax, fontSizeMin, fontSizePrev, onFinish, ref, resolution])
+
+    return {
+        fontSize: `${isCalculatingRef.current ? fontSize : Array.from(candidateSizes)[candidateSizes.size - 1]}px`,
+        ref,
+    }
+}
+
+export default useFitText

--- a/frontend/src/lib/hooks/useFitText.ts
+++ b/frontend/src/lib/hooks/useFitText.ts
@@ -94,7 +94,7 @@ const useFitText = ({
     }, [text])
 
     useLayoutEffect(() => {
-        // Don't start calculating font size until the `resizeKey` is incremented
+        // Don't start calculating font size until the `calcKey` is incremented
         // above in the `ResizeObserver` callback. This avoids an extra resize
         // on initialization.
         if (calcKey === 0 || finishedSeeking) {


### PR DESCRIPTION
## Problem

Text in text cards basically didn't resize. Yuck.

And in checking this I discovered that text card preview was totally broken. Double Yuck!

### broken preview after fixing resizing

<img width="598" alt="preview-before" src="https://user-images.githubusercontent.com/984817/202914452-df5a87f1-34e2-427e-8744-432f078059fc.png">

### broken preview before fixing resizing

<img width="503" alt="Screenshot 2022-11-20 at 16 43 28" src="https://user-images.githubusercontent.com/984817/202914504-4acc0c79-777d-431e-aee5-bd7581199e2e.png">

## Changes

I couldn't figure out how to make this work with the react textfit library. Which hasn't had a commit in 2 years and has several "this doesn't work >= React 17" issues. Alternatives all seem to be abandoned too 🤷 

* In the end based on that library and another one, I wrote a `useFitText` hook
* fixed preview pane by passing in width and height

![2022-11-20 16 04 03](https://user-images.githubusercontent.com/984817/202914875-ccd28a26-781d-4013-a43f-757609225b1d.gif)

## How did you test this code?

👀