### PR TITLE
fix(property-filters): Fix operators for groups

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -12,10 +12,7 @@ import {
     TaxonomicFilterGroupType,
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
-import {
-    isPropertyFilterWithOperator,
-    propertyFilterTypeToTaxonomicFilterType,
-} from 'lib/components/PropertyFilters/utils'
+import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
 import { PropertyFilterInternalProps } from 'lib/components/PropertyFilters/types'
 import clsx from 'clsx'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -169,7 +166,7 @@ export function TaxonomicPropertyFilter({
                                 propertyDefinitions={propertyDefinitions}
                                 type={filter?.type}
                                 propkey={filter?.key}
-                                operator={isPropertyFilterWithOperator(filter) ? filter.operator : null}
+                                operator={filter?.operator}
                                 value={filter?.value}
                                 placeholder="Enter value..."
                                 endpoint={filter?.key && activeTaxonomicGroup?.valuesEndpoint?.(filter.key)}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -166,7 +166,7 @@ export function TaxonomicPropertyFilter({
                                 propertyDefinitions={propertyDefinitions}
                                 type={filter?.type}
                                 propkey={filter?.key}
-                                operator={filter?.operator}
+                                operator={filter?.operator as any}
                                 value={filter?.value}
                                 placeholder="Enter value..."
                                 endpoint={filter?.key && activeTaxonomicGroup?.valuesEndpoint?.(filter.key)}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -46,7 +46,6 @@ import { FeatureFlagRecordings } from './FeatureFlagRecordingsCard'
 import { billingLogic } from 'scenes/billing/billingLogic'
 import { LemonSelect } from '@posthog/lemon-ui'
 import { EventsTable } from 'scenes/events'
-import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
@@ -819,7 +818,7 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                                 <span className="simple-tag tag-light-blue text-primary-alt">
                                                     {property.type === 'cohort' ? 'Cohort' : property.key}{' '}
                                                 </span>
-                                                {isPropertyFilterWithOperator(property) ? (
+                                                {property.operator ? (
                                                     <span>{allOperatorsToHumanName(property.operator)} </span>
                                                 ) : null}
                                                 {[

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -818,7 +818,7 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                                 <span className="simple-tag tag-light-blue text-primary-alt">
                                                     {property.type === 'cohort' ? 'Cohort' : property.key}{' '}
                                                 </span>
-                                                {property.operator ? (
+                                                {(property?.operator as any) ? (
                                                     <span>{allOperatorsToHumanName(property.operator)} </span>
                                                 ) : null}
                                                 {[


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/12827 caused filters for any group property to always be displayed as "equals", causing confusion.

## Changes

I don't fully understand when `isPropertyFilterWithOperator` shouldn't be true, but given the fact that we didn't have this until that PR probably means we can revert this for now until Marius comes back

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
