### PR TITLE
chore(plugin-server): add docs for running functional tests

### DIFF
--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -19,7 +19,34 @@ Let's get you developing the plugin server in no time:
 
 1. Start the plugin server in autoreload mode with `yarn start:dev`, or in compiled mode with `yarn build && yarn start:dist`, and develop away!
 
-1. Prepare for running tests with `yarn setup:test`, which will run the necessary migrations. Run the tests themselves with `yarn test:{1,2}`.
+1. Prepare for running tests with `yarn setup:test`, which will run the
+   necessary migrations. Run the tests themselves with `yarn test:{1,2}`.
+
+1. Prepare for running functional tests. See notes below.
+
+## Functional tests
+
+Functional tests are provided located in `functional_tests`. They provide tests
+for high level functionality of the plugin-server, i.e. functionality that any
+client of the plugin-server should be able to use. It attempts to assume nothing
+of the implementation details of the plugin-server.
+
+At the time of writing it assumes:
+
+1. that events are pushed into Kafka topics.
+1. that side-effects of the plugin-server are updates to ClickHouse table data.
+1. that the plugin-server reads certain data from Postgres tables e.g.
+   `posthog_team`, `posthog_pluginsource` etc. These would ideally be wrapped in
+   some implementation detail agnostic API.
+
+It specifically doesn't assume details of the running plugin-server process e.g.
+runtime stack.
+
+See `bin/ci_functional_tests.sh` for how these tests are run in CI. For local
+testing:
+
+1. start the plugin-server with `yarn start:dev`
+1. run the tests with `yarn functional_tests --watch`
 
 ## CLI flags
 

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -39,7 +39,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_SASL_PASSWORD: null,
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv() ? 0 : 1000,
-        KAFKA_MAX_MESSAGE_BATCH_SIZE: 900_000,
+        KAFKA_MAX_MESSAGE_BATCH_SIZE: isDevEnv() ? 0 : 900_000,
         KAFKA_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 500,
         APP_METRICS_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 20_000,
         REDIS_URL: 'redis://127.0.0.1',
@@ -48,7 +48,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         POSTHOG_REDIS_PORT: 6379,
         BASE_DIR: '.',
         PLUGINS_RELOAD_PUBSUB_CHANNEL: 'reload-plugins',
-        WORKER_CONCURRENCY: coreCount,
+        WORKER_CONCURRENCY: isDevEnv() ? 1 : coreCount,
         TASK_TIMEOUT: 30,
         TASKS_PER_WORKER: 10,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,
@@ -83,10 +83,10 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY: 1,
         CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS_TEAMS: '',
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
-        CONVERSION_BUFFER_ENABLED: !isTestEnv(),
+        CONVERSION_BUFFER_ENABLED: isDevEnv() ? true : !isTestEnv(),
         CONVERSION_BUFFER_ENABLED_TEAMS: '',
         CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS: '',
-        BUFFER_CONVERSION_SECONDS: 60, // KEEP IN SYNC WITH posthog/settings/ingestion.py
+        BUFFER_CONVERSION_SECONDS: isDevEnv() ? 2 : 60, // KEEP IN SYNC WITH posthog/settings/ingestion.py
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min
         KAFKA_HEALTHCHECK_SECONDS: 20,
         OBJECT_STORAGE_ENABLED: false,
@@ -101,7 +101,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         HISTORICAL_EXPORTS_MAX_RETRY_COUNT: 15,
         HISTORICAL_EXPORTS_INITIAL_FETCH_TIME_WINDOW: 10 * 60 * 1000,
         HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER: 1.5,
-        APP_METRICS_GATHERED_FOR_ALL: false,
+        APP_METRICS_GATHERED_FOR_ALL: isDevEnv() ? true : false,
         MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR: 0,
     }
 }


### PR DESCRIPTION
To make it more easy to run these tests, I've also added defaults for certain config variables for when run in dev mode.

These tests were already run in production via
`plugin-server/bin/ci_functional_tests.sh` but it isn't obvious how they should be run locally. You can of course run `ci_functional_tests.sh` locally but this is not particularly great developer experience, i.e. the iteration time is pretty large.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
