### PR TITLE
feat(ingestion-buffer): update anonymous event definition in emitToBufferStep

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -110,7 +110,7 @@ export function shouldSendEventToBuffer(
 
     // shouldBufferAnonymousEvents indicated buffering should happen
     // for all anonymous events, irrespective of the person existing or not
-    const sendToBuffer = (shouldBufferAnonymousEvents && isAnonymousEvent) || !processEventImmediately
+    const sendToBuffer = shouldBufferAnonymousEvents || !processEventImmediately
 
     if (sendToBuffer) {
         hub.statsd?.increment('conversion_events_buffer_size', { teamId: event.team_id.toString() })

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -93,6 +93,7 @@ export function shouldSendEventToBuffer(
         (event.event == '$identify' && !!event.properties && !!event.properties['$anon_distinct_id']) ||
         (event.event == `$create_alias` && !!event.properties && !!event.properties['alias'])
 
+    // KLUDGE: This definition is not currently not encompassing all anonymous events
     const isAnonymousEvent =
         event.properties && event.properties['$device_id'] && event.distinct_id === event.properties['$device_id']
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -113,7 +113,7 @@ export function shouldSendEventToBuffer(
     // for all anonymous events, irrespective of the person existing or not
     let sendToBuffer = !processEventImmediately
     if (shouldBufferAnonymousEvents) {
-        sendToBuffer = !isIdentifyingEvent
+        sendToBuffer = !isIdentifyingEvent && !isMobileLibrary
     }
 
     if (sendToBuffer) {

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -111,7 +111,10 @@ export function shouldSendEventToBuffer(
 
     // shouldBufferAnonymousEvents indicated buffering should happen
     // for all anonymous events, irrespective of the person existing or not
-    const sendToBuffer = shouldBufferAnonymousEvents || !processEventImmediately
+    let sendToBuffer = !processEventImmediately
+    if (shouldBufferAnonymousEvents) {
+        sendToBuffer = !isIdentifyingEvent
+    }
 
     if (sendToBuffer) {
         hub.statsd?.increment('conversion_events_buffer_size', { teamId: event.team_id.toString() })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -232,6 +232,7 @@ describe('shouldSendEventToBuffer()', () => {
             properties: { $lib: 'posthog-android' },
         }
 
+        expect(shouldSendEventToBuffer(runner.hub, eventIos, {} as Person, 2)).toEqual(false)
         expect(shouldSendEventToBuffer(runner.hub, eventIos, undefined, 2)).toEqual(false)
         expect(shouldSendEventToBuffer(runner.hub, eventAndroid, undefined, 2)).toEqual(false)
     })
@@ -250,9 +251,9 @@ describe('shouldSendEventToBuffer()', () => {
     it('handles teamIdsToBufferAnonymousEventsFor', () => {
         runner.hub.MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR = 2
 
-        expect(shouldSendEventToBuffer(runner.hub, anonEvent, {} as Person, 1)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 1)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 2)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 3)).toEqual(false)
+        expect(shouldSendEventToBuffer(runner.hub, anonEvent, {} as Person, 1)).toEqual(false)
     })
 })


### PR DESCRIPTION
@tiina303 do you think we should do this? at least to see the impact for our team?

-----

this makes the `shouldBufferAnonymousEvents` setting buffer all events that are non-merging and not from mobile libs