### PR TITLE
chore: track running celery tasks tagged by name

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -182,19 +182,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
 # Set up clickhouse query instrumentation
 @task_prerun.connect
 def pre_run_signal_handler(task_id, task, **kwargs):
-    track_task_prerun(task)
-    set_up_instrumentation(task)
-
-
-def track_task_prerun(task):
     from statshog.defaults.django import statsd
 
-    statsd.incr("celery_tasks_metrics.pre_run", tags={"name": task.name})
-
-
-def set_up_instrumentation(task):
     from posthog.clickhouse.query_tagging import tag_queries
 
+    statsd.incr("celery_tasks_metrics.pre_run", tags={"name": task.name})
     tag_queries(kind="celery", id=task.name)
 
 


### PR DESCRIPTION
## Problem

see: #12929 

we can track celery tasks in statsd but we aren't tagging them by name so we don't know what tasks are running when tasks are running

## Changes

adds a statsd counter that is tagged by task name

## How did you test this code?

running it locally and seeing breakpoints hit while celery runs