### PR TITLE
fix: enable optimize_move_to_prewhere on ch >= 22.8

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -22,7 +22,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 8
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---
 # name: TestClickhouseStickiness.test_aggregate_by_groups.1
@@ -49,7 +49,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 1
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_aggregate_by_groups.2
@@ -76,7 +76,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 2
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_aggregate_by_groups.3
@@ -103,7 +103,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 3
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_compare
@@ -129,7 +129,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 9
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---
 # name: TestClickhouseStickiness.test_compare.1
@@ -155,7 +155,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 9
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---
 # name: TestClickhouseStickiness.test_filter_by_group_properties
@@ -189,7 +189,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 8
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---
 # name: TestClickhouseStickiness.test_filter_by_group_properties.1
@@ -222,7 +222,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 1
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_filter_by_group_properties.2
@@ -255,7 +255,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 2
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_filter_by_group_properties.3
@@ -288,7 +288,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 3
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_stickiness_all_time
@@ -325,7 +325,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 9
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---
 # name: TestClickhouseStickiness.test_stickiness_hours
@@ -351,7 +351,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 10
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---
 # name: TestClickhouseStickiness.test_stickiness_people_endpoint
@@ -376,7 +376,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 1
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_stickiness_people_paginated
@@ -401,7 +401,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 1
   LIMIT 100
-  OFFSET 0 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 0
   '
 ---
 # name: TestClickhouseStickiness.test_stickiness_people_paginated.1
@@ -426,7 +426,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals = 1
   LIMIT 100
-  OFFSET 100 SETTINGS optimize_move_to_prewhere = 0
+  OFFSET 100
   '
 ---
 # name: TestClickhouseStickiness.test_timezones
@@ -452,7 +452,7 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 16
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---
 # name: TestClickhouseStickiness.test_timezones.1
@@ -478,6 +478,6 @@
      GROUP BY aggregation_target)
   WHERE num_intervals <= 16
   GROUP BY num_intervals
-  ORDER BY num_intervals SETTINGS optimize_move_to_prewhere = 0
+  ORDER BY num_intervals
   '
 ---

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -3,6 +3,7 @@ import json
 import time
 import types
 from dataclasses import dataclass
+from functools import lru_cache
 from time import perf_counter
 from typing import (
     Any,
@@ -51,10 +52,20 @@ SLOW_QUERY_THRESHOLD_MS = 15000
 QUERY_TIMEOUT_THREAD = get_timer_thread("posthog.client", SLOW_QUERY_THRESHOLD_MS)
 
 
-# Optimize_move_to_prewhere setting is set because of this regression test
-# test_ilike_regression_with_current_clickhouse_version
-# https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/test/test_trends.py#L1566
-settings_override = {"optimize_move_to_prewhere": 0}
+@lru_cache(maxsize=1)
+def default_settings() -> Dict:
+    from posthog.version_requirement import ServiceVersionRequirement
+
+    # On CH 22.3 we need to disable optimize_move_to_prewhere due to a bug. This is verified fixed on 22.8 (LTS),
+    # so we only disable on versions below that.
+    # This is calculated once per deploy
+    clickhouse_at_least_228, _ = ServiceVersionRequirement(
+        service="clickhouse", supported_version=">=22.8.0"
+    ).is_service_in_accepted_version()
+    if clickhouse_at_least_228:
+        return {}
+    else:
+        return {"optimize_move_to_prewhere": 0}
 
 
 def default_client():
@@ -152,7 +163,7 @@ def sync_execute(
 
         timeout_task = QUERY_TIMEOUT_THREAD.schedule(_notify_of_slow_query_failure)
 
-        settings = {**settings_override, **(settings or {}), "log_comment": json.dumps(tags, separators=(",", ":"))}
+        settings = {**default_settings(), **(settings or {}), "log_comment": json.dumps(tags, separators=(",", ":"))}
 
         try:
             result = client.execute(

--- a/posthog/queries/stickiness/stickiness.py
+++ b/posthog/queries/stickiness/stickiness.py
@@ -39,7 +39,6 @@ class Stickiness:
         WHERE num_intervals <= %(num_intervals)s
         GROUP BY num_intervals
         ORDER BY num_intervals
-        SETTINGS optimize_move_to_prewhere = 0
         """
 
         counts = insight_sync_execute(

--- a/posthog/queries/stickiness/stickiness_actors.py
+++ b/posthog/queries/stickiness/stickiness_actors.py
@@ -35,8 +35,6 @@ class StickinessActors(ActorBaseQuery):
         SELECT DISTINCT aggregation_target AS actor_id FROM ({events_query}) WHERE num_intervals = %(stickiness_day)s
         {"LIMIT %(limit)s" if limit_actors else ""}
         {"OFFSET %(offset)s" if limit_actors else ""}
-
-        SETTINGS optimize_move_to_prewhere = 0
         """,
             {
                 **event_params,


### PR DESCRIPTION
We've previously tested that all tests pass with this setting in https://github.com/PostHog/posthog/pull/12966,
extracting this code from the other PR for earlier mergeability.

Related: https://github.com/PostHog/posthog/issues/12902