### PR TITLE
fix(group-analytics): Allow accessing group page when group key has dot

### DIFF
--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -65,7 +65,8 @@ export const groupLogic = kea<groupLogicType>({
         ],
     },
     urlToAction: ({ actions }) => ({
-        '/groups/:groupTypeIndex/:groupKey': ({ groupTypeIndex, groupKey }) => {
+        '/groups/:groupTypeIndex/*': ({ groupTypeIndex, _: groupKey }) => {
+            console.log(groupTypeIndex, groupKey)
             if (groupTypeIndex && groupKey) {
                 actions.setGroup(+groupTypeIndex, decodeURIComponent(groupKey))
                 actions.loadGroup()

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -297,7 +297,7 @@ export const routes: Record<string, Scene> = {
     [urls.person('*', false)]: Scene.Person,
     [urls.persons()]: Scene.Persons,
     [urls.groups(':groupTypeIndex')]: Scene.Groups,
-    [urls.group(':groupTypeIndex', ':groupKey', false)]: Scene.Group,
+    [urls.group(':groupTypeIndex', '*', false)]: Scene.Group,
     [urls.cohort(':id')]: Scene.Cohort,
     [urls.cohorts()]: Scene.Cohorts,
     [urls.experiments()]: Scene.Experiments,


### PR DESCRIPTION
## Problem

It wasn't possible to open group pages for groups whose key contains a dot (`.`). [Users Slack thread.](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1669167158057309)

## Changes

Turns out the issue resides in `kea-router`. However, in this case there's no need to go deep into that library, and this fix should work around the problem perfectly.