### PR TITLE
feat: enable sentry python profiling

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -77,6 +77,11 @@ def sentry_init() -> None:
             # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
             send_default_pii=True,
             traces_sampler=traces_sampler,
+            _experiments={
+                # https://docs.sentry.io/platforms/python/profiling/
+                # The profiles_sample_rate setting is relative to the traces_sample_rate setting.
+                "profiles_sample_rate": 0.1,
+            },
         )
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -58,7 +58,7 @@ redis==4.3.4
 requests==2.25.1
 requests-oauthlib==1.3.0
 selenium==4.1.5
-sentry-sdk==1.7.0
+sentry-sdk==1.11.1
 semantic_version==2.8.5
 slack_sdk==3.17.1
 social-auth-app-django==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -310,7 +310,7 @@ selenium==4.1.5
     # via -r requirements.in
 semantic-version==2.8.5
     # via -r requirements.in
-sentry-sdk==1.7.0
+sentry-sdk==1.11.1
     # via -r requirements.in
 six==1.16.0
     # via
@@ -361,13 +361,15 @@ unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3[secure,socks]==1.26.5
+urllib3[secure,socks]==1.26.13
     # via
     #   botocore
     #   geoip2
     #   requests
     #   selenium
     #   sentry-sdk
+urllib3-secure-extra==0.1.0
+    # via urllib3
 vine==1.3.0
     # via
     #   amqp


### PR DESCRIPTION
## Problem

Sentry has profiling for Python in alpha

## Changes

Upgrades Sentry and enables profiling for a small subset of traced requests

## How did you test this code?

Ran with Sentry locally and saw that we still send errors to Sentry. Our account is dropping all performance and profiling events until the 1st so I can't see what profiling looks like until then