### PR TITLE
feat(lemon-ui): Support multiple digits in `LemonBadge`

### DIFF
--- a/frontend/src/lib/components/LemonBadge/LemonBadge.scss
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.scss
@@ -1,23 +1,22 @@
 .LemonBadge {
-    --lemon-counter-size: 1.25rem;
-    --lemon-counter-font-size: 0.75rem;
-    --scale-small: 0.8;
-    --scale-large: 1.2;
-    --position-offset: 0.5rem;
+    --lemon-badge-size: 1.5rem;
+    --lemon-badge-font-size: 0.75rem;
+    --lemon-badge-position-offset: 0.5rem;
 
     flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     color: var(--white);
-    border: 2px solid var(--bg-light);
-    width: var(--lemon-counter-size);
-    height: var(--lemon-counter-size);
-    font-size: var(--lemon-counter-font-size);
-    line-height: var(--lemon-counter-size);
-    padding: 0;
-    border-radius: 100%;
-    box-sizing: content-box;
+    border: 0.125rem solid var(--bg-light);
+    min-width: var(--lemon-badge-size); // This is a minimum to accomodate multiple digits
+    height: var(--lemon-badge-size);
+    font-size: var(--lemon-badge-font-size);
+    line-height: var(--lemon-badge-size);
+    padding: calc(
+        var(--lemon-badge-size) / 8
+    ); // Just enough so the overall size is unaffected with a single digit (i.e. badge stays round)
+    border-radius: calc(var(--lemon-badge-size) / 2);
     user-select: none;
     pointer-events: none;
     position: absolute;
@@ -41,44 +40,33 @@
     }
 
     &.LemonBadge--position-top-left {
-        top: calc(var(--position-offset) * -1);
-        left: calc(var(--position-offset) * -1);
+        top: calc(var(--lemon-badge-position-offset) * -1);
+        left: calc(var(--lemon-badge-position-offset) * -1);
     }
 
     &.LemonBadge--position-top-right {
-        top: calc(var(--position-offset) * -1);
-        right: calc(var(--position-offset) * -1);
+        top: calc(var(--lemon-badge-position-offset) * -1);
+        right: calc(var(--lemon-badge-position-offset) * -1);
     }
 
     &.LemonBadge--position-bottom-left {
-        bottom: calc(var(--position-offset) * -1);
-        left: calc(var(--position-offset) * -1);
+        bottom: calc(var(--lemon-badge-position-offset) * -1);
+        left: calc(var(--lemon-badge-position-offset) * -1);
     }
 
     &.LemonBadge--position-bottom-right {
-        bottom: calc(var(--position-offset) * -1);
-        right: calc(var(--position-offset) * -1);
+        bottom: calc(var(--lemon-badge-position-offset) * -1);
+        right: calc(var(--lemon-badge-position-offset) * -1);
     }
 
     &.LemonBadge--small {
-        width: calc(var(--lemon-counter-size) * var(--scale-small));
-        height: calc(var(--lemon-counter-size) * var(--scale-small));
-        font-size: calc(var(--lemon-counter-font-size) * var(--scale-small));
-        line-height: calc(var(--lemon-counter-size) * var(--scale-small));
+        --lemon-badge-size: 1.25rem;
+        --lemon-badge-font-size: 0.625rem;
     }
 
     &.LemonBadge--large {
-        width: calc(var(--lemon-counter-size) * var(--scale-large));
-        height: calc(var(--lemon-counter-size) * var(--scale-large));
-        font-size: calc(var(--lemon-counter-font-size) * var(--scale-large));
-        line-height: calc(var(--lemon-counter-size) * var(--scale-large));
-    }
-
-    &.LemonBadge--large {
-        width: calc(var(--lemon-counter-size) * var(--scale-large));
-        height: calc(var(--lemon-counter-size) * var(--scale-large));
-        font-size: calc(var(--lemon-counter-font-size) * var(--scale-large));
-        line-height: calc(var(--lemon-counter-size) * var(--scale-large));
+        --lemon-badge-size: 1.75rem;
+        --lemon-badge-font-size: 0.875rem;
     }
 
     &.LemonBadge--enter {

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
@@ -16,11 +16,12 @@ const Template: ComponentStory<typeof LemonBadge> = ({ count, ...props }: LemonB
 
     return (
         <>
-            <div className="flex space-x-4">
-                Count: <LemonBadge count={countOverride} {...props} />
+            <div className="flex items-center min-h-6">
+                <div>Count: </div>
+                <LemonBadge count={countOverride} {...props} />
             </div>
             <br />
-            <div className="flex space-x-4">
+            <div className="flex space-x-1">
                 <LemonButton type="primary" onClick={() => setCount((countOverride || 0) + 1)}>
                     Increment
                 </LemonButton>
@@ -35,8 +36,8 @@ const Template: ComponentStory<typeof LemonBadge> = ({ count, ...props }: LemonB
 export const Standard = Template.bind({})
 Standard.args = { count: 1 }
 
-export const OverNine = Template.bind({})
-OverNine.args = { count: 10 }
+export const MultipleDigits = Template.bind({})
+MultipleDigits.args = { count: 975, maxDigits: 3 }
 
 export const ShowZero = Template.bind({})
 ShowZero.args = { count: 0, showZero: true }

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
@@ -6,8 +6,9 @@ export interface LemonBadgeProps {
     count?: number | JSX.Element
     size?: 'small' | 'medium' | 'large'
     position?: 'none' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+    /** Maximum number of digits shown. Default: 1. */
+    maxDigits?: number
     showZero?: boolean
-    borderless?: boolean
     className?: string
     status?: 'primary' | 'danger' | 'muted'
     style?: React.CSSProperties
@@ -23,6 +24,7 @@ export function LemonBadge({
     count,
     size = 'medium',
     position = 'none',
+    maxDigits = 1,
     showZero = false,
     className,
     status = 'primary',
@@ -33,9 +35,9 @@ export function LemonBadge({
         typeof count === 'object'
             ? count
             : typeof count === 'number' && count !== 0
-            ? count < 10
+            ? count < Math.pow(10, maxDigits)
                 ? String(count)
-                : '9+'
+                : `${'9'.repeat(maxDigits)}+`
             : showZero
             ? '0'
             : '1'


### PR DESCRIPTION
## Changes

Adds support for showing multiple digits at a time to `LemonBadge`. This is needed for #12773.

<img width="246" alt="Screenshot 2022-11-24 at 16 54 50" src="https://user-images.githubusercontent.com/4550621/203835364-d17f2478-1176-4459-9def-0e1e47c13c2e.png">