### PR TITLE
fix(trends): Disallow renaming formula series

### DIFF
--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -154,7 +154,9 @@ export function InsightContainer({
                         <InsightsTable
                             isLegend
                             filterKey={isTrendsFilter(filters) ? `trends_${activeView}` : ''}
-                            canEditSeriesNameInline={isTrendsFilter(filters) && insightMode === ItemMode.Edit}
+                            canEditSeriesNameInline={
+                                isTrendsFilter(filters) && !filters.formula && insightMode === ItemMode.Edit
+                            }
                             canCheckUncheckSeries={canEditInsight}
                         />
                     </BindLogic>


### PR DESCRIPTION
## Problem

Resolves #9478.

## Changes

This hides the rename button for the formula output series.