### PR TITLE
fix(recordings): fix infinite reloading recordings list page

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -259,8 +259,10 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         },
     })),
     subscriptions(({ actions }) => ({
-        staticRecordings: () => {
-            actions.getSessionRecordings({})
+        staticRecordings: (staticRecording, oldStaticRecording) => {
+            if (!equal(staticRecording, oldStaticRecording)) {
+                actions.getSessionRecordings({})
+            }
         },
     })),
     selectors({


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C049AAXETJA/p1669150740098959

## Changes

Fixes infinite recordings list bug

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

locally reproduced bug and this PR fixes it
