### PR TITLE
fix: errors on billing page

### DIFF
--- a/frontend/src/scenes/billing/v2/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/billingLogic.ts
@@ -186,7 +186,7 @@ export const billingLogic = kea<billingLogicType>([
         loadBillingSuccess: () => {
             if (
                 router.values.location.pathname.includes('/organization/billing') &&
-                router.values.searchParams.get('success')
+                router.values.searchParams['success']
             ) {
                 // if the activation is successful, we reload the user to get the updated billing info on the organization
                 actions.loadUser()


### PR DESCRIPTION
## Problem

This listener would always error out, because `get()` isn't a function on an object (unless you're in python land)

I don't understand what this part of the code is supposed to do, so unsure whether the intended flow should happen or not once this is fixed, given that our previous testing didn't seem to suggest anything wrong with the current flow 😅 .

Hence, will wait for Em or Ben's review here.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
