### PR TITLE
ci(stale-bot): Increase operations limit and track issues too

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,14 +9,19 @@ jobs:
         if: ${{ github.repository == 'PostHog/posthog' }}
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/stale@v4
+            - uses: actions/stale@v6
               with:
-                  days-before-issue-stale: 9999
-                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week."
-                  close-pr-message: 'This PR was closed due to 2 weeks of inactivity. Feel free to reopen it if still relevant.'
+                  days-before-issue-stale: 730
+                  days-before-issue-close: 14
+                  stale-issue-message: "This issue hasn't seen activity in two years! If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in two weeks."
+                  close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
+                  stale-issue-label: stale
+                  remove-issue-stale-when-updated: true
                   days-before-pr-stale: 7
                   days-before-pr-close: 7
-                  stale-issue-label: stale
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week."
+                  close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-pr-label: stale
-                  operations-per-run: 30
+                  remove-pr-stale-when-updated: true
+                  operations-per-run: 250
                   repo-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

A few tweaks to the configuration of the stale bot:

- Issues are now marked stale too, after two years of zero activity
- Higher GitHub operations limit
- Upgraded action from v4 to v6