### PR TITLE
fix(demo): Reduce scope of transaction in `generate_demo_data`

### DIFF
--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, cast
 
 from django.conf import settings
 from django.core import exceptions
+from django.db import transaction
 
 from posthog.client import query_with_columns, sync_execute
 from posthog.demo.graphile_worker import (
@@ -75,11 +76,12 @@ class MatrixManager:
             organization_kwargs: Dict[str, Any] = {"name": organization_name}
             if settings.DEMO:
                 organization_kwargs["plugins_access_level"] = Organization.PluginsAccessLevel.INSTALL
-            organization = Organization.objects.create(**organization_kwargs)
-            new_user = User.objects.create_and_join(
-                organization, email, password, first_name, OrganizationMembership.Level.ADMIN, is_staff=is_staff
-            )
-            team = self.create_team(organization)
+            with transaction.atomic():
+                organization = Organization.objects.create(**organization_kwargs)
+                new_user = User.objects.create_and_join(
+                    organization, email, password, first_name, OrganizationMembership.Level.ADMIN, is_staff=is_staff
+                )
+                team = self.create_team(organization)
             if self.print_steps:
                 print(f"Saving simulated data...")
             self.run_on_team(team, new_user)

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -5,7 +5,6 @@ from time import monotonic
 
 from django.core import exceptions
 from django.core.management.base import BaseCommand
-from django.db import transaction
 
 from posthog.demo.matrix import Matrix, MatrixManager
 from posthog.demo.products.hedgebox import HedgeboxMatrix
@@ -64,24 +63,23 @@ class Command(BaseCommand):
             email = options["email"]
             password = options["password"]
             matrix_manager = MatrixManager(matrix, print_steps=True)
-            with transaction.atomic():
-                try:
-                    if options["reset_master"]:
-                        matrix_manager.reset_master()
-                    else:
-                        matrix_manager.ensure_account_and_save(
-                            email, "Employee 427", "Hedgebox Inc.", password=password, disallow_collision=True
-                        )
-                except exceptions.ValidationError as e:
-                    print(f"Error: {e}")
+            try:
+                if options["reset_master"]:
+                    matrix_manager.reset_master()
                 else:
-                    print(
-                        "Master project reset!"
-                        if options["reset_master"]
-                        else f"Demo data ready! Log in as {email} with password {password}.\n"
-                        "If running DEMO mode locally, log in instantly with this link:\n"
-                        f"http://localhost:8000/signup?email={email}"
+                    matrix_manager.ensure_account_and_save(
+                        email, "Employee 427", "Hedgebox Inc.", password=password, disallow_collision=True
                     )
+            except exceptions.ValidationError as e:
+                print(f"Error: {e}")
+            else:
+                print(
+                    "Master project reset!"
+                    if options["reset_master"]
+                    else f"Demo data ready! Log in as {email} with password {password}.\n"
+                    "If running DEMO mode locally, log in instantly with this link:\n"
+                    f"http://localhost:8000/signup?email={email}"
+                )
         else:
             print("Dry run - not saving results.")
 


### PR DESCRIPTION
## Changes

In the `generate_demo_data` we had this transaction with potential for being extremely long, which made it painful if anything failed when the command was running – all of the effort was wasted if at the end it turned out there's a Postgres integrity error.