### PR TITLE
feat(dashboards): Updating filters should hit the cache

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -950,7 +950,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
             await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 filters: values.filters,
             })
-            actions.refreshAllDashboardItems({ action: 'update_filters' })
+            actions.loadDashboardItems({ action: 'update_filters' })
         },
         setDates: ({ dateFrom, dateTo, reloadDashboard }) => {
             if (reloadDashboard) {


### PR DESCRIPTION
When updating dashboard filters, we would never hit the cache for these queries. Now we do.

Solves https://github.com/PostHog/posthog/issues/12901