### PR TITLE
fix: should be checking if someone has access to tags before trying to load them

### DIFF
--- a/frontend/src/models/tagsModel.ts
+++ b/frontend/src/models/tagsModel.ts
@@ -1,16 +1,18 @@
-import { afterMount, kea, path } from 'kea'
+import { afterMount, connect, kea, path } from 'kea'
 import api from 'lib/api'
 
 import type { tagsModelType } from './tagsModelType'
 import { loaders } from 'kea-loaders'
+import { organizationLogic } from 'scenes/organizationLogic'
 
 export const tagsModel = kea<tagsModelType>([
     path(['models', 'tagsModel']),
-    loaders(() => ({
+    connect({ values: [organizationLogic, ['hasDashboardCollaboration']] }),
+    loaders(({ values }) => ({
         tags: {
             __default: [] as string[],
             loadTags: async () => {
-                return (await api.tags.list()) || []
+                return values.hasDashboardCollaboration ? (await api.tags.list()) || [] : []
             },
         },
     })),


### PR DESCRIPTION
## Problem

in [this community slack thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1669372577736279) the user reports an error message when loading the page.

This is because if you aren't on a paid plan the tags API returns a 402 and we added a tagsModel that loads the tags on mount. We shouldn't be loading the tags if you don't have access to tagging.

## Changes

checks before loading tags and returns an empty array if the user doesn't have access.

## How did you test this code?

👀 
