### PR TITLE
feat(data-exploration): add trends insight query

### DIFF
--- a/frontend/src/queries/Query/Query.stories.tsx
+++ b/frontend/src/queries/Query/Query.stories.tsx
@@ -37,3 +37,6 @@ EventsTable.args = { query: examples['EventsTable'] }
 
 export const LegacyTrendsQuery = BasicTemplate.bind({})
 LegacyTrendsQuery.args = { query: examples['LegacyTrendsQuery'] }
+
+export const InsightTrendsQuery = BasicTemplate.bind({})
+InsightTrendsQuery.args = { query: examples['InsightTrendsQuery'] }

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -1,6 +1,6 @@
 import { isDataNode, isDataTableNode, isLegacyQuery, isTrendsQuery } from '../utils'
 import { LegacyInsightQuery } from '~/queries/nodes/LegacyInsightQuery/LegacyInsightQuery'
-import { TrendsQuery } from '~/queries/nodes/TrendsQuery/TrendsQuery'
+import { TrendsInsightQuery } from '~/queries/nodes/TrendsInsightQuery/TrendsInsightQuery'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { DataNode } from '~/queries/nodes/DataNode/DataNode'
 import { Node } from '~/queries/schema'
@@ -28,7 +28,7 @@ export function Query(props: QueryProps): JSX.Element {
     } else if (isDataNode(query)) {
         component = <DataNode query={query} />
     } else if (isTrendsQuery(query)) {
-        component = <TrendsQuery query={query} />
+        component = <TrendsInsightQuery query={query} />
     }
 
     if (component) {

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -1,5 +1,6 @@
-import { isDataNode, isDataTableNode, isLegacyQuery } from '../utils'
+import { isDataNode, isDataTableNode, isLegacyQuery, isTrendsQuery } from '../utils'
 import { LegacyInsightQuery } from '~/queries/nodes/LegacyInsightQuery/LegacyInsightQuery'
+import { TrendsQuery } from '~/queries/nodes/TrendsQuery/TrendsQuery'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { DataNode } from '~/queries/nodes/DataNode/DataNode'
 import { Node } from '~/queries/schema'
@@ -26,6 +27,8 @@ export function Query(props: QueryProps): JSX.Element {
         component = <DataTable query={query} setQuery={setQuery} />
     } else if (isDataNode(query)) {
         component = <DataNode query={query} />
+    } else if (isTrendsQuery(query)) {
+        component = <TrendsQuery query={query} />
     }
 
     if (component) {

--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -1,6 +1,6 @@
 // This file contains example queries, used in storybook and in the /query interface.
 import { EventsNode, DataTableNode, LegacyQuery, Node, NodeKind, TrendsQuery } from '~/queries/schema'
-import { ChartDisplayType, InsightType, PropertyFilterType, PropertyOperator } from '~/types'
+import { ChartDisplayType, InsightType, PropertyFilterType, PropertyOperator, PropertyMathType } from '~/types'
 import { defaultDataTableStringColumns } from '~/queries/nodes/DataTable/DataTable'
 
 const Events: EventsNode = {
@@ -30,6 +30,49 @@ const LegacyTrendsQuery: LegacyQuery = {
 
 const TrendsQuery: TrendsQuery = {
     kind: NodeKind.TrendsQuery,
+    interval: 'day',
+    dateRange: {
+        date_from: '-7d',
+    },
+    series: [
+        {
+            kind: NodeKind.EventsNode,
+            name: '$pageview',
+            custom_name: 'Views',
+            event: '$pageview',
+            properties: [
+                {
+                    type: PropertyFilterType.Event,
+                    key: '$browser',
+                    operator: PropertyOperator.Exact,
+                    value: 'Chrome',
+                },
+                {
+                    type: PropertyFilterType.Cohort,
+                    key: 'id',
+                    value: 2,
+                },
+            ],
+            limit: 100, // TODO - can't find a use for `limits` in insights/trends
+        },
+        {
+            kind: NodeKind.ActionsNode,
+            id: 1,
+            name: 'Interacted with file',
+            custom_name: 'Interactions',
+            properties: [
+                {
+                    type: PropertyFilterType.Event,
+                    key: '$geoip_country_code',
+                    operator: PropertyOperator.Exact,
+                    value: ['US'],
+                },
+            ],
+            math: PropertyMathType.Average,
+            math_property: '$session_duration',
+        },
+    ],
+    filterTestAccounts: false,
 }
 
 export const examples: Record<string, Node> = {

--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -35,7 +35,7 @@ const LegacyTrendsQuery: LegacyQuery = {
     },
 }
 
-const TrendsQuery: TrendsQuery = {
+const InsightTrendsQuery: TrendsQuery = {
     kind: NodeKind.TrendsQuery,
     interval: 'day',
     dateRange: {
@@ -115,7 +115,7 @@ export const examples: Record<string, Node> = {
     Events,
     EventsTable,
     LegacyTrendsQuery,
-    TrendsQuery,
+    InsightTrendsQuery,
 }
 
 export const stringifiedExamples: Record<string, string> = Object.fromEntries(

--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -1,6 +1,13 @@
 // This file contains example queries, used in storybook and in the /query interface.
 import { EventsNode, DataTableNode, LegacyQuery, Node, NodeKind, TrendsQuery } from '~/queries/schema'
-import { ChartDisplayType, InsightType, PropertyFilterType, PropertyOperator, PropertyMathType } from '~/types'
+import {
+    ChartDisplayType,
+    InsightType,
+    PropertyFilterType,
+    PropertyOperator,
+    PropertyMathType,
+    FilterLogicalOperator,
+} from '~/types'
 import { defaultDataTableStringColumns } from '~/queries/nodes/DataTable/DataTable'
 
 const Events: EventsNode = {
@@ -73,6 +80,28 @@ const TrendsQuery: TrendsQuery = {
         },
     ],
     filterTestAccounts: false,
+    properties: {
+        type: FilterLogicalOperator.And,
+        values: [
+            {
+                type: FilterLogicalOperator.Or,
+                values: [
+                    {
+                        type: PropertyFilterType.Event,
+                        key: '$current_url',
+                        operator: PropertyOperator.Exact,
+                        value: ['https://hedgebox.net/files/'],
+                    },
+                    {
+                        type: PropertyFilterType.Event,
+                        key: '$geoip_country_code',
+                        operator: PropertyOperator.Exact,
+                        value: ['US', 'AU'],
+                    },
+                ],
+            },
+        ],
+    },
 }
 
 export const examples: Record<string, Node> = {

--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -1,5 +1,5 @@
 // This file contains example queries, used in storybook and in the /query interface.
-import { EventsNode, DataTableNode, LegacyQuery, Node, NodeKind } from '~/queries/schema'
+import { EventsNode, DataTableNode, LegacyQuery, Node, NodeKind, TrendsQuery } from '~/queries/schema'
 import { ChartDisplayType, InsightType, PropertyFilterType, PropertyOperator } from '~/types'
 import { defaultDataTableStringColumns } from '~/queries/nodes/DataTable/DataTable'
 
@@ -28,10 +28,15 @@ const LegacyTrendsQuery: LegacyQuery = {
     },
 }
 
+const TrendsQuery: TrendsQuery = {
+    kind: NodeKind.TrendsQuery,
+}
+
 export const examples: Record<string, Node> = {
     Events,
     EventsTable,
     LegacyTrendsQuery,
+    TrendsQuery,
 }
 
 export const stringifiedExamples: Record<string, string> = Object.fromEntries(

--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -102,6 +102,13 @@ const TrendsQuery: TrendsQuery = {
             },
         ],
     },
+    trendsFilter: {
+        display: ChartDisplayType.ActionsAreaGraph,
+    },
+    breakdown: {
+        breakdown: '$geoip_country_code',
+        breakdown_type: 'event',
+    },
 }
 
 export const examples: Record<string, Node> = {

--- a/frontend/src/queries/nodes/TrendsInsightQuery/TrendsInsightQuery.tsx
+++ b/frontend/src/queries/nodes/TrendsInsightQuery/TrendsInsightQuery.tsx
@@ -46,7 +46,7 @@ const filtersFromTrendsQuery = (query: TrendsQuery): Partial<FilterType> => {
 }
 
 /** Use new TrendsQuery and transform it into old insight props to display the trends graph. */
-export function TrendsQuery({ query }: { query: TrendsQuery }): JSX.Element {
+export function TrendsInsightQuery({ query }: { query: TrendsQuery }): JSX.Element {
     const filters: Partial<FilterType> = filtersFromTrendsQuery(query)
     const insightProps: InsightLogicProps = { dashboardItemId: 'new', cachedInsight: { filters } }
 

--- a/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
+++ b/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
@@ -41,6 +41,7 @@ const filtersFromTrendsQuery = (query: TrendsQuery): Partial<FilterType> => {
         properties: query.properties,
         filter_test_accounts: query.filterTestAccounts,
         ...query.trendsFilter,
+        ...query.breakdown,
     }
 }
 

--- a/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
+++ b/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
@@ -1,0 +1,9 @@
+import { TrendsQuery } from '~/queries/schema'
+
+export function TrendsQuery({ query }: { query: TrendsQuery }): JSX.Element {
+    return (
+        <span>
+            TrendsQuery: <pre>{JSON.stringify(query, null, 2)}</pre>
+        </span>
+    )
+}

--- a/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
+++ b/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
@@ -40,6 +40,7 @@ const filtersFromTrendsQuery = (query: TrendsQuery): Partial<FilterType> => {
         ...seriesToActionsAndEvents(query.series),
         properties: query.properties,
         filter_test_accounts: query.filterTestAccounts,
+        ...query.trendsFilter,
     }
 }
 

--- a/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
+++ b/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
@@ -1,9 +1,56 @@
-import { TrendsQuery } from '~/queries/schema'
+import { TrendsQuery, EventsNode, ActionsNode } from '~/queries/schema'
+import { InsightLogicProps, FilterType, InsightType, ActionFilter } from '~/types'
+import { isEventsNode } from '~/queries/utils'
+import { BindLogic } from 'kea'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { AdHocInsight } from 'lib/components/AdHocInsight/AdHocInsight'
 
+const seriesToActionsAndEvents = (
+    series: (EventsNode | ActionsNode)[]
+): { events: ActionFilter[]; actions: ActionFilter[] } => {
+    const actions: ActionFilter[] = []
+    const events: ActionFilter[] = []
+    series.forEach((node, index) => {
+        const entity: ActionFilter = {
+            type: isEventsNode(node) ? 'events' : 'actions',
+            id: (isEventsNode(node) ? node.event : node.id) || null,
+            order: index,
+            name: node.name || null,
+            custom_name: node.custom_name,
+            math: node.math,
+            math_property: node.math_property,
+            math_group_type_index: node.math_group_type_index,
+            properties: node.properties as any, // TODO,
+        }
+
+        if (isEventsNode(node)) {
+            events.push(entity)
+        } else {
+            actions.push(entity)
+        }
+    })
+    return { actions, events }
+}
+
+const filtersFromTrendsQuery = (query: TrendsQuery): Partial<FilterType> => {
+    return {
+        insight: InsightType.TRENDS,
+        interval: query.interval,
+        ...query.dateRange,
+        ...seriesToActionsAndEvents(query.series),
+        properties: query.globalPropertyFilters,
+        filter_test_accounts: query.filterTestAccounts,
+    }
+}
+
+/** Use new TrendsQuery and transform it into old insight props to display the trends graph. */
 export function TrendsQuery({ query }: { query: TrendsQuery }): JSX.Element {
+    const filters: Partial<FilterType> = filtersFromTrendsQuery(query)
+    const insightProps: InsightLogicProps = { dashboardItemId: 'new', cachedInsight: { filters } }
+
     return (
-        <span>
-            TrendsQuery: <pre>{JSON.stringify(query, null, 2)}</pre>
-        </span>
+        <BindLogic logic={insightLogic} props={insightProps} key={JSON.stringify(filters)}>
+            <AdHocInsight filters={filters} style={{ height: 500, border: '1px var(--primary) solid' }} />
+        </BindLogic>
     )
 }

--- a/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
+++ b/frontend/src/queries/nodes/TrendsQuery/TrendsQuery.tsx
@@ -38,7 +38,7 @@ const filtersFromTrendsQuery = (query: TrendsQuery): Partial<FilterType> => {
         interval: query.interval,
         ...query.dateRange,
         ...seriesToActionsAndEvents(query.series),
-        properties: query.globalPropertyFilters,
+        properties: query.properties,
         filter_test_accounts: query.filterTestAccounts,
     }
 }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1655,7 +1655,8 @@
             "additionalProperties": false,
             "properties": {
                 "dateRange": {
-                    "$ref": "#/definitions/DateRange"
+                    "$ref": "#/definitions/DateRange",
+                    "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
                     "description": "Exclude internal and test users by applying the respective filters",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1670,6 +1670,20 @@
                     "const": "TrendsQuery",
                     "type": "string"
                 },
+                "properties": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/AnyPropertyFilter"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "$ref": "#/definitions/PropertyGroupFilter"
+                        }
+                    ],
+                    "description": "Property filters for all series"
+                },
                 "series": {
                     "description": "Events and actions to include",
                     "items": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1697,6 +1697,53 @@
                         ]
                     },
                     "type": "array"
+                },
+                "trendsFilter": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "aggregation_axis_format": {
+                            "$ref": "#/definitions/AggregationAxisFormat"
+                        },
+                        "aggregation_axis_postfix": {
+                            "type": "string"
+                        },
+                        "aggregation_axis_prefix": {
+                            "type": "string"
+                        },
+                        "breakdown_histogram_bin_count": {
+                            "type": "number"
+                        },
+                        "compare": {
+                            "type": "boolean"
+                        },
+                        "display": {
+                            "$ref": "#/definitions/ChartDisplayType"
+                        },
+                        "formula": {},
+                        "hidden_legend_keys": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "not": {}
+                                    }
+                                ]
+                            },
+                            "type": "object"
+                        },
+                        "show_legend": {
+                            "type": "boolean"
+                        },
+                        "shown_as": {
+                            "$ref": "#/definitions/ShownAsValue"
+                        },
+                        "smoothing_intervals": {
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "required": ["kind", "series"],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1161,6 +1161,43 @@
             "enum": ["first_touch", "last_touch", "all_events", "step"],
             "type": "string"
         },
+        "BreakdownFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "aggregation_group_type_index": {
+                    "type": "number"
+                },
+                "breakdown": {
+                    "$ref": "#/definitions/BreakdownKeyType"
+                },
+                "breakdown_group_type_index": {
+                    "type": ["number", "null"]
+                },
+                "breakdown_normalize_url": {
+                    "type": "boolean"
+                },
+                "breakdown_type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BreakdownType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "breakdown_value": {
+                    "type": ["string", "number"]
+                },
+                "breakdowns": {
+                    "items": {
+                        "$ref": "#/definitions/Breakdown"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "BreakdownKeyType": {
             "anyOf": [
                 {
@@ -1654,6 +1691,9 @@
         "TrendsQuery": {
             "additionalProperties": false,
             "properties": {
+                "breakdown": {
+                    "$ref": "#/definitions/BreakdownFilter"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange",
                     "description": "Date range for the query"
@@ -1700,6 +1740,7 @@
                 },
                 "trendsFilter": {
                     "additionalProperties": false,
+                    "description": "Properties specific to the trends insight",
                     "properties": {
                         "aggregation_axis_format": {
                             "$ref": "#/definitions/AggregationAxisFormat"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2,6 +2,56 @@
     "$ref": "#/definitions/QuerySchema",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+        "ActionsNode": {
+            "additionalProperties": false,
+            "properties": {
+                "custom_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "number"
+                },
+                "kind": {
+                    "const": "ActionsNode",
+                    "type": "string"
+                },
+                "math": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/BaseMathType"
+                        },
+                        {
+                            "$ref": "#/definitions/PropertyMathType"
+                        },
+                        {
+                            "$ref": "#/definitions/CountPerActorMathType"
+                        }
+                    ]
+                },
+                "math_group_type_index": {
+                    "enum": [0, 1, 2, 3, 4],
+                    "type": "number"
+                },
+                "math_property": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "properties": {
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
+                },
+                "response": {
+                    "description": "Cached query response",
+                    "type": "object"
+                }
+            },
+            "required": ["id", "kind"],
+            "type": "object"
+        },
         "AggregationAxisFormat": {
             "enum": ["numeric", "duration", "duration_ms", "percentage", "percentage_scaled"],
             "type": "string"
@@ -1076,6 +1126,10 @@
                 }
             ]
         },
+        "BaseMathType": {
+            "enum": ["total", "dau", "weekly_active", "monthly_active", "unique_session"],
+            "type": "string"
+        },
         "BinCountValue": {
             "anyOf": [
                 {
@@ -1141,6 +1195,18 @@
                 "ActionsBarValue",
                 "WorldMap",
                 "BoldNumber"
+            ],
+            "type": "string"
+        },
+        "CountPerActorMathType": {
+            "enum": [
+                "avg_count_per_actor",
+                "min_count_per_actor",
+                "max_count_per_actor",
+                "median_count_per_actor",
+                "p90_count_per_actor",
+                "p95_count_per_actor",
+                "p99_count_per_actor"
             ],
             "type": "string"
         },
@@ -1224,13 +1290,12 @@
             "additionalProperties": false,
             "properties": {
                 "date_from": {
+                    "description": "TODO",
                     "type": ["string", "null"]
                 },
                 "date_to": {
+                    "description": "ISO 8601 date string, TODO: relative_date_parse",
                     "type": ["string", "null"]
-                },
-                "interval": {
-                    "$ref": "#/definitions/IntervalType"
                 }
             },
             "type": "object"
@@ -1336,6 +1401,9 @@
         "EventsNode": {
             "additionalProperties": false,
             "properties": {
+                "custom_name": {
+                    "type": "string"
+                },
                 "event": {
                     "type": "string"
                 },
@@ -1346,18 +1414,34 @@
                 "limit": {
                     "type": "number"
                 },
-                "properties": {
+                "math": {
                     "anyOf": [
                         {
-                            "items": {
-                                "$ref": "#/definitions/AnyPropertyFilter"
-                            },
-                            "type": "array"
+                            "$ref": "#/definitions/BaseMathType"
                         },
                         {
-                            "$ref": "#/definitions/PropertyGroupFilter"
+                            "$ref": "#/definitions/PropertyMathType"
+                        },
+                        {
+                            "$ref": "#/definitions/CountPerActorMathType"
                         }
                     ]
+                },
+                "math_group_type_index": {
+                    "enum": [0, 1, 2, 3, 4],
+                    "type": "number"
+                },
+                "math_property": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "properties": {
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
                 },
                 "response": {
                     "additionalProperties": false,
@@ -1507,6 +1591,10 @@
             "required": ["type", "values"],
             "type": "object"
         },
+        "PropertyMathType": {
+            "enum": ["avg", "sum", "min", "max", "median", "p90", "p95", "p99"],
+            "type": "string"
+        },
         "PropertyOperator": {
             "description": "Sync with plugin-server/src/types.ts",
             "enum": [
@@ -1538,6 +1626,9 @@
                     "$ref": "#/definitions/EventsNode"
                 },
                 {
+                    "$ref": "#/definitions/ActionsNode"
+                },
+                {
                     "$ref": "#/definitions/DataTableNode"
                 },
                 {
@@ -1566,12 +1657,34 @@
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
+                "filterTestAccounts": {
+                    "description": "Exclude internal and test users by applying the respective filters",
+                    "type": "boolean"
+                },
+                "interval": {
+                    "$ref": "#/definitions/IntervalType",
+                    "description": "Granularity of the response. Can be one of `hour`, `day`, `week` or `month`"
+                },
                 "kind": {
                     "const": "TrendsQuery",
                     "type": "string"
+                },
+                "series": {
+                    "description": "Events and actions to include",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/EventsNode"
+                            },
+                            {
+                                "$ref": "#/definitions/ActionsNode"
+                            }
+                        ]
+                    },
+                    "type": "array"
                 }
             },
-            "required": ["kind"],
+            "required": ["kind", "series"],
             "type": "object"
         }
     }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -894,9 +894,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "group_type_index": {
-                            "type": ["number", "null"]
-                        },
                         "key": {
                             "type": "string"
                         },
@@ -920,9 +917,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "group_type_index": {
-                            "type": ["number", "null"]
-                        },
                         "key": {
                             "type": "string"
                         },
@@ -946,9 +940,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "group_type_index": {
-                            "type": ["number", "null"]
-                        },
                         "key": {
                             "enum": ["tag_name", "text", "href", "selector"],
                             "type": "string"
@@ -972,9 +963,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "group_type_index": {
-                            "type": ["number", "null"]
-                        },
                         "key": {
                             "const": "$session_duration",
                             "type": "string"
@@ -998,9 +986,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "group_type_index": {
-                            "type": ["number", "null"]
-                        },
                         "key": {
                             "const": "id",
                             "type": "string"
@@ -1021,9 +1006,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "group_type_index": {
-                            "type": ["number", "null"]
-                        },
                         "key": {
                             "const": "duration",
                             "type": "string"
@@ -1040,6 +1022,54 @@
                         },
                         "value": {
                             "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "group_type_index": {
+                            "type": ["number", "null"]
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/PropertyOperator"
+                        },
+                        "type": {
+                            "const": "group",
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/PropertyFilterValue"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "key": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/PropertyOperator"
+                        },
+                        "type": {
+                            "const": "feature",
+                            "description": "Event property with \"$feature/\" prepended",
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/PropertyFilterValue"
                         }
                     },
                     "type": "object"
@@ -1104,6 +1134,7 @@
             "enum": [
                 "ActionsLineGraph",
                 "ActionsLineGraphCumulative",
+                "ActionsAreaGraph",
                 "ActionsTable",
                 "ActionsPie",
                 "ActionsBar",
@@ -1188,6 +1219,21 @@
                     "type": "string"
                 }
             ]
+        },
+        "DateRange": {
+            "additionalProperties": false,
+            "properties": {
+                "date_from": {
+                    "type": ["string", "null"]
+                },
+                "date_to": {
+                    "type": ["string", "null"]
+                },
+                "interval": {
+                    "$ref": "#/definitions/IntervalType"
+                }
+            },
+            "type": "object"
         },
         "ElementType": {
             "additionalProperties": false,
@@ -1496,6 +1542,9 @@
                 },
                 {
                     "$ref": "#/definitions/LegacyQuery"
+                },
+                {
+                    "$ref": "#/definitions/TrendsQuery"
                 }
             ]
         },
@@ -1510,6 +1559,20 @@
         "StepOrderValue": {
             "enum": ["strict", "unordered", "ordered"],
             "type": "string"
+        },
+        "TrendsQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "const": "TrendsQuery",
+                    "type": "string"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
         }
     }
 }

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -3,13 +3,16 @@ import {
     AnyPropertyFilter,
     EventType,
     PropertyFilterType,
-    PropertyGroupFilter,
     IntervalType,
+    BaseMathType,
+    PropertyMathType,
+    CountPerActorMathType,
 } from '~/types'
 
 export enum NodeKind {
     // Data nodes
     EventsNode = 'EventsNode',
+    ActionsNode = 'ActionsNode',
 
     // Interface nodes
     DataTableNode = 'DataTableNode',
@@ -22,6 +25,7 @@ export enum NodeKind {
 export type QuerySchema =
     // Data nodes (see utils.ts)
     | EventsNode
+    | ActionsNode
 
     // Interface nodes
     | DataTableNode
@@ -42,15 +46,28 @@ export interface DataNode extends Node {
     response?: Record<string, any>
 }
 
-export interface EventsNode extends DataNode {
+export interface EntityNode extends DataNode {
+    name?: string
+    custom_name?: string
+    math?: BaseMathType | PropertyMathType | CountPerActorMathType
+    math_property?: string
+    math_group_type_index?: 0 | 1 | 2 | 3 | 4
+    properties?: AnyPropertyFilter[]
+}
+
+export interface EventsNode extends EntityNode {
     kind: NodeKind.EventsNode
     event?: string
-    properties?: AnyPropertyFilter[] | PropertyGroupFilter
     limit?: number
     response?: {
         results: EventType[]
         next?: string
     }
+}
+
+export interface ActionsNode extends EntityNode {
+    kind: NodeKind.ActionsNode
+    id: number
 }
 
 // Data table node
@@ -85,6 +102,12 @@ interface InsightsQueryBase extends Node {
 
 export interface TrendsQuery extends InsightsQueryBase {
     kind: NodeKind.TrendsQuery
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalType
+    /** Events and actions to include */
+    series: (EventsNode | ActionsNode)[]
 }
 
 // TODO: not supported by "ts-json-schema-generator" nor "typescript-json-schema" :(
@@ -104,5 +127,4 @@ export interface LegacyQuery extends Node {
 export interface DateRange {
     date_from?: string | null
     date_to?: string | null
-    interval?: IntervalType
 }

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1,4 +1,11 @@
-import { AnyPartialFilterType, AnyPropertyFilter, EventType, PropertyFilterType, PropertyGroupFilter } from '~/types'
+import {
+    AnyPartialFilterType,
+    AnyPropertyFilter,
+    EventType,
+    PropertyFilterType,
+    PropertyGroupFilter,
+    IntervalType,
+} from '~/types'
 
 export enum NodeKind {
     // Data nodes
@@ -7,6 +14,9 @@ export enum NodeKind {
     // Interface nodes
     DataTableNode = 'DataTableNode',
     LegacyQuery = 'LegacyQuery',
+
+    // New queries, not yet implemented
+    TrendsQuery = 'TrendsQuery',
 }
 
 export type QuerySchema =
@@ -16,6 +26,9 @@ export type QuerySchema =
     // Interface nodes
     | DataTableNode
     | LegacyQuery
+
+    // New queries, not yet implemented
+    | TrendsQuery
 
 /** Node base class, everything else inherits from here */
 export interface Node {
@@ -65,6 +78,15 @@ export interface DataTableColumn {
     key: string
 }
 
+// Base class should not be used directly
+interface InsightsQueryBase extends Node {
+    dateRange?: DateRange
+}
+
+export interface TrendsQuery extends InsightsQueryBase {
+    kind: NodeKind.TrendsQuery
+}
+
 // TODO: not supported by "ts-json-schema-generator" nor "typescript-json-schema" :(
 // export type PropertyColumnString = `${PropertyFilterType}.${string}`
 export type PropertyColumnString = string
@@ -75,4 +97,12 @@ export type DataTableStringColumn = PropertyColumnString | 'person'
 export interface LegacyQuery extends Node {
     kind: NodeKind.LegacyQuery
     filters: AnyPartialFilterType
+}
+
+// Various utility types below
+
+export interface DateRange {
+    date_from?: string | null
+    date_to?: string | null
+    interval?: IntervalType
 }

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -8,6 +8,8 @@ import {
     BaseMathType,
     PropertyMathType,
     CountPerActorMathType,
+    FilterType,
+    TrendsFilterType,
 } from '~/types'
 
 export enum NodeKind {
@@ -112,6 +114,8 @@ export interface TrendsQuery extends InsightsQueryBase {
     interval?: IntervalType
     /** Events and actions to include */
     series: (EventsNode | ActionsNode)[]
+    /** Properties specific to the trends insight */
+    trendsFilter?: Omit<TrendsFilterType, keyof FilterType> // using everything except what it inherits from FilterType
 }
 
 // TODO: not supported by "ts-json-schema-generator" nor "typescript-json-schema" :(

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1,6 +1,7 @@
 import {
     AnyPartialFilterType,
     AnyPropertyFilter,
+    PropertyGroupFilter,
     EventType,
     PropertyFilterType,
     IntervalType,
@@ -101,6 +102,8 @@ interface InsightsQueryBase extends Node {
     dateRange?: DateRange
     /** Exclude internal and test users by applying the respective filters */
     filterTestAccounts?: boolean
+    /** Property filters for all series */
+    properties?: AnyPropertyFilter[] | PropertyGroupFilter
 }
 
 export interface TrendsQuery extends InsightsQueryBase {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -97,13 +97,14 @@ export interface DataTableColumn {
 
 // Base class should not be used directly
 interface InsightsQueryBase extends Node {
+    /** Date range for the query */
     dateRange?: DateRange
+    /** Exclude internal and test users by applying the respective filters */
+    filterTestAccounts?: boolean
 }
 
 export interface TrendsQuery extends InsightsQueryBase {
     kind: NodeKind.TrendsQuery
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean
     /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
     interval?: IntervalType
     /** Events and actions to include */

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1,6 +1,9 @@
 import {
     AnyPartialFilterType,
     AnyPropertyFilter,
+    Breakdown,
+    BreakdownKeyType,
+    BreakdownType,
     PropertyGroupFilter,
     EventType,
     PropertyFilterType,
@@ -116,6 +119,7 @@ export interface TrendsQuery extends InsightsQueryBase {
     series: (EventsNode | ActionsNode)[]
     /** Properties specific to the trends insight */
     trendsFilter?: Omit<TrendsFilterType, keyof FilterType> // using everything except what it inherits from FilterType
+    breakdown?: BreakdownFilter
 }
 
 // TODO: not supported by "ts-json-schema-generator" nor "typescript-json-schema" :(
@@ -135,4 +139,15 @@ export interface LegacyQuery extends Node {
 export interface DateRange {
     date_from?: string | null
     date_to?: string | null
+}
+
+export interface BreakdownFilter {
+    // TODO: unclutter
+    breakdown_type?: BreakdownType | null
+    breakdown?: BreakdownKeyType
+    breakdown_normalize_url?: boolean
+    breakdowns?: Breakdown[]
+    breakdown_value?: string | number
+    breakdown_group_type_index?: number | null
+    aggregation_group_type_index?: number | undefined // Groups aggregation
 }

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -1,11 +1,15 @@
-import { EventsNode, DataTableNode, LegacyQuery, TrendsQuery, Node, NodeKind } from '~/queries/schema'
+import { EventsNode, ActionsNode, DataTableNode, LegacyQuery, TrendsQuery, Node, NodeKind } from '~/queries/schema'
 
-export function isDataNode(node?: Node): node is EventsNode {
+export function isDataNode(node?: Node): node is EventsNode | ActionsNode {
     return isEventsNode(node)
 }
 
 export function isEventsNode(node?: Node): node is EventsNode {
     return node?.kind === NodeKind.EventsNode
+}
+
+export function isActionsNode(node?: Node): node is ActionsNode {
+    return node?.kind === NodeKind.ActionsNode
 }
 
 export function isDataTableNode(node?: Node): node is DataTableNode {

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -1,4 +1,4 @@
-import { EventsNode, DataTableNode, LegacyQuery, Node, NodeKind } from '~/queries/schema'
+import { EventsNode, DataTableNode, LegacyQuery, TrendsQuery, Node, NodeKind } from '~/queries/schema'
 
 export function isDataNode(node?: Node): node is EventsNode {
     return isEventsNode(node)
@@ -14,4 +14,8 @@ export function isDataTableNode(node?: Node): node is DataTableNode {
 
 export function isLegacyQuery(node?: Node): node is LegacyQuery {
     return node?.kind === NodeKind.LegacyQuery
+}
+
+export function isTrendsQuery(node?: Node): node is TrendsQuery {
+    return node?.kind === NodeKind.TrendsQuery
 }


### PR DESCRIPTION
## Problem

As part of the overall data exploration effort, we need a schema for all insight queries. This PR adds the schema for the **trends insight query** and adds a translation utility that translates `TrendsQuery` -> `FilterType` for displaying the trends graph.

## Changes

Implemented functionality:

- [x] entities
  - [x] order for multiple entitities
  - [x] event entities
    - [x] name e.g. "$pageview"
    - [x] custom_name e.g. "View"
    - [x] math e.g. "Count per user [average]"
    - [x] math_property for property values e.g. "Property value [average] - Time"
    - [x] properties e.g. "Where [Country Code] [=equals] [US]" AND "Real persons"
  - [x] action entitities
    - [x] name e.g. "Interacted with file"
    - [x] custom_name e.g. "File interactions US"
    - [x] math e.g. "Count per user [average]"
    - [x] math_property for property values e.g. "Property value [average] - Time"
    - [x] properties e.g. "Where [Country Code] [=equals] [US]" AND "Real persons"
- [ ] formula e.g. "(A + B) / 100" -> Running into 500 error
- [x] compare e.g. "Compare to previous time period [y]"
- [x] interval e.g. "grouped by [Hour]"
- [x] date_from e.g. "Date range [Today]"
- [x] date_to e.g. "Date range [Oct 4 - Nov 8]"
- [x] filter_test_accounts e.g. "Filter out internal and test users [y]"
- [x] properties e.g. "Match [all] filters in this group - [Current URL] [=equals] [https://hedgebox.net/signup/]" - AND ...
- [x] aggregation_axis_format e.g. "Unit [Duration (ms)]"
- [x] display e.g. "Chart type [Area]"
- [x] breakdown, breakdown_type, breakdown_normalize_url - "Breakdown by [Current URL]"
- [x] show_legend e.g. "Show legend [y]"
- [ ] new_entity - don't get why we send it to the api?

Based on https://github.com/PostHog/posthog/pull/12745/commits/063c92bac430820b2f9e43c160b2ab90aa864d00#diff-ded0c9540aa3ecad86352099c18e2374a5bb152e8afb989bb413d0ba6269d61dL101.

## How did you test this code?

Comparing the existing trends api requests and visualizations with the new one at `/query`, using the above functionality checklist.

## Future work

- Type response
- Add support for an "ActionDefinitionsNode" i.e. an action that has the steps/series inlined