### PR TITLE
fix(invite-signup): Stop confusing password managers with masked emails

### DIFF
--- a/cypress/e2e/invites.js
+++ b/cypress/e2e/invites.js
@@ -47,7 +47,7 @@ describe('Invite Signup', () => {
         })
         cy.get('.error-view-container').should('not.exist')
         cy.get('.InviteSignupSummary span').should('contain', "You've been invited to join")
-        cy.get('input[type="email"]').should('have.value', `n**********${target_email[11]}@posthog.com`)
+        cy.get('input[type="email"]').should('have.value', target_email)
         cy.get('[data-attr="password"]').type('12345678')
         cy.get('.ant-progress-bg').should('not.have.css', 'width', '0px') // Password strength indicator is working
         cy.get('[data-attr="first_name"]').type('Bob')

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -20,7 +20,7 @@ from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.event_usage import alias_invite_id, report_user_joined_organization, report_user_signed_up
 from posthog.models import Organization, OrganizationDomain, OrganizationInvite, Team, User
 from posthog.permissions import CanCreateOrg
-from posthog.utils import get_can_create_org, mask_email_address
+from posthog.utils import get_can_create_org
 
 logger = structlog.get_logger(__name__)
 
@@ -244,7 +244,7 @@ class InviteSignupViewset(generics.CreateAPIView):
         return response.Response(
             {
                 "id": str(invite.id),
-                "target_email": mask_email_address(invite.target_email),
+                "target_email": invite.target_email,
                 "first_name": invite.first_name,
                 "organization_name": invite.organization.name,
             }

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -647,7 +647,7 @@ class TestInviteSignupAPI(APIBaseTest):
             response.json(),
             {
                 "id": str(invite.id),
-                "target_email": "t*****9@posthog.com",
+                "target_email": "test+19@posthog.com",
                 "first_name": "",
                 "organization_name": self.CONFIG_ORGANIZATION_NAME,
             },
@@ -664,7 +664,7 @@ class TestInviteSignupAPI(APIBaseTest):
             response.json(),
             {
                 "id": str(invite.id),
-                "target_email": "t*****8@posthog.com",
+                "target_email": "test+58@posthog.com",
                 "first_name": "Jane",
                 "organization_name": self.CONFIG_ORGANIZATION_NAME,
             },
@@ -684,7 +684,7 @@ class TestInviteSignupAPI(APIBaseTest):
             response.json(),
             {
                 "id": str(invite.id),
-                "target_email": "t*****9@posthog.com",
+                "target_email": "test+29@posthog.com",
                 "first_name": "",
                 "organization_name": "Test, Inc",
             },
@@ -719,8 +719,7 @@ class TestInviteSignupAPI(APIBaseTest):
             {
                 "type": "validation_error",
                 "code": "invalid_recipient",
-                "detail": "This invite is intended for another email address: t*****9@posthog.com."
-                " You tried to sign up with test+39@posthog.com.",
+                "detail": "This invite is intended for another email address.",
                 "attr": None,
             },
         )

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -26,7 +26,7 @@ from posthog.constants import MAX_SLUG_LENGTH, AvailableFeature
 from posthog.email import is_email_available
 from posthog.models.utils import LowercaseSlugField, UUIDModel, create_with_slug, sane_repr
 from posthog.redis import get_client
-from posthog.utils import absolute_uri, mask_email_address
+from posthog.utils import absolute_uri
 
 if TYPE_CHECKING:
     from posthog.models import Team, User
@@ -313,8 +313,7 @@ class OrganizationInvite(UUIDModel):
 
         if _email and _email != self.target_email:
             raise exceptions.ValidationError(
-                f"This invite is intended for another email address: {mask_email_address(self.target_email)}"
-                f". You tried to sign up with {_email}.",
+                "This invite is intended for another email address.",
                 code="invalid_recipient",
             )
 

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -22,7 +22,6 @@ from posthog.utils import (
     get_compare_period_dates,
     get_default_event_name,
     load_data_from_request,
-    mask_email_address,
     relative_date_parse,
     should_refresh,
 )
@@ -121,18 +120,6 @@ class TestFormatUrls(TestCase):
 
 
 class TestGeneralUtils(TestCase):
-    def test_mask_email_address(self):
-        self.assertEqual(mask_email_address("hey@posthog.com"), "h*y@posthog.com")
-        self.assertEqual(mask_email_address("richard@gmail.com"), "r*****d@gmail.com")
-        self.assertEqual(
-            mask_email_address("m@posthog.com"), "*@posthog.com"
-        )  # one letter emails are masked differently
-        self.assertEqual(mask_email_address("test+alias@posthog.com"), "t********s@posthog.com")
-
-        with self.assertRaises(ValueError) as e:
-            mask_email_address("not an email")
-        self.assertEqual(str(e.exception), "Please provide a valid email address.")
-
     def test_available_timezones(self):
         timezones = get_available_timezones_with_offsets()
         self.assertEqual(timezones.get("Europe/Moscow"), 3)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -910,23 +910,6 @@ def is_anonymous_id(distinct_id: str) -> bool:
     return bool(re.match(ANONYMOUS_REGEX, distinct_id))
 
 
-def mask_email_address(email_address: str) -> str:
-    """
-    Grabs an email address and returns it masked in a human-friendly way to protect PII.
-        Example: testemail@posthog.com -> t********l@posthog.com
-    """
-    index = email_address.find("@")
-
-    if index == -1:
-        raise ValueError("Please provide a valid email address.")
-
-    if index == 1:
-        # Username is one letter, mask it differently
-        return f"*{email_address[index:]}"
-
-    return f"{email_address[0]}{'*' * (index - 2)}{email_address[index-1:]}"
-
-
 def is_valid_regex(value: Any) -> bool:
     try:
         re.compile(value)


### PR DESCRIPTION
## Problem

Previously our invite page only showed invited emails in a masked form, e.g. `michael@posthog.com` would be `m*****l@posthog.com`. However, password managers have been taking those emails at face value and saving credentials with asterisks left in, which in turn has been confusing for users. This drawback seems to significantly outweigh the potential benefit of the full email not being shown if the invite link is shared with an unauthorized person.

## Changes

This removes email masking.