### PR TITLE
chore(dashboards): de-emphesize refresh button

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -100,12 +100,12 @@ function DashboardScene(): JSX.Element {
                 <EmptyDashboardComponent loading={itemsLoading} />
             ) : (
                 <div>
-                    {![
-                        DashboardPlacement.Public,
-                        DashboardPlacement.Export,
-                        DashboardPlacement.InternalMetrics,
-                    ].includes(placement) && (
-                        <>
+                    <div className="flex space-x-4 justify-between">
+                        {![
+                            DashboardPlacement.Public,
+                            DashboardPlacement.Export,
+                            DashboardPlacement.InternalMetrics,
+                        ].includes(placement) && (
                             <div className="flex space-x-4">
                                 <div className="flex items-center h-8">
                                     <DateFilter
@@ -128,23 +128,25 @@ function DashboardScene(): JSX.Element {
                                     propertyFilters={dashboard?.filters.properties}
                                 />
                             </div>
-                            <LemonDivider className="my-4" />
-                        </>
-                    )}
-                    {placement !== DashboardPlacement.Export && (
-                        <div className="flex pb-4 space-x-4 dashoard-items-actions">
-                            <div
-                                className="left-item"
-                                style={placement === DashboardPlacement.Public ? { textAlign: 'right' } : undefined}
-                            >
-                                {[DashboardPlacement.Public, DashboardPlacement.InternalMetrics].includes(placement) ? (
-                                    <LastRefreshText />
-                                ) : (
-                                    <DashboardReloadAction />
-                                )}
+                        )}
+                        {placement !== DashboardPlacement.Export && (
+                            <div className="flex space-x-4 dashoard-items-actions">
+                                <div
+                                    className="left-item"
+                                    style={placement === DashboardPlacement.Public ? { textAlign: 'right' } : undefined}
+                                >
+                                    {[DashboardPlacement.Public, DashboardPlacement.InternalMetrics].includes(
+                                        placement
+                                    ) ? (
+                                        <LastRefreshText />
+                                    ) : (
+                                        <DashboardReloadAction />
+                                    )}
+                                </div>
                             </div>
-                        </div>
-                    )}
+                        )}
+                    </div>
+                    {placement !== DashboardPlacement.Export && <LemonDivider className="my-4" />}
                     <DashboardItems />
                 </div>
             )}

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -13,7 +13,8 @@ export const LastRefreshText = (): JSX.Element => {
     const { lastRefreshed } = useValues(dashboardLogic)
     return (
         <span>
-            Last updated <b>{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</b>
+            Last updated{' '}
+            <span className="font-medium">{lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</span>
         </span>
     )
 }


### PR DESCRIPTION
Problem: The refresh button is very much emphesized right now, and refreshing is expensive

This change de-emphesizes refreshes by moving the button to the right and making the font stick out less.

## Screenshots

### Before - dashboard

![image](https://user-images.githubusercontent.com/148820/203522747-610a7cf6-3c84-4fd0-b82f-66ae1d7c01af.png)

### Before - shared dashboard
![image](https://user-images.githubusercontent.com/148820/203522789-d5352d4d-5c8c-438a-80e3-4b7dc380b37d.png)

### After - dashboard
![image](https://user-images.githubusercontent.com/148820/203522936-62bda8d1-a9ce-4a34-88d3-ee7f03a34ec9.png)

### After - shared dashboard

![image](https://user-images.githubusercontent.com/148820/203522989-3831d42b-5617-4af4-a768-389ce72a6b29.png)
