### PR TITLE
chore: configure sentry profiling using an environment variable

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -7,6 +7,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
+from posthog.settings import get_from_env
 from posthog.settings.base_variables import TEST
 
 
@@ -68,6 +69,8 @@ def sentry_init() -> None:
         sentry_sdk.utils.MAX_STRING_LENGTH = 10_000_000
         # https://docs.sentry.io/platforms/python/
         sentry_logging = sentry_logging = LoggingIntegration(level=logging.INFO, event_level=None)
+        profiles_sample_rate = get_from_env("SENTRY_PROFILES_SAMPLE_RATE", type_cast=float, default=0.0)
+
         sentry_sdk.init(
             dsn=os.environ["SENTRY_DSN"],
             environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
@@ -80,7 +83,7 @@ def sentry_init() -> None:
             _experiments={
                 # https://docs.sentry.io/platforms/python/profiling/
                 # The profiles_sample_rate setting is relative to the traces_sample_rate setting.
-                "profiles_sample_rate": 0.1,
+                "profiles_sample_rate": profiles_sample_rate,
             },
         )
 

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -68,7 +68,7 @@ def sentry_init() -> None:
     if not TEST and os.getenv("SENTRY_DSN"):
         sentry_sdk.utils.MAX_STRING_LENGTH = 10_000_000
         # https://docs.sentry.io/platforms/python/
-        sentry_logging = sentry_logging = LoggingIntegration(level=logging.INFO, event_level=None)
+        sentry_logging = LoggingIntegration(level=logging.INFO, event_level=None)
         profiles_sample_rate = get_from_env("SENTRY_PROFILES_SAMPLE_RATE", type_cast=float, default=0.0)
 
         sentry_sdk.init(

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -132,6 +132,23 @@ class TestGeneralUtils(TestCase):
         mock_env.return_value = "4"
         self.assertEqual(get_from_env("test_key", type_cast=int), 4)
 
+    @patch("os.getenv")
+    def test_fetching_env_var_parsed_as_float(self, mock_env):
+        mock_env.return_value = ""
+        self.assertEqual(get_from_env("test_key", optional=True, type_cast=float, default=0.0), None)
+
+        mock_env.return_value = ""
+        self.assertEqual(get_from_env("test_key", type_cast=float, default=0.0), 0.0)
+
+        mock_env.return_value = "4"
+        self.assertEqual(get_from_env("test_key", type_cast=float), 4.0)
+
+    @patch("os.getenv")
+    def test_fetching_env_var_parsed_as_float_from_nonsense_input(self, mock_env):
+        with pytest.raises(ValueError):
+            mock_env.return_value = "wat"
+            get_from_env("test_key", type_cast=float)
+
 
 class TestRelativeDateParse(TestCase):
     @freeze_time("2020-01-31T12:22:23")


### PR DESCRIPTION
## Problem

see #12980 

instead of always having sentry profiling on this allows you to turn it off using an environment variable

Tested by running locally with a test DSN and seeing events still received
