### PR TITLE
chore: better error when json is none

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -183,7 +183,7 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
             raise Exception(f"export API call failed with status_code: {response.status_code}. {response_json}")
 
         # Figure out how to handle funnel polling....
-        data = []  # response.json()
+        data = response.json()
 
         if data is None:
             unexpected_empty_json_response = UnexpectedEmptyJsonResponse("JSON is None when calling API for data")

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -152,11 +152,7 @@ def _convert_response_to_csv_data(data: Any) -> List[Any]:
 
 
 class UnexpectedEmptyJsonResponse(Exception):
-    def __init__(self, message: str, response: requests.models.Response) -> None:
-        super().__init__(message)
-
-        self.response = response
-        self.response_text = response.text
+    pass
 
 
 def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: int = 3_500) -> None:
@@ -190,7 +186,15 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
         data = response.json()
 
         if not data:
-            raise UnexpectedEmptyJsonResponse("JSON is None when calling API for data", response)
+            unexpected_empty_json_response = UnexpectedEmptyJsonResponse("JSON is None when calling API for data")
+            logger.error(
+                "csv_exporter.json_was_none",
+                exc=unexpected_empty_json_response,
+                exc_info=True,
+                response_text=response.text,
+            )
+
+            raise unexpected_empty_json_response
 
         csv_rows = _convert_response_to_csv_data(data)
 

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -183,9 +183,9 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
             raise Exception(f"export API call failed with status_code: {response.status_code}. {response_json}")
 
         # Figure out how to handle funnel polling....
-        data = response.json()
+        data = []  # response.json()
 
-        if not data:
+        if data is None:
             unexpected_empty_json_response = UnexpectedEmptyJsonResponse("JSON is None when calling API for data")
             logger.error(
                 "csv_exporter.json_was_none",

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -151,6 +151,14 @@ def _convert_response_to_csv_data(data: Any) -> List[Any]:
     return []
 
 
+class UnexpectedEmptyJsonResponse(Exception):
+    def __init__(self, message: str, response: requests.models.Response) -> None:
+        super().__init__(message)
+
+        self.response = response
+        self.response_text = response.text
+
+
 def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: int = 3_500) -> None:
     resource = exported_asset.export_context
 
@@ -180,6 +188,10 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
 
         # Figure out how to handle funnel polling....
         data = response.json()
+
+        if not data:
+            raise UnexpectedEmptyJsonResponse("JSON is None when calling API for data", response)
+
         csv_rows = _convert_response_to_csv_data(data)
 
         all_csv_rows = all_csv_rows + csv_rows


### PR DESCRIPTION
## Problem

If the csv exporter encounters a response from the API whose `response.json()` return `None` (which is a valid outcome for that method). We log an error because we still try and decode it as JSON. 

## Changes

raises an error that includes the response and its response text 

## How did you test this code?

* adding a developer test
* hardcoding a `None` response locally and seeing response text in the logs