### PR TITLE
fix(time-to-see-data): Reduce dashboard API payload size 2x

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -180,6 +180,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
 
                     await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                         tiles: [{ id: tileId, color }],
+                        no_items_field: true,
                     })
                     const matchingTile = values.tiles.find((tile) => tile.id === tileId)
                     if (matchingTile) {
@@ -191,6 +192,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     try {
                         await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                             tiles: [{ id: tile.id, deleted: true }],
+                            no_items_field: true,
                         })
                         dashboardsModel.actions.tileRemovedFromDashboard({
                             tile: tile,
@@ -215,6 +217,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                         }
                         return await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                             tiles: [newTile],
+                            no_items_field: true,
                         } as Partial<InsightModel>)
                     } catch (e) {
                         lemonToast.error('Could not duplicate tile: ' + e)
@@ -234,6 +237,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             {
                                 tile,
                                 toDashboard,
+                                no_items_field: true,
                             }
                         )
                     }
@@ -525,6 +529,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 return (refresh?: boolean) =>
                     `api/projects/${teamLogic.values.currentTeamId}/dashboards/${id}/?${toParams({
                         refresh,
+                        no_items_field: true,
                     })}`
             },
         ],
@@ -798,6 +803,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
 
             return await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 tiles: values.allItems?.tiles || [],
+                no_items_field: true,
             })
         },
         moveToDashboardSuccess: ({ payload }) => {
@@ -949,6 +955,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
             await breakpoint(200)
             await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 filters: values.filters,
+                no_items_field: true,
             })
             actions.refreshAllDashboardItems({ action: 'update_filters' })
         },

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -27,7 +27,7 @@ from posthog.models import Dashboard, DashboardTile, Insight, Team, Text
 from posthog.models.team.team import get_available_features_for_team
 from posthog.models.user import User
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.utils import should_refresh
+from posthog.utils import should_ignore_dashboard_items_field, should_refresh
 
 logger = structlog.get_logger(__name__)
 
@@ -342,7 +342,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
 
     @extend_schema(deprecated=True, description="items is deprecated, use tiles instead")
     def get_items(self, dashboard: Dashboard):
-        if self.context["view"].action == "list":
+        if self.context["view"].action == "list" or should_ignore_dashboard_items_field(self.context["request"]):
             return None
 
         # used by insight serializer to load insight filters in correct context

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1051,7 +1051,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         response_json = response.json()
         return response_json.get("id", None), response_json
 
-    def _get_dashboard(self, dashboard_id: int, query_params="") -> Dict:
+    def _get_dashboard(self, dashboard_id: int, query_params: str = "") -> Dict:
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/{query_params}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return response.json()

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -990,6 +990,20 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         expected_dashboards_on_insight = dashboard_two_json["tiles"][0]["insight"]["dashboards"]
         assert expected_dashboards_on_insight == [dashboard_two_id]
 
+    def test_dashboard_items_deprecation(self) -> None:
+        dashboard_id, _ = self._create_dashboard({"name": "items deprecation"})
+        self._create_insight({"dashboards": [dashboard_id]})
+
+        default_dashboard_json = self._get_dashboard(dashboard_id, query_params="")
+
+        assert len(default_dashboard_json["tiles"]) == 1
+        assert len(default_dashboard_json["items"]) == 1
+
+        no_items_dashboard_json = self._get_dashboard(dashboard_id, query_params="?no_items_field")
+
+        assert len(no_items_dashboard_json["tiles"]) == 1
+        assert no_items_dashboard_json["items"] is None
+
     def _soft_delete(
         self,
         model_id: int,
@@ -1037,7 +1051,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         response_json = response.json()
         return response_json.get("id", None), response_json
 
-    def _get_dashboard(self, dashboard_id: int) -> Dict:
-        response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/")
+    def _get_dashboard(self, dashboard_id: int, query_params="") -> Dict:
+        response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/{query_params}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return response.json()

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -956,8 +956,16 @@ def get_available_timezones_with_offsets() -> Dict[str, float]:
 
 
 def should_refresh(request: Request) -> bool:
-    query_param = request.query_params.get("refresh")
-    data_value = request.data.get("refresh")
+    return _request_has_key_set("refresh", request)
+
+
+def should_ignore_dashboard_items_field(request: Request) -> bool:
+    return _request_has_key_set("no_items_field", request)
+
+
+def _request_has_key_set(key: str, request: Request) -> bool:
+    query_param = request.query_params.get(key)
+    data_value = request.data.get(key)
 
     return (query_param is not None and (query_param == "" or query_param.lower() == "true")) or data_value is True
 


### PR DESCRIPTION
## Note for the release

/dashboards API `items` field is now deprecated and will be removed in release 1.(X+1 where X is current release). Use `tiles` api instead.

## Problem

We have a client whose dashboard API response weighs 220MB after decompression and I believe it was causing some dashboards to load slower. This is a lot of data, and 50% of this is completely unused in the frontend

## Changes

- Add a `no_items_field` query parameter which removes `items` field to be returned from the API

## How did you test this code?

- See unit tests
- Checking payloads returned in FE
