### PR TITLE
feat(signup): add experiment for signup product details

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -86,7 +86,8 @@ export function BridgePage({
                                     <WelcomeLogo view={view} />
                                 </div>
                             )}
-                            {featureFlags[FEATURE_FLAGS.SIGNUP_PRODUCT_INFO_EXPERIMENT] === 'test' && showSignupCta ? (
+                            {featureFlags[FEATURE_FLAGS.SIGNUP_PRODUCT_BENEFITS_EXPERIMENT] === 'test' &&
+                            showSignupCta ? (
                                 <div className="mb-16 max-w-100">
                                     {productBenefits.map((benefit, i) => (
                                         <div className="flex flex-row gap-4 mb-4" key={i}>

--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -10,6 +10,9 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { router } from 'kea-router'
 import { Region } from '~/types'
 import { CLOUD_HOSTNAMES } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { IconCheckCircleOutline } from '../icons'
 
 export type BridgePageProps = {
     className?: string
@@ -40,6 +43,7 @@ export function BridgePage({
 }: BridgePageProps): JSX.Element {
     const [messageShowing, setMessageShowing] = useState(false)
     const { preflight } = useValues(preflightLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     useEffect(() => {
         const t = setTimeout(() => {
@@ -53,6 +57,24 @@ export function BridgePage({
         return `https://${CLOUD_HOSTNAMES[region]}${pathname}${search}${hash}`
     }
 
+    const productBenefits: {
+        benefit: string
+        description: string
+    }[] = [
+        {
+            benefit: 'Free for 1M events every month',
+            description: 'Product analytics, feature flags, experiments, and more.',
+        },
+        {
+            benefit: 'Start collecting events immediately',
+            description: 'Integrate with developer-friendly APIs or use our easy autocapture script.',
+        },
+        {
+            benefit: 'Join industry leaders who run their product on PostHog',
+            description: 'Brex, Airbus, Hasura, Y Combinator, and thousands more trust Posthog as their Product OS.',
+        },
+    ]
+
     return (
         <div className={clsx('BridgePage', fixedWidth && 'BridgePage--fixed-width', className)}>
             <div className="BridgePage__main">
@@ -64,12 +86,34 @@ export function BridgePage({
                                     <WelcomeLogo view={view} />
                                 </div>
                             )}
-                            <LaptopHog3 alt="" draggable="false" />
-                            {message ? (
-                                <CSSTransition in={messageShowing} timeout={200} classNames="BridgePage__art__message-">
-                                    <div className="BridgePage__art__message">{message}</div>
-                                </CSSTransition>
-                            ) : null}
+                            {featureFlags[FEATURE_FLAGS.SIGNUP_PRODUCT_INFO_EXPERIMENT] !== 'test' && showSignupCta ? (
+                                <div className="mb-16 max-w-100">
+                                    {productBenefits.map((benefit, i) => (
+                                        <div className="flex flex-row gap-4 mb-4" key={i}>
+                                            <div>
+                                                <IconCheckCircleOutline className="mt-2 w-4 h-4 text-primary" />
+                                            </div>
+                                            <div>
+                                                <h3 className="mb-0 font-bold">{benefit.benefit}</h3>
+                                                <p className="m-0 text-sm">{benefit.description}</p>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <>
+                                    <LaptopHog3 alt="" draggable="false" />
+                                    {message ? (
+                                        <CSSTransition
+                                            in={messageShowing}
+                                            timeout={200}
+                                            classNames="BridgePage__art__message-"
+                                        >
+                                            <div className="BridgePage__art__message">{message}</div>
+                                        </CSSTransition>
+                                    ) : null}
+                                </>
+                            )}
                         </div>
                         {showSignupCta && (
                             <div className="BridgePage__cta border rounded p-4 mt-8 text-center">

--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -86,7 +86,7 @@ export function BridgePage({
                                     <WelcomeLogo view={view} />
                                 </div>
                             )}
-                            {featureFlags[FEATURE_FLAGS.SIGNUP_PRODUCT_INFO_EXPERIMENT] !== 'test' && showSignupCta ? (
+                            {featureFlags[FEATURE_FLAGS.SIGNUP_PRODUCT_INFO_EXPERIMENT] === 'test' && showSignupCta ? (
                                 <div className="mb-16 max-w-100">
                                     {productBenefits.map((benefit, i) => (
                                         <div className="flex flex-row gap-4 mb-4" key={i}>

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -133,6 +133,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_V2_EXPERIMENT: 'onboarding-v2-experiment', // owner: #team-growth
     RECORDING_AUTOPLAY: 'recording-autoplay', // owner: #team-session-recordings
     SIGNUP_FORM_EXPERIMENT: 'signup-form-experiment', // owner: #team-growth
+    SIGNUP_PRODUCT_INFO_EXPERIMENT: 'signup-product-info-experiment', // owner: #team-growth
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -133,7 +133,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_V2_EXPERIMENT: 'onboarding-v2-experiment', // owner: #team-growth
     RECORDING_AUTOPLAY: 'recording-autoplay', // owner: #team-session-recordings
     SIGNUP_FORM_EXPERIMENT: 'signup-form-experiment', // owner: #team-growth
-    SIGNUP_PRODUCT_INFO_EXPERIMENT: 'signup-product-info-experiment', // owner: #team-growth
+    SIGNUP_PRODUCT_BENEFITS_EXPERIMENT: 'signup-product-benefits-experiment', // owner: #team-growth
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */


### PR DESCRIPTION
## Problem

We'd like to improve conversion on the signup page. One thing that may result in low conversion is that, aside from a cute hedgehog, there's nothin on the signup page to convince someone that they do actually want to join.

## Changes

This PR introduces a new feature flag `signup-product-benefits-experiment`, which when set to `test` shows a list of benefits someone gets by signing up:

![image](https://user-images.githubusercontent.com/18598166/203182357-51b78199-9af0-410d-8b35-df56a7fc67ee.png)

Without the `test` flag, it's just the normal hedgehog (which is much cuter, tbh, but we will see what gets people to convert). 

![image](https://user-images.githubusercontent.com/18598166/203182446-2d223f63-dba6-46ac-85d8-4891ecbfa8cb.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I checked it on varying screen sizes and it squished okay to a point and then disappeared when on a small enough screen like it's supposed to.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
