### PR TITLE
fix(ingestion): fix noisy 'Invalid unit value NaN' errors

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -115,6 +115,7 @@
         "pino-pretty": "^9.1.0",
         "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
+        "timekeeper": "^2.2.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.7.4"

--- a/plugin-server/src/worker/ingestion/event-pipeline/4-processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/4-processPersonsStep.ts
@@ -12,7 +12,7 @@ export async function processPersonsStep(
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
     const event = normalizeEvent(pluginEvent)
-    const timestamp = parseEventTimestamp(event, runner.hub.statsd)
+    const timestamp = parseEventTimestamp(event)
 
     const newPersonContainer: LazyPersonContainer = await updatePersonState(
         event,

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
@@ -11,8 +11,8 @@ export async function prepareEventStep(
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
     const { ip, site_url, team_id, uuid } = event
-    const invalidTimestampCallback = function (teamId: number) {
-        runner.hub.statsd?.increment('process_event_invalid_timestamp', { teamId: String(teamId) })
+    const invalidTimestampCallback = function () {
+        runner.hub.statsd?.increment('process_event_invalid_timestamp', { teamId: String(team_id) })
     }
     const preIngestionEvent = await runner.hub.eventsProcessor.processEvent(
         String(event.distinct_id),

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
@@ -11,12 +11,15 @@ export async function prepareEventStep(
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
     const { ip, site_url, team_id, uuid } = event
+    const invalidTimestampCallback = function (teamId: number) {
+        runner.hub.statsd?.increment('process_event_invalid_timestamp', { teamId: String(teamId) })
+    }
     const preIngestionEvent = await runner.hub.eventsProcessor.processEvent(
         String(event.distinct_id),
         ip,
         event,
         team_id,
-        parseEventTimestamp(event, runner.hub.statsd),
+        parseEventTimestamp(event, invalidTimestampCallback),
         uuid! // it will throw if it's undefined,
     )
 

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -12,8 +12,8 @@ export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimesta
 
     const parsedTs = handleTimestamp(data, now, sentAt)
     const ts = parsedTs.isValid ? parsedTs : DateTime.utc()
-    if (!parsedTs.isValid && callback) {
-        callback(data['team_id'])
+    if (!parsedTs.isValid) {
+        callback?.(data['team_id'])
     }
     return ts
 }

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -29,7 +29,7 @@ function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | nu
                 // otherwise we can't get a diff to add to now
                 return now.plus(timestamp.diff(sentAt))
             } catch (error) {
-                status.error('⚠️', 'Error when handling timestamp:', error)
+                status.error('⚠️', 'Error when handling timestamp:', { error: error.message })
                 Sentry.captureException(error, { extra: { data, now, sentAt } })
             }
         }

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -1,37 +1,39 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
-import { StatsD } from 'hot-shots'
 import { DateTime, Duration } from 'luxon'
 
 import { status } from '../../utils/status'
 
-export function parseEventTimestamp(data: PluginEvent, statsd?: StatsD | undefined): DateTime {
+type InvalidTimestampCallback = (teamId: number) => void
+
+export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimestampCallback): DateTime {
     const now = DateTime.fromISO(data['now']).toUTC()
     const sentAt = data['sent_at'] ? DateTime.fromISO(data['sent_at']).toUTC() : null
 
     const parsedTs = handleTimestamp(data, now, sentAt)
     const ts = parsedTs.isValid ? parsedTs : DateTime.utc()
-    if (!parsedTs.isValid) {
-        statsd?.increment('process_event_invalid_timestamp', { teamId: String(data['team_id']) })
+    if (!parsedTs.isValid && callback) {
+        callback(data['team_id'])
     }
     return ts
 }
 
 function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | null): DateTime {
     if (data['timestamp']) {
-        if (sentAt) {
+        const timestamp = parseDate(data['timestamp'])
+        if (sentAt && sentAt.isValid && timestamp.isValid) {
             // sent_at - timestamp == now - x
             // x = now + (timestamp - sent_at)
             try {
                 // timestamp and sent_at must both be in the same format: either both with or both without timezones
                 // otherwise we can't get a diff to add to now
-                return now.plus(parseDate(data['timestamp']).diff(sentAt))
+                return now.plus(timestamp.diff(sentAt))
             } catch (error) {
                 status.error('⚠️', 'Error when handling timestamp:', error)
                 Sentry.captureException(error, { extra: { data, now, sentAt } })
             }
         }
-        return parseDate(data['timestamp'])
+        return timestamp
     }
     if (data['offset']) {
         return now.minus(Duration.fromMillis(data['offset']))

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -4,7 +4,7 @@ import { DateTime, Duration } from 'luxon'
 
 import { status } from '../../utils/status'
 
-type InvalidTimestampCallback = (teamId: number) => void
+type InvalidTimestampCallback = () => void
 
 export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimestampCallback): DateTime {
     const now = DateTime.fromISO(data['now']).toUTC()
@@ -13,7 +13,7 @@ export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimesta
     const parsedTs = handleTimestamp(data, now, sentAt)
     const ts = parsedTs.isValid ? parsedTs : DateTime.utc()
     if (!parsedTs.isValid) {
-        callback?.(data['team_id'])
+        callback?.()
     }
     return ts
 }

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -133,7 +133,7 @@ describe('parseEventTimestamp()', () => {
 
         const callbackMock = jest.fn()
         const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls).toEqual([[123]])
+        expect(callbackMock.mock.calls).toEqual([[]])
 
         const difference = rightNow.diff(timestamp, 'millisecond').seconds
         expect(difference).toBeLessThan(1)

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -8464,6 +8464,11 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
+timekeeper@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/timekeeper/-/timekeeper-2.2.0.tgz#9645731fce9e3280a18614a57a9d1b72af3ca368"
+  integrity sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==
+
 tiny-lru@7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"


### PR DESCRIPTION
## Problem

First part of the changes to address https://github.com/PostHog/posthog/issues/13015. This should remove the Sentry events for the case of bad input (double-quoted timestamp value) we are seeing.

## Changes

- make sure we check that the timestamp is valid before doing maths, fail fast if it's not the case
- move the statsd reporting to a callback function, we'll extend it later with an ingestion warning
- only report the error once, through prepareEvenStep

## How did you test this code?

Added test cases to the existing coverage
