### PR TITLE
feat(plugins-schedule): add clear metric for number of scheduled tasks executed

### DIFF
--- a/plugin-server/src/main/graphile-worker/schedule.ts
+++ b/plugin-server/src/main/graphile-worker/schedule.ts
@@ -32,5 +32,6 @@ export async function runScheduledTasks(server: Hub, piscina: Piscina, taskType:
     for (const pluginConfigId of server.pluginSchedule?.[taskType] || []) {
         status.info('⏲️', `Running ${taskType} for plugin config with ID ${pluginConfigId}`)
         await piscina.run({ task: taskType, args: { pluginConfigId } })
+        server.statsd?.increment('completed_scheduled_task', { taskType })
     }
 }


### PR DESCRIPTION
A clear metric for tracking how many scheduled tasks we're executing successfully per $interval