### PR TITLE
fix(area-graph): display regular series color when compare flag is set (fixed #12947)

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -271,7 +271,7 @@ export function LineGraph_({
     function processDataset(dataset: ChartDataset<any>): ChartDataset<any> {
         const mainColor = dataset?.status
             ? getBarColorFromStatus(dataset.status)
-            : getSeriesColor(dataset.id, isCompare)
+            : getSeriesColor(dataset.id, isCompare && !isArea)
         const hoverColor = dataset?.status ? getBarColorFromStatus(dataset.status, true) : mainColor
         const areaBackgroundColor = hexToRGBA(mainColor, 0.5)
         const areaIncompletePattern = createPinstripePattern(areaBackgroundColor)


### PR DESCRIPTION
## Problem

This fixes https://github.com/PostHog/posthog/issues/12947.

## Changes

- Respecting the `isArea` flag when getting chart colors.

## How did you test this code?

Manual testing - see issue description.