### PR TITLE
feat: Move links to top area to improve available vertical space

### DIFF
--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1998,15 +1998,3 @@ export function IconSkipBackward(props: SvgIconProps): JSX.Element {
         </SvgIcon>
     )
 }
-
-/** Material Design Content Save Outline icon. */
-export function IconSave(props: SvgIconProps): JSX.Element {
-    return (
-        <SvgIcon viewBox="0 0 24 24" {...props}>
-            <path
-                fill="currentColor"
-                d="M17 3H5C3.89 3 3 3.9 3 5V19C3 20.1 3.89 21 5 21H19C20.1 21 21 20.1 21 19V7L17 3M19 19H5V5H16.17L19 7.83V19M12 12C10.34 12 9 13.34 9 15S10.34 18 12 18 15 16.66 15 15 13.66 12 12 12M6 6H15V10H6V6Z"
-            />
-        </SvgIcon>
-    )
-}

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -19,6 +19,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { PropertyIcon } from 'lib/components/PropertyIcon'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { SessionRecordingPlayerLogicProps } from './sessionRecordingPlayerLogic'
+import { PlayerMetaLinks } from './PlayerMetaLinks'
 
 export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPlayerLogicProps): JSX.Element {
     const {
@@ -76,7 +77,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                         />
                     )}
                 </div>
-                <div className="flex-1 overflow-hidden ph-no-capture">
+                <div className="overflow-hidden ph-no-capture">
                     <div className="font-bold">
                         {!sessionPerson || !recordingStartTime ? (
                             <LemonSkeleton className="w-1/3 my-1" />
@@ -136,6 +137,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                         ) : null}
                     </div>
                 </div>
+
                 <LemonButton
                     className={clsx('PlayerMeta__expander', isFullScreen ? 'rotate-90' : '')}
                     status="stealth"
@@ -145,6 +147,10 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                     tooltip={isMetadataExpanded ? 'Hide person properties' : 'Show person properties'}
                     tooltipPlacement={isFullScreen ? 'bottom' : 'left'}
                 />
+
+                <div className="flex-1">
+                    <PlayerMetaLinks sessionRecordingId={sessionRecordingId} playerKey={playerKey} />
+                </div>
             </div>
             {sessionPerson && (
                 <CSSTransition

--- a/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
@@ -5,14 +5,16 @@ import {
 import { useActions, useValues } from 'kea'
 import { LemonButton } from 'lib/components/LemonButton'
 import { openPlayerAddToPlaylistDialog } from 'scenes/session-recordings/player/add-to-playlist/PlayerAddToPlaylist'
-import { IconLink, IconSave, IconWithCount } from 'lib/components/icons'
+import { IconLink, IconPlus, IconWithCount } from 'lib/components/icons'
 import { openPlayerShareDialog } from 'scenes/session-recordings/player/share/PlayerShare'
+import { playerSettingsLogic } from './playerSettingsLogic'
 
-export function PlayerHeader({ sessionRecordingId, playerKey }: SessionRecordingPlayerLogicProps): JSX.Element {
+export function PlayerMetaLinks({ sessionRecordingId, playerKey }: SessionRecordingPlayerLogicProps): JSX.Element {
     const logic = sessionRecordingPlayerLogic({ sessionRecordingId, playerKey })
     const { recordingStartTime, sessionPlayerData } = useValues(logic)
     const { setPause } = useActions(logic)
     const playlists = sessionPlayerData.metadata.playlists ?? []
+    const { isFullScreen } = useValues(playerSettingsLogic)
 
     const onShare = (): void => {
         setPause()
@@ -32,18 +34,23 @@ export function PlayerHeader({ sessionRecordingId, playerKey }: SessionRecording
     }
 
     return (
-        <div className="py-2 px-3 flex flex-row justify-end gap-3">
-            <LemonButton icon={<IconLink />} status="primary-alt" onClick={() => onShare()} tooltip="Share recording">
+        <div className="flex flex-row justify-end gap-2">
+            <LemonButton
+                icon={<IconLink />}
+                onClick={onShare}
+                tooltip="Share recording"
+                size={isFullScreen ? 'small' : 'medium'}
+            >
                 Share
             </LemonButton>
             <LemonButton
-                status="primary-alt"
                 onClick={onAddToPlaylist}
                 icon={
                     <IconWithCount count={playlists.length}>
-                        <IconSave />
+                        <IconPlus />
                     </IconWithCount>
                 }
+                size={isFullScreen ? 'small' : 'medium'}
                 tooltip="Save recording to static playlist"
             >
                 Save

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.scss
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.scss
@@ -13,13 +13,6 @@
         border-radius: 0px;
     }
 
-    .SessionRecordingPlayer__header {
-        width: 100%;
-        background-color: var(--side);
-        min-width: 1px;
-        border-bottom: 1px solid var(--border);
-    }
-
     .SessionRecordingPlayer__body {
         position: relative;
         z-index: 0;

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -21,7 +21,6 @@ import { RecordingNotFound } from 'scenes/session-recordings/player/RecordingNot
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { SessionRecordingType } from '~/types'
 import { PlayerFrameOverlay } from './PlayerFrameOverlay'
-import { PlayerHeader } from 'scenes/session-recordings/player/PlayerHeader'
 
 export function useFrameRef({
     sessionRecordingId,
@@ -139,9 +138,6 @@ export function SessionRecordingPlayer({
                 {includeMeta || isFullScreen ? (
                     <PlayerMeta sessionRecordingId={sessionRecordingId} playerKey={playerKey} />
                 ) : null}
-                <div className="SessionRecordingPlayer__header">
-                    <PlayerHeader sessionRecordingId={sessionRecordingId} playerKey={playerKey} />
-                </div>
                 <div className="SessionRecordingPlayer__body">
                     <PlayerFrame sessionRecordingId={sessionRecordingId} ref={frame} playerKey={playerKey} />
                     <PlayerFrameOverlay


### PR DESCRIPTION
## Problem

Great work was done to add playlists and sharing but the button placement left something to be desired 😉

## Changes

* Removes the extra vertical bar
* Moves header buttons to "MetaLinks" at the right hand side of the top area.
* Removes the Floppy disk icon (@alexkim205 generally the PlusIcon is our go to for this sort of stuff)

|Before|After|
|----|----|
|<img width="1002" alt="Screenshot 2022-11-30 at 10 11 02" src="https://user-images.githubusercontent.com/2536520/204754752-d405b308-3075-404c-8eca-04bc67ab39eb.png">|<img width="987" alt="Screenshot 2022-11-30 at 10 10 46" src="https://user-images.githubusercontent.com/2536520/204754791-bb8819de-4dce-45d7-8ae1-321bb750d877.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 