### PR TITLE
chore: reduce sample rate for sentry performance

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -35,19 +35,19 @@ def traces_sampler(sampling_context: dict) -> float:
             return 0.0000001  # 0.00001%
         # Probes/monitoring endpoints
         elif path.startswith(("/_health", "/_readyz", "/_livez")):
-            return 0.0001  # 0.01%
+            return 0.00001  # 0.001%
         # API endpoints
         elif path.startswith("/api/projects") and path.endswith("/persons/"):
-            return 0.0001  # 0.01%
+            return 0.00001  # 0.001%
         elif path.startswith("/api/persons/"):
-            return 0.0001  # 0.01%
+            return 0.00001  # 0.001%
         elif path.startswith("/api/feature_flag"):
-            return 0.0001  # 0.01%
+            return 0.00001  # 0.001%
         elif path.startswith("/api"):
-            return 0.01  # 1%
+            return 0.001  # 0.1%
         else:
             # Default sample rate for HTTP requests
-            return 0.001  # 0.1%
+            return 0.0001  # 0.01%
 
     elif op == "celery.task":
         task = sampling_context.get("celery_job", {}).get("task")


### PR DESCRIPTION
## Problem

We used up the free allocation of sentry performance transactions in about a week last month. This is a shame cos it's really useful.

See https://sentry.io/organizations/posthog/stats/?dataCategory=transactions&project=1899813&statsPeriod=30d

## Changes

Reduces sample rate for a set of paths to try and stay well under the limit this month. 

## How did you test this code?

Restarting the app locally