### PR TITLE
feat(time-to-see-data): ClickHouse query tagging

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -17,7 +17,6 @@ from ee.clickhouse.queries.column_optimizer import EnterpriseColumnOptimizer
 from ee.clickhouse.queries.groups_join_query import GroupsJoinQuery
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.materialized_columns import get_materialized_columns
-from posthog.client import sync_execute
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS, FunnelCorrelationType
 from posthog.models import Team
 from posthog.models.element.element import chain_to_elements
@@ -26,6 +25,7 @@ from posthog.models.filters import Filter
 from posthog.models.property.util import get_property_string_expr
 from posthog.models.team.team import groups_on_events_querying_enabled
 from posthog.queries.funnels.utils import get_funnel_order_actor_class
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.person_distinct_id_query import get_team_distinct_ids_query
 from posthog.queries.person_query import PersonQuery
 
@@ -802,7 +802,7 @@ class FunnelCorrelation:
         """
 
         query, params = self.get_contingency_table_query()
-        results_with_total = sync_execute(query, params)
+        results_with_total = insight_sync_execute(query, params, query_type="funnel_correlation", filter=self._filter)
 
         # Get the total success/failure counts from the results
         results = [result for result in results_with_total if result[0] != self.TOTAL_IDENTIFIER]

--- a/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
@@ -18,6 +18,7 @@ from posthog.queries.funnels.funnel_event_query import FunnelEventQuery
 
 class FunnelCorrelationActors(ActorBaseQuery):
     _filter: Filter
+    QUERY_TYPE = "funnel_correlation_actors"
 
     def __init__(self, filter: Filter, team: Team, base_uri: str = "/", **kwargs) -> None:
         self._base_uri = base_uri
@@ -52,6 +53,7 @@ class FunnelCorrelationActors(ActorBaseQuery):
 
 class _FunnelEventsCorrelationActors(ActorBaseQuery):
     _filter: Filter
+    QUERY_TYPE = "funnel_events_correlation_actors"
 
     def __init__(self, filter: Filter, team: Team, base_uri: str = "/") -> None:
         self._funnel_correlation = FunnelCorrelation(filter, team, base_uri=base_uri)
@@ -135,6 +137,7 @@ class _FunnelEventsCorrelationActors(ActorBaseQuery):
 
 class _FunnelPropertyCorrelationActors(ActorBaseQuery):
     _filter: Filter
+    QUERY_TYPE = "funnel_property_correlation_actors"
 
     def __init__(self, filter: Filter, team: Team, base_uri: str = "/") -> None:
         # Filtering on persons / groups properties can be pushed down to funnel_actors CTE

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -504,11 +504,7 @@ def _annotate_tagged_query(query, args):
     Adds in a /* */ so we can look in clickhouses `system.query_log`
     to easily marry up to the generating code.
     """
-    from copy import copy
-
-    tags = copy(get_query_tags())
-    if isinstance(args, dict) and "team_id" in args:
-        tags["team_id"] = args["team_id"]
+    tags = get_query_tags()
     # Annotate the query with information on the request/task
     if "kind" in tags:
         user_id = f" user_id:{tags['user_id']}" if "user_id" in tags else ""

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -152,7 +152,7 @@ def sync_execute(
 
         timeout_task = QUERY_TIMEOUT_THREAD.schedule(_notify_of_slow_query_failure)
 
-        settings = {**settings_override, **(settings or {})}
+        settings = {**settings_override, **(settings or {}), "log_comment": json.dumps(tags, separators=(",", ":"))}
 
         try:
             result = client.execute(

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -163,7 +163,12 @@ class CHQueries:
         route = resolve(request.path)
         route_id = f"{route.route} ({route.func.__name__})"
 
-        tag_queries(user_id=request.user.pk, kind="request", id=request.path)
+        tag_queries(
+            user_id=request.user.pk,
+            kind="request",
+            id=request.path,
+            route_id=route.route,
+        )
 
         response: HttpResponse = self.get_response(request)
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -172,8 +172,8 @@ class CHQueries:
             route_id=route.route,
         )
 
-        if user.team:
-            tag_queries(team_id=user.team.pk)
+        if hasattr(user, "current_team_id") and user.current_team_id:
+            tag_queries(team_id=user.current_team_id)
 
         response: HttpResponse = self.get_response(request)
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -163,12 +163,17 @@ class CHQueries:
         route = resolve(request.path)
         route_id = f"{route.route} ({route.func.__name__})"
 
+        user = cast(User, request.user)
+
         tag_queries(
-            user_id=request.user.pk,
+            user_id=user.pk,
             kind="request",
             id=request.path,
             route_id=route.route,
         )
+
+        if user.team:
+            tag_queries(team_id=user.team.pk)
 
         response: HttpResponse = self.get_response(request)
 

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -45,4 +45,13 @@ class BaseFilter(BaseParamMixin):
         "Allow making copy of filter whilst preserving the class"
         return type(self)(data={**self._data, **overrides}, **self.kwargs)
 
+    def query_tags(self) -> Dict[str, Any]:
+        ret = {}
+
+        for _, func in inspect.getmembers(self, inspect.ismethod):
+            if hasattr(func, "include_query_tags"):  # provided by @include_query_tags decorator
+                ret.update(func())
+
+        return ret
+
     __repr__ = sane_repr("_data", "kwargs", include_id=False)

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -456,6 +456,10 @@ class EntitiesMixin(BaseParamMixin):
             **({"exclusions": [entity.to_dict() for entity in self.exclusions]} if len(self.exclusions) > 0 else {}),
         }
 
+    @include_dict
+    def entities_query_tags(self):
+        return {"entity_math": list(set(entity.math for entity in self.entities if entity.math))}
+
 
 # These arguments are used to specify the target entity for insight actor retrieval on trend graphs
 class EntityIdMixin(BaseParamMixin):

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -247,6 +247,13 @@ class BreakdownMixin(BaseParamMixin):
         bool_to_test = self._data.get("breakdown_normalize_url", False)
         return process_bool(bool_to_test)
 
+    @include_query_tags
+    def breakdown_query_tags(self):
+        if self.breakdown_type:
+            return {"breakdown_by": [self.breakdown_type]}
+
+        return {}
+
 
 class BreakdownValueMixin(BaseParamMixin):
     @cached_property

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -406,7 +406,7 @@ class DateMixin(BaseParamMixin):
     @include_query_tags
     def query_tags_dates(self):
         if self.date_from and self.date_to:
-            delta = self.date_to - self.date_to
+            delta = self.date_to - self.date_from
             return {"query_time_range_days": delta.days}
         return {}
 

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -100,6 +100,10 @@ class ClientQueryIdMixin(BaseParamMixin):
     def client_query_id(self) -> Optional[str]:
         return self._data.get(CLIENT_QUERY_ID, None)
 
+    @include_query_tags
+    def client_query_tags(self):
+        return {"client_query_id": self.client_query_id} if self.client_query_id else {}
+
 
 class FilterTestAccountsMixin(BaseParamMixin):
     @cached_property
@@ -456,7 +460,7 @@ class EntitiesMixin(BaseParamMixin):
             **({"exclusions": [entity.to_dict() for entity in self.exclusions]} if len(self.exclusions) > 0 else {}),
         }
 
-    @include_dict
+    @include_query_tags
     def entities_query_tags(self):
         return {"entity_math": list(set(entity.math for entity in self.entities if entity.math))}
 

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -48,7 +48,7 @@ from posthog.constants import (
 )
 from posthog.models.entity import Entity, ExclusionEntity, MathType
 from posthog.models.filters.mixins.base import BaseParamMixin, BreakdownType
-from posthog.models.filters.mixins.utils import cached_property, include_dict, process_bool
+from posthog.models.filters.mixins.utils import cached_property, include_dict, include_query_tags, process_bool
 from posthog.models.filters.utils import GroupTypeIndex, validate_group_type_index
 from posthog.utils import DEFAULT_DATE_FROM_DAYS, relative_date_parse_with_delta_mapping
 
@@ -391,6 +391,13 @@ class DateMixin(BaseParamMixin):
             result_dict.update({EXPLICIT_DATE: "true"})
 
         return result_dict
+
+    @include_query_tags
+    def query_tags_dates(self):
+        if self.date_from and self.date_to:
+            delta = self.date_to - self.date_to
+            return {"query_time_range_days": delta.days}
+        return {}
 
 
 class EntitiesMixin(BaseParamMixin):

--- a/posthog/models/filters/mixins/property.py
+++ b/posthog/models/filters/mixins/property.py
@@ -5,7 +5,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.constants import PROPERTIES, PropertyOperatorType
 from posthog.models.filters.mixins.base import BaseParamMixin
-from posthog.models.filters.mixins.utils import cached_property, include_dict
+from posthog.models.filters.mixins.utils import cached_property, include_dict, include_query_tags
 from posthog.models.property import Property, PropertyGroup
 
 
@@ -123,3 +123,11 @@ class PropertyMixin(BaseParamMixin):
         return (
             {PROPERTIES: self.property_groups.to_dict()} if self.property_groups and self.property_groups.values else {}
         )
+
+    @include_query_tags
+    def properties_query_tags(self):
+        filter_by_type = set(prop.type for prop in self.property_groups.flat)
+        for entity in getattr(self, "entities", []):
+            filter_by_type |= set(prop.type for prop in entity.property_groups.flat)
+
+        return {"filter_by_type": list(filter_by_type)}

--- a/posthog/models/filters/mixins/utils.py
+++ b/posthog/models/filters/mixins/utils.py
@@ -15,6 +15,11 @@ def include_dict(f):
     return f
 
 
+def include_query_tags(f):
+    f.include_query_tags = True
+    return f
+
+
 def process_bool(bool_to_test: Optional[Union[str, bool]]) -> bool:
     if isinstance(bool_to_test, bool):
         return bool_to_test

--- a/posthog/models/filters/mixins/utils.py
+++ b/posthog/models/filters/mixins/utils.py
@@ -16,6 +16,12 @@ def include_dict(f):
 
 
 def include_query_tags(f):
+    """
+    Decorates a method and adds the result of it to query tags stored in `log_comment`
+    in system.query_log when querying insights.
+
+    To get access to these tags, you might need to modify `metrics_query_log` schema.
+    """
     f.include_query_tags = True
     return f
 

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -16,7 +16,6 @@ from typing import (
 from django.db.models import OuterRef, Subquery
 from django.db.models.query import Prefetch, QuerySet
 
-from posthog.client import sync_execute
 from posthog.constants import INSIGHT_FUNNELS, INSIGHT_PATHS, INSIGHT_TRENDS
 from posthog.models import Entity, Filter, PersonDistinctId, Team
 from posthog.models.filters.mixins.utils import cached_property
@@ -24,6 +23,7 @@ from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.group import Group
 from posthog.models.person import Person
+from posthog.queries.insight import insight_sync_execute
 
 
 class EventInfoForRecording(TypedDict):
@@ -65,6 +65,8 @@ SerializedActor = Union[SerializedGroup, SerializedPerson]
 class ActorBaseQuery:
     # Whether actor values are included as the second column of the actors query
     ACTOR_VALUES_INCLUDED = False
+    # What query type to report
+    QUERY_TYPE = "actors"
 
     entity: Optional[Entity] = None
 
@@ -97,7 +99,7 @@ class ActorBaseQuery:
     ) -> Tuple[Union[QuerySet[Person], QuerySet[Group]], Union[List[SerializedGroup], List[SerializedPerson]], int]:
         """Get actors in data model and dict formats. Builds query and executes"""
         query, params = self.actor_query()
-        raw_result = sync_execute(query, params)
+        raw_result = insight_sync_execute(query, params, query_type=self.QUERY_TYPE, filter=self._filter)
         actors, serialized_actors = self.get_actors_from_result(raw_result)
 
         if hasattr(self._filter, "include_recordings") and self._filter.include_recordings and self._filter.insight in [INSIGHT_PATHS, INSIGHT_TRENDS, INSIGHT_FUNNELS]:  # type: ignore
@@ -116,7 +118,7 @@ class ActorBaseQuery:
             and session_id in %(session_ids)s
         """
         params = {"team_id": self._team.pk, "session_ids": list(session_ids)}
-        raw_result = sync_execute(query, params)
+        raw_result = insight_sync_execute(query, params, query_type="actors_session_ids_with_recordings")
         return {row[0] for row in raw_result}
 
     def add_matched_recordings_to_serialized_actors(

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -186,7 +186,7 @@ def get_breakdown_prop_values(
             **date_params,
         },
         query_type="get_breakdown_prop_values",
-        filters=filter,
+        filter=filter,
     )[0][0]
 
 

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from django.forms import ValidationError
 
-from posthog.client import sync_execute
 from posthog.constants import BREAKDOWN_TYPES, PropertyOperatorType
 from posthog.models.cohort import Cohort
 from posthog.models.cohort.util import format_filter_query
@@ -21,6 +20,7 @@ from posthog.models.team.team import groups_on_events_querying_enabled
 from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.column_optimizer.column_optimizer import ColumnOptimizer
 from posthog.queries.groups_join_query import GroupsJoinQuery
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.person_distinct_id_query import get_team_distinct_ids_query
 from posthog.queries.person_query import PersonQuery
 from posthog.queries.query_date_range import QueryDateRange
@@ -169,7 +169,7 @@ def get_breakdown_prop_values(
             null_person_filter=null_person_filter,
             **entity_format_params,
         )
-    return sync_execute(
+    return insight_sync_execute(
         elements_query,
         {
             "key": filter.breakdown,
@@ -185,6 +185,8 @@ def get_breakdown_prop_values(
             **extra_params,
             **date_params,
         },
+        query_type="get_breakdown_prop_values",
+        filters=filter,
     )[0][0]
 
 

--- a/posthog/queries/funnels/funnel.py
+++ b/posthog/queries/funnels/funnel.py
@@ -26,6 +26,8 @@ class ClickhouseFunnel(ClickhouseFunnelBase):
 
     """
 
+    QUERY_TYPE = "funnel"
+
     def get_query(self):
         max_steps = len(self._filter.entities)
 

--- a/posthog/queries/funnels/funnel_persons.py
+++ b/posthog/queries/funnels/funnel_persons.py
@@ -9,6 +9,7 @@ from posthog.queries.funnels.sql import FUNNEL_PERSONS_BY_STEP_SQL
 
 class ClickhouseFunnelActors(ClickhouseFunnel, ActorBaseQuery):
     _filter: Filter
+    QUERY_TYPE = "funnel_actors"
 
     @cached_property
     def aggregation_group_type_index(self):

--- a/posthog/queries/funnels/funnel_strict.py
+++ b/posthog/queries/funnels/funnel_strict.py
@@ -4,6 +4,8 @@ from posthog.queries.funnels.base import ClickhouseFunnelBase
 
 
 class ClickhouseFunnelStrict(ClickhouseFunnelBase):
+    QUERY_TYPE = "funnel_strict"
+
     def get_query(self):
         max_steps = len(self._filter.entities)
 

--- a/posthog/queries/funnels/funnel_strict_persons.py
+++ b/posthog/queries/funnels/funnel_strict_persons.py
@@ -9,6 +9,7 @@ from posthog.queries.funnels.sql import FUNNEL_PERSONS_BY_STEP_SQL
 
 class ClickhouseFunnelStrictActors(ClickhouseFunnelStrict, ActorBaseQuery):
     _filter: Filter
+    QUERY_TYPE = "funnel_strict_actors"
 
     @cached_property
     def aggregation_group_type_index(self):

--- a/posthog/queries/funnels/funnel_time_to_convert.py
+++ b/posthog/queries/funnels/funnel_time_to_convert.py
@@ -8,6 +8,8 @@ from posthog.queries.funnels.utils import get_funnel_order_class
 
 
 class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
+    QUERY_TYPE = "funnel_time_to_convert"
+
     def __init__(self, filter: Filter, team: Team) -> None:
         super().__init__(filter, team)
         self.funnel_order = get_funnel_order_class(filter)(filter, team)

--- a/posthog/queries/funnels/funnel_trends.py
+++ b/posthog/queries/funnels/funnel_trends.py
@@ -47,6 +47,8 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
     If no people have reached step {from_step} in the period, {conversion_rate} is zero.
     """
 
+    QUERY_TYPE = "funnel_trends"
+
     def __init__(self, filter: Filter, team: Team) -> None:
 
         super().__init__(filter, team)

--- a/posthog/queries/funnels/funnel_trends_persons.py
+++ b/posthog/queries/funnels/funnel_trends_persons.py
@@ -12,6 +12,7 @@ from posthog.queries.funnels.sql import FUNNEL_PERSONS_BY_STEP_SQL
 
 class ClickhouseFunnelTrendsActors(ClickhouseFunnelTrends, ActorBaseQuery):
     _filter: Filter
+    QUERY_TYPE = "funnel_trends_actors"
 
     @cached_property
     def aggregation_group_type_index(self):

--- a/posthog/queries/funnels/funnel_unordered.py
+++ b/posthog/queries/funnels/funnel_unordered.py
@@ -33,6 +33,8 @@ class ClickhouseFunnelUnordered(ClickhouseFunnelBase):
     See test_advanced_funnel_multiple_exclusions_between_steps for details.
     """
 
+    QUERY_TYPE = "funnel_unordered"
+
     def _serialize_step(self, step: Entity, count: int, people: Optional[List[uuid.UUID]] = None) -> Dict[str, Any]:
         return {
             "action_id": None,

--- a/posthog/queries/funnels/funnel_unordered_persons.py
+++ b/posthog/queries/funnels/funnel_unordered_persons.py
@@ -9,6 +9,7 @@ from posthog.queries.funnels.sql import FUNNEL_PERSONS_BY_STEP_SQL
 
 class ClickhouseFunnelUnorderedActors(ClickhouseFunnelUnordered, ActorBaseQuery):
     _filter: Filter
+    QUERY_TYPE = "funnel_unordered_actors"
 
     @cached_property
     def aggregation_group_type_index(self):

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -1,9 +1,10 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.client import sync_execute
-from posthog.models import Filter
 
+if TYPE_CHECKING:
+    from posthog.models import Filter
 
 # Wrapper around sync_execute, adding query tags for insights performance
 def insight_sync_execute(

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -11,7 +11,7 @@ def insight_sync_execute(
     args=None,
     *,
     query_type: str,
-    filters: Filter,
+    filter: Filter,
     settings=None,
     client_query_id: Optional[str] = None,
     client_query_team_id: Optional[int] = None,
@@ -20,7 +20,7 @@ def insight_sync_execute(
         query_type=query_type,
         has_joins="JOIN" in query,
         has_json_operations="JSONExtract" in query or "JSONHas" in query,
-        **filters.query_tags(),
+        **filter.query_tags(),
     )
 
     return sync_execute(

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -12,7 +12,7 @@ def insight_sync_execute(
     args=None,
     *,
     query_type: str,
-    filter: Filter = None,
+    filter: "Filter" = None,
     settings=None,
     client_query_id: Optional[str] = None,
     client_query_team_id: Optional[int] = None,

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -1,10 +1,9 @@
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.client import sync_execute
+from posthog.types import FilterType
 
-if TYPE_CHECKING:
-    from posthog.models import Filter
 
 # Wrapper around sync_execute, adding query tags for insights performance
 def insight_sync_execute(
@@ -12,7 +11,7 @@ def insight_sync_execute(
     args=None,
     *,
     query_type: str,
-    filter: "Filter" = None,
+    filter: Optional["FilterType"] = None,
     settings=None,
     client_query_id: Optional[str] = None,
     client_query_team_id: Optional[int] = None,

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from posthog.clickhouse.query_tagging import tag_queries
+from posthog.client import sync_execute
+from posthog.models import Filter
+
+
+# Wrapper around sync_execute, adding query tags for insights performance
+def insight_sync_execute(
+    query,
+    args=None,
+    *,
+    query_type: str,
+    filters: Filter,
+    settings=None,
+    client_query_id: Optional[str] = None,
+    client_query_team_id: Optional[int] = None,
+):
+    tag_queries(
+        query_type=query_type,
+        has_joins="JOIN" in query,
+        has_json_operations="JSONExtract" in query or "JSONHas" in query,
+        **filters.query_tags(),
+    )
+
+    return sync_execute(
+        query, args=args, settings=settings, client_query_id=client_query_id, client_query_team_id=client_query_team_id
+    )

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -11,7 +11,7 @@ def insight_sync_execute(
     args=None,
     *,
     query_type: str,
-    filter: Filter,
+    filter: Filter = None,
     settings=None,
     client_query_id: Optional[str] = None,
     client_query_team_id: Optional[int] = None,
@@ -20,8 +20,10 @@ def insight_sync_execute(
         query_type=query_type,
         has_joins="JOIN" in query,
         has_json_operations="JSONExtract" in query or "JSONHas" in query,
-        **filter.query_tags(),
     )
+
+    if filter is not None:
+        tag_queries(**filter.query_tags())
 
     return sync_execute(
         query, args=args, settings=settings, client_query_id=client_query_id, client_query_team_id=client_query_team_id

--- a/posthog/queries/paths/paths.py
+++ b/posthog/queries/paths/paths.py
@@ -5,11 +5,11 @@ from typing import Dict, List, Literal, Optional, Tuple, Union, cast
 from rest_framework.exceptions import ValidationError
 
 from posthog.clickhouse.materialized_columns import ColumnName
-from posthog.client import sync_execute
 from posthog.constants import LIMIT, PATH_EDGE_LIMIT
 from posthog.models import Filter, Team
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.property import PropertyName
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.paths.paths_event_query import PathEventQuery
 from posthog.queries.paths.sql import PATH_ARRAY_QUERY
 
@@ -84,8 +84,13 @@ class Paths:
 
     def _exec_query(self) -> List[Tuple]:
         query = self.get_query()
-        return sync_execute(
-            query, self.params, client_query_id=self._filter.client_query_id, client_query_team_id=self._team.pk
+        return insight_sync_execute(
+            query,
+            self.params,
+            query_type="paths",
+            filter=self._filter,
+            client_query_id=self._filter.client_query_id,
+            client_query_team_id=self._team.pk,
         )
 
     def get_query(self) -> str:

--- a/posthog/queries/paths/paths_actors.py
+++ b/posthog/queries/paths/paths_actors.py
@@ -25,6 +25,8 @@ class PathsActors(Paths, ActorBaseQuery):  # type: ignore
         other path item between start and end key.
     """
 
+    QUERY_TYPE = "paths"
+
     def actor_query(self, limit_actors: Optional[bool] = True) -> Tuple[str, Dict]:
         paths_per_person_query = self.get_paths_per_person_query()
         person_path_filter = self.get_person_path_filter()

--- a/posthog/queries/retention/actors_query.py
+++ b/posthog/queries/retention/actors_query.py
@@ -27,6 +27,8 @@ class RetentionActorsByPeriod(ActorBaseQuery):
     _filter: RetentionFilter
     _retention_events_query = RetentionEventsQuery
 
+    QUERY_TYPE = "retention_actors_by_period"
+
     def __init__(self, team: Team, filter: RetentionFilter):
         super().__init__(team, filter)
 

--- a/posthog/queries/retention/actors_query.py
+++ b/posthog/queries/retention/actors_query.py
@@ -1,10 +1,11 @@
 import dataclasses
 from typing import List, Optional
 
-from posthog.client import substitute_params, sync_execute
+from posthog.client import substitute_params
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.team import Team
 from posthog.queries.actor_base_query import ActorBaseQuery
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.retention.event_query import RetentionEventsQuery
 from posthog.queries.retention.sql import RETENTION_BREAKDOWN_ACTOR_SQL
 from posthog.queries.retention.types import BreakdownValues
@@ -61,9 +62,9 @@ class RetentionActorsByPeriod(ActorBaseQuery):
             retention_events_query=self._retention_events_query,
         )
 
+        results = insight_sync_execute(actor_query, query_type="retention_actors", filter=self._filter)
         actor_appearances = [
-            AppearanceRow(actor_id=str(row[0]), appearance_count=len(row[1]), appearances=row[1])
-            for row in sync_execute(actor_query)
+            AppearanceRow(actor_id=str(row[0]), appearance_count=len(row[1]), appearances=row[1]) for row in results
         ]
 
         _, serialized_actors = self.get_actors_from_result(

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -3,10 +3,11 @@ from urllib.parse import urlencode
 
 import pytz
 
-from posthog.client import substitute_params, sync_execute
+from posthog.client import substitute_params
 from posthog.constants import RETENTION_FIRST_TIME, RetentionQueryType
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.team import Team
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.retention.actors_query import RetentionActorsByPeriod, build_actor_activity_query
 from posthog.queries.retention.event_query import RetentionEventsQuery
 from posthog.queries.retention.sql import RETENTION_BREAKDOWN_SQL
@@ -32,9 +33,11 @@ class Retention:
     ) -> Dict[CohortKey, Dict[str, Any]]:
 
         actor_query = build_actor_activity_query(filter=filter, team=team, retention_events_query=self.event_query)
-        result = sync_execute(
+        result = insight_sync_execute(
             RETENTION_BREAKDOWN_SQL.format(actor_query=actor_query),
             settings={"timeout_before_checking_execution_speed": 60},
+            filter=filter,
+            query_type="retention_by_breakdown_values",
             client_query_id=filter.client_query_id,
             client_query_team_id=team.pk,
         )

--- a/posthog/queries/stickiness/stickiness.py
+++ b/posthog/queries/stickiness/stickiness.py
@@ -2,13 +2,13 @@ import copy
 import urllib.parse
 from typing import Any, Dict, List
 
-from posthog.client import sync_execute
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.action import Action
 from posthog.models.entity import Entity
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.team import Team
 from posthog.queries.base import handle_compare
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.stickiness.stickiness_actors import StickinessActors
 from posthog.queries.stickiness.stickiness_event_query import StickinessEventsQuery
 from posthog.utils import encode_get_request_params
@@ -42,9 +42,11 @@ class Stickiness:
         SETTINGS optimize_move_to_prewhere = 0
         """
 
-        counts = sync_execute(
+        counts = insight_sync_execute(
             query,
             {**event_params, "num_intervals": filter.total_intervals},
+            query_type="stickiness",
+            filter=filter,
             client_query_id=filter.client_query_id,
             client_query_team_id=team.pk,
         )

--- a/posthog/queries/stickiness/stickiness_actors.py
+++ b/posthog/queries/stickiness/stickiness_actors.py
@@ -13,6 +13,8 @@ class StickinessActors(ActorBaseQuery):
     entity: Entity
     _filter: StickinessFilter
 
+    QUERY_TYPE = "stickiness"
+
     def __init__(self, team: Team, entity: Entity, filter: StickinessFilter, **kwargs):
         super().__init__(team, filter, entity, **kwargs)
 

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -4848,7 +4848,7 @@ def trend_test_factory(trends):
             with self.assertRaises(ValidationError):
                 trends().run(Filter(data={"events": [{"id": "sign up", "math": "sum"}]}), self.team)
 
-        @patch("posthog.queries.trends.trends.sync_execute")
+        @patch("posthog.queries.trends.trends.insight_sync_execute")
         def test_should_throw_exception(self, patch_sync_execute):
             self._create_events()
             patch_sync_execute.side_effect = Exception()

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -6,12 +6,16 @@ from typing import Any, Dict, List
 from sentry_sdk import push_scope
 
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
-from posthog.client import sync_execute
 from posthog.constants import NON_TIME_SERIES_DISPLAY_TYPES, TRENDS_CUMULATIVE
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.breakdown_props import get_breakdown_cohort_name
+<<<<<<< HEAD
 from posthog.queries.trends.util import ensure_value_is_json_serializable, parse_response
+=======
+from posthog.queries.insight import insight_sync_execute
+from posthog.queries.trends.util import parse_response
+>>>>>>> dc09e6181... Tag trends formula query
 
 
 class TrendsFormula:
@@ -73,7 +77,12 @@ class TrendsFormula:
             scope.set_context("filter", filter.to_dict())
             scope.set_tag("team", team)
             scope.set_context("query", {"sql": sql, "params": params})
-            result = sync_execute(sql, params)
+            result = insight_sync_execute(
+                sql,
+                params,
+                query_type="trends_formula",
+                filter=filter,
+            )
             response = []
             for item in result:
                 additional_values: Dict[str, Any] = {"label": self._label(filter, item)}

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -20,7 +20,7 @@ class TrendsFormula:
         queries = []
         params: Dict[str, Any] = {}
         for idx, entity in enumerate(filter.entities):
-            sql, entity_params, _ = self._get_sql_for_entity(filter, team, entity)  # type: ignore
+            query_type, sql, entity_params, _ = self._get_sql_for_entity(filter, team, entity)  # type: ignore
             sql = sql.replace("%(", f"%({idx}_")
             entity_params = {f"{idx}_{key}": value for key, value in entity_params.items()}
             queries.append(sql)

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -10,12 +10,8 @@ from posthog.constants import NON_TIME_SERIES_DISPLAY_TYPES, TRENDS_CUMULATIVE
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.breakdown_props import get_breakdown_cohort_name
-<<<<<<< HEAD
-from posthog.queries.trends.util import ensure_value_is_json_serializable, parse_response
-=======
 from posthog.queries.insight import insight_sync_execute
-from posthog.queries.trends.util import parse_response
->>>>>>> dc09e6181... Tag trends formula query
+from posthog.queries.trends.util import ensure_value_is_json_serializable, parse_response
 
 
 class TrendsFormula:

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -147,7 +147,9 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
 
         return merged_results
 
-    def _run_query_for_threading(self, result: List, index: int, query_type, sql, params, client_query_id: str, team_id: int):
+    def _run_query_for_threading(
+        self, result: List, index: int, query_type, sql, params, client_query_id: str, team_id: int
+    ):
         with push_scope() as scope:
             scope.set_context("query", {"sql": sql, "params": params})
             result[index] = insight_sync_execute(

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -23,6 +23,7 @@ from posthog.models.entity import Entity
 from posthog.models.filters import Filter
 from posthog.models.team import Team
 from posthog.queries.base import handle_compare
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.trends.breakdown import TrendsBreakdown
 from posthog.queries.trends.formula import TrendsFormula
 from posthog.queries.trends.lifecycle import Lifecycle
@@ -31,17 +32,20 @@ from posthog.utils import generate_cache_key, get_safe_cache
 
 
 class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
-    def _get_sql_for_entity(self, filter: Filter, team: Team, entity: Entity) -> Tuple[str, Dict, Callable]:
+    def _get_sql_for_entity(self, filter: Filter, team: Team, entity: Entity) -> Tuple[str, str, Dict, Callable]:
         if filter.breakdown and filter.display not in NON_BREAKDOWN_DISPLAY_TYPES:
+            query_type = "trends_breakdown"
             sql, params, parse_function = TrendsBreakdown(
                 entity, filter, team, using_person_on_events=team.actor_on_events_querying_enabled
             ).get_query()
         elif filter.shown_as == TRENDS_LIFECYCLE:
+            query_type = "trends_lifecycle"
             sql, params, parse_function = self._format_lifecycle_query(entity, filter, team)
         else:
+            query_type = "trends_total_volume"
             sql, params, parse_function = self._total_volume_query(entity, filter, team)
 
-        return sql, params, parse_function
+        return query_type, sql, params, parse_function
 
     # Use cached result even on refresh if team has strict caching enabled
     def get_cached_result(self, filter: Filter, team: Team) -> Optional[List[Dict[str, Any]]]:
@@ -123,7 +127,15 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
             scope.set_context("filter", filter.to_dict())
             scope.set_tag("team", team)
             scope.set_context("query", {"sql": sql, "params": params})
-            result = sync_execute(sql, params, client_query_id=filter.client_query_id, client_query_team_id=team.pk)
+            query_type, sql, params, parse_function = self._get_sql_for_entity(adjusted_filter, team, entity)
+            result = insight_sync_execute(
+                sql,
+                params,
+                query_type=query_type,
+                filters=adjusted_filter,
+                client_query_id=filter.client_query_id,
+                client_query_team_id=team.pk,
+            )
             result = parse_function(result)
             serialized_data = self._format_serialized(entity, result)
             merged_results, cached_result = self.merge_results(
@@ -150,7 +162,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
 
         for entity in filter.entities:
             adjusted_filter, cached_result = self.adjusted_filter(filter, team)
-            sql, params, parse_function = self._get_sql_for_entity(adjusted_filter, team, entity)
+            query_type, sql, params, parse_function = self._get_sql_for_entity(adjusted_filter, team, entity)
             parse_functions[entity.index] = parse_function
             sql_statements_with_params[entity.index] = (sql, params)
             thread = threading.Thread(

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -132,7 +132,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
                 sql,
                 params,
                 query_type=query_type,
-                filters=adjusted_filter,
+                filter=adjusted_filter,
                 client_query_id=filter.client_query_id,
                 client_query_team_id=team.pk,
             )

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -121,12 +121,11 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
 
     def _run_query(self, filter: Filter, team: Team, entity: Entity) -> List[Dict[str, Any]]:
         adjusted_filter, cached_result = self.adjusted_filter(filter, team)
-        sql, params, parse_function = self._get_sql_for_entity(adjusted_filter, team, entity)
         with push_scope() as scope:
+            query_type, sql, params, parse_function = self._get_sql_for_entity(adjusted_filter, team, entity)
             scope.set_context("filter", filter.to_dict())
             scope.set_tag("team", team)
             scope.set_context("query", {"sql": sql, "params": params})
-            query_type, sql, params, parse_function = self._get_sql_for_entity(adjusted_filter, team, entity)
             result = insight_sync_execute(
                 sql,
                 params,

--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -35,6 +35,7 @@ def _handle_date_interval(filter: Filter) -> Filter:
 
 class TrendsActors(ActorBaseQuery):
     ACTOR_VALUES_INCLUDED = True
+    QUERY_TYPE = "trends_actors"
 
     entity: Entity
     _filter: Filter

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -6,8 +6,8 @@ import pytz
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
-from posthog.client import sync_execute
 from posthog.models.event import DEFAULT_EARLIEST_TIME_DELTA
+from posthog.queries.insight import insight_sync_execute
 
 EARLIEST_TIMESTAMP = "2015-01-01"
 
@@ -50,7 +50,11 @@ def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] 
 
 
 def get_earliest_timestamp(team_id: int) -> datetime:
-    results = sync_execute(GET_EARLIEST_TIMESTAMP_SQL, {"team_id": team_id, "earliest_timestamp": EARLIEST_TIMESTAMP})
+    results = insight_sync_execute(
+        GET_EARLIEST_TIMESTAMP_SQL,
+        {"team_id": team_id, "earliest_timestamp": EARLIEST_TIMESTAMP},
+        query_type="get_earliest_timestamp",
+    )
     if len(results) > 0:
         return results[0][0]
     else:


### PR DESCRIPTION
## Problem

I want to know which backend queries are causing me performance issues https://github.com/PostHog/product-internal/pull/385

## Changes

- Log metadata about query as JSON in query_log
- Remove tagging from statsd metrics (breaking change but we're the main users of these dashboard)
- Annotate all (?) insights with new metadata
- Create a materialized view gathering data via system.query_log table

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
