### PR TITLE
fix: update placement and verbiage for sign in and register links on auth forms

### DIFF
--- a/cypress/e2e/auth.js
+++ b/cypress/e2e/auth.js
@@ -78,6 +78,8 @@ describe('Auth', () => {
 
 describe('Password Reset', () => {
     beforeEach(() => {
+        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com').blur()
+        cy.get('[data-attr=forgot-password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
         cy.get('[data-attr=top-menu-toggle]').click()
         cy.get('[data-attr=top-menu-item-logout]').click()
         cy.location('pathname').should('eq', '/login')

--- a/cypress/e2e/auth.js
+++ b/cypress/e2e/auth.js
@@ -78,14 +78,14 @@ describe('Auth', () => {
 
 describe('Password Reset', () => {
     beforeEach(() => {
-        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com').blur()
-        cy.get('[data-attr=forgot-password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
         cy.get('[data-attr=top-menu-toggle]').click()
         cy.get('[data-attr=top-menu-item-logout]').click()
         cy.location('pathname').should('eq', '/login')
     })
 
     it('Can request password reset', () => {
+        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com').blur()
+        cy.get('[data-attr=forgot-password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
         cy.get('[data-attr="forgot-password"]').click()
         cy.location('pathname').should('eq', '/reset')
         cy.get('[data-attr="reset-email"]').type('test@posthog.com')

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -113,7 +113,17 @@ export function Login(): JSX.Element {
                         />
                     </Field>
                     <div className={clsx('PasswordWrapper', isPasswordHidden && 'zero-height')}>
-                        <Field name="password" label="Password">
+                        <Field
+                            name="password"
+                            label={
+                                <div className="flex flex-1 items-center justify-between gap-2">
+                                    <span>Password</span>
+                                    <Link to="/reset" data-attr="forgot-password">
+                                        Forgot your password?
+                                    </Link>
+                                </div>
+                            }
+                        >
                             <LemonInput
                                 type="password"
                                 ref={passwordInputRef}
@@ -142,16 +152,14 @@ export function Login(): JSX.Element {
                         <SSOLoginButton provider="saml" email={login.email} status="primary" />
                     )}
                 </Form>
-                <div className="flex items-center justify-center flex-wrap gap-4 mt-4 font-semibold">
-                    {preflight?.cloud && (
-                        <Link to="/signup" data-attr="signup">
+                {preflight?.cloud && (
+                    <div className="text-center mt-4">
+                        Don't have an account?{' '}
+                        <Link to="/signup" data-attr="signup" className="font-bold">
                             Create an account
                         </Link>
-                    )}
-                    <Link to="/reset" data-attr="forgot-password">
-                        Forgot your password?
-                    </Link>
-                </div>
+                    </div>
+                )}
                 <SocialLoginButtons caption="Or log in with" topDivider />
             </div>
         </BridgePage>

--- a/frontend/src/scenes/authentication/signup/signupForm/SignupForm.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/SignupForm.tsx
@@ -41,24 +41,26 @@ export function SignupForm(): JSX.Element | null {
                     ? 'Get started'
                     : 'Tell us a bit about yourself'}
             </h2>
-            {!preflight?.demo && (preflight?.cloud || preflight?.initiated) && (
-                // If we're in the demo environment, login is unified with signup and it's passwordless
-                // For now, if you're not on Cloud, you wouldn't see this page,
-                // but future-proofing this (with `preflight.initiated`) in case this changes
-                <div className="text-center">
-                    Already have an account?{' '}
-                    <Link to="/login" data-attr="signup-login-link">
-                        Log in
-                    </Link>
-                </div>
-            )}
             {!isSignupPanel2Submitting && signupPanel2ManualErrors?.generic && (
                 <AlertMessage type="error">
                     {signupPanel2ManualErrors.generic?.detail || 'Could not complete your signup. Please try again.'}
                 </AlertMessage>
             )}
             {panel === 0 ? (
-                <SignupPanel1 />
+                <>
+                    <SignupPanel1 />
+                    {!preflight?.demo && (preflight?.cloud || preflight?.initiated) && (
+                        // If we're in the demo environment, login is unified with signup and it's passwordless
+                        // For now, if you're not on Cloud, you wouldn't see this page,
+                        // but future-proofing this (with `preflight.initiated`) in case this changes
+                        <div className="text-center mt-4">
+                            Already have an account?{' '}
+                            <Link to="/login" data-attr="signup-login-link" className="font-bold">
+                                Log in
+                            </Link>
+                        </div>
+                    )}
+                </>
             ) : (
                 <>
                     <SignupPanel2 />


### PR DESCRIPTION
This is a redo of #12227. Because I changed a lot about the signup form it was easier to just make a new PR than fix that one up and deal with merge conflicts, etc. 

## Problem
Closes https://github.com/PostHog/posthog/issues/9520

The auth forms (sign in, login) both link back to the other so that someone can easily go from one to another. However, the location and verbiage of these links was inconsistent between the two forms.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
- On the register (/signup) form, the link to log in was moved to below the "Create Account" button.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/18598166/195490430-abc2bb6b-a222-430f-92b0-c8987c08a137.png)  | ![image](https://user-images.githubusercontent.com/18598166/195490242-39a12c34-2163-4401-af39-a9136205a978.png)  |

- On the login form, the "forgot password" link was moved to above the password field, next to the label
- On the login form, the "Create an account" link had some descriptive text appended to the front to be consistent with the verbiage on the register form

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/18598166/195491258-be9c09f8-4cef-4922-908e-9fc4fbd24848.png)  | ![image](https://user-images.githubusercontent.com/18598166/195491207-f1d453cf-a1e2-4f47-9e1f-a1fe8a9dcee3.png)  |

The changes were based on the [designs](https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/?node-id=3558%3A32653) provided in https://github.com/PostHog/posthog/issues/9520 

## Concerns

1. For the "Forgot Password" link placement I followed the existing convention found in the register form where the extra stuff (ie. password strength indicator) is included in the `<label>` element. However, I do have slight misgivings about this pattern since it's likely not the best for accessibility to have all that in the `label`. I considered modifying the `Field` component to handle this properly, but decided to go with convention for now and make those changes if requested. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

- I clicked the links to make sure they go where they are expected to go. 
- I tested on different screen widths to make sure it all shows up and looks decent.
- I ran `yarn test` and got some errors:

```
Summary of all failing tests
 FAIL  lib/components/ActivityLog/activityLogLogic.plugin.test.tsx (14.679 s)
  ● the activity log logic › humanizing plugins › can handle exports finishing

    expect(element).toHaveTextContent()

    Expected element to have text content:
      Finished exporting historical events between 2021-10-29 and 2021-11-04 (inclusive).
    Received:
      Finished exporting historical events between 2021-10-28 and 2021-11-03 (inclusive).

      157 |             const actual = logic.values.humanizedActivity
      158 | 
    > 159 |             expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
          |                                                                    ^
      160 |                 'Finished exporting historical events between 2021-10-29 and 2021-11-04 (inclusive).'
      161 |             )
      162 |         })

      at _callee9$ (lib/components/ActivityLog/activityLogLogic.plugin.test.tsx:159:68)
      at tryCatch (../../node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (../../node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (../../node_modules/regenerator-runtime/runtime.js:119:21)
      at asyncGeneratorStep (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)

  ● the activity log logic › humanizing plugins › can handle exports failing

    expect(element).toHaveTextContent()

    Expected element to have text content:
      Fatal error exporting historical events between 2021-10-29 and 2021-11-04 (inclusive). Check logs for more details.
    Received:
      Fatal error exporting historical events between 2021-10-28 and 2021-11-03 (inclusive). Check logs for more details.

      175 |             const actual = logic.values.humanizedActivity
      176 | 
    > 177 |             expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
          |                                                                    ^
      178 |                 'Fatal error exporting historical events between 2021-10-29 and 2021-11-04 (inclusive). Check logs for more details.'
      179 |             )
      180 |         })

      at _callee10$ (lib/components/ActivityLog/activityLogLogic.plugin.test.tsx:177:68)
      at tryCatch (../../node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (../../node_modules/regenerator-runtime/runtime.js:294:22)
      at Generator.next (../../node_modules/regenerator-runtime/runtime.js:119:21)
      at asyncGeneratorStep (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)


Test Suites: 1 failed, 85 passed, 86 total
Tests:       2 failed, 3 skipped, 844 passed, 849 total
Snapshots:   14 passed, 14 total
Time:        267.03 s
Ran all test suites.
```

These don't seem to be related to my changes here. Additionally, when running the tests on master I get the same errors, so I don't think they need to be considered for this PR.