### PR TITLE
chore(lemon-ui): Extract `LemonBadge.Number` out of `LemonBadge`

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -161,7 +161,7 @@ const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({ index, date }
                 />
             ) : (
                 <LemonBadge
-                    content={<IconPlusMini className="w-full h-full" />}
+                    content={<IconPlusMini />}
                     size="small"
                     style={active && isDateLocked ? { outline: '0.125rem solid var(--primary)' } : undefined}
                 />

--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -153,11 +153,19 @@ const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({ index, date }
                     : () => activateDate(date, buttonRef.current as HTMLButtonElement)
             }
         >
-            <LemonBadge
-                count={annotations.length || <IconPlusMini className="w-full h-full" />}
-                size="small"
-                style={active && isDateLocked ? { outline: '0.125rem solid var(--primary)' } : undefined}
-            />
+            {annotations.length ? (
+                <LemonBadge.Number
+                    count={annotations.length}
+                    size="small"
+                    style={active && isDateLocked ? { outline: '0.125rem solid var(--primary)' } : undefined}
+                />
+            ) : (
+                <LemonBadge
+                    content={<IconPlusMini className="w-full h-full" />}
+                    size="small"
+                    style={active && isDateLocked ? { outline: '0.125rem solid var(--primary)' } : undefined}
+                />
+            )}
         </button>
     )
 })

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.scss
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.scss
@@ -13,15 +13,21 @@
     height: var(--lemon-badge-size);
     font-size: var(--lemon-badge-font-size);
     line-height: var(--lemon-badge-size);
-    padding: calc(
-        var(--lemon-badge-size) / 8
-    ); // Just enough so the overall size is unaffected with a single digit (i.e. badge stays round)
+    // Just enough so the overall size is unaffected with a single digit (i.e. badge stays round)
+    padding: calc(var(--lemon-badge-size) / 8);
     border-radius: calc(var(--lemon-badge-size) / 2);
     user-select: none;
     pointer-events: none;
     position: absolute;
     font-weight: 700;
     z-index: 1; // Make sure it is at least in front of non-absolute items
+
+    > * {
+        // For non-text content, make sure that content fills up the whole badge, and that the badge stays round
+        width: calc(var(--lemon-badge-size) - 0.25rem);
+        height: calc(var(--lemon-badge-size) - 0.25rem);
+        margin: calc(-1 * var(--lemon-badge-size) / 8);
+    }
 
     &.LemonBadge--primary {
         background: var(--primary);

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
@@ -1,95 +1,73 @@
-import { useState } from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
-import { LemonBadge, LemonBadgeNumberProps } from './LemonBadge'
+import { LemonBadge } from './LemonBadge'
 import { LemonButton } from '../LemonButton'
+import { IconPlusMini } from '../icons'
 
 export default {
-    title: 'Lemon UI/Lemon Badge',
+    title: 'Lemon UI/Lemon Badge/Lemon Badge',
     component: LemonBadge,
     parameters: {
         chromatic: { disableSnapshot: false },
     },
-} as ComponentMeta<typeof LemonBadge.Number>
+} as ComponentMeta<typeof LemonBadge>
 
-const Template: ComponentStory<typeof LemonBadge.Number> = ({ count, ...props }: LemonBadgeNumberProps) => {
-    const [countOverride, setCount] = useState(count as number)
-
-    return (
-        <>
-            <div className="flex items-center min-h-6">
-                <div>Count: </div>
-                <LemonBadge.Number count={countOverride} {...props} />
-            </div>
-            <br />
-            <div className="flex space-x-1">
-                <LemonButton type="primary" onClick={() => setCount((countOverride || 0) + 1)}>
-                    Increment
-                </LemonButton>
-                <LemonButton type="secondary" onClick={() => setCount((countOverride || 0) - 1)}>
-                    Decrement
-                </LemonButton>
-            </div>
-        </>
-    )
-}
+const Template: ComponentStory<typeof LemonBadge> = (props) => (
+    <div className="flex">
+        <LemonBadge {...props} />
+    </div>
+)
 
 export const Standard = Template.bind({})
-Standard.args = { count: 1 }
+Standard.args = { content: '@' }
 
-export const MultipleDigits = Template.bind({})
-MultipleDigits.args = { count: 975, maxDigits: 3 }
-
-export const ShowZero = Template.bind({})
-ShowZero.args = { count: 0, showZero: true }
-
-export const Positioning: ComponentStory<typeof LemonBadge.Number> = () => {
+export const Positioning: ComponentStory<typeof LemonBadge> = () => {
     return (
         <div className="space-y-4">
             <LemonButton type="secondary">
                 top-right
-                <LemonBadge.Number count={4} position="top-right" />
+                <LemonBadge content={<IconPlusMini />} position="top-right" />
             </LemonButton>
 
             <LemonButton type="secondary">
                 top-left
-                <LemonBadge.Number count={4} position="top-left" />
+                <LemonBadge content={<IconPlusMini />} position="top-left" />
             </LemonButton>
 
             <LemonButton type="secondary">
                 bottom-right
-                <LemonBadge.Number count={4} position="bottom-right" />
+                <LemonBadge content={<IconPlusMini />} position="bottom-right" />
             </LemonButton>
 
             <LemonButton type="secondary">
                 bottom-left
-                <LemonBadge.Number count={4} position="bottom-left" />
+                <LemonBadge content={<IconPlusMini />} position="bottom-left" />
             </LemonButton>
         </div>
     )
 }
 
-export const Sizes: ComponentStory<typeof LemonBadge.Number> = () => {
+export const Sizes: ComponentStory<typeof LemonBadge> = () => {
     return (
         <div className="flex space-x-2 items-center">
             <span>small:</span>
-            <LemonBadge.Number count={4} size="small" />
+            <LemonBadge content={<IconPlusMini />} size="small" />
             <span>medium:</span>
-            <LemonBadge.Number count={4} size="medium" />
+            <LemonBadge content={<IconPlusMini />} size="medium" />
             <span>large:</span>
-            <LemonBadge.Number count={4} size="large" />
+            <LemonBadge content={<IconPlusMini />} size="large" />
         </div>
     )
 }
 
-export const Status: ComponentStory<typeof LemonBadge.Number> = () => {
+export const Status: ComponentStory<typeof LemonBadge> = () => {
     return (
         <div className="flex space-x-2 items-center">
             <span>primary:</span>
-            <LemonBadge.Number count={4} status="primary" />
+            <LemonBadge content={<IconPlusMini />} status="primary" />
             <span>danger:</span>
-            <LemonBadge.Number count={4} status="danger" />
+            <LemonBadge content={<IconPlusMini />} status="danger" />
             <span>muted:</span>
-            <LemonBadge.Number count={4} status="muted" />
+            <LemonBadge content={<IconPlusMini />} status="muted" />
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
-import { LemonBadge, LemonBadgeProps } from './LemonBadge'
+import { LemonBadge, LemonBadgeNumberProps } from './LemonBadge'
 import { LemonButton } from '../LemonButton'
 
 export default {
@@ -9,16 +9,16 @@ export default {
     parameters: {
         chromatic: { disableSnapshot: false },
     },
-} as ComponentMeta<typeof LemonBadge>
+} as ComponentMeta<typeof LemonBadge.Number>
 
-const Template: ComponentStory<typeof LemonBadge> = ({ count, ...props }: LemonBadgeProps) => {
+const Template: ComponentStory<typeof LemonBadge.Number> = ({ count, ...props }: LemonBadgeNumberProps) => {
     const [countOverride, setCount] = useState(count as number)
 
     return (
         <>
             <div className="flex items-center min-h-6">
                 <div>Count: </div>
-                <LemonBadge count={countOverride} {...props} />
+                <LemonBadge.Number count={countOverride} {...props} />
             </div>
             <br />
             <div className="flex space-x-1">
@@ -42,54 +42,54 @@ MultipleDigits.args = { count: 975, maxDigits: 3 }
 export const ShowZero = Template.bind({})
 ShowZero.args = { count: 0, showZero: true }
 
-export const Positioning: ComponentStory<typeof LemonBadge> = () => {
+export const Positioning: ComponentStory<typeof LemonBadge.Number> = () => {
     return (
         <div className="space-y-4">
             <LemonButton type="secondary">
                 top-right
-                <LemonBadge count={4} position="top-right" />
+                <LemonBadge.Number count={4} position="top-right" />
             </LemonButton>
 
             <LemonButton type="secondary">
                 top-left
-                <LemonBadge count={4} position="top-left" />
+                <LemonBadge.Number count={4} position="top-left" />
             </LemonButton>
 
             <LemonButton type="secondary">
                 bottom-right
-                <LemonBadge count={4} position="bottom-right" />
+                <LemonBadge.Number count={4} position="bottom-right" />
             </LemonButton>
 
             <LemonButton type="secondary">
                 bottom-left
-                <LemonBadge count={4} position="bottom-left" />
+                <LemonBadge.Number count={4} position="bottom-left" />
             </LemonButton>
         </div>
     )
 }
 
-export const Sizes: ComponentStory<typeof LemonBadge> = () => {
+export const Sizes: ComponentStory<typeof LemonBadge.Number> = () => {
     return (
         <div className="flex space-x-2 items-center">
             <span>small:</span>
-            <LemonBadge count={4} size="small" />
+            <LemonBadge.Number count={4} size="small" />
             <span>medium:</span>
-            <LemonBadge count={4} size="medium" />
+            <LemonBadge.Number count={4} size="medium" />
             <span>large:</span>
-            <LemonBadge count={4} size="large" />
+            <LemonBadge.Number count={4} size="large" />
         </div>
     )
 }
 
-export const Status: ComponentStory<typeof LemonBadge> = () => {
+export const Status: ComponentStory<typeof LemonBadge.Number> = () => {
     return (
         <div className="flex space-x-2 items-center">
             <span>primary:</span>
-            <LemonBadge count={4} status="primary" />
+            <LemonBadge.Number count={4} status="primary" />
             <span>danger:</span>
-            <LemonBadge count={4} status="danger" />
+            <LemonBadge.Number count={4} status="danger" />
             <span>muted:</span>
-            <LemonBadge count={4} status="muted" />
+            <LemonBadge.Number count={4} status="muted" />
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
 import { humanFriendlyNumber } from 'lib/utils'
-import { ReactNode } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import './LemonBadge.scss'
 
@@ -14,7 +13,7 @@ interface LemonBadgePropsBase {
 }
 
 export interface LemonBadgeProps extends LemonBadgePropsBase {
-    content: ReactNode
+    content: string | JSX.Element
     visible?: boolean
 }
 
@@ -28,7 +27,7 @@ export interface LemonBadgeNumberProps extends LemonBadgePropsBase {
 /** An icon-sized badge. */
 export function LemonBadge({
     content,
-    visible,
+    visible = true,
     size = 'medium',
     position = 'none',
     className,

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
@@ -1,17 +1,56 @@
 import clsx from 'clsx'
+import { humanFriendlyNumber } from 'lib/utils'
+import { ReactNode } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import './LemonBadge.scss'
 
-export interface LemonBadgeProps {
-    count?: number | JSX.Element
+interface LemonBadgePropsBase {
     size?: 'small' | 'medium' | 'large'
     position?: 'none' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-    /** Maximum number of digits shown. Default: 1. */
-    maxDigits?: number
-    showZero?: boolean
     className?: string
     status?: 'primary' | 'danger' | 'muted'
     style?: React.CSSProperties
+    title?: string
+}
+
+export interface LemonBadgeProps extends LemonBadgePropsBase {
+    content: ReactNode
+    visible?: boolean
+}
+
+export interface LemonBadgeNumberProps extends LemonBadgePropsBase {
+    count: number
+    /** Maximum number of digits shown at once. Default value: 1 (so all numbers above 9 are shown as "9+"). */
+    maxDigits?: number
+    showZero?: boolean
+}
+
+/** An icon-sized badge. */
+export function LemonBadge({
+    content,
+    visible,
+    size = 'medium',
+    position = 'none',
+    className,
+    status = 'primary',
+    ...spanProps
+}: LemonBadgeProps): JSX.Element {
+    return (
+        <CSSTransition in={visible} timeout={150} classNames="LemonBadge-" mountOnEnter unmountOnExit>
+            <span
+                className={clsx(
+                    'LemonBadge',
+                    `LemonBadge--${size}`,
+                    `LemonBadge--${status}`,
+                    `LemonBadge--position-${position}`,
+                    className
+                )}
+                {...spanProps}
+            >
+                {content}
+            </span>
+        </CSSTransition>
+    )
 }
 
 /** An icon-sized badge for displaying a count.
@@ -20,16 +59,12 @@ export interface LemonBadgeProps {
  * JSX elements are rendered outright to support use cases where the badge is meant to show an icon.
  * If `showZero` is set to `true`, the component won't be hidden if the count is 0.
  */
-export function LemonBadge({
+function LemonBadgeNumber({
     count,
-    size = 'medium',
-    position = 'none',
     maxDigits = 1,
     showZero = false,
-    className,
-    status = 'primary',
-    ...spanProps
-}: LemonBadgeProps): JSX.Element {
+    ...badgeProps
+}: LemonBadgeNumberProps): JSX.Element {
     // NOTE: We use 1 for the text if not showing so the fade out animation looks right
     const text =
         typeof count === 'object'
@@ -44,20 +79,13 @@ export function LemonBadge({
     const hide = count === undefined || (count == 0 && !showZero)
 
     return (
-        <CSSTransition in={!hide} timeout={150} classNames="LemonBadge-" mountOnEnter unmountOnExit>
-            <span
-                className={clsx(
-                    'LemonBadge',
-                    `LemonBadge--${size}`,
-                    `LemonBadge--${status}`,
-                    `LemonBadge--position-${position}`,
-                    className
-                )}
-                title={String(count)}
-                {...spanProps}
-            >
-                {text}
-            </span>
-        </CSSTransition>
+        <LemonBadge
+            visible={!hide}
+            title={typeof count === 'number' ? humanFriendlyNumber(count) : undefined}
+            content={text}
+            {...badgeProps}
+        />
     )
 }
+
+LemonBadge.Number = LemonBadgeNumber

--- a/frontend/src/lib/components/LemonBadge/LemonBadgeNumber.stories.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadgeNumber.stories.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { LemonBadge, LemonBadgeNumberProps } from './LemonBadge'
+import { LemonButton } from '../LemonButton'
+
+export default {
+    title: 'Lemon UI/Lemon Badge/Lemon Badge Number',
+    component: LemonBadge.Number,
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+} as ComponentMeta<typeof LemonBadge.Number>
+
+const Template: ComponentStory<typeof LemonBadge.Number> = ({ count, ...props }: LemonBadgeNumberProps) => {
+    const [countOverride, setCount] = useState(count)
+
+    return (
+        <>
+            <div className="flex items-center min-h-6">
+                <div>Count: </div>
+                <LemonBadge.Number count={countOverride} {...props} />
+            </div>
+            <br />
+            <div className="flex space-x-1">
+                <LemonButton type="primary" onClick={() => setCount((countOverride || 0) + 1)}>
+                    Increment
+                </LemonButton>
+                <LemonButton type="secondary" onClick={() => setCount((countOverride || 0) - 1)}>
+                    Decrement
+                </LemonButton>
+            </div>
+        </>
+    )
+}
+
+export const Standard = Template.bind({})
+Standard.args = { count: 1 }
+
+export const MultipleDigits = Template.bind({})
+MultipleDigits.args = { count: 975, maxDigits: 3 }
+
+export const ShowZero = Template.bind({})
+ShowZero.args = { count: 0, showZero: true }

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -19,7 +19,7 @@ export function IconWithCount({
     return (
         <span style={{ position: 'relative', display: 'inline-flex' }}>
             {children}
-            <LemonBadge count={count} size="small" position="top-right" showZero={showZero} status={status} />
+            <LemonBadge.Number count={count} size="small" position="top-right" showZero={showZero} status={status} />
         </span>
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilterGroup.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilterGroup.tsx
@@ -44,7 +44,7 @@ export function EditorFilterGroup({ editorFilterGroup, insight, insightProps }: 
                     >
                         <div className="flex items-center space-x-2 font-semibold">
                             <span>{title}</span>
-                            <LemonBadge count={count} />
+                            <LemonBadge.Number count={count || 0} />
                         </div>
                     </LemonButton>
                 </div>


### PR DESCRIPTION
## Problem

When working on #12773, I realized how weird it is that `count` in `LemonBadge` can be any JSX element. However, that use case for `LemonBadge` is completely valid – it's the number case that is narrower. So it should be a sub-component.

## Changes

`LemonBadge` is now the general case, and `LemonBadge.Number` is now the `count` case.

## How did you test this code?

Added stories:
<img width="224" alt="Screenshot 2022-11-25 at 00 35 34" src="https://user-images.githubusercontent.com/4550621/203878537-ef9a2a65-492c-422f-8cef-e5c047eaaabf.png">
