### PR TITLE
chore(funnels): Fix funnel tooltip style

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarChart.scss
+++ b/frontend/src/scenes/funnels/FunnelBarChart.scss
@@ -112,6 +112,9 @@
     width: 100%;
     border-radius: var(--radius);
     cursor: pointer;
+    .InsightCard & {
+        cursor: default;
+    }
 }
 
 .StepBar__backdrop {

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -17,7 +17,7 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 
 /** The tooltip is offset horizontally by a few pixels from the bar to give it some breathing room. */
-const FUNNEL_TOOLTIP_OFFSET_PX = 2
+const FUNNEL_TOOLTIP_OFFSET_PX = 4
 
 interface FunnelTooltipProps {
     showPersonsModal: boolean
@@ -37,7 +37,7 @@ function FunnelTooltip({
     const { cohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
     return (
-        <div className="FunnelTooltip InsightTooltip mx-2 mt-1 mb-2 p-2">
+        <div className="FunnelTooltip InsightTooltip p-2">
             <LemonRow icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />} fullWidth>
                 <strong>
                     <EntityFilterInfo


### PR DESCRIPTION
## Problem

Two things were annoying me around the funnel tooltip:
1. It was offset too much from the bar due to some margin added at some point.
2. The bars had cursor pointer on dashboards, which was misleadingly suggesting that they were interactive.

<img width="497" alt="before" src="https://user-images.githubusercontent.com/4550621/203824417-8705304d-df3b-407f-a6f6-116be3abc877.png">

## Changes

Fixed the above:

<img width="486" alt="after" src="https://user-images.githubusercontent.com/4550621/203824412-4f4aa2ab-072a-4092-ae53-531bb895db17.png">
