### PR TITLE
fix(group-analytics): Allow accessing group page when group key has dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "kea-forms": "^3.0.3",
         "kea-loaders": "^3.0.0",
         "kea-localstorage": "^3.0.0",
-        "kea-router": "^3.1.1",
+        "kea-router": "^3.1.3",
         "kea-subscriptions": "^3.0.0",
         "kea-waitfor": "^0.2.1",
         "kea-window-values": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13324,10 +13324,10 @@ kea-localstorage@^3.0.0:
   resolved "https://registry.yarnpkg.com/kea-localstorage/-/kea-localstorage-3.0.0.tgz#eae89f0ff4f90006efecee02ac2ef19224193091"
   integrity sha512-5g/7Sb5HjXLVTTYB9aUgizISUmnQZHqFm7ab+K3sLLh6gp3UEaKJMs5yq2rFPAfr7QR8OpMkfhKA0Ykg5UaOMQ==
 
-kea-router@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/kea-router/-/kea-router-3.1.1.tgz#ae9825f28699450ab2f0f79478b304daa721ba80"
-  integrity sha512-k0h3x1rlTS4g5V8LhOToASW3UCjlrJ/9IFzVXMAHZdvR/Ou5Z51QmWEOCZDlZCJoVsHlX+OJwZxT/6uK3FCKHQ==
+kea-router@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/kea-router/-/kea-router-3.1.3.tgz#a5779e36cbd3ae0400474d23de898a7fd0fd2f35"
+  integrity sha512-+Pk+RZ4PzEXskL3D3903M33Mt94vqJlHb0LCBRn7lFTg0age/53n8CkMvB6QT9SgvtDXqiWgViCWdtaACDQY7A==
   dependencies:
     url-pattern "^1.0.3"
 


### PR DESCRIPTION
## Problem

It wasn't possible to open group pages for groups whose key contains a dot (`.`). [Users Slack thread.](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1669167158057309)

## Changes

This is like #12934, except better, because now the problem is fixed at the root.