### PR TITLE
fix(ingestion): update heuristic for buffering anonymous events

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -108,7 +108,9 @@ export function shouldSendEventToBuffer(
 
     const processEventImmediately = isMobileLibrary || person || isIdentifyingEvent || isAnonymousEvent
 
-    const sendToBuffer = shouldBufferAnonymousEvents || !processEventImmediately
+    // shouldBufferAnonymousEvents indicated buffering should happen
+    // for all anonymous events, irrespective of the person existing or not
+    const sendToBuffer = (shouldBufferAnonymousEvents && isAnonymousEvent) || !processEventImmediately
 
     if (sendToBuffer) {
         hub.statsd?.increment('conversion_events_buffer_size', { teamId: event.team_id.toString() })

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -106,10 +106,9 @@ export function shouldSendEventToBuffer(
 
     const shouldBufferAnonymousEvents = teamId <= hub.MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR
 
-    const processEventImmediately =
-        isMobileLibrary || person || isIdentifyingEvent || (isAnonymousEvent && !shouldBufferAnonymousEvents)
+    const processEventImmediately = isMobileLibrary || person || isIdentifyingEvent || isAnonymousEvent
 
-    const sendToBuffer = !processEventImmediately
+    const sendToBuffer = shouldBufferAnonymousEvents || !processEventImmediately
 
     if (sendToBuffer) {
         hub.statsd?.increment('conversion_events_buffer_size', { teamId: event.team_id.toString() })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -250,6 +250,7 @@ describe('shouldSendEventToBuffer()', () => {
     it('handles teamIdsToBufferAnonymousEventsFor', () => {
         runner.hub.MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR = 2
 
+        expect(shouldSendEventToBuffer(runner.hub, anonEvent, {} as Person, 1)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 1)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 2)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 3)).toEqual(false)


### PR DESCRIPTION
We should buffer anonymous events irrespective of the person existing or not. 

The fact that we didn't do this is why shipping this didn't change anything.