### PR TITLE
fix: Set Ubuntu 22.04 to not ask user before restarting service for hobby CI

### DIFF
--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -26,6 +26,7 @@ if branch_regex.match(branch):
 hostname = f"{name}.posthog.cc"
 user_data = (
     f"#!/bin/bash \n"
+    "sed -i \"s/#\\$nrconf{restart} = 'i';/\\$nrconf{restart} = 'a';/g\" /etc/needrestart/needrestart.conf \n"
     f"wget https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/deploy-hobby \n"
     f"chmod +x deploy-hobby \n"
     f"./deploy-hobby {release_tag} {hostname} 1 \n"


### PR DESCRIPTION
This fixes CI with hobby deploy where ubuntu prompts the user before restarting a service getting updated
