### PR TITLE
fix(time-to-see-data): Remove tagging from sync_execute

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -171,7 +171,7 @@ def sync_execute(
             execution_time = perf_counter() - start_time
 
             QUERY_TIMEOUT_THREAD.cancel(timeout_task)
-            timing("clickhouse_sync_execution_time", execution_time * 1000.0, tags=tags)
+            timing("clickhouse_sync_execution_time", execution_time * 1000.0)
 
             if app_settings.SHELL_PLUS_PRINT_SQL:
                 print("Execution time: %.6fs" % (execution_time,))


### PR DESCRIPTION
Accidentally forgot to remove this in https://github.com/PostHog/posthog/pull/12911