### PR TITLE
feat: Update auto refresh threshold for dashboards to 20h

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -203,3 +203,6 @@ export const CLOUD_HOSTNAMES = {
 }
 
 export const SESSION_RECORDINGS_PLAYLIST_FREE_COUNT = 5
+
+// If _any_ item on a dashboard is older than this, dashboard is automatically reloaded
+export const AUTO_REFRESH_DASHBOARD_THRESHOLD_HOURS = 20

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -4,7 +4,11 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { router } from 'kea-router'
 import { clearDOMTextSelection, isUserLoggedIn, toParams, uuid } from 'lib/utils'
 import { insightsModel } from '~/models/insightsModel'
-import { DashboardPrivilegeLevel, OrganizationMembershipLevel } from 'lib/constants'
+import {
+    AUTO_REFRESH_DASHBOARD_THRESHOLD_HOURS,
+    DashboardPrivilegeLevel,
+    OrganizationMembershipLevel,
+} from 'lib/constants'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import {
     AnyPropertyFilter,
@@ -992,7 +996,10 @@ export const dashboardLogic = kea<dashboardLogicType>({
             sharedListeners.reportLoadTiming(...args)
 
             // Initial load of actual data for dashboard items after general dashboard is fetched
-            if (values.lastRefreshed && values.lastRefreshed.isBefore(now().subtract(3, 'hours'))) {
+            if (
+                values.lastRefreshed &&
+                values.lastRefreshed.isBefore(now().subtract(AUTO_REFRESH_DASHBOARD_THRESHOLD_HOURS, 'hours'))
+            ) {
                 actions.refreshAllDashboardItems({ action: 'refresh_automatic' })
             } else {
                 const notYetLoadedItems = values.tiles?.filter(


### PR DESCRIPTION
## Problem

If a user visits a dashboard, we currently refresh _all_ insights if any insight is older than 3 hours.

Given our cache is regularly over 10 hours behind, most dashboards get refreshed this way automatically.

## Changes

Only refresh once the cache is >=20 hours old.

We should also figure out how to deprioritize the UX for reloads.
