### PR TITLE
fix: Proper fix for recording links logic order

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -258,16 +258,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
             actions.getSessionRecordingsProperties({})
         },
     })),
-    subscriptions(({ actions, props }) => ({
-        staticRecordings: (staticRecording, oldStaticRecording) => {
-            if (!props.isStatic) {
-                return
-            }
-            if (!equal(staticRecording || [], oldStaticRecording || [])) {
-                actions.getSessionRecordings({})
-            }
-        },
-    })),
     selectors({
         sessionRecordingIdToProperties: [
             (s) => [s.sessionRecordingsPropertiesResponse],
@@ -314,15 +304,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
             (filters) =>
                 (filters?.actions?.length || 0) + (filters?.events?.length || 0) + (filters?.properties?.length || 0),
         ],
-    }),
-
-    afterMount(({ actions, values }) => {
-        const hashParams = router.values.hashParams
-        const nulledSessionRecordingId = hashParams.sessionRecordingId ?? null
-        if (nulledSessionRecordingId !== values.selectedRecordingId) {
-            actions.setSelectedRecordingId(nulledSessionRecordingId)
-        }
-        actions.getSessionRecordings({})
     }),
 
     actionToUrl(({ props, values }) => {
@@ -378,4 +359,22 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
             '*': urlToAction,
         }
     }),
+
+    subscriptions(({ actions, props }) => ({
+        staticRecordings: (staticRecording, oldStaticRecording) => {
+            if (!props.isStatic) {
+                return
+            }
+            if (!equal(staticRecording || [], oldStaticRecording || [])) {
+                actions.getSessionRecordings({})
+            }
+        },
+    })),
+
+    // NOTE: It is important this comes after urlToAction, as it will override the default behavior
+    afterMount(({ actions }) => {
+        actions.getSessionRecordings({})
+    }),
 ])
+
+// http://localhost:8000/recordings/recent?filters=%7B%22session_recording_duration%22%3A%7B%22type%22%3A%22recording%22%2C%22key%22%3A%22duration%22%2C%22value%22%3A60%2C%22operator%22%3A%22gt%22%7D%2C%22properties%22%3A%5B%5D%2C%22events%22%3A%5B%7B%22id%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22name%22%3A%22%24pageview%22%7D%5D%2C%22actions%22%3A%5B%5D%2C%22date_from%22%3A%222022-11-08%22%7D#sessionRecordingId=184c38db35712c0-06fe2f55feab86-40292c33-384000-184c38db35820b5

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -376,5 +376,3 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         actions.getSessionRecordings({})
     }),
 ])
-
-// http://localhost:8000/recordings/recent?filters=%7B%22session_recording_duration%22%3A%7B%22type%22%3A%22recording%22%2C%22key%22%3A%22duration%22%2C%22value%22%3A60%2C%22operator%22%3A%22gt%22%7D%2C%22properties%22%3A%5B%5D%2C%22events%22%3A%5B%7B%22id%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22name%22%3A%22%24pageview%22%7D%5D%2C%22actions%22%3A%5B%5D%2C%22date_from%22%3A%222022-11-08%22%7D#sessionRecordingId=184c38db35712c0-06fe2f55feab86-40292c33-384000-184c38db35820b5


### PR DESCRIPTION
## Problem

Figured out what was really going wrong. The afterMount was triggering before the router based stuff - not good. 

## Changes

* Moving the afterMount to _after_ the other stuff means all the url parsing will happen _before_ it gets overridden by the get call
* Added a NOTE as a reminder for the future. Couldn't seem to make a test that replicates this. We probably want to look into E2E tests...


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just manually but we should think about E2E tests for these flows soon