### PR TITLE
fix: text card layout

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCard.scss
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.scss
@@ -17,10 +17,6 @@
         padding-inline-start: 1.5em;
     }
 
-    p {
-        margin-bottom: 0;
-    }
-
     img {
         max-width: 100%;
     }

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -33,7 +33,7 @@ interface TextCardBodyProps extends Pick<React.HTMLAttributes<HTMLDivElement>, '
 export function TextContent({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
     return (
         // eslint-disable-next-line react/forbid-dom-props
-        <div className="p-2 w-full overflow-y-auto" onClick={() => closeDetails?.()} style={style}>
+        <div className="relative p-2 w-full overflow-auto" onClick={() => closeDetails?.()} style={style}>
             <ReactMarkdown>{text}</ReactMarkdown>
         </div>
     )
@@ -42,7 +42,7 @@ export function TextContent({ text, closeDetails, style }: TextCardBodyProps): J
 export function TextCardBody({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
     return (
         // eslint-disable-next-line react/forbid-dom-props
-        <div className="TextCard-Body" onClick={() => closeDetails?.()} style={style}>
+        <div className="TextCard-Body w-full" onClick={() => closeDetails?.()} style={style}>
             <TextContent text={text} />
         </div>
     )

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -33,7 +33,7 @@ interface TextCardBodyProps extends Pick<React.HTMLAttributes<HTMLDivElement>, '
 export function TextContent({ text, closeDetails, style }: TextCardBodyProps): JSX.Element {
     return (
         // eslint-disable-next-line react/forbid-dom-props
-        <div className="relative p-2 w-full overflow-auto" onClick={() => closeDetails?.()} style={style}>
+        <div className="p-2 w-full overflow-auto" onClick={() => closeDetails?.()} style={style}>
             <ReactMarkdown>{text}</ReactMarkdown>
         </div>
     )


### PR DESCRIPTION
## Problem

Text cards were overflowing their bounds and text was too bunched up

## Changes

* don't remove margin bottom from paragraphs in text cards
* restrain width of text cards

### before

![before](https://user-images.githubusercontent.com/984817/204521297-a0962238-2b4f-4489-b31d-c909d26cd999.gif)

### after

![after](https://user-images.githubusercontent.com/984817/204521158-5ce92398-c617-48ba-a857-fdb957f873d6.gif)


## How did you test this code?

running it locally