### PR TITLE
fix: lock cloud users above threshold

### DIFF
--- a/frontend/src/scenes/billing/BillingLocked.tsx
+++ b/frontend/src/scenes/billing/BillingLocked.tsx
@@ -5,16 +5,21 @@ import { BillingSubscribedTheme } from './BillingSubscribed'
 import { compactNumber } from 'lib/utils'
 import { LemonButton } from '@posthog/lemon-ui'
 import { IconCancel } from 'lib/components/icons'
+import { BillingLockedV2 } from './v2/BillingLocked'
 
 export const scene: SceneExport = {
     component: BillingLocked,
 }
 
 export function BillingLocked(): JSX.Element | null {
-    const { billing } = useValues(billingLogic)
+    const { billing, billingVersion } = useValues(billingLogic)
+
+    if (billingVersion === 'v2') {
+        return <BillingLockedV2 />
+    }
     return (
         <BillingSubscribedTheme>
-            <div className="flex items-center justify-center gap-2">
+            <div className="flex items-center gap-2">
                 <IconCancel className="text-danger text-3xl mb-2" />
                 <h2>Please enter a credit card</h2>
             </div>

--- a/frontend/src/scenes/billing/v2/BillingLocked.scss
+++ b/frontend/src/scenes/billing/v2/BillingLocked.scss
@@ -1,0 +1,26 @@
+.BillingLocked {
+    background-color: var(--bg-bridge);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+    min-height: 100vh;
+
+    .BillingLocked__main {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex: 1;
+        padding: 2rem;
+    }
+
+    .BillingLocked__content {
+        position: relative;
+        box-shadow: var(--shadow-elevation);
+        width: 100%;
+        padding: 2rem;
+        background-color: white;
+        border-radius: var(--radius);
+    }
+}

--- a/frontend/src/scenes/billing/v2/BillingLocked.tsx
+++ b/frontend/src/scenes/billing/v2/BillingLocked.tsx
@@ -1,0 +1,35 @@
+import { useValues } from 'kea'
+import { billingLogic } from './billingLogic'
+import { Billing } from '../Billing'
+import { AlertMessage } from 'lib/components/AlertMessage'
+import './BillingLocked.scss'
+
+export function BillingLockedV2(): JSX.Element | null {
+    const { billing } = useValues(billingLogic)
+
+    const productOverLimit =
+        billing &&
+        billing.products.find((x) => {
+            return x.percentage_usage > 1
+        })
+
+    return (
+        <div className="BillingLocked">
+            <div className="BillingLocked__main">
+                <div className="BillingLocked__content">
+                    {productOverLimit && (
+                        <div className="mb-4">
+                            <AlertMessage type="error">
+                                <b>Usage limit exceeded</b>
+                                <br />
+                                You have exceeded the usage limit for {productOverLimit.name}. Please upgrade your plan
+                                or data loss may occur.
+                            </AlertMessage>
+                        </div>
+                    )}
+                    <Billing />
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/billing/v2/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/billingLogic.ts
@@ -14,8 +14,11 @@ import posthog from 'posthog-js'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 import { pluralize } from 'lib/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { urls } from 'scenes/urls'
 
 export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of event usage near limit
+export const ALLOCATION_THRESHOLD_BLOCK = 1.2 // Threshold to block usage
 
 export interface BillingAlertConfig {
     status: 'info' | 'warning' | 'error'
@@ -93,7 +96,6 @@ export const billingLogic = kea<billingLogicType>([
             (billing, billingLoading): BillingVersion | undefined =>
                 !billingLoading || billing ? (billing ? 'v2' : 'v1') : undefined,
         ],
-
         billingAlert: [
             (s) => [s.billing, s.preflight],
             (billing, preflight): BillingAlertConfig | undefined => {
@@ -143,6 +145,22 @@ export const billingLogic = kea<billingLogicType>([
                         ).toPrecision(2)}% of your ${productApproachingLimit.type.toLowerCase()} allocation.`,
                     }
                 }
+            },
+        ],
+        isUserLocked: [
+            (s) => [s.billing, s.preflight, s.billingVersion, s.featureFlags],
+            (billing, preflight, billingVersion, featureFlags): boolean => {
+                if (!billing || !preflight?.cloud) {
+                    return false
+                }
+                // lock cloud users out if they are above the usage limit on any product
+                return Boolean(
+                    billingVersion === 'v2' &&
+                        billing.products.find((x) => {
+                            return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
+                        }) &&
+                        featureFlags[FEATURE_FLAGS.BILLING_LOCK_EVERYTHING]
+                )
             },
         ],
     }),
@@ -199,7 +217,13 @@ export const billingLogic = kea<billingLogicType>([
         actions.loadBilling()
     }),
 
-    urlToAction(({ actions }) => ({
+    urlToAction(({ actions, values }) => ({
+        '*': () => {
+            if (values.isUserLocked && router.values.location.pathname !== '/organization/billing/locked') {
+                posthog.capture('billing locked screen shown')
+                router.actions.replace(urls.billingLocked())
+            }
+        },
         '/organization/billing': (_params, _search, hash) => {
             if (hash.license) {
                 actions.setShowLicenseDirectInput(true)


### PR DESCRIPTION
## Problem
- We want to lock users who are above their product usage thresholds 

## Changes
- If users on billing v2 are 1.2 times their maximum usage threshold on any of their product, we want to block the interface to only show the billing page

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- Tested locally that lock is enforced
