### PR TITLE
perf: Optimize deleting `CohortPeople`

### DIFF
--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -11,7 +11,7 @@ def delete_bulky_postgres_data(team_ids: List[int]):
     "Efficiently delete large tables for teams from postgres. Using normal CASCADE delete here can time out"
 
     _raw_delete(PersonDistinctId.objects.filter(team_id__in=team_ids))
-    _raw_delete(CohortPeople.objects.filter(person__team_id__in=team_ids))
+    _raw_delete(CohortPeople.objects.filter(cohort__team_id__in=team_ids))
     _raw_delete(Person.objects.filter(team_id__in=team_ids))
 
 


### PR DESCRIPTION
## Problem

Should resolve #12853, but we'll see.

## Changes

It seems that this generated query is too slow:
```SQL
DELETE FROM "posthog_cohortpeople" WHERE "posthog_cohortpeople"."id" IN (
     SELECT U0."id" FROM "posthog_cohortpeople" U0 INNER JOIN "posthog_person" U1
     ON (U0."person_id" = U1."id") WHERE U1."team_id" IN (%s)
)
```

I suspect the JOIN with `posthog_person` is the slow part, since the earlier JOIN-less `posthog_persondistinctid` DELETE query runs totally fine. Let's try joining with the much smaller `posthog_cohort` table then.