### PR TITLE
fix: property definition API performance

### DIFF
--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -33,9 +33,12 @@ class QueryContext:
     numerical_filter: str = ""
     search_query: str = ""
     event_property_filter: str = ""
+    event_name_filter: str = ""
     is_feature_flag_filter: str = ""
 
     event_property_field: str = "NULL"
+
+    event_name_join_filter: str = ""
 
     params: Dict = dataclasses.field(default_factory=dict)
 
@@ -77,23 +80,33 @@ class QueryContext:
         self, event_names: Optional[str], is_event_property: Optional[str]
     ) -> "QueryContext":
         event_property_filter = ""
+        event_name_filter = ""
         event_property_field = "NULL"
+        event_name_join_filter = ""
 
         # Passed as JSON instead of duplicate properties like event_names[] to work with frontend's combineUrl
         if event_names:
             event_names = json.loads(event_names)
 
-        if event_names and len(event_names) > 0:
-            event_property_field = "(SELECT count(1) > 0 FROM posthog_eventproperty WHERE posthog_eventproperty.team_id=posthog_propertydefinition.team_id AND posthog_eventproperty.event IN %(event_names)s AND posthog_eventproperty.property = posthog_propertydefinition.name)"
-            if is_event_property == "true":
-                event_property_filter = f"AND {event_property_field} = true"
-            elif is_event_property == "false":
-                event_property_filter = f"AND {event_property_field} = false"
+        is_filtering_by_event_names = event_names and len(event_names) > 0
+
+        if is_filtering_by_event_names or is_event_property is not None:
+            event_property_field = "case when posthog_eventproperty.id is null then false else true end"
+
+        if is_filtering_by_event_names:
+            event_name_join_filter += " AND posthog_eventproperty.event in %(event_names)s"
+
+        if is_event_property == "true":
+            event_property_filter = f"AND {event_property_field} = true"
+        elif is_event_property == "false":
+            event_property_filter = f"AND {event_property_field} = false"
 
         return dataclasses.replace(
             self,
             event_property_filter=event_property_filter,
             event_property_field=event_property_field,
+            event_name_join_filter=event_name_join_filter,
+            event_name_filter=event_name_filter,
             params={**self.params, "event_names": tuple(event_names or [])},
         )
 
@@ -116,9 +129,10 @@ class QueryContext:
         query = f"""
             SELECT {self.property_definition_fields},{self.event_property_field} AS is_event_property
             FROM {self.table}
-            WHERE team_id = {self.team_id} AND name NOT IN %(excluded_properties)s
-             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
-            ORDER BY is_event_property DESC, query_usage_30_day DESC NULLS LAST, name ASC
+            left join posthog_eventproperty on posthog_eventproperty.team_id = posthog_propertydefinition.team_id and posthog_eventproperty.property = posthog_propertydefinition.name {self.event_name_join_filter}
+            WHERE posthog_propertydefinition.team_id = {self.team_id} AND posthog_propertydefinition.name NOT IN %(excluded_properties)s
+             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter} {self.event_name_filter}
+            ORDER BY is_event_property DESC, posthog_propertydefinition.query_usage_30_day DESC NULLS LAST, posthog_propertydefinition.name ASC
             LIMIT {self.limit} OFFSET {self.offset}
             """
 
@@ -128,8 +142,9 @@ class QueryContext:
         query = f"""
             SELECT count(*) as full_count
             FROM {self.table}
-            WHERE team_id = {self.team_id} AND name NOT IN %(excluded_properties)s
-             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
+            left join posthog_eventproperty on posthog_eventproperty.team_id = posthog_propertydefinition.team_id and posthog_eventproperty.property = posthog_propertydefinition.name {self.event_name_join_filter}
+            WHERE posthog_propertydefinition.team_id = {self.team_id} AND posthog_propertydefinition.name NOT IN %(excluded_properties)s
+             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter} {self.event_name_filter}
             """
 
         return query
@@ -233,7 +248,7 @@ class PropertyDefinitionViewSet(
         queryset = PropertyDefinition.objects
 
         property_definition_fields = ", ".join(
-            [f'"{f.column}"' for f in PropertyDefinition._meta.get_fields() if hasattr(f, "column")]  # type: ignore
+            [f'posthog_propertydefinition."{f.column}"' for f in PropertyDefinition._meta.get_fields() if hasattr(f, "column")]  # type: ignore
         )
 
         use_enterprise_taxonomy = self.request.user.organization.is_feature_available(AvailableFeature.INGESTION_TAXONOMY)  # type: ignore
@@ -244,7 +259,7 @@ class PropertyDefinitionViewSet(
                 # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
                 property_definition_fields = ", ".join(
                     [
-                        f'"{f.column}"'  # type: ignore
+                        f'posthog_propertydefinition."{f.column}"'  # type: ignore
                         for f in EnterprisePropertyDefinition._meta.get_fields()
                         if hasattr(f, "column") and f.column not in ["deprecated_tags", "tags"]  # type: ignore
                     ]

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -259,7 +259,7 @@ class PropertyDefinitionViewSet(
                 # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
                 property_definition_fields = ", ".join(
                     [
-                        f'posthog_propertydefinition."{f.column}"'  # type: ignore
+                        f'{f.cached_col.alias}."{f.column}"'  # type: ignore
                         for f in EnterprisePropertyDefinition._meta.get_fields()
                         if hasattr(f, "column") and f.column not in ["deprecated_tags", "tags"]  # type: ignore
                     ]


### PR DESCRIPTION
## Problem

The event property list when opening the taxonomic filter was super slow. On investigation we were inefficiently comparing against the `posthog_eventproperty` table to check if something is or isn't a property seen with a particular event

Alongside this the API surface is confusing. If you send an `event_name` param nothing happens unless you send `is_event_property`. In combination they mean "has this property been seen (or not) with this event"

If you sent an incorrect combination you didn't get a validation error instead you'd get for e.g. `is_event_property=null`

On visual inspection the API was taking 7 to 21 seconds for 100 results for the PostHog team.

## Changes

The query is now fast enough that we can separate those parameters

* `is_event_property` is always returned
* when `event_names` is not provided it means "has this been seen on _any_ event"
* when `event_names` is provided it means "has this been seen on these events"
* you can filter by `is_event_property` is true or false

### original query 

The query started in the shape

```
SELECT "id",
       "team_id",
       "name",
       "is_numerical",
       "query_usage_30_day",
       "property_type",
       "property_type_format",
       "volume_30_day",
       (SELECT count(1) > 0
        FROM posthog_eventproperty
        WHERE posthog_eventproperty.team_id = posthog_propertydefinition.team_id
          AND posthog_eventproperty.event IN ('$pageview') AND posthog_eventproperty.property = posthog_propertydefinition.name) AS is_event_property
FROM posthog_propertydefinition
WHERE team_id = 2
  AND (name NOT LIKE '$feature/%')
ORDER BY is_event_property DESC, query_usage_30_day DESC NULLS LAST, name ASC
LIMIT 100 OFFSET 0
```

running `explain analyze` for this query in metabase shows `Execution Time: 7950.894 ms`

### new query

The query is in the shape

```
SELECT ppd."id",
       ppd."team_id",
       ppd."name",
       ppd."is_numerical",
       ppd."query_usage_30_day",
       ppd."property_type",
       ppd."property_type_format",
       ppd."volume_30_day",
       case when pep.id is null then false else true end as is_event_property
FROM posthog_propertydefinition ppd
left join posthog_eventproperty pep on pep.team_id = ppd.team_id and pep.property = ppd.name and pep.event in ('$pageview')
WHERE ppd.team_id = 2
  AND (ppd.name NOT LIKE '$feature/%')
ORDER BY is_event_property DESC, query_usage_30_day DESC NULLS LAST, name ASC
LIMIT 100 OFFSET 0
```

running `explain analyze` for this query in metabase shows `Execution Time:262.654 ms`

## How did you test this code?

running queries in metabase
adding developer tests
locally with my 👀
