### PR TITLE
feat: prevent billing for events in demo projects

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -90,7 +90,9 @@ def get_cached_current_usage(organization: Organization) -> Dict[str, int]:
     # TODO BW: For self-hosted this should be priced across all orgs
 
     if usage is None:
-        teams = Team.objects.filter(organization=organization).exclude(organization__for_internal_metrics=True)
+        teams = Team.objects.filter(organization=organization, is_demo=False).exclude(
+            organization__for_internal_metrics=True
+        )
 
         usage = {
             "events": 0,

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -90,9 +90,7 @@ def get_cached_current_usage(organization: Organization) -> Dict[str, int]:
     # TODO BW: For self-hosted this should be priced across all orgs
 
     if usage is None:
-        teams = Team.objects.filter(organization=organization).exclude(
-            organization__for_internal_metrics=True, is_demo=True
-        )
+        teams = Team.objects.filter(organization=organization).exclude(organization__for_internal_metrics=True)
 
         usage = {
             "events": 0,
@@ -102,8 +100,9 @@ def get_cached_current_usage(organization: Organization) -> Dict[str, int]:
         (start_period, end_period) = get_this_month_date_range()
 
         for team in teams:
-            usage["recordings"] += get_recording_count_for_team_and_period(team.id, start_period, end_period)
-            usage["events"] += get_event_count_for_team_and_period(team.id, start_period, end_period)
+            if not team.is_demo:
+                usage["recordings"] += get_recording_count_for_team_and_period(team.id, start_period, end_period)
+                usage["events"] += get_event_count_for_team_and_period(team.id, start_period, end_period)
 
         cache.set(
             cache_key,

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -90,8 +90,8 @@ def get_cached_current_usage(organization: Organization) -> Dict[str, int]:
     # TODO BW: For self-hosted this should be priced across all orgs
 
     if usage is None:
-        teams = Team.objects.filter(organization=organization, is_demo=False).exclude(
-            organization__for_internal_metrics=True
+        teams = Team.objects.filter(organization=organization).exclude(
+            organization__for_internal_metrics=True, is_demo=True
         )
 
         usage = {

--- a/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
@@ -280,7 +280,7 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
             },
         ],
         generatingDemoData: [
-            false,
+            false as boolean | null,
             {
                 setState: (_, { generatingDemoData }) => generatingDemoData,
             },

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -19,7 +19,7 @@ import requests
 import structlog
 from django.conf import settings
 from django.db import connection
-from django.db.models import Count
+from django.db.models import Count, Q
 from posthoganalytics.client import Client
 from psycopg2 import sql
 from sentry_sdk import capture_exception
@@ -424,7 +424,9 @@ def send_all_org_usage_reports(
     )
 
     teams: Sequence[Team] = list(
-        Team.objects.select_related("organization").exclude(organization__for_internal_metrics=True)
+        Team.objects.select_related("organization").exclude(
+            Q(organization__for_internal_metrics=True) | Q(is_demo=True)
+        )
     )
 
     org_reports: Dict[str, OrgReport] = {}


### PR DESCRIPTION
## Problem

We're letting people create demo projects in their orgs, but we want to make sure these don't count against their e=plan limits.

## Changes

I found a function that seems to calculate the number of events for an org in a given time frame and I simply excluded demo teams from the calculation. On the `/organization/billing` page it only shows events for non-demo projects, as expected. However, this seemed a little too easy, so if there is anything I am missing please let me know 😄 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
