### PR TITLE
fix(insights): group property filters with operators

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -13,6 +13,7 @@ import {
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 import {
+    isGroupPropertyFilter,
     isPropertyFilterWithOperator,
     propertyFilterTypeToTaxonomicFilterType,
 } from 'lib/components/PropertyFilters/utils'
@@ -79,7 +80,10 @@ export function TaxonomicPropertyFilter({
 
     const taxonomicFilter = (
         <TaxonomicFilter
-            groupType={propertyFilterTypeToTaxonomicFilterType(filter?.type, filter?.group_type_index)}
+            groupType={propertyFilterTypeToTaxonomicFilterType(
+                filter?.type,
+                isGroupPropertyFilter(filter) ? filter.group_type_index : undefined
+            )}
             value={cohortOrOtherValue}
             onChange={taxonomicOnChange}
             taxonomicGroupTypes={groupTypes}
@@ -180,7 +184,9 @@ export function TaxonomicPropertyFilter({
                                             value: newValue || null,
                                             operator: newOperator,
                                             type: filter?.type,
-                                            group_type_index: filter?.group_type_index,
+                                            ...(isGroupPropertyFilter(filter)
+                                                ? { group_type_index: filter.group_type_index }
+                                                : {}),
                                         } as AnyPropertyFilter)
                                     }
                                     if (

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -5,6 +5,7 @@ import type { taxonomicPropertyFilterLogicType } from './taxonomicPropertyFilter
 import { cohortsModel } from '~/models/cohortsModel'
 import { TaxonomicFilterGroup, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import {
+    isGroupPropertyFilter,
     isPropertyFilterWithOperator,
     propertyFilterTypeToTaxonomicFilterType,
     taxonomicFilterTypeToPropertyFilterType,
@@ -64,7 +65,7 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
         activeTaxonomicGroup: [
             (s) => [s.filter, s.taxonomicGroups],
             (filter, groups): TaxonomicFilterGroup | undefined => {
-                if (filter) {
+                if (isGroupPropertyFilter(filter)) {
                     const taxonomicGroupType = propertyFilterTypeToTaxonomicFilterType(
                         filter.type,
                         filter.group_type_index

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -5,7 +5,9 @@ import {
     ElementPropertyFilter,
     EventDefinition,
     EventPropertyFilter,
+    FeaturePropertyFilter,
     FilterLogicalOperator,
+    GroupPropertyFilter,
     PersonPropertyFilter,
     PropertyFilter,
     PropertyFilterType,
@@ -71,6 +73,12 @@ export function isSessionPropertyFilter(filter?: AnyFilterLike | null): filter i
 export function isRecordingDurationFilter(filter?: AnyFilterLike | null): filter is RecordingDurationFilter {
     return filter?.type === PropertyFilterType.Recording
 }
+export function isGroupPropertyFilter(filter?: AnyFilterLike | null): filter is GroupPropertyFilter {
+    return filter?.type === PropertyFilterType.Group
+}
+export function isFeaturePropertyFilter(filter?: AnyFilterLike | null): filter is FeaturePropertyFilter {
+    return filter?.type === PropertyFilterType.Feature
+}
 
 export function isAnyPropertyfilter(filter?: AnyFilterLike | null): filter is AnyPropertyFilter {
     return (
@@ -79,7 +87,9 @@ export function isAnyPropertyfilter(filter?: AnyFilterLike | null): filter is An
         isElementPropertyFilter(filter) ||
         isSessionPropertyFilter(filter) ||
         isCohortPropertyFilter(filter) ||
-        isRecordingDurationFilter(filter)
+        isRecordingDurationFilter(filter) ||
+        isFeaturePropertyFilter(filter) ||
+        isGroupPropertyFilter(filter)
     )
 }
 
@@ -90,14 +100,18 @@ export function isPropertyFilterWithOperator(
     | PersonPropertyFilter
     | ElementPropertyFilter
     | SessionPropertyFilter
-    | RecordingDurationFilter {
+    | RecordingDurationFilter
+    | FeaturePropertyFilter
+    | GroupPropertyFilter {
     return (
         !isPropertyGroupFilterLike(filter) &&
         (isEventPropertyFilter(filter) ||
             isPersonPropertyFilter(filter) ||
             isElementPropertyFilter(filter) ||
             isSessionPropertyFilter(filter) ||
-            isRecordingDurationFilter(filter))
+            isRecordingDurationFilter(filter) ||
+            isFeaturePropertyFilter(filter) ||
+            isGroupPropertyFilter(filter))
     )
 }
 
@@ -132,7 +146,7 @@ export function propertyFilterTypeToTaxonomicFilterType(
     if (!filterType) {
         return undefined
     }
-    if (filterType == 'group') {
+    if (filterType === 'group') {
         return `${TaxonomicFilterGroupType.GroupsPrefix}_${groupTypeIndex}` as TaxonomicFilterGroupType
     }
     return propertyFilterMapping[filterType]

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -43,6 +43,7 @@ import {
     isStickinessFilter,
     isTrendsFilter,
 } from 'scenes/insights/sharedUtils'
+import { isGroupPropertyFilter } from 'lib/components/PropertyFilters/utils'
 export enum DashboardEventSource {
     LongPress = 'long_press',
     MoreDropdown = 'more_dropdown',
@@ -115,7 +116,12 @@ function flattenProperties(properties: AnyPropertyFilter[]): string[] {
 
 function hasGroupProperties(properties: AnyPropertyFilter[] | PropertyGroupFilter | undefined): boolean {
     const flattenedProperties = convertPropertyGroupToProperties(properties)
-    return !!flattenedProperties && flattenedProperties.some((property) => property.group_type_index != undefined)
+    return (
+        !!flattenedProperties &&
+        flattenedProperties.some(
+            (property) => isGroupPropertyFilter(property) && property.group_type_index !== undefined
+        )
+    )
 }
 
 function usedCohortFilterIds(properties: AnyPropertyFilter[] | PropertyGroupFilter | undefined): PropertyFilterValue[] {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -414,7 +414,6 @@ interface BasePropertyFilter {
     value: PropertyFilterValue
     label?: string
     type?: PropertyFilterType
-    group_type_index?: number | null
 }
 
 /** Sync with plugin-server/src/types.ts */
@@ -449,6 +448,17 @@ export interface CohortPropertyFilter extends BasePropertyFilter {
     value: number
 }
 
+export interface GroupPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.Group
+    group_type_index?: number | null
+    operator: PropertyOperator
+}
+
+export interface FeaturePropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.Feature
+    operator: PropertyOperator
+}
+
 export type PropertyFilter =
     | EventPropertyFilter
     | PersonPropertyFilter
@@ -456,6 +466,8 @@ export type PropertyFilter =
     | SessionPropertyFilter
     | CohortPropertyFilter
     | RecordingDurationFilter
+    | GroupPropertyFilter
+    | FeaturePropertyFilter
 
 export type AnyPropertyFilter =
     | Partial<EventPropertyFilter>
@@ -464,6 +476,8 @@ export type AnyPropertyFilter =
     | Partial<SessionPropertyFilter>
     | Partial<CohortPropertyFilter>
     | Partial<RecordingDurationFilter>
+    | Partial<GroupPropertyFilter>
+    | Partial<FeaturePropertyFilter>
 
 export type AnyFilterLike = AnyPropertyFilter | PropertyGroupFilter | PropertyGroupFilterValue
 


### PR DESCRIPTION
## Problem

Alternative approach to https://github.com/PostHog/posthog/pull/12937

## Changes

Group property filters again support operators.

## How did you test this code?

Tested locally. In master, changing a group filter to "not equals" didn't have any effect (save -> reload -> it's gone). Now it does.