### PR TITLE
fix(role-based-access): edit permissions UI fixes

### DIFF
--- a/frontend/src/scenes/ResourcePermissionModal.tsx
+++ b/frontend/src/scenes/ResourcePermissionModal.tsx
@@ -15,10 +15,7 @@ import {
 import { rolesLogic } from './organization/Settings/Roles/rolesLogic'
 import { organizationLogic } from './organizationLogic'
 
-interface ResourcePermissionModalProps {
-    title: string
-    visible: boolean
-    onClose: () => void
+interface ResourcePermissionProps {
     addableRoles: RoleType[]
     addableRolesLoading: boolean
     onChange: (newValue: string[]) => void
@@ -28,6 +25,12 @@ interface ResourcePermissionModalProps {
     deleteAssociatedRole: (id: RoleType['id']) => void
     isNewResource: boolean
     resourceType: Resource
+}
+
+interface ResourcePermissionModalProps extends ResourcePermissionProps {
+    title: string
+    visible: boolean
+    onClose: () => void
 }
 
 export function roleLemonSelectOptions(roles: RoleType[]): LemonSelectMultipleOptionItem[] {
@@ -54,21 +57,49 @@ export function ResourcePermissionModal({
     roles,
     deleteAssociatedRole,
     isNewResource,
-    resourceType,
 }: ResourcePermissionModalProps): JSX.Element {
+    return (
+        <>
+            <LemonModal title={title} isOpen={visible} onClose={onClose}>
+                <ResourcePermission
+                    resourceType={Resource.FEATURE_FLAGS}
+                    isNewResource={isNewResource}
+                    onChange={onChange}
+                    rolesToAdd={rolesToAdd}
+                    addableRoles={addableRoles}
+                    addableRolesLoading={addableRolesLoading}
+                    onAdd={onAdd}
+                    roles={roles}
+                    deleteAssociatedRole={deleteAssociatedRole}
+                />
+            </LemonModal>
+        </>
+    )
+}
+
+export function ResourcePermission({
+    rolesToAdd,
+    addableRoles,
+    onChange,
+    addableRolesLoading,
+    onAdd,
+    roles,
+    deleteAssociatedRole,
+    isNewResource,
+    resourceType,
+}: ResourcePermissionProps): JSX.Element {
     const { allPermissions } = useValues(permissionsLogic)
     const { roles: possibleRolesWithAccess } = useValues(rolesLogic)
     const { isAdminOrOwner } = useValues(organizationLogic)
 
     const resourceLevel = allPermissions.find((permission) => permission.resource === resourceType)
-
     // TODO: feature_flag_access_level should eventually be generic in this component
     const rolesWithAccess = possibleRolesWithAccess.filter(
         (role) => role.feature_flags_access_level === AccessLevel.WRITE
     )
 
     return (
-        <LemonModal title={title} isOpen={visible} onClose={onClose}>
+        <>
             {resourceLevel && <OrganizationResourcePermissionLabel resourceLevel={resourceLevel} />}
             {<OrganizationResourcePermissionRoles roles={rolesWithAccess} />}
             {isAdminOrOwner && (
@@ -126,7 +157,7 @@ export function ResourcePermissionModal({
                     )}
                 </>
             )}
-        </LemonModal>
+        </>
     )
 }
 

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -48,7 +48,7 @@ import { LemonSelect } from '@posthog/lemon-ui'
 import { EventsTable } from 'scenes/events'
 import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
 import { featureFlagPermissionsLogic } from './featureFlagPermissionsLogic'
-import { ResourcePermissionModal } from 'scenes/ResourcePermissionModal'
+import { ResourcePermission, ResourcePermissionModal } from 'scenes/ResourcePermissionModal'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 
 export const scene: SceneExport = {
@@ -241,6 +241,9 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                 </Field>
                             </Col>
                             <Col span={12}>
+                                <LemonButton type="secondary" onClick={() => setModalOpen(true)} className="mb-4">
+                                    Set permissions
+                                </LemonButton>
                                 <FeatureFlagInstructions featureFlagKey={featureFlag.key || 'my-flag'} />
                             </Col>
                         </Row>
@@ -388,13 +391,19 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         <Tabs.TabPane tab="Permissions" key="permissions">
                                             <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
                                                 {featureFlag.can_edit && (
-                                                    <LemonButton
-                                                        type="secondary"
-                                                        onClick={() => setModalOpen(true)}
-                                                        className="mb-4"
-                                                    >
-                                                        Set permissions
-                                                    </LemonButton>
+                                                    <ResourcePermission
+                                                        resourceType={Resource.FEATURE_FLAGS}
+                                                        isNewResource={id === 'new'}
+                                                        onChange={(roleIds) => setRolesToAdd(roleIds)}
+                                                        rolesToAdd={rolesToAdd}
+                                                        addableRoles={addableRoles}
+                                                        addableRolesLoading={unfilteredAddableRolesLoading}
+                                                        onAdd={() => addAssociatedRoles()}
+                                                        roles={derivedRoles}
+                                                        deleteAssociatedRole={(id) =>
+                                                            deleteAssociatedRole({ roleId: id })
+                                                        }
+                                                    />
                                                 )}
                                             </PayGateMini>
                                         </Tabs.TabPane>

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -30,6 +30,7 @@ import { forms } from 'kea-forms'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { dayjs } from 'lib/dayjs'
 import { filterTrendsClientSideParams } from 'scenes/insights/sharedUtils'
+import { featureFlagPermissionsLogic } from './featureFlagPermissionsLogic'
 
 const getDefaultRollbackCondition = (): FeatureFlagRollbackConditions => ({
     operator: 'gt',
@@ -388,6 +389,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 try {
                     if (!updatedFlag.id) {
                         const newFlag = await api.create(`api/projects/${values.currentTeamId}/feature_flags`, flag)
+                        featureFlagPermissionsLogic({ flagId: null })?.actions.addAssociatedRoles(newFlag.id)
                         return newFlag
                     } else {
                         return await api.update(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

- Add back `set permissions` on new feature flag that I had deleted
- For existing feature flags, allow for permissions setting without having to click on "edit the feature flag"

## Changes

<img width="863" alt="Screen Shot 2022-11-28 at 3 23 41 PM" src="https://user-images.githubusercontent.com/25164963/204373803-44d270a5-bd36-4de0-8e77-ebd348982c09.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
