### PR TITLE
fix(recordings): event start time filter is incorrectly filtering out recordings

### DIFF
--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -70,7 +70,7 @@ class SessionRecordingList(EventQuery):
         SELECT
             session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
@@ -30,7 +30,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -90,7 +90,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -150,7 +150,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -210,7 +210,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -284,7 +284,7 @@
   FROM
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -361,7 +361,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -421,7 +421,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -463,7 +463,7 @@
   FROM
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -539,7 +539,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -602,7 +602,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -793,7 +793,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -859,7 +859,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
@@ -665,7 +665,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,
@@ -728,7 +728,7 @@
   JOIN
     (SELECT session_id,
             any(window_id) as window_id,
-            MIN(first_event_timestamp) as start_time,
+            minIf(first_event_timestamp, first_event_timestamp != '1970-01-01 00:00:00') as start_time,
             MAX(last_event_timestamp) as end_time,
             SUM(click_count) as click_count,
             SUM(keypress_count) as keypress_count,


### PR DESCRIPTION
## Problem

There was a bug (https://github.com/PostHog/posthog/pull/11927) introduced with the new materialized `event_summary` columns where materializing a new datetime column off an empty array was using a default min datetime value of January 01, 1970 12AM. We later query on this specific datetime column, which was filtering out recordings that actually DO fall within this date range.

## Changes

Replace min with minif aggregate function in query to disregard min datetime values.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

All historical tests pass.