### PR TITLE
feat: remove version from docker compose to support new spec

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,6 @@
 # If you are looking at self-hosted deployment options check
 # https://posthog.com/docs/self-host
 #
-version: '3'
 
 services:
     db:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -4,7 +4,6 @@
 # Please take a look at https://posthog.com/docs/self-host/deploy/hobby
 # for more info.
 #
-version: '3'
 
 services:
     db:


### PR DESCRIPTION
## Problem

This is mainly for myself, but it will allow us to use extends in our composes which is exactly what we should be doing
https://github.com/moby/moby/issues/31101#issuecomment-922378041
https://github.com/compose-spec/compose-spec/blob/master/spec.md#extends

## Changes

Remove version from docker-compose files

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
