### PR TITLE
fix(recordings): empty static playlists should return no recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -208,6 +208,7 @@ export function SessionRecordingsPlaylist({
         personUUID,
         filters: defaultFilters,
         updateSearchParams,
+        isStatic,
         staticRecordings,
     })
     const {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
@@ -241,6 +241,7 @@ describe('sessionRecordingsListLogic', () => {
             beforeEach(() => {
                 logic = sessionRecordingsListLogic({
                     key: 'static-tests',
+                    isStatic: true,
                     staticRecordings: [{ id: '1' }, { id: '2' }],
                 })
                 logic.mount()

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -1,6 +1,6 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import api, { PaginatedResponse } from 'lib/api'
-import { objectsEqual, toParams } from 'lib/utils'
+import { toParams } from 'lib/utils'
 import {
     PropertyFilter,
     PropertyFilterType,
@@ -18,6 +18,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import equal from 'fast-deep-equal'
 import { dayjs } from 'lib/dayjs'
 import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
 
 export type PersonUUID = string
 interface Params {
@@ -100,17 +101,13 @@ export interface SessionRecordingListLogicProps {
     personUUID?: PersonUUID
     filters?: RecordingFilters
     updateSearchParams?: boolean
+    isStatic?: boolean
     staticRecordings?: SessionRecordingPlaylistType['playlist_items']
 }
 
 export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
     path((key) => ['scenes', 'session-recordings', 'playlist', 'sessionRecordingsListLogic', key]),
     props({} as SessionRecordingListLogicProps),
-    propsChanged(({ actions, props }, oldProps) => {
-        if (props.staticRecordings && !objectsEqual(props.staticRecordings, oldProps.staticRecordings)) {
-            actions.getSessionRecordings({ static_recordings: props.staticRecordings })
-        }
-    }),
     key((props) => `${props.key}-${props.updateSearchParams ?? '-with-search'}`),
     connect({
         actions: [
@@ -119,7 +116,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         ],
     }),
     actions({
-        getSessionRecordings: (filters: Partial<RecordingFilters>) => ({ filters }),
         setFilters: (filters: Partial<RecordingFilters>) => ({ filters }),
         replaceFilters: (filters: RecordingFilters) => ({ filters }),
         setShowFilters: (showFilters: boolean) => ({ showFilters }),
@@ -136,14 +132,21 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                 has_next: false,
             } as SessionRecordingsResponse,
             {
-                getSessionRecordings: async ({ filters: nextFilters }, breakpoint) => {
-                    const paramsDict = {
+                getSessionRecordings: async (_, breakpoint) => {
+                    let paramsDict = {
                         ...values.filters,
                         person_uuid: props.personUUID ?? '',
                         limit: PLAYLIST_LIMIT,
-                        static_recordings: props.staticRecordings ?? undefined,
-                        ...nextFilters,
                     }
+
+                    // If list should be a static list
+                    if (props.isStatic) {
+                        paramsDict = {
+                            ...paramsDict,
+                            static_recordings: values.staticRecordings ?? [],
+                        }
+                    }
+
                     const params = toParams(paramsDict)
                     await breakpoint(100) // Debounce for lots of quick filter changes
 
@@ -255,6 +258,12 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
             actions.getSessionRecordingsProperties({})
         },
     })),
+    subscriptions(({ actions }) => ({
+        staticRecordings: (staticRecordings) => {
+            console.log('STATIC RECORDINGS CHANGEd', staticRecordings)
+            actions.getSessionRecordings({})
+        },
+    })),
     selectors({
         sessionRecordingIdToProperties: [
             (s) => [s.sessionRecordingsPropertiesResponse],
@@ -263,6 +272,10 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                     Object.fromEntries(propertiesResponse.results.map(({ id, properties }) => [id, properties])) ?? {}
                 )
             },
+        ],
+        staticRecordings: [
+            () => [(_, props) => props.staticRecordings],
+            (staticRecordings) => staticRecordings ?? null,
         ],
         activeSessionRecording: [
             (s) => [s.selectedRecordingId, s.sessionRecordings],
@@ -332,7 +345,7 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         }
 
         return {
-            loadSessionRecordings: () => buildURL(true),
+            getSessionRecordings: () => buildURL(true),
             setSelectedRecordingId: () => buildURL(false),
             setFilters: () => buildURL(true),
         }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -259,8 +259,7 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         },
     })),
     subscriptions(({ actions }) => ({
-        staticRecordings: (staticRecordings) => {
-            console.log('STATIC RECORDINGS CHANGEd', staticRecordings)
+        staticRecordings: () => {
             actions.getSessionRecordings({})
         },
     })),

--- a/posthog/models/filters/mixins/session_recordings.py
+++ b/posthog/models/filters/mixins/session_recordings.py
@@ -28,8 +28,11 @@ class SessionRecordingsMixin(BaseParamMixin):
         return None
 
     @cached_property
-    def static_recordings(self) -> List[MinimalStaticSessionRecording]:
-        static_recordings_str = self._data.get(SESSION_RECORDINGS_FILTER_STATIC_RECORDINGS, "[]")
+    def static_recordings(self) -> Optional[List[MinimalStaticSessionRecording]]:
+        static_recordings_str = self._data.get(SESSION_RECORDINGS_FILTER_STATIC_RECORDINGS, None)
+        if static_recordings_str is None:
+            return None
+
         static_recordings = json.loads(static_recordings_str)
         return [
             MinimalStaticSessionRecording(id=recording.get("id", None), created_at=recording.get("created_at", None))

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -194,10 +194,11 @@ class SessionRecordingList(EventQuery):
         return start_time_clause, start_time_params
 
     def _get_static_recordings_clause(self) -> Tuple[str, Dict[str, Any]]:
-        static_session_ids = [session["id"] for session in self._filter.static_recordings]
 
-        if not static_session_ids:
+        if self._filter.static_recordings is None:
             return "", {}
+
+        static_session_ids = [session["id"] for session in self._filter.static_recordings]
 
         return "AND session_id in %(static_session_ids)s", {"static_session_ids": static_session_ids}
 


### PR DESCRIPTION
## Problem

There was a bug where if we specified an empty `static_recordings` param in the list api, we'd return a list of recordings based of an empty dynamic playlist filter. Instead, if we specify an empty array of recordings, we should return an empty list of recordings. In the case of dynamic playlists, `static_recordings` is null.

## Changes

Make fix and add test

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Add test
