### PR TITLE
fix(recordings): remove save changes button from static playlist

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -137,17 +137,20 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
                                 </>
                             }
                         />
-                        <LemonDivider vertical />
-                        <>
-                            <LemonButton
-                                type="primary"
-                                disabled={!hasChanges}
-                                loading={hasChanges && playlistLoading}
-                                onClick={saveChanges}
-                            >
-                                Save changes
-                            </LemonButton>
-                        </>
+
+                        {!playlist.is_static && (
+                            <>
+                                <LemonDivider vertical />
+                                <LemonButton
+                                    type="primary"
+                                    disabled={!hasChanges}
+                                    loading={hasChanges && playlistLoading}
+                                    onClick={saveChanges}
+                                >
+                                    Save changes
+                                </LemonButton>
+                            </>
+                        )}
                     </div>
                 }
                 caption={


### PR DESCRIPTION
## Problem

Static playlists save changes button should be hidden.

## Changes

Hides save changes button on static playlists

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

