### PR TITLE
feat(recordings): include country name in recording icon property

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistItem.tsx
@@ -42,10 +42,16 @@ export function SessionRecordingPlaylistItem({
         <div className="flex flex-row flex-nowrap shrink-0 gap-1 h-6 ph-no-capture">
             {!recordingPropertiesLoading ? (
                 iconPropertyKeys.map((property) => {
-                    const value =
-                        property === '$device_type'
-                            ? iconProperties?.['$device_type'] || iconProperties?.['$initial_device_type']
-                            : iconProperties?.[property]
+                    let value = iconProperties?.[property]
+                    if (property === '$device_type') {
+                        value = iconProperties?.['$device_type'] || iconProperties?.['$initial_device_type']
+                    }
+
+                    let tooltipValue = value
+                    if (property === '$geoip_country_code') {
+                        tooltipValue = `${iconProperties?.['$geoip_country_name']} (${value})`
+                    }
+
                     return (
                         <PropertyIcon
                             key={property}
@@ -53,11 +59,11 @@ export function SessionRecordingPlaylistItem({
                             className={iconClassnames}
                             property={property}
                             value={value}
-                            tooltipTitle={(_, value) => (
+                            tooltipTitle={() => (
                                 <div className="text-center">
                                     Click to filter for
                                     <br />
-                                    <span className="font-medium">{value ?? 'N/A'}</span>
+                                    <span className="font-medium">{tooltipValue ?? 'N/A'}</span>
                                 </div>
                             )}
                         />

--- a/posthog/queries/session_recordings/session_recording_properties.py
+++ b/posthog/queries/session_recordings/session_recording_properties.py
@@ -31,6 +31,7 @@ class SessionRecordingProperties(EventQuery):
         "$host",
         "$pathname",
         "$geoip_country_code",
+        "$geoip_country_name",
     }
 
     # First $pageview event in a recording is used to extract metadata (brower, location, etc.) without


### PR DESCRIPTION
## Problem

Users want to see the full country name when hovering over the recording property icon. 

## Changes

Now that's possible!

<img width="237" alt="Screenshot 2022-11-25 at 11 24 58 AM" src="https://user-images.githubusercontent.com/13460330/204025167-5a5b1c06-fd64-4f9d-930c-72caf38c8397.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Backend tests
