### PR TITLE
feat: simplify the docker-compose setup so we do less version coordinations

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -36,8 +36,8 @@ runs:
           shell: bash
           run: |
               export CLICKHOUSE_SERVER_IMAGE=${{ inputs.clickhouse-server-image }}
-              docker-compose -f docker-compose.dev.yml down
-              docker-compose -f docker-compose.dev.yml up -d
+              docker compose -f docker-compose.dev.yml down
+              docker compose -f docker-compose.dev.yml up -d
 
         - name: Add Kafka to /etc/hosts
           shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ concurrency: 'benchmarks' # Ensure only one of this runs at a time
 jobs:
     run-benchmarks:
         name: Clickhouse queries
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         environment: clickhouse-benchmarks
 
         # Benchmarks are expensive to run so we only run them (periodically) against master branch and for PRs labeled `performance`

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,8 +48,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ concurrency: 'benchmarks' # Ensure only one of this runs at a time
 jobs:
     run-benchmarks:
         name: Clickhouse queries
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         environment: clickhouse-benchmarks
 
         # Benchmarks are expensive to run so we only run them (periodically) against master branch and for PRs labeled `performance`

--- a/.github/workflows/ci-async-migrations.yml
+++ b/.github/workflows/ci-async-migrations.yml
@@ -32,8 +32,8 @@ jobs:
               shell: bash
               run: |
                   export CLICKHOUSE_SERVER_IMAGE_VERSION=${{ inputs.clickhouse-server-image-version }}
-                  docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@v4

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -67,7 +67,7 @@ jobs:
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-backend.yml
                         - .github/workflows/backend-tests-action/action.yml
-                        # We use docker-compose for tests, make sure we rerun on
+                        # We use docker compose for tests, make sure we rerun on
                         # changes to docker-compose.dev.yml e.g. dependency
                         # version changes
                         - docker-compose.dev.yml
@@ -88,8 +88,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@v4
@@ -142,8 +142,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@v4
@@ -331,8 +331,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f master/docker-compose.dev.yml down
-                  docker-compose -f master/docker-compose.dev.yml up -d
+                  docker compose -f master/docker-compose.dev.yml down
+                  docker compose -f master/docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@v4

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -237,8 +237,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Wait for ClickHouse
               run: ./bin/check_kafka_clickhouse_up

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
     code-quality:
         name: Code quality
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         defaults:
             run:
                 working-directory: 'plugin-server'
@@ -65,7 +65,7 @@ jobs:
 
     tests:
         name: Tests (${{matrix.shard}})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         strategy:
             fail-fast: false
@@ -151,7 +151,7 @@ jobs:
 
     functional-tests:
         name: Functional tests
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         env:
             REDIS_URL: 'redis://localhost'

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -84,8 +84,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Add Kafka to /etc/hosts
               run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
@@ -166,8 +166,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Add Kafka to /etc/hosts
               run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
     code-quality:
         name: Code quality
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         defaults:
             run:
                 working-directory: 'plugin-server'
@@ -65,7 +65,7 @@ jobs:
 
     tests:
         name: Tests (${{matrix.shard}})
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
@@ -151,7 +151,7 @@ jobs:
 
     functional-tests:
         name: Functional tests
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         env:
             REDIS_URL: 'redis://localhost'

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -148,7 +148,7 @@ sudo apt install -y docker-ce
 
 # setup docker-compose
 echo "Setting up Docker Compose"
-sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose || true
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.13.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose || true
 sudo chmod +x /usr/local/bin/docker-compose
 
 # enable docker without sudo

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -157,6 +157,7 @@ sudo usermod -aG docker "${USER}" || true
 # start up the stack
 echo "Configuring Docker Compose...."
 rm -f docker-compose.yml
+cp posthog/docker-compose.base.yml docker-compose.base.yml
 cp posthog/docker-compose.hobby.yml docker-compose.yml.tmpl
 envsubst < docker-compose.yml.tmpl > docker-compose.yml
 rm docker-compose.yml.tmpl

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,0 +1,63 @@
+#
+# docker-compose file used ONLY for local development.
+# For more info, see:
+# https://posthog.com/handbook/engineering/developing-locally
+#
+# If you are looking at self-hosted deployment options check
+# https://posthog.com/docs/self-host
+#
+
+services:
+    db:
+        image: postgres:12-alpine
+        restart: on-failure
+        environment:
+            POSTGRES_USER: posthog
+            POSTGRES_DB: posthog
+            POSTGRES_PASSWORD: posthog
+        command: postgres -c 'max_connections=1000'
+
+    redis:
+        image: redis:6.2.7-alpine
+        restart: on-failure
+        command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+
+    clickhouse:
+        #
+        # Note: please keep the default version in sync across
+        #       `posthog` and the `charts-clickhouse` repos
+        #
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:22.3}
+        restart: on-failure
+        depends_on:
+            - kafka
+            - zookeeper
+    zookeeper:
+        image: zookeeper:3.7.0
+        restart: on-failure
+
+    kafka:
+        image: bitnami/kafka:2.8.1-debian-10-r99
+        restart: on-failure
+        depends_on:
+            - zookeeper
+        environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
+
+    object_storage:
+        image: minio/minio:RELEASE.2022-06-25T15-50-16Z
+        restart: on-failure
+        environment:
+            MINIO_ROOT_USER: object_storage_root_user
+            MINIO_ROOT_PASSWORD: object_storage_root_password
+        entrypoint: sh
+        command: -c 'mkdir -p /data/posthog && minio server --address ":19000" --console-address ":19001" /data' # create the 'posthog' bucket before starting the service
+
+    maildev:
+        image: maildev/maildev:2.0.5
+        restart: on-failure

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,7 +1,5 @@
 #
-# docker-compose file used ONLY for local development.
-# For more info, see:
-# https://posthog.com/handbook/engineering/developing-locally
+# docker-compose base file used for local development, hobby deploys, and other compose use cases.
 #
 # If you are looking at self-hosted deployment options check
 # https://posthog.com/docs/self-host

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,33 +9,23 @@
 
 services:
     db:
-        image: postgres:12-alpine
-        restart: on-failure
-        environment:
-            POSTGRES_USER: posthog
-            POSTGRES_DB: posthog
-            POSTGRES_PASSWORD: posthog
+        extends:
+            file: docker-compose.base.yml
+            service: db
         ports:
             - '5432:5432'
-        command: postgres -c 'max_connections=1000'
 
     redis:
-        image: redis:6.2.7-alpine
-        restart: on-failure
+        extends:
+            file: docker-compose.base.yml
+            service: redis
         ports:
             - '6379:6379'
-        command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
 
     clickhouse:
-        #
-        # Note: please keep the default version in sync across
-        #       `posthog` and the `charts-clickhouse` repos
-        #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:22.3}
-        restart: on-failure
-        depends_on:
-            - kafka
-            - zookeeper
+        extends:
+            file: docker-compose.base.yml
+            service: clickhouse
         ports:
             - '8123:8123'
             - '9000:9000'
@@ -46,40 +36,31 @@ services:
             - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
+
     zookeeper:
-        image: zookeeper:3.7.0
-        restart: on-failure
+        extends:
+            file: docker-compose.base.yml
+            service: zookeeper
 
     kafka:
-        image: bitnami/kafka:2.8.1-debian-10-r99
-        restart: on-failure
-        depends_on:
-            - zookeeper
+        extends:
+            file: docker-compose.base.yml
+            service: kafka
         ports:
             - '9092:9092'
-        environment:
-            KAFKA_BROKER_ID: 1001
-            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
-            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
-            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
-            ALLOW_PLAINTEXT_LISTENER: 'true'
 
     object_storage:
-        image: minio/minio:RELEASE.2022-06-25T15-50-16Z
-        restart: on-failure
+        extends:
+            file: docker-compose.base.yml
+            service: object_storage
         ports:
             - '19000:19000'
             - '19001:19001'
-        environment:
-            MINIO_ROOT_USER: object_storage_root_user
-            MINIO_ROOT_PASSWORD: object_storage_root_password
-        entrypoint: sh
-        command: -c 'mkdir -p /data/posthog && minio server --address ":19000" --console-address ":19001" /data' # create the 'posthog' bucket before starting the service
 
     maildev:
-        image: maildev/maildev:2.0.5
-        restart: on-failure
+        extends:
+            file: docker-compose.base.yml
+            service: maildev
         ports:
             - '1080:1080'
             - '1025:1025'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,6 @@
 # If you are looking at self-hosted deployment options check
 # https://posthog.com/docs/self-host
 #
-version: '3'
 
 services:
     db:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -4,7 +4,6 @@
 # Please take a look at https://posthog.com/docs/self-host/deploy/hobby
 # for more info.
 #
-version: '3'
 
 services:
     db:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -7,24 +7,23 @@
 
 services:
     db:
-        image: postgres:12-alpine
-        restart: on-failure
-        environment:
-            POSTGRES_USER: posthog
-            POSTGRES_DB: posthog
-            POSTGRES_PASSWORD: posthog
+        extends:
+            file: docker-compose.base.yml
+            service: db
         volumes:
             - postgres-data:/var/lib/postgresql/data
     redis:
-        image: redis:6.2.7-alpine
-        restart: on-failure
-        command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+        extends:
+            file: docker-compose.base.yml
+            service: redis
     clickhouse:
         #
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:22.3}
+        extends:
+            file: docker-compose.base.yml
+            service: clickhouse
         restart: on-failure
         depends_on:
             - kafka
@@ -36,24 +35,17 @@ services:
             - ./posthog/docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
             - clickhouse-data:/var/lib/clickhouse
     zookeeper:
-        image: zookeeper:3.7.0
-        restart: on-failure
+        extends:
+            file: docker-compose.base.yml
+            service: zookeeper
         volumes:
             - zookeeper-datalog:/datalog
             - zookeeper-data:/data
             - zookeeper-logs:/logs
     kafka:
-        image: bitnami/kafka:2.8.1-debian-10-r99
-        restart: on-failure
-        depends_on:
-            - zookeeper
-        environment:
-            KAFKA_BROKER_ID: 1001
-            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
-            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
-            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
-            ALLOW_PLAINTEXT_LISTENER: 'true'
+        extends:
+            file: docker-compose.base.yml
+            service: kafka
 
     worker: &worker
         image: posthog/posthog:$POSTHOG_APP_TAG
@@ -115,15 +107,12 @@ services:
             - object_storage
 
     object_storage:
-        image: minio/minio:RELEASE.2022-09-17T00-09-45Z.fips
+        extends:
+            file: docker-compose.base.yml
+            service: object_storage
         restart: on-failure
         volumes:
             - object_storage:/data
-        environment:
-            MINIO_ROOT_USER: object_storage_root_user
-            MINIO_ROOT_PASSWORD: object_storage_root_password
-        entrypoint: sh
-        command: -c 'mkdir -p /data/posthog && minio server --address ":19000" --console-address ":19001" /data' # create the 'posthog' bucket before starting the service
 
     asyncmigrationscheck:
         <<: *worker

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -22,9 +22,9 @@
         "prepublishOnly": "yarn build",
         "setup:dev:clickhouse": "cd .. && DEBUG=1 python manage.py migrate_clickhouse",
         "setup:test": "cd .. && TEST=1 python manage.py setup_test_environment",
-        "services:start": "cd .. && docker-compose -f docker-compose.dev.yml up",
-        "services:stop": "cd .. && docker-compose -f docker-compose.dev.yml down",
-        "services:clean": "cd .. && docker-compose -f docker-compose.dev.yml rm -v",
+        "services:start": "cd .. && docker compose -f docker-compose.dev.yml up",
+        "services:stop": "cd .. && docker compose -f docker-compose.dev.yml down",
+        "services:clean": "cd .. && docker compose -f docker-compose.dev.yml rm -v",
         "services": "yarn services:stop && yarn services:clean && yarn services:start"
     },
     "bin": {


### PR DESCRIPTION
- feat: remove version from docker compose to support new spec
- feat: simplify the docker-compose setup so we do less version coordinations

depends on https://github.com/PostHog/posthog/pull/12997

This moves from `docker-compose` to `docker compose` which is how github differentiates between v1 and v2

## Problem

This makes it easier by having a base docker-compose template for development by using `extends`. Very exciting!
https://github.com/compose-spec/compose-spec/blob/master/spec.md#extends

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
