### PR TITLE
feat: open invite modal by url

### DIFF
--- a/frontend/src/scenes/organization/Settings/inviteLogic.ts
+++ b/frontend/src/scenes/organization/Settings/inviteLogic.ts
@@ -132,4 +132,11 @@ export const inviteLogic = kea<inviteLogicType>({
     events: ({ actions }) => ({
         afterMount: [actions.loadInvites],
     }),
+    urlToAction: ({ actions }) => ({
+        '*': (_, searchParams) => {
+            if (searchParams.invite_modal) {
+                actions.showInviteModal()
+            }
+        },
+    }),
 })


### PR DESCRIPTION
## Problem
We want to be able to open the invite modal from the URL (e.g. from emails)

## Changes
- adding `?invite_modal=true` as a search parameter triggers the invitation modal

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- Tested locally