### PR TITLE
fix: old docs URL to runbook

### DIFF
--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -133,7 +133,7 @@ export function PreflightCheck(): JSX.Element {
                                     troubleshooting guide
                                 </a>{' '}
                                 or our{' '}
-                                <a href="https://posthog.com/docs/self-host/runbook" target="_blank">
+                                <a href="https://posthog.com/docs/runbook" target="_blank">
                                     self host runbook
                                 </a>
                                 .


### PR DESCRIPTION
## Problem
New PR to close this old one which can't pass due to it being a fork: #12063

## Changes
- Updates an old URL

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Not needed
