### PR TITLE
chore: Set Strict-Transport-Security

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -259,3 +259,6 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
 )
 
 KAFKA_PRODUCE_ACK_TIMEOUT_SECONDS = int(os.getenv("KAFKA_PRODUCE_ACK_TIMEOUT_SECONDS", None) or 10)
+
+# Security Headers
+SECURE_HSTS_SECONDS = int(os.getenv("SECURE_HSTS_SECONDS", None) or 30)


### PR DESCRIPTION
## Problem

The security header `Strict-Transport-Security` is disabled; we need to enable it to force the site to use HTTPS.
This change sets the header with a max-age of 30 seconds.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
