### PR TITLE
fix(homepage): Don't load dashboard twice

### DIFF
--- a/cypress/e2e/projectHomepage.js
+++ b/cypress/e2e/projectHomepage.js
@@ -6,7 +6,7 @@ describe('Project Homepage', () => {
 
     it('Shows home dashboard on load', () => {
         cy.wait('@getDashboard').its('response.statusCode').should('eq', 200)
-        cy.verifyCallCount(`getDashboard`, 1) // Only loads once
+        cy.get(`getDashboard.all`).should('have.length', 1) // Only loads once
         cy.get('[data-attr=insight-card]').its('length').should('be.gte', 1)
     })
 })

--- a/cypress/e2e/projectHomepage.js
+++ b/cypress/e2e/projectHomepage.js
@@ -1,0 +1,12 @@
+describe('Project Homepage', () => {
+    beforeEach(() => {
+        cy.intercept('GET', /\/api\/projects\/\d+\/dashboards\/\d+\//).as('getDashboard')
+        cy.clickNavMenu('projecthomepage')
+    })
+
+    it('Shows home dashboard on load', () => {
+        cy.wait('@getDashboard').its('response.statusCode').should('eq', 200)
+        cy.verifyCallCount(`getDashboard`, 1) // Only loads once
+        cy.get('[data-attr=insight-card]').its('length').should('be.gte', 1)
+    })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,3 +30,9 @@ Cypress.Commands.add('map', { prevSubject: true }, (subject, method) => {
 Cypress.Commands.add('clickNavMenu', (name) => {
     cy.get(`[data-attr="menu-item-${name}"]`).click()
 })
+
+Cypress.Commands.add(`verifyCallCount`, (alias, expectedNumberOfCalls) => {
+    cy.get(`${alias}.all`).then((calls) => {
+        cy.wrap(calls.length).should(`equal`, expectedNumberOfCalls)
+    })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,9 +30,3 @@ Cypress.Commands.add('map', { prevSubject: true }, (subject, method) => {
 Cypress.Commands.add('clickNavMenu', (name) => {
     cy.get(`[data-attr="menu-item-${name}"]`).click()
 })
-
-Cypress.Commands.add(`verifyCallCount`, (alias, expectedNumberOfCalls) => {
-    cy.get(`${alias}.all`).then((calls) => {
-        cy.wrap(calls.length).should(`equal`, expectedNumberOfCalls)
-    })
-})

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -21,13 +21,14 @@ import { NewInsightButton } from 'scenes/saved-insights/SavedInsights'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
 import { Link } from '@posthog/lemon-ui'
 import { urls } from 'scenes/urls'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
 export function ProjectHomepage(): JSX.Element {
-    const { dashboardLogic } = useValues(projectHomepageLogic)
+    const { dashboardLogicProps } = useValues(projectHomepageLogic)
     const { currentTeam } = useValues(teamLogic)
     const {
         allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
-    } = useValues(dashboardLogic)
+    } = useValues(dashboardLogic(dashboardLogicProps))
     const { showInviteModal } = useActions(inviteLogic)
     const { showPrimaryDashboardModal } = useActions(primaryDashboardModalLogic)
     const topListContainerRef = useRef<HTMLDivElement | null>(null)

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -1,13 +1,11 @@
-import { afterMount, BuiltLogic, connect, kea, path, selectors } from 'kea'
+import { afterMount, connect, kea, path, selectors } from 'kea'
 
 import type { projectHomepageLogicType } from './projectHomepageLogicType'
 import { teamLogic } from 'scenes/teamLogic'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { DashboardLogicProps } from 'scenes/dashboard/dashboardLogic'
 import { DashboardPlacement, InsightModel, PersonType } from '~/types'
 import api from 'lib/api'
-import { subscriptions } from 'kea-subscriptions'
 import { loaders } from 'kea-loaders'
-import { dashboardLogicType } from 'scenes/dashboard/dashboardLogicType'
 
 export const projectHomepageLogic = kea<projectHomepageLogicType>([
     path(['scenes', 'project-homepage', 'projectHomepageLogic']),
@@ -17,13 +15,12 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
 
     selectors({
         primaryDashboardId: [() => [teamLogic.selectors.currentTeam], (currentTeam) => currentTeam?.primary_dashboard],
-        dashboardLogic: [
+        dashboardLogicProps: [
             (s) => [s.primaryDashboardId],
-            (primaryDashboardId): BuiltLogic<dashboardLogicType> =>
-                dashboardLogic({
-                    id: primaryDashboardId ?? undefined,
-                    placement: DashboardPlacement.ProjectHomepage,
-                }),
+            (primaryDashboardId): DashboardLogicProps => ({
+                id: primaryDashboardId ?? undefined,
+                placement: DashboardPlacement.ProjectHomepage,
+            }),
         ],
     }),
 
@@ -50,15 +47,7 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
         ],
     })),
 
-    subscriptions(({ cache }: projectHomepageLogicType) => ({
-        dashboardLogic: (logic: ReturnType<typeof dashboardLogic.build>) => {
-            cache.unmount?.()
-            cache.unmount = logic ? logic.mount() : null
-        },
-    })),
-
-    afterMount(({ cache, actions }) => {
-        cache.unmount?.()
+    afterMount(({ actions }) => {
         actions.loadRecentInsights()
         actions.loadPersons()
     }),


### PR DESCRIPTION
## Problem

Should resolve #12999.

## Changes

Building and mounting a logic within a logic is prone to weird problems, and that's what we were doing in `projectHomePageLogic`, resulting in the homepage dashboard being fetched twice on load. Instead it's much more reliable to mount logics at the React level, and only build props in the logic.

## How did you test this code?

Added a Cypress test.