### PR TITLE
feat: management command to sync postgres persons to clickhouse

### DIFF
--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -10,9 +10,6 @@ from posthog.models.person.util import _delete_ch_distinct_id, create_person, cr
 
 logger = structlog.get_logger(__name__)
 
-PERSON_TABLE = "person"
-DISTINCT_ID_TABLE = "persondistinctid"
-
 
 class Command(BaseCommand):
     help = """Sync person or distinct id tables from postgres to ClickHouse.
@@ -23,9 +20,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--team-id", default=None, type=int, help="Specify a team to fix data for.")
-        parser.add_argument(
-            "--tables", default=[PERSON_TABLE, DISTINCT_ID_TABLE], action="append", help="Which tables to sync"
-        )
+        parser.add_argument("--person", action="store_true", help="Sync persons")
+        parser.add_argument("--person-distinct-id", action="store_true", help="Sync person distinct IDs")
         parser.add_argument(
             "--deletes", action="store_true", help="process deletes for data in ClickHouse but not Postgres"
         )
@@ -35,7 +31,7 @@ class Command(BaseCommand):
         run(options)
 
 
-def run(options):
+def run(options, sync: bool = False):  # sync used for unittests
     live_run = options["live_run"]
     deletes = options["deletes"]
 
@@ -43,41 +39,32 @@ def run(options):
         logger.error("You must specify --team-id to run this script")
         exit(1)
 
-    if not set(options["tables"]) <= {PERSON_TABLE, DISTINCT_ID_TABLE}:
-        logger.error("Illegal value in --tables")
-        exit(1)
-
     team_id = options["team_id"]
 
-    if PERSON_TABLE in options["tables"]:
-        run_person_sync(team_id, live_run, deletes)
+    if options["person"]:
+        run_person_sync(team_id, live_run, deletes, sync)
 
-    if DISTINCT_ID_TABLE in options["tables"]:
-        run_distinct_id_sync(team_id, live_run, deletes)
+    if options["person_distinct_id"]:
+        run_distinct_id_sync(team_id, live_run, deletes, sync)
 
 
-def run_person_sync(team_id: int, live_run: bool, deletes: bool):
+def run_person_sync(team_id: int, live_run: bool, deletes: bool, sync: bool):
     logger.info("Running person table sync")
     # lookup what needs to be updated in ClickHouse and send kafka messages for only those
     persons = Person.objects.filter(team_id=team_id)
     rows = sync_execute(
         """
-            SELECT id, max(version) FROM person WHERE team_id = %(team)s GROUP BY id HAVING max(is_deleted) = 0
+            SELECT id, max(version) FROM person WHERE team_id = %(team_id)s GROUP BY id HAVING max(is_deleted) = 0
         """,
         {
-            "team": team_id,
+            "team_id": team_id,
         },
     )
     ch_persons_to_version = {row[0]: row[1] for row in rows}
 
     for person in persons:
         ch_version = ch_persons_to_version.get(person.uuid, None)
-        if ch_version > person.version:
-            logger.info(
-                f"Clickhouse version ({ch_version}) for '{person.uuid}' is higher than in Postgres ({person.version}). Ignoring."
-            )
-            continue
-        if ch_version != person.version:
+        if ch_version is None or ch_version < person.version:
             logger.info(f"Updating {person.uuid} to version {person.version}")
             if live_run:
                 # Update ClickHouse via Kafka message
@@ -85,10 +72,15 @@ def run_person_sync(team_id: int, live_run: bool, deletes: bool):
                     team_id=team_id,
                     version=person.version,
                     uuid=str(person.uuid),
-                    properties=person.properties,  # TODO: check that the format is correct
+                    properties=person.properties,
                     is_identified=person.is_identified,
-                    created_at=person.created_at,  # TODO: check formatting
+                    created_at=person.created_at,
+                    sync=sync,
                 )
+        elif ch_version > person.version:
+            logger.info(
+                f"Clickhouse version ({ch_version}) for '{person.uuid}' is higher than in Postgres ({person.version}). Ignoring."
+            )
 
     if deletes:
         logger.info("Processing person deletions")
@@ -104,48 +96,50 @@ def run_person_sync(team_id: int, live_run: bool, deletes: bool):
                         version=int(version or 0)
                         + 100,  # keep in sync with deletePerson in plugin-server/src/utils/db/db.ts
                         is_deleted=True,
+                        sync=sync,
                     )
 
 
-def run_distinct_id_sync(team_id: int, live_run: bool, deletes: bool):
+def run_distinct_id_sync(team_id: int, live_run: bool, deletes: bool, sync: bool):
     logger.info("Running person distinct id table sync")
     # lookup what needs to be updated in ClickHouse and send kafka messages for only those
     person_distinct_ids = PersonDistinctId.objects.filter(team_id=team_id)
     rows = sync_execute(
         """
-            SELECT distinct_id, max(version) FROM person_distinct_id2 WHERE team_id = %(team)s GROUP BY distinct_id HAVING max(is_deleted) = 0
+            SELECT distinct_id, max(version) FROM person_distinct_id2 WHERE team_id = %(team_id)s GROUP BY distinct_id HAVING max(is_deleted) = 0
         """,
         {
-            "team": team_id,
+            "team_id": team_id,
         },
     )
     ch_distinct_id_to_version = {row[0]: row[1] for row in rows}
 
-    for pdid in person_distinct_ids:
-        ch_version = ch_distinct_id_to_version.get(pdid.distinct_id, None)
-        # logger.info(f"{pdid.distinct_id} - {pdid.version} -  {ch_version}")
-        if ch_version or 0 > pdid.version:
-            # This could be happening due to person deletions - check out fix_person_distinct_ids_after_delete management cmd.
-            # Ignoring here to be safe.
-            logger.info(
-                f"Clickhouse version ({ch_version}) for '{pdid.distinct_id}' is higher than in Postgres ({pdid.version}). Ignoring."
-            )
-            continue
-        if ch_version != pdid.version:
-            logger.info(f"Updating {pdid.distinct_id} to version {pdid.version}")
+    for person_distinct_id in person_distinct_ids:
+        ch_version = ch_distinct_id_to_version.get(person_distinct_id.distinct_id, None)
+        if ch_version is None or ch_version < person_distinct_id.version:
+            logger.info(f"Updating {person_distinct_id.distinct_id} to version {person_distinct_id.version}")
             if live_run:
                 # Update ClickHouse via Kafka message
                 create_person_distinct_id(
                     team_id=team_id,
-                    distinct_id=pdid.distinct_id,
-                    person_id=str(pdid.person.uuid),
-                    version=pdid.version,
+                    distinct_id=person_distinct_id.distinct_id,
+                    person_id=str(person_distinct_id.person.uuid),
+                    version=person_distinct_id.version,
                     is_deleted=False,
+                    sync=sync,
                 )
+        elif ch_version > person_distinct_id.version:
+            # This could be happening due to person deletions - check out fix_person_distinct_ids_after_delete management cmd.
+            # Ignoring here to be safe.
+            logger.info(
+                f"Clickhouse version ({ch_version}) for '{person_distinct_id.distinct_id}' is higher than in Postgres ({person_distinct_id.version}). Ignoring."
+            )
+            continue
 
     if deletes:
+        postgres_distinct_ids = {person_distinct_id.distinct_id for person_distinct_id in person_distinct_ids}
         for distinct_id, version in ch_distinct_id_to_version.items():
-            if distinct_id in person_distinct_ids:
+            if distinct_id not in postgres_distinct_ids:
                 logger.info(f"Deleting distinct ID {distinct_id}")
                 if live_run:
-                    _delete_ch_distinct_id(team_id, UUID(int=0), distinct_id, version)
+                    _delete_ch_distinct_id(team_id, UUID(int=0), distinct_id, version, sync=sync)

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -1,0 +1,151 @@
+from uuid import UUID
+
+import structlog
+from django.core.management.base import BaseCommand
+
+from posthog.client import sync_execute
+from posthog.models.person import PersonDistinctId
+from posthog.models.person.person import Person
+from posthog.models.person.util import _delete_ch_distinct_id, create_person, create_person_distinct_id
+
+logger = structlog.get_logger(__name__)
+
+PERSON_TABLE = "person"
+DISTINCT_ID_TABLE = "persondistinctid"
+
+
+class Command(BaseCommand):
+    help = """Sync person or distinct id tables from postgres to ClickHouse.
+        Lookup from Postgres and with a lower version in ClickHouse will be updated.
+        Note higher versions in ClickHouse will be ignored.
+        Recommended: run first without `--live-run` and first for person table, then distinct_id table
+        """
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", default=None, type=int, help="Specify a team to fix data for.")
+        parser.add_argument(
+            "--tables", default=[PERSON_TABLE, DISTINCT_ID_TABLE], action="append", help="Which tables to sync"
+        )
+        parser.add_argument(
+            "--deletes", action="store_true", help="process deletes for data in ClickHouse but not Postgres"
+        )
+        parser.add_argument("--live-run", action="store_true", help="Run changes, default is dry-run")
+
+    def handle(self, *args, **options):
+        run(options)
+
+
+def run(options):
+    live_run = options["live_run"]
+    deletes = options["deletes"]
+
+    if not options["team_id"]:
+        logger.error("You must specify --team-id to run this script")
+        exit(1)
+
+    if not set(options["tables"]) <= {PERSON_TABLE, DISTINCT_ID_TABLE}:
+        logger.error("Illegal value in --tables")
+        exit(1)
+
+    team_id = options["team_id"]
+
+    if PERSON_TABLE in options["tables"]:
+        run_person_sync(team_id, live_run, deletes)
+
+    if DISTINCT_ID_TABLE in options["tables"]:
+        run_distinct_id_sync(team_id, live_run, deletes)
+
+
+def run_person_sync(team_id: int, live_run: bool, deletes: bool):
+    logger.info("Running person table sync")
+    # lookup what needs to be updated in ClickHouse and send kafka messages for only those
+    persons = Person.objects.filter(team_id=team_id)
+    rows = sync_execute(
+        """
+            SELECT id, max(version) FROM person WHERE team_id = %(team)s GROUP BY id HAVING max(is_deleted) = 0
+        """,
+        {
+            "team": team_id,
+        },
+    )
+    ch_persons_to_version = {row[0]: row[1] for row in rows}
+
+    for person in persons:
+        ch_version = ch_persons_to_version.get(person.uuid, None)
+        if ch_version > person.version:
+            logger.info(
+                f"Clickhouse version ({ch_version}) for '{person.uuid}' is higher than in Postgres ({person.version}). Ignoring."
+            )
+            continue
+        if ch_version != person.version:
+            logger.info(f"Updating {person.uuid} to version {person.version}")
+            if live_run:
+                # Update ClickHouse via Kafka message
+                create_person(
+                    team_id=team_id,
+                    version=person.version,
+                    uuid=person.uuid,
+                    properties=person.properties,  # TODO: check that the format is correct
+                    is_identified=person.is_identified,
+                    created_at=person.created_at,  # TODO: check formatting
+                )
+
+    if deletes:
+        logger.info("Processing person deletions")
+        postgres_uuids = {person.uuid for person in persons}
+        for uuid, version in ch_persons_to_version.items():
+            if uuid not in postgres_uuids:
+                logger.info(f"Deleting person with uuid={uuid}")
+                if live_run:
+                    create_person(
+                        uuid=str(uuid),
+                        team_id=team_id,
+                        properties={},
+                        version=int(version or 0)
+                        + 100,  # keep in sync with deletePerson in plugin-server/src/utils/db/db.ts
+                        is_deleted=True,
+                    )
+
+
+def run_distinct_id_sync(team_id: int, live_run: bool, deletes: bool):
+    logger.info("Running person distinct id table sync")
+    # lookup what needs to be updated in ClickHouse and send kafka messages for only those
+    person_distinct_ids = PersonDistinctId.objects.filter(team_id=team_id)
+    rows = sync_execute(
+        """
+            SELECT distinct_id, max(version) FROM person_distinct_id2 WHERE team_id = %(team)s GROUP BY distinct_id HAVING max(is_deleted) = 0
+        """,
+        {
+            "team": team_id,
+        },
+    )
+    ch_distinct_id_to_version = {row[0]: row[1] for row in rows}
+
+    for pdid in person_distinct_ids:
+        ch_version = ch_distinct_id_to_version.get(pdid.distinct_id, None)
+        # logger.info(f"{pdid.distinct_id} - {pdid.version} -  {ch_version}")
+        if ch_version or 0 > pdid.version:
+            # This could be happening due to person deletions - check out fix_person_distinct_ids_after_delete management cmd.
+            # Ignoring here to be safe.
+            logger.info(
+                f"Clickhouse version ({ch_version}) for '{pdid.distinct_id}' is higher than in Postgres ({pdid.version}). Ignoring."
+            )
+            continue
+        if ch_version != pdid.version:
+            logger.info(f"Updating {pdid.distinct_id} to version {pdid.version}")
+            if live_run:
+                # Update ClickHouse via Kafka message
+                create_person_distinct_id(
+                    team_id=team_id,
+                    distinct_id=pdid.distinct_id,
+                    person_id=str(pdid.person.uuid),
+                    version=pdid.version,
+                    is_deleted=False,
+                )
+
+    if deletes:
+        for distinct_id, version in ch_distinct_id_to_version.items():
+            if distinct_id in person_distinct_ids:
+                logger.info(f"Deleting distinct ID {distinct_id}")
+                if live_run:
+                    _delete_ch_distinct_id(team_id, UUID(int=0), distinct_id, version)

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -84,7 +84,7 @@ def run_person_sync(team_id: int, live_run: bool, deletes: bool):
                 create_person(
                     team_id=team_id,
                     version=person.version,
-                    uuid=person.uuid,
+                    uuid=str(person.uuid),
                     properties=person.properties,  # TODO: check that the format is correct
                     is_identified=person.is_identified,
                     created_at=person.created_at,  # TODO: check formatting

--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -33,7 +33,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         self.assertEqual(ch_persons, [(person.uuid, self.team.pk, '{"a": 1234}', True, 0, False)])
 
     def test_persons_deleted(self):
-        uuid = create_person(uuid=str(uuid4()), team_id=self.team.pk, version=5, properties='{"abc":123}', sync=True)
+        uuid = create_person(uuid=str(uuid4()), team_id=self.team.pk, version=5, properties={"abc": 123}, sync=True)
 
         run_person_sync(self.team.pk, live_run=True, deletes=True, sync=True)
 

--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -1,0 +1,271 @@
+import logging
+from uuid import UUID, uuid4
+
+import pytest
+
+from posthog.client import sync_execute
+from posthog.management.commands.sync_persons_to_clickhouse import run, run_distinct_id_sync, run_person_sync
+from posthog.models.person.person import Person, PersonDistinctId
+from posthog.models.person.sql import PERSON_DISTINCT_ID2_TABLE
+from posthog.models.person.util import create_person, create_person_distinct_id
+from posthog.models.signals import mute_selected_signals
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+
+@pytest.mark.ee
+class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_persons_sync(self):
+        with mute_selected_signals():  # without creating/updating in clickhouse
+            person = Person.objects.create(
+                team_id=self.team.pk, properties={"a": 1234}, is_identified=True, version=0, uuid=uuid4()
+            )
+
+        run_person_sync(self.team.pk, live_run=True, deletes=False, sync=True)
+
+        ch_persons = sync_execute(
+            """
+            SELECT id, team_id, properties, is_identified, version, is_deleted FROM person WHERE team_id = %(team_id)s
+            """,
+            {"team_id": self.team.pk},
+        )
+        self.assertEqual(ch_persons, [(person.uuid, self.team.pk, '{"a": 1234}', True, 0, False)])
+
+    def test_persons_deleted(self):
+        uuid = create_person(uuid=str(uuid4()), team_id=self.team.pk, version=5, properties='{"abc":123}', sync=True)
+
+        run_person_sync(self.team.pk, live_run=True, deletes=True, sync=True)
+
+        ch_persons = sync_execute(
+            """
+            SELECT id, team_id, properties, is_identified, version, is_deleted FROM person FINAL WHERE team_id = %(team_id)s
+            """,
+            {"team_id": self.team.pk},
+        )
+        self.assertEqual(ch_persons, [(UUID(uuid), self.team.pk, "{}", False, 105, True)])
+
+    def test_distinct_ids_sync(self):
+        with mute_selected_signals():  # without creating/updating in clickhouse
+            person = Person.objects.create(team_id=self.team.pk, version=0, uuid=uuid4())
+            PersonDistinctId.objects.create(team=self.team, person=person, distinct_id="test-id", version=0)
+
+        run_distinct_id_sync(self.team.pk, live_run=True, deletes=False, sync=True)
+
+        ch_person_distinct_ids = sync_execute(
+            f"""
+            SELECT person_id, team_id, distinct_id, version, is_deleted FROM {PERSON_DISTINCT_ID2_TABLE} WHERE team_id = %(team_id)s
+            """,
+            {"team_id": self.team.pk},
+        )
+        self.assertEqual(ch_person_distinct_ids, [(person.uuid, self.team.pk, "test-id", 0, False)])
+
+    def test_distinct_ids_deleted(self):
+        uuid = uuid4()
+        create_person_distinct_id(
+            team_id=self.team.pk, distinct_id="test-id-7", person_id=str(uuid), is_deleted=False, version=7, sync=True
+        )
+        run_distinct_id_sync(self.team.pk, live_run=True, deletes=True, sync=True)
+
+        ch_person_distinct_ids = sync_execute(
+            f"""
+            SELECT person_id, team_id, distinct_id, version, is_deleted FROM {PERSON_DISTINCT_ID2_TABLE} FINAL WHERE team_id = %(team_id)s
+            """,
+            {"team_id": self.team.pk},
+        )
+        self.assertEqual(ch_person_distinct_ids, [(UUID(int=0), self.team.pk, "test-id-7", 107, True)])
+
+    def test_live_run_everything(self):
+        self.everything_test_run(True)
+
+    def test_dry_run_everything(self):
+        # verify we don't change anything
+        self.everything_test_run(False)
+
+    def everything_test_run(self, live_run):
+        # 2 persons who shouldn't be changed
+        person_not_changed_1 = Person.objects.create(
+            team_id=self.team.pk, properties={"abcdef": 1111}, version=0, uuid=uuid4()
+        )
+        person_not_changed_2 = Person.objects.create(
+            team_id=self.team.pk, properties={"abcdefg": 11112}, version=1, uuid=uuid4()
+        )
+
+        # 2 persons who should be created
+        with mute_selected_signals():  # without creating/updating in clickhouse
+            person_should_be_created_1 = Person.objects.create(
+                team_id=self.team.pk, properties={"abcde": 12553633}, version=2, uuid=uuid4()
+            )
+            person_should_be_created_2 = Person.objects.create(
+                team_id=self.team.pk, properties={"abcdeit34": 12553633}, version=3, uuid=uuid4()
+            )
+
+            # 2 persons who have updates
+            person_should_update_1 = Person.objects.create(
+                team_id=self.team.pk, properties={"abcde": 12553}, version=5, uuid=uuid4()
+            )
+            person_should_update_2 = Person.objects.create(
+                team_id=self.team.pk, properties={"abc": 125}, version=7, uuid=uuid4()
+            )
+        create_person(
+            uuid=str(person_should_update_1.uuid),
+            team_id=person_should_update_1.team.pk,
+            properties={"a": 13},
+            version=4,
+            sync=True,
+        )
+        create_person(
+            uuid=str(person_should_update_2.uuid),
+            team_id=person_should_update_2.team.pk,
+            properties={"a": 1},
+            version=6,
+            sync=True,
+        )
+
+        # 2 persons need to be deleted
+        deleted_person_1_uuid = create_person(
+            uuid=str(uuid4()), team_id=self.team.pk, version=7, properties={"abcd": 123}, sync=True
+        )
+        deleted_person_2_uuid = create_person(
+            uuid=str(uuid4()), team_id=self.team.pk, version=8, properties={"abcef": 123}, sync=True
+        )
+
+        # 2 distinct id no update
+        PersonDistinctId.objects.create(
+            team=self.team, person=person_not_changed_1, distinct_id="distinct_id", version=0
+        )
+        PersonDistinctId.objects.create(
+            team=self.team, person=person_not_changed_1, distinct_id="distinct_id-9", version=9
+        )
+
+        # # 2 distinct id to be created
+        with mute_selected_signals():  # without creating/updating in clickhouse
+            PersonDistinctId.objects.create(
+                team=self.team, person=person_not_changed_1, distinct_id="distinct_id-10", version=10
+            )
+            PersonDistinctId.objects.create(
+                team=self.team, person=person_not_changed_1, distinct_id="distinct_id-11", version=11
+            )
+
+            # 2 distinct id that need to update
+            PersonDistinctId.objects.create(
+                team=self.team, person=person_not_changed_2, distinct_id="distinct_id-12", version=13
+            )
+            PersonDistinctId.objects.create(
+                team=self.team, person=person_not_changed_2, distinct_id="distinct_id-14", version=15
+            )
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="distinct_id-12",
+            person_id=str(person_not_changed_1.uuid),
+            is_deleted=False,
+            version=12,
+            sync=True,
+        )
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="distinct_id-14",
+            person_id=str(person_not_changed_1.uuid),
+            is_deleted=False,
+            version=14,
+            sync=True,
+        )
+
+        # 2 distinct ids need to be deleted
+        deleted_distinct_id_1_uuid = uuid4()
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="distinct_id-17",
+            person_id=str(deleted_distinct_id_1_uuid),
+            is_deleted=False,
+            version=17,
+            sync=True,
+        )
+        deleted_distinct_id_2_uuid = uuid4()
+        create_person_distinct_id(
+            team_id=self.team.pk,
+            distinct_id="distinct_id-18",
+            person_id=str(deleted_distinct_id_2_uuid),
+            is_deleted=False,
+            version=18,
+            sync=True,
+        )
+
+        # Run the script for everything
+        options = {
+            "live_run": live_run,
+            "team_id": self.team.pk,
+            "person": True,
+            "person_distinct_id": True,
+            "deletes": True,
+        }
+        run(options, sync=True)
+
+        ch_persons = sync_execute(
+            """
+            SELECT id, team_id, properties, is_identified, version, is_deleted FROM person FINAL WHERE team_id = %(team_id)s ORDER BY version
+            """,
+            {"team_id": self.team.pk},
+        )
+        ch_person_distinct_ids = sync_execute(
+            f"""
+            SELECT person_id, team_id, distinct_id, version, is_deleted FROM {PERSON_DISTINCT_ID2_TABLE} FINAL WHERE team_id = %(team_id)s ORDER BY version
+            """,
+            {"team_id": self.team.pk},
+        )
+
+        if not live_run:
+            self.assertEqual(
+                ch_persons,
+                [
+                    (person_not_changed_1.uuid, self.team.pk, '{"abcdef": 1111}', False, 0, False),
+                    (person_not_changed_2.uuid, self.team.pk, '{"abcdefg": 11112}', False, 1, False),
+                    (person_should_update_1.uuid, self.team.pk, '{"a": 13}', False, 4, False),
+                    (person_should_update_2.uuid, self.team.pk, '{"a": 1}', False, 6, False),
+                    (UUID(deleted_person_1_uuid), self.team.pk, '{"abcd": 123}', False, 7, False),
+                    (UUID(deleted_person_2_uuid), self.team.pk, '{"abcef": 123}', False, 8, False),
+                ],
+            )
+            self.assertEqual(
+                ch_person_distinct_ids,
+                [
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id", 0, False),
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id-9", 9, False),
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id-12", 12, False),
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id-14", 14, False),
+                    (deleted_distinct_id_1_uuid, self.team.pk, "distinct_id-17", 17, False),
+                    (deleted_distinct_id_2_uuid, self.team.pk, "distinct_id-18", 18, False),
+                ],
+            )
+        else:
+            self.assertEqual(
+                ch_persons,
+                [
+                    (person_not_changed_1.uuid, self.team.pk, '{"abcdef": 1111}', False, 0, False),
+                    (person_not_changed_2.uuid, self.team.pk, '{"abcdefg": 11112}', False, 1, False),
+                    (person_should_be_created_1.uuid, self.team.pk, '{"abcde": 12553633}', False, 2, False),
+                    (person_should_be_created_2.uuid, self.team.pk, '{"abcdeit34": 12553633}', False, 3, False),
+                    (person_should_update_1.uuid, self.team.pk, '{"abcde": 12553}', False, 5, False),
+                    (person_should_update_2.uuid, self.team.pk, '{"abc": 125}', False, 7, False),
+                    (UUID(deleted_person_1_uuid), self.team.pk, "{}", False, 107, True),
+                    (UUID(deleted_person_2_uuid), self.team.pk, "{}", False, 108, True),
+                ],
+            )
+            self.assertEqual(
+                ch_person_distinct_ids,
+                [
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id", 0, False),
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id-9", 9, False),
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id-10", 10, False),
+                    (person_not_changed_1.uuid, self.team.pk, "distinct_id-11", 11, False),
+                    (person_not_changed_2.uuid, self.team.pk, "distinct_id-12", 13, False),
+                    (person_not_changed_2.uuid, self.team.pk, "distinct_id-14", 15, False),
+                    (UUID(int=0), self.team.pk, "distinct_id-17", 117, True),
+                    (UUID(int=0), self.team.pk, "distinct_id-18", 118, True),
+                ],
+            )
+
+
+@pytest.fixture(autouse=True)
+def set_log_level(caplog):
+    caplog.set_level(logging.INFO)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

For various reasons ClickHouse persons and distinct id tables can get out of sync from postgres, solving this problem is a much bigger undertaking. Meanwhile if that has happened we need an easy way to sync things up - that's the goal of this management command.

self-hosted customer problem example: https://posthog.slack.com/archives/C03G21222QY/p1669211215266339?thread_ts=1667573220.010609&cid=C03G21222QY

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Tested locally - running this and various combinations (had a person that needed updating and a person that needed deleting same for distinctIDs)
```
DEBUG=1 python manage.py sync_persons_to_clickhouse --team-id 2 --delete --live-run
```
