### PR TITLE
fix: text card font size and preview pane

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -1,5 +1,4 @@
 import './TextCard.scss'
-import { Textfit } from 'react-textfit'
 import { ResizeHandle1D, ResizeHandle2D } from 'lib/components/Cards/handles'
 import clsx from 'clsx'
 import { DashboardTile, DashboardType } from '~/types'
@@ -10,7 +9,7 @@ import { urls } from 'scenes/urls'
 import ReactMarkdown from 'react-markdown'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { CardMeta, Resizeable } from 'lib/components/Cards/Card'
 
 interface TextCardProps extends React.HTMLAttributes<HTMLDivElement>, Resizeable {
@@ -31,16 +30,20 @@ interface TextCardBodyProps extends Pick<React.HTMLAttributes<HTMLDivElement>, '
     closeDetails?: () => void
 }
 
-export function TextCardBody({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
-    useEffect(() => {
-        window.dispatchEvent(new Event('resize'))
-    }, [style?.height])
-
+export function TextContent({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
     return (
-        <div className="TextCard-Body p-2 w-full overflow-y-auto" onClick={() => closeDetails?.()} style={style}>
-            <Textfit mode={'multi'} min={14} max={100}>
-                <ReactMarkdown>{text}</ReactMarkdown>
-            </Textfit>
+        // eslint-disable-next-line react/forbid-dom-props
+        <div className="p-2 w-full overflow-y-auto" onClick={() => closeDetails?.()} style={style}>
+            <ReactMarkdown>{text}</ReactMarkdown>
+        </div>
+    )
+}
+
+export function TextCardBody({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div className="TextCard-Body" onClick={() => closeDetails?.()} style={style}>
+            <TextContent text={text} />
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx'
 import TextareaAutosize from 'react-textarea-autosize'
 import { Tabs } from 'antd'
 import { IconMarkdown, IconTools } from 'lib/components/icons'
-import { TextCardBody } from 'lib/components/Cards/TextCard/TextCard'
+import { TextContent } from 'lib/components/Cards/TextCard/TextCard'
 import api from 'lib/api'
 import { lemonToast } from 'lib/components/lemonToast'
 import posthog from 'posthog-js'
@@ -75,6 +75,8 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
     const [filesToUpload, setFilesToUpload] = useState<File[]>([])
     const dropRef = createRef<HTMLDivElement>()
 
+    const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
     useEffect(() => {
         const uploadFiles = async (): Promise<void> => {
             if (filesToUpload.length === 0) {
@@ -105,7 +107,7 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
         <Tabs>
             <Tabs.TabPane tab="Write" key="write-card" destroyInactiveTabPane={true}>
                 <div ref={dropRef} className={clsx('LemonTextMarkdown flex flex-col p-2 space-y-1 rounded')}>
-                    <LemonTextArea {...editAreaProps} autoFocus value={value} onChange={onChange} />
+                    <LemonTextArea ref={textAreaRef} {...editAreaProps} autoFocus value={value} onChange={onChange} />
                     <div className="text-muted inline-flex items-center space-x-1">
                         <IconMarkdown className={'text-2xl'} />
                         <span>Markdown formatting support</span>
@@ -137,7 +139,7 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
                 </div>
             </Tabs.TabPane>
             <Tabs.TabPane tab="Preview" key={'preview-card'}>
-                <TextCardBody text={value} />
+                <TextContent text={value} />
             </Tabs.TabPane>
         </Tabs>
     )


### PR DESCRIPTION
## Problem

text card preview is broken

<img width="514" alt="Screenshot 2022-11-23 at 17 17 27" src="https://user-images.githubusercontent.com/984817/203609121-bd3f67b6-4bb5-4a2d-9fe7-b7c331158df3.png">

## Changes

* working preview

![2022-11-23 17 08 13](https://user-images.githubusercontent.com/984817/203608859-659599b2-9a37-4cd0-9bc5-272671469026.gif)


## How did you test this code?

👀
