### PR TITLE
feat(plugin-jobs): allow jobs to have a debounce key

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -204,6 +204,7 @@ export interface Hub extends PluginsServerConfig {
     lastActivityType: string
     statelessVms: StatelessVmMap
     conversionBufferEnabledTeams: Set<number>
+    enqueuePluginJob: (job: EnqueuedPluginJob) => Promise<void>
 }
 
 export interface PluginServerCapabilities {


### PR DESCRIPTION
Graphile Worker allows passing a `jobKey` for debouncing jobs, but we didn't connect this to our jobs API. This is very useful given plugins run in many different VMs. Think for example triggering a job on `setupPlugin`.