### PR TITLE
fix(recordings): disable save changes button if there are no changes

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -52,7 +52,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         filters: [
             null as RecordingFilters | null,
             {
-                loadPlaylistSuccess: (_, { playlist }) => playlist.filters || null,
+                setPlaylist: (_, { playlist }) => playlist?.filters || null,
                 setFilters: (_, { filters }) => filters,
             },
         ],


### PR DESCRIPTION
## Problem

There are bugs around saving playlists. If I go to an existing dynamic playlist and user the browser “back”, it asks me if I want to save. When I click “no”, I am back on the playlist list. Then I click to open another playlist and again it prompts me if I want to save this playlist (from the playlist list view), which doesn’t make sense

## Changes

Make sure local filters gets updated in logic.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Leaving recording prompt is no longer trigger happy