### PR TITLE
fix(onboarding-v2): the "help is on the way" panel not showing

### DIFF
--- a/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/v2/IngestionWizard.tsx
@@ -52,8 +52,7 @@ export function IngestionWizardV2(): JSX.Element {
 function IngestionContainer({ children }: { children: React.ReactNode }): JSX.Element {
     const { isInviteModalShown } = useValues(inviteLogic)
     const { hideInviteModal } = useActions(inviteLogic)
-    const { isSmallScreen, hasInvitedMembers } = useValues(ingestionLogicV2)
-    const { next } = useActions(ingestionLogicV2)
+    const { isSmallScreen } = useValues(ingestionLogicV2)
 
     return (
         <div className="flex h-full flex-col">
@@ -64,15 +63,7 @@ function IngestionContainer({ children }: { children: React.ReactNode }): JSX.El
                     <SitePopover />
                 </div>
             </div>
-            <InviteModal
-                isOpen={isInviteModalShown}
-                onClose={() => {
-                    hideInviteModal()
-                    if (hasInvitedMembers) {
-                        next({ isTechnicalUser: false })
-                    }
-                }}
-            />
+            <InviteModal isOpen={isInviteModalShown} onClose={hideInviteModal} />
             <div className="flex h-full">
                 {!isSmallScreen && <Sidebar />}
                 {/* <div className="IngestionContainer" */}

--- a/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
@@ -511,7 +511,11 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         },
         inviteTeamMembersSuccess: () => {
             if (router.values.location.pathname.includes('/ingestion')) {
-                actions.setState({ ...values.currentState, hasInvitedMembers: true } as IngestionState)
+                actions.setState({
+                    ...values.currentState,
+                    isTechnicalUser: false,
+                    hasInvitedMembers: true,
+                } as IngestionState)
             }
         },
     })),


### PR DESCRIPTION
## Problem

If email service is available then the "Help is on the way" panel wouldn't show after invite. I'm not entirely sure why, but this seems to fix it locally for me. 🤞 it works in prod too!

## Changes

The "Help is on the way" panel should now show up after inviting someone regardless of whether email service is available.

![image](https://user-images.githubusercontent.com/18598166/204660921-c0db67b9-cf81-46c6-988f-64970ba61fff.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
