### PR TITLE
fix(error-toast): Choose error message more intelligently

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -66,7 +66,7 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
                     ) {
                         lemonToast.error(
                             `${identifierToHuman(actionKey)} on reducer ${identifierToHuman(reducerKey)} failed: ${
-                                error.status !== 0 ? error.detail || 'PostHog may be offline' : 'PostHog may be offline'
+                                error.detail || error.statusText || 'PostHog may be offline'
                             }`
                         )
                     }


### PR DESCRIPTION
## Changes

This will make it so that we show "PostHog may be offline" less. We've been showing that even for server errors which should have the "Internal Server Error" message – it wasn't used because it's in `statusText` and not `detail`.