### PR TITLE
feat(time-to-see-data): Save filter object to metrics_query_log table

### DIFF
--- a/posthog/models/query_metrics/sql.py
+++ b/posthog/models/query_metrics/sql.py
@@ -144,7 +144,7 @@ PARTITION BY toYYYYMM(timestamp)
 ORDER BY (toDate(timestamp), team_id, query_type)
 AS
 SELECT
-    hostName() AS hostName,
+    getMacro('replica') AS host,
     event_time AS timestamp,
     query_duration_ms,
     read_rows,
@@ -152,12 +152,10 @@ SELECT
     result_rows,
     result_bytes,
     memory_usage,
-    query,
-    tables,
-    columns,
     is_initial_query,
     exception_code,
     JSONExtractInt(log_comment, 'team_id') AS team_id,
+    dictGet('team_events_last_month_dictionary', 'event_count', team_id) AS team_events_last_month,
     JSONExtractInt(log_comment, 'user_id') AS user_id,
     JSONExtractString(log_comment, 'kind') AS kind,
     JSONExtractString(log_comment, 'query_type') AS query_type,
@@ -170,7 +168,10 @@ SELECT
     JSONExtract(log_comment, 'filter_by_type', 'Array(String)') as filter_by_type,
     JSONExtract(log_comment, 'breakdown_by', 'Array(String)') as breakdown_by,
     JSONExtract(log_comment, 'entity_math', 'Array(String)') as entity_math,
-    dictGet('team_events_last_month_dictionary', 'event_count', team_id) AS team_events_last_month,
+    JSONExtractString(log_comment, 'filter') AS filter,
+    tables,
+    columns,
+    query,
     log_comment
 FROM system.query_log
 WHERE JSONHas(log_comment, 'team_id')

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -23,7 +23,7 @@ def insight_sync_execute(
     )
 
     if filter is not None:
-        tag_queries(**filter.query_tags())
+        tag_queries(filter=filter.to_dict(), **filter.query_tags())
 
     return sync_execute(
         query, args=args, settings=settings, client_query_id=client_query_id, client_query_team_id=client_query_team_id


### PR DESCRIPTION
## Problem

I want to know how long my backend queries are taking _and debug them_.

Follow-up to https://github.com/PostHog/posthog/pull/12884

## Changes

Include `filter` in metrics_query_log table

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
