### PR TITLE
fix(storybook): update dashboard api response to new format

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,7 +8,9 @@ import { useAvailableFeatures } from '~/mocks/features'
 
 const setupMsw = () => {
     // Make sure the msw worker is started
-    worker.start()
+    worker.start({
+        quiet: true,
+    })
     ;(window as any).__mockServiceWorker = worker
     ;(window as any).POSTHOG_APP_CONTEXT = getStorybookAppContext()
 }

--- a/frontend/src/scenes/dashboard/__mocks__/dashboard1.json
+++ b/frontend/src/scenes/dashboard/__mocks__/dashboard1.json
@@ -1,1295 +1,4664 @@
 {
     "id": 1,
-    "name": "My App Dashboard",
-    "description": "",
+    "name": "🔑 Key metrics",
+    "description": "Company overview.",
+    "items": null,
     "pinned": true,
-    "items": [
-        {
-            "id": 2,
-            "short_id": "W88Cowcy",
-            "name": "Cumulative DAUs",
-            "derived_name": null,
-            "filters": {
-                "events": [
-                    {
-                        "id": "$pageview",
-                        "math": "dau",
-                        "type": "events"
-                    }
-                ],
-                "display": "ActionsLineGraphCumulative",
-                "insight": "TRENDS",
-                "interval": "day",
-                "date_from": "-7d",
-                "date_to": null
-            },
-            "filters_hash": "cache_047cf098889443aedbcf8dc0d8324f30",
-            "order": null,
-            "deleted": false,
-            "dashboards": [1],
-            "layouts": {
-                "sm": {
-                    "h": 5,
-                    "w": 6,
-                    "x": 6,
-                    "y": 0,
-                    "minH": 5,
-                    "minW": 3,
-                    "moved": false,
-                    "static": false
-                },
-                "xs": {
-                    "h": 5,
-                    "w": 1,
-                    "x": 0,
-                    "y": 5,
-                    "minH": 5,
-                    "minW": 3
-                }
-            },
-            "color": "black",
-            "last_refresh": "2022-03-14T21:19:49.471076Z",
-            "refreshing": false,
-            "result": [
-                {
-                    "action": {
-                        "id": "$pageview",
-                        "type": "events",
-                        "order": null,
-                        "name": "$pageview",
-                        "custom_name": null,
-                        "math": "dau",
-                        "math_property": null,
-                        "math_group_type_index": null,
-                        "properties": {}
-                    },
-                    "label": "$pageview",
-                    "count": 26891,
-                    "data": [6783, 17005, 23595, 25772, 26838, 26838, 26838, 26891],
-                    "labels": [
-                        "7-Mar-2022",
-                        "8-Mar-2022",
-                        "9-Mar-2022",
-                        "10-Mar-2022",
-                        "11-Mar-2022",
-                        "12-Mar-2022",
-                        "13-Mar-2022",
-                        "14-Mar-2022"
-                    ],
-                    "days": [
-                        "2022-03-07",
-                        "2022-03-08",
-                        "2022-03-09",
-                        "2022-03-10",
-                        "2022-03-11",
-                        "2022-03-12",
-                        "2022-03-13",
-                        "2022-03-14"
-                    ],
-                    "persons_urls": [
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-07"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-07&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-08"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-08&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-09"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-09&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-10"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-10&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-11"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-11&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-12"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-12&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-13"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-13&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau",
-                                "date_from": "2022-03-07T00:00:00Z",
-                                "date_to": "2022-03-14"
-                            },
-                            "url": "api/projects/1/persons/trends/?date_from=2022-03-07+00%3A00%3A00%2B00%3A00&date_to=2022-03-14&display=ActionsLineGraphCumulative&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        }
-                    ],
-                    "filter": {
-                        "date_from": "-7d",
-                        "date_to": "2022-03-14T21:19:48.944275+00:00",
-                        "display": "ActionsLineGraphCumulative",
-                        "events": [
-                            {
-                                "id": "$pageview",
-                                "type": "events",
-                                "order": null,
-                                "name": "$pageview",
-                                "custom_name": null,
-                                "math": "dau",
-                                "math_property": null,
-                                "math_group_type_index": null,
-                                "properties": {}
-                            }
-                        ],
-                        "insight": "TRENDS",
-                        "interval": "day"
-                    }
-                }
-            ],
-            "created_at": "2022-03-11T13:03:32.423632Z",
-            "created_by": null,
-            "description": "Shows the total cumulative number of unique users that have been using your app.",
-            "updated_at": "2022-03-16T10:23:48.175127Z",
-            "tags": [],
-            "favorited": false,
-            "saved": false,
-            "last_modified_at": "2022-03-11T13:03:32.418832Z",
-            "last_modified_by": null,
-            "is_sample": false,
-            "effective_restriction_level": 21,
-            "effective_privilege_level": 37
-        },
-        {
-            "id": 5,
-            "short_id": "MxlmjYui",
-            "name": "Users by browser (last 2 weeks)",
-            "derived_name": null,
-            "filters": {
-                "events": [
-                    {
-                        "id": "$pageview",
-                        "math": "dau",
-                        "type": "events"
-                    }
-                ],
-                "display": "ActionsPie",
-                "insight": "TRENDS",
-                "interval": "day",
-                "breakdown": "$browser",
-                "date_from": "-7d",
-                "breakdown_type": "person",
-                "date_to": null
-            },
-            "filters_hash": "cache_d2bb26ae515b0bc13b530da044ce7e0f",
-            "order": null,
-            "deleted": false,
-            "dashboards": [1],
-            "layouts": {
-                "sm": {
-                    "h": 5,
-                    "w": 6,
-                    "x": 6,
-                    "y": 5,
-                    "minH": 5,
-                    "minW": 3,
-                    "moved": false,
-                    "static": false
-                },
-                "xs": {
-                    "h": 5,
-                    "w": 1,
-                    "x": 0,
-                    "y": 10,
-                    "minH": 5,
-                    "minW": 3
-                }
-            },
-            "color": null,
-            "last_refresh": "2022-03-14T21:19:49.832796Z",
-            "refreshing": false,
-            "result": [
-                {
-                    "action": {
-                        "id": "$pageview",
-                        "type": "events",
-                        "order": null,
-                        "name": "$pageview",
-                        "custom_name": null,
-                        "math": "dau",
-                        "math_property": null,
-                        "math_group_type_index": null,
-                        "properties": {}
-                    },
-                    "label": "$pageview - none",
-                    "count": 0,
-                    "data": [],
-                    "labels": [],
-                    "days": [
-                        "2022-03-07",
-                        "2022-03-08",
-                        "2022-03-09",
-                        "2022-03-10",
-                        "2022-03-11",
-                        "2022-03-12",
-                        "2022-03-13",
-                        "2022-03-14"
-                    ],
-                    "aggregated_value": 26890,
-                    "filter": {
-                        "breakdown": "$browser",
-                        "breakdown_type": "person",
-                        "date_from": "-7d",
-                        "date_to": "2022-03-14T21:19:48.955740+00:00",
-                        "display": "ActionsPie",
-                        "events": "[{\"id\": \"$pageview\", \"type\": \"events\", \"order\": null, \"name\": \"$pageview\", \"custom_name\": null, \"math\": \"dau\", \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
-                        "insight": "TRENDS",
-                        "interval": "day"
-                    },
-                    "persons": {
-                        "filter": {
-                            "entity_id": "$pageview",
-                            "entity_type": "events",
-                            "breakdown_value": "",
-                            "breakdown_type": "person"
-                        },
-                        "url": "api/projects/1/persons/trends/?breakdown=%24browser&breakdown_type=person&date_from=-7d&date_to=2022-03-14T21%3A19%3A48.955740%2B00%3A00&display=ActionsPie&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&breakdown_value="
-                    },
-                    "breakdown_value": ""
-                },
-                {
-                    "action": {
-                        "id": "$pageview",
-                        "type": "events",
-                        "order": null,
-                        "name": "$pageview",
-                        "custom_name": null,
-                        "math": "dau",
-                        "math_property": null,
-                        "math_group_type_index": null,
-                        "properties": {}
-                    },
-                    "label": "$pageview - Chrome",
-                    "count": 0,
-                    "data": [],
-                    "labels": [],
-                    "days": [
-                        "2022-03-07",
-                        "2022-03-08",
-                        "2022-03-09",
-                        "2022-03-10",
-                        "2022-03-11",
-                        "2022-03-12",
-                        "2022-03-13",
-                        "2022-03-14"
-                    ],
-                    "aggregated_value": 1,
-                    "filter": {
-                        "breakdown": "$browser",
-                        "breakdown_type": "person",
-                        "date_from": "-7d",
-                        "date_to": "2022-03-14T21:19:48.955740+00:00",
-                        "display": "ActionsPie",
-                        "events": "[{\"id\": \"$pageview\", \"type\": \"events\", \"order\": null, \"name\": \"$pageview\", \"custom_name\": null, \"math\": \"dau\", \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
-                        "insight": "TRENDS",
-                        "interval": "day"
-                    },
-                    "persons": {
-                        "filter": {
-                            "entity_id": "$pageview",
-                            "entity_type": "events",
-                            "breakdown_value": "Chrome",
-                            "breakdown_type": "person"
-                        },
-                        "url": "api/projects/1/persons/trends/?breakdown=%24browser&breakdown_type=person&date_from=-7d&date_to=2022-03-14T21%3A19%3A48.955740%2B00%3A00&display=ActionsPie&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events&breakdown_value=Chrome"
-                    },
-                    "breakdown_value": "Chrome"
-                }
-            ],
-            "created_at": "2022-03-11T13:03:32.433477Z",
-            "created_by": null,
-            "description": "Shows a breakdown of browsers used to visit your app per unique users in the last 14 days.",
-            "updated_at": "2022-03-16T10:23:48.191399Z",
-            "tags": [],
-            "favorited": false,
-            "saved": false,
-            "last_modified_at": "2022-03-11T13:03:32.432337Z",
-            "last_modified_by": null,
-            "is_sample": false,
-            "effective_restriction_level": 21,
-            "effective_privilege_level": 37
-        },
-        {
-            "id": 3,
-            "short_id": "nsffgDba",
-            "name": "Repeat users over time",
-            "derived_name": null,
-            "filters": {
-                "events": [
-                    {
-                        "id": "$pageview",
-                        "math": "dau",
-                        "type": "events"
-                    }
-                ],
-                "insight": "TRENDS",
-                "interval": "day",
-                "shown_as": "Stickiness",
-                "entity_id": "$pageview",
-                "entity_type": "events",
-                "date_to": null,
-                "date_from": "-7d"
-            },
-            "filters_hash": "cache_950108d673eadd0f35bcbc6198bc073f",
-            "order": null,
-            "deleted": false,
-            "dashboards": [1],
-            "layouts": {
-                "sm": {
-                    "h": 5,
-                    "w": 6,
-                    "x": 0,
-                    "y": 10,
-                    "minH": 5,
-                    "minW": 3,
-                    "moved": false,
-                    "static": false
-                },
-                "xs": {
-                    "h": 5,
-                    "w": 1,
-                    "x": 0,
-                    "y": 20,
-                    "minH": 5,
-                    "minW": 3
-                }
-            },
-            "color": "black",
-            "last_refresh": "2022-03-14T21:19:49.442495Z",
-            "refreshing": false,
-            "result": [
-                {
-                    "action": {
-                        "id": "$pageview",
-                        "type": "events",
-                        "order": null,
-                        "name": "$pageview",
-                        "custom_name": null,
-                        "math": "dau",
-                        "math_property": null,
-                        "math_group_type_index": null,
-                        "properties": {}
-                    },
-                    "label": "$pageview",
-                    "count": 26891,
-                    "data": [26776, 115, 0, 0, 0, 0, 0, 0],
-                    "labels": ["1 day", "2 days", "3 days", "4 days", "5 days", "6 days", "7 days", "8 days"],
-                    "days": [1, 2, 3, 4, 5, 6, 7, 8],
-                    "filter": {
-                        "date_from": "-7d",
-                        "events": "[{\"id\": \"$pageview\", \"type\": \"events\", \"order\": null, \"name\": \"$pageview\", \"custom_name\": null, \"math\": \"dau\", \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
-                        "entity_id": "$pageview",
-                        "entity_type": "events",
-                        "insight": "TRENDS",
-                        "interval": "day",
-                        "shown_as": "Stickiness"
-                    },
-                    "persons_urls": [
-                        {
-                            "filter": {
-                                "stickiness_days": 1,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=1&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 2,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=2&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 3,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=3&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 4,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=4&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 5,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=5&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 6,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=6&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 7,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=7&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 8,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&entity_id=%24pageview&entity_type=events&insight=TRENDS&interval=day&shown_as=Stickiness&stickiness_days=8&entity_math=dau"
-                        }
-                    ]
-                }
-            ],
-            "created_at": "2022-03-11T13:03:32.426395Z",
-            "created_by": null,
-            "description": "Shows you how many users visited your app for a specific number of days (e.g. a user that visited your app twice in the time period will be shown under \"2 days\").",
-            "updated_at": "2022-03-16T10:23:48.202006Z",
-            "tags": [],
-            "favorited": false,
-            "saved": false,
-            "last_modified_at": "2022-03-11T13:03:32.425509Z",
-            "last_modified_by": null,
-            "is_sample": false,
-            "effective_restriction_level": 21,
-            "effective_privilege_level": 37
-        },
-        {
-            "id": 6,
-            "short_id": "6C9YAfSl",
-            "name": "Users by traffic source",
-            "derived_name": "Retention of users based on doing Pageview for the first time and returning with the same event",
-            "filters": {
-                "period": "Day",
-                "display": "ActionsTable",
-                "insight": "RETENTION",
-                "properties": [],
-                "target_entity": {
-                    "id": "$pageview",
-                    "name": "$pageview",
-                    "type": "events"
-                },
-                "retention_type": "retention_first_time",
-                "returning_entity": {
-                    "id": "$pageview",
-                    "name": "$pageview",
-                    "type": "events"
-                },
-                "date_to": null,
-                "date_from": "-7d"
-            },
-            "filters_hash": "cache_137486649ad59a8c60a1fb4d75e16fb6",
-            "order": null,
-            "deleted": false,
-            "dashboards": [1],
-            "layouts": {
-                "sm": {
-                    "h": 5,
-                    "w": 6,
-                    "x": 6,
-                    "y": 10,
-                    "minH": 5,
-                    "minW": 3,
-                    "moved": false,
-                    "static": false
-                },
-                "xs": {
-                    "h": 5,
-                    "w": 1,
-                    "x": 0,
-                    "y": 25,
-                    "minH": 5,
-                    "minW": 3
-                }
-            },
-            "color": null,
-            "last_refresh": "2022-03-14T21:19:50.310435Z",
-            "refreshing": false,
-            "result": [
-                {
-                    "values": [
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 0",
-                    "date": "2022-03-04T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B0%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 1",
-                    "date": "2022-03-05T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B1%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 2",
-                    "date": "2022-03-06T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B2%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 6783,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B3%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 31,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B3%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=1&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 20,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B3%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=2&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 7,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B3%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=3&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 3",
-                    "date": "2022-03-07T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B3%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 10222,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B4%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 32,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B4%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=1&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 11,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B4%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=2&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 2,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B4%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=3&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 4",
-                    "date": "2022-03-08T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B4%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 6590,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B5%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 8,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B5%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=1&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 5",
-                    "date": "2022-03-09T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B5%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 2177,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B6%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 3,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B6%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=1&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 6",
-                    "date": "2022-03-10T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B6%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 1066,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B7%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 1,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B7%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&selected_interval=3&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        }
-                    ],
-                    "label": "Day 7",
-                    "date": "2022-03-11T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B7%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 8",
-                    "date": "2022-03-12T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B8%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 0,
-                            "people": []
-                        },
-                        {
-                            "count": 0,
-                            "people": []
-                        }
-                    ],
-                    "label": "Day 9",
-                    "date": "2022-03-13T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B9%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                },
-                {
-                    "values": [
-                        {
-                            "count": 53,
-                            "people": [],
-                            "people_url": "/api/person/retention/?breakdown_values=%5B10%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                        }
-                    ],
-                    "label": "Day 10",
-                    "date": "2022-03-14T00:00:00Z",
-                    "people_url": "/api/person/retention/?breakdown_values=%5B10%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Day&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=11"
-                }
-            ],
-            "created_at": "2022-03-11T13:03:32.436101Z",
-            "created_by": null,
-            "description": "Shows a breakdown of where unique users came from when visiting your app.",
-            "updated_at": "2022-03-16T10:23:48.216576Z",
-            "tags": [],
-            "favorited": false,
-            "saved": true,
-            "last_modified_at": "2022-03-11T19:37:11.415831Z",
-            "last_modified_by": {
-                "id": 1,
-                "uuid": "017f7913-c1ee-0000-faff-0fe5ace3849a",
-                "distinct_id": "Q1OD2NmnqqbqrLR45mYm2p1VNNbSO9DBFsMig90GWkK",
-                "first_name": "Marius",
-                "email": "marius@posthog.com"
-            },
-            "is_sample": false,
-            "effective_restriction_level": 21,
-            "effective_privilege_level": 37
-        },
-        {
-            "id": 1,
-            "short_id": "L2IOIfgD",
-            "name": "Daily Active Users (DAUs) 123",
-            "derived_name": "User stickiness based on $pageview",
-            "filters": {
-                "events": [
-                    {
-                        "id": "$pageview",
-                        "math": "dau",
-                        "type": "events"
-                    }
-                ],
-                "date_to": null,
-                "display": "ActionsLineGraph",
-                "insight": "STICKINESS",
-                "interval": "day",
-                "shown_as": "Stickiness",
-                "date_from": "-7d",
-                "properties": {
-                    "type": "AND",
-                    "values": []
-                }
-            },
-            "filters_hash": "cache_1511038b6f6d660b29aefda6cca9f264",
-            "order": null,
-            "deleted": false,
-            "dashboards": [1],
-            "layouts": {
-                "sm": {
-                    "h": 5,
-                    "w": 6,
-                    "x": 0,
-                    "y": 0,
-                    "minH": 5,
-                    "minW": 3,
-                    "moved": false,
-                    "static": false
-                },
-                "xs": {
-                    "h": 5,
-                    "w": 1,
-                    "x": 0,
-                    "y": 0,
-                    "minH": 5,
-                    "minW": 3
-                }
-            },
-            "color": null,
-            "last_refresh": "2022-03-14T21:19:49.470379Z",
-            "refreshing": false,
-            "result": [
-                {
-                    "action": {
-                        "id": "$pageview",
-                        "type": "events",
-                        "order": null,
-                        "name": "$pageview",
-                        "custom_name": null,
-                        "math": "dau",
-                        "math_property": null,
-                        "math_group_type_index": null,
-                        "properties": {}
-                    },
-                    "label": "$pageview",
-                    "count": 20166,
-                    "data": [20109, 57, 0, 0, 0, 0, 0, 0],
-                    "labels": ["1 day", "2 days", "3 days", "4 days", "5 days", "6 days", "7 days", "8 days"],
-                    "days": [1, 2, 3, 4, 5, 6, 7, 8],
-                    "filter": {
-                        "date_from": "-7d",
-                        "events": "[{\"id\": \"$pageview\", \"type\": \"events\", \"order\": null, \"name\": \"$pageview\", \"custom_name\": null, \"math\": \"dau\", \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
-                        "insight": "STICKINESS",
-                        "interval": "day",
-                        "shown_as": "Stickiness"
-                    },
-                    "persons_urls": [
-                        {
-                            "filter": {
-                                "stickiness_days": 1,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=1&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 2,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=2&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 3,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=3&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 4,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=4&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 5,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=5&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 6,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=6&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 7,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=7&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        },
-                        {
-                            "filter": {
-                                "stickiness_days": 8,
-                                "entity_id": "$pageview",
-                                "entity_type": "events",
-                                "entity_math": "dau"
-                            },
-                            "url": "api/person/stickiness/?date_from=-7d&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22dau%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=STICKINESS&interval=day&shown_as=Stickiness&stickiness_days=8&entity_id=%24pageview&entity_type=events&entity_math=dau"
-                        }
-                    ]
-                }
-            ],
-            "created_at": "2022-03-11T13:03:32.416312Z",
-            "created_by": null,
-            "description": "Shows the number of unique users that use your app every day.",
-            "updated_at": "2022-03-16T10:23:48.232463Z",
-            "tags": [],
-            "favorited": false,
-            "saved": true,
-            "last_modified_at": "2022-03-15T21:29:01.764122Z",
-            "last_modified_by": {
-                "id": 1,
-                "uuid": "017f7913-c1ee-0000-faff-0fe5ace3849a",
-                "distinct_id": "Q1OD2NmnqqbqrLR45mYm2p1VNNbSO9DBFsMig90GWkK",
-                "first_name": "Marius",
-                "email": "marius@posthog.com"
-            },
-            "is_sample": false,
-            "effective_restriction_level": 21,
-            "effective_privilege_level": 37
-        },
-        {
-            "id": 4,
-            "short_id": "qWKBKCSI",
-            "name": "Sample - Purchase conversion funnel",
-            "derived_name": null,
-            "filters": {
-                "events": [
-                    {
-                        "id": "$pageview",
-                        "type": "events",
-                        "order": 0
-                    },
-                    {
-                        "id": "$autocapture",
-                        "name": "Clicked purchase button",
-                        "type": "events",
-                        "order": 1,
-                        "properties": [
-                            {
-                                "key": "$event_type",
-                                "type": "event",
-                                "value": "click"
-                            },
-                            {
-                                "key": "text",
-                                "type": "element",
-                                "value": "Purchase"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "$autocapture",
-                        "name": "Submitted checkout form",
-                        "type": "events",
-                        "order": 2,
-                        "properties": [
-                            {
-                                "key": "$event_type",
-                                "type": "event",
-                                "value": "submit"
-                            },
-                            {
-                                "key": "$pathname",
-                                "type": "event",
-                                "value": "/purchase"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "Order Completed",
-                        "name": "Order Completed",
-                        "type": "events",
-                        "order": 3
-                    }
-                ],
-                "insight": "FUNNELS",
-                "date_to": null,
-                "date_from": "-7d"
-            },
-            "filters_hash": "cache_3fbba30540e42272dc5742216364a13d",
-            "order": null,
-            "deleted": false,
-            "dashboards": [1],
-            "layouts": {
-                "sm": {
-                    "h": 5,
-                    "w": 6,
-                    "x": 0,
-                    "y": 5,
-                    "minH": 5,
-                    "minW": 3,
-                    "moved": false,
-                    "static": false
-                },
-                "xs": {
-                    "h": 5,
-                    "w": 1,
-                    "x": 0,
-                    "y": 15,
-                    "minH": 5,
-                    "minW": 3
-                }
-            },
-            "color": null,
-            "last_refresh": "2022-03-14T21:19:50.682187Z",
-            "refreshing": false,
-            "result": [
-                {
-                    "action_id": "$pageview",
-                    "name": "$pageview",
-                    "custom_name": null,
-                    "order": 0,
-                    "people": [],
-                    "count": 26891,
-                    "type": "events",
-                    "average_conversion_time": null,
-                    "median_conversion_time": null,
-                    "converted_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=1&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
-                    "dropped_people_url": null
-                },
-                {
-                    "action_id": "$autocapture",
-                    "name": "$autocapture",
-                    "custom_name": null,
-                    "order": 1,
-                    "people": [],
-                    "count": 0,
-                    "type": "events",
-                    "average_conversion_time": null,
-                    "median_conversion_time": null,
-                    "converted_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=2&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
-                    "dropped_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-2&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100"
-                },
-                {
-                    "action_id": "$autocapture",
-                    "name": "$autocapture",
-                    "custom_name": null,
-                    "order": 2,
-                    "people": [],
-                    "count": 0,
-                    "type": "events",
-                    "average_conversion_time": null,
-                    "median_conversion_time": null,
-                    "converted_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=3&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
-                    "dropped_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-3&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100"
-                },
-                {
-                    "action_id": "Order Completed",
-                    "name": "Order Completed",
-                    "custom_name": null,
-                    "order": 3,
-                    "people": [],
-                    "count": 0,
-                    "type": "events",
-                    "average_conversion_time": null,
-                    "median_conversion_time": null,
-                    "converted_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=4&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
-                    "dropped_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-4&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100"
-                }
-            ],
-            "created_at": "2022-03-11T13:03:32.430404Z",
-            "created_by": null,
-            "description": "This is a sample of how a user funnel could look like. It represents the number of users that performed a specific action at each step.",
-            "updated_at": "2022-03-16T10:23:48.278785Z",
-            "tags": [],
-            "favorited": false,
-            "saved": false,
-            "last_modified_at": "2022-03-11T13:03:32.427820Z",
-            "last_modified_by": null,
-            "is_sample": true,
-            "effective_restriction_level": 21,
-            "effective_privilege_level": 37
-        }
-    ],
-    "created_at": "2022-03-11T13:03:32.412546Z",
+    "created_at": "2022-11-28T10:36:16.957671Z",
     "created_by": null,
     "is_shared": false,
     "deleted": false,
     "creation_mode": "default",
-    "filters": {
-        "date_to": null,
-        "date_from": "-7d"
-    },
-    "tags": [],
+    "filters": {},
+    "tiles": [
+        {
+            "id": 1,
+            "insight": {
+                "id": 1,
+                "short_id": "NqD3cS7N",
+                "name": "Weekly signups",
+                "derived_name": null,
+                "filters": {
+                    "events": [{ "id": "signed_up", "type": "events", "order": 0 }],
+                    "actions": [],
+                    "display": "ActionsLineGraph",
+                    "insight": "TRENDS",
+                    "interval": "week",
+                    "date_from": "-8w"
+                },
+                "filters_hash": "cache_e70019305379d96e7996f34fc0a3fc1f",
+                "order": null,
+                "deleted": false,
+                "dashboards": [1],
+                "last_refresh": "2022-11-30T11:14:29.621791Z",
+                "refreshing": false,
+                "result": [
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up",
+                        "count": 50.0,
+                        "data": [4.0, 2.0, 6.0, 6.0, 6.0, 5.0, 12.0, 7.0, 2.0],
+                        "labels": [
+                            "2-Oct-2022",
+                            "9-Oct-2022",
+                            "16-Oct-2022",
+                            "23-Oct-2022",
+                            "30-Oct-2022",
+                            "6-Nov-2022",
+                            "13-Nov-2022",
+                            "20-Nov-2022",
+                            "27-Nov-2022"
+                        ],
+                        "days": [
+                            "2022-10-02",
+                            "2022-10-09",
+                            "2022-10-16",
+                            "2022-10-23",
+                            "2022-10-30",
+                            "2022-11-06",
+                            "2022-11-13",
+                            "2022-11-20",
+                            "2022-11-27"
+                        ],
+                        "persons_urls": [
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-10-02",
+                                    "date_to": "2022-10-02",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-02&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-10-02&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-10-09",
+                                    "date_to": "2022-10-09",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-09&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-10-09&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-10-16",
+                                    "date_to": "2022-10-16",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-16&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-10-16&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-10-23",
+                                    "date_to": "2022-10-23",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-23&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-10-23&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-10-30",
+                                    "date_to": "2022-10-30",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-30&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-10-30&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-11-06",
+                                    "date_to": "2022-11-06",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-06&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-11-06&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-11-13",
+                                    "date_to": "2022-11-13",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-13&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-11-13&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-11-20",
+                                    "date_to": "2022-11-20",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-20&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-11-20&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "signed_up",
+                                    "entity_type": "events",
+                                    "entity_math": null,
+                                    "date_from": "2022-11-27",
+                                    "date_to": "2022-11-27",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-27&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&smoothing_intervals=1&entity_id=signed_up&entity_type=events&date_to=2022-11-27&entity_order=0"
+                            }
+                        ],
+                        "filter": {
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "date_from": "-8w",
+                            "display": "ActionsLineGraph",
+                            "events": [
+                                {
+                                    "id": "signed_up",
+                                    "type": "events",
+                                    "order": 0,
+                                    "name": "signed_up",
+                                    "custom_name": null,
+                                    "math": null,
+                                    "math_property": null,
+                                    "math_group_type_index": null,
+                                    "properties": {}
+                                }
+                            ],
+                            "insight": "TRENDS",
+                            "interval": "week",
+                            "smoothing_intervals": 1
+                        }
+                    }
+                ],
+                "created_at": "2022-11-28T10:36:16.971721Z",
+                "created_by": null,
+                "description": null,
+                "updated_at": "2022-11-28T10:36:16.971752Z",
+                "favorited": false,
+                "saved": true,
+                "last_modified_at": "2022-11-05T10:35:59.100351Z",
+                "last_modified_by": {
+                    "id": 1,
+                    "uuid": "0184bdce-e55b-0000-7a1f-cff0c8a9fbdd",
+                    "distinct_id": "66DmhJ27SbenLic9Zb17i508LEmgSq6fQTJ0t5btBhw",
+                    "first_name": "Employee 427",
+                    "email": "test@posthog.com"
+                },
+                "is_sample": false,
+                "effective_restriction_level": 21,
+                "effective_privilege_level": 37,
+                "timezone": null,
+                "tags": []
+            },
+            "text": null,
+            "last_refresh": "2022-11-30T11:14:29.621791Z",
+            "is_cached": true,
+            "layouts": {
+                "sm": { "h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3 },
+                "xs": { "h": 5, "w": 1, "x": 0, "y": 0, "minH": 5, "minW": 3, "moved": false, "static": false }
+            },
+            "color": "blue",
+            "filters_hash": "cache_e70019305379d96e7996f34fc0a3fc1f",
+            "refreshing": false,
+            "refresh_attempt": 0
+        },
+        {
+            "id": 2,
+            "insight": {
+                "id": 2,
+                "short_id": "Mwbqlk39",
+                "name": "Last month's signups by country",
+                "derived_name": null,
+                "filters": {
+                    "events": [{ "id": "signed_up", "type": "events", "order": 0 }],
+                    "actions": [],
+                    "display": "WorldMap",
+                    "insight": "TRENDS",
+                    "breakdown": "$geoip_country_code",
+                    "date_from": "-1m",
+                    "breakdown_type": "event"
+                },
+                "filters_hash": "cache_ceb3f58b5afdd69bd25c42f87b0359c9",
+                "order": null,
+                "deleted": false,
+                "dashboards": [1],
+                "last_refresh": "2022-11-30T11:14:29.717689Z",
+                "refreshing": false,
+                "result": [
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up - US",
+                        "count": 0,
+                        "data": [],
+                        "labels": [],
+                        "days": [
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "aggregated_value": 26,
+                        "filter": {
+                            "breakdown": "$geoip_country_code",
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "breakdown_type": "event",
+                            "date_from": "-1m",
+                            "display": "WorldMap",
+                            "events": "[{\"id\": \"signed_up\", \"type\": \"events\", \"order\": 0, \"name\": \"signed_up\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                            "insight": "TRENDS",
+                            "interval": "day",
+                            "smoothing_intervals": 1
+                        },
+                        "persons": {
+                            "filter": {
+                                "entity_id": "signed_up",
+                                "entity_type": "events",
+                                "breakdown_value": "US",
+                                "breakdown_type": "event"
+                            },
+                            "url": "api/projects/1/persons/trends/?breakdown=%24geoip_country_code&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=-1m&display=WorldMap&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=signed_up&entity_type=events&breakdown_value=US"
+                        },
+                        "breakdown_value": "US"
+                    },
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up - FR",
+                        "count": 0,
+                        "data": [],
+                        "labels": [],
+                        "days": [
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "aggregated_value": 1,
+                        "filter": {
+                            "breakdown": "$geoip_country_code",
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "breakdown_type": "event",
+                            "date_from": "-1m",
+                            "display": "WorldMap",
+                            "events": "[{\"id\": \"signed_up\", \"type\": \"events\", \"order\": 0, \"name\": \"signed_up\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                            "insight": "TRENDS",
+                            "interval": "day",
+                            "smoothing_intervals": 1
+                        },
+                        "persons": {
+                            "filter": {
+                                "entity_id": "signed_up",
+                                "entity_type": "events",
+                                "breakdown_value": "FR",
+                                "breakdown_type": "event"
+                            },
+                            "url": "api/projects/1/persons/trends/?breakdown=%24geoip_country_code&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=-1m&display=WorldMap&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=signed_up&entity_type=events&breakdown_value=FR"
+                        },
+                        "breakdown_value": "FR"
+                    },
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up - PK",
+                        "count": 0,
+                        "data": [],
+                        "labels": [],
+                        "days": [
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "aggregated_value": 1,
+                        "filter": {
+                            "breakdown": "$geoip_country_code",
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "breakdown_type": "event",
+                            "date_from": "-1m",
+                            "display": "WorldMap",
+                            "events": "[{\"id\": \"signed_up\", \"type\": \"events\", \"order\": 0, \"name\": \"signed_up\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                            "insight": "TRENDS",
+                            "interval": "day",
+                            "smoothing_intervals": 1
+                        },
+                        "persons": {
+                            "filter": {
+                                "entity_id": "signed_up",
+                                "entity_type": "events",
+                                "breakdown_value": "PK",
+                                "breakdown_type": "event"
+                            },
+                            "url": "api/projects/1/persons/trends/?breakdown=%24geoip_country_code&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=-1m&display=WorldMap&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=signed_up&entity_type=events&breakdown_value=PK"
+                        },
+                        "breakdown_value": "PK"
+                    },
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up - SH",
+                        "count": 0,
+                        "data": [],
+                        "labels": [],
+                        "days": [
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "aggregated_value": 1,
+                        "filter": {
+                            "breakdown": "$geoip_country_code",
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "breakdown_type": "event",
+                            "date_from": "-1m",
+                            "display": "WorldMap",
+                            "events": "[{\"id\": \"signed_up\", \"type\": \"events\", \"order\": 0, \"name\": \"signed_up\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                            "insight": "TRENDS",
+                            "interval": "day",
+                            "smoothing_intervals": 1
+                        },
+                        "persons": {
+                            "filter": {
+                                "entity_id": "signed_up",
+                                "entity_type": "events",
+                                "breakdown_value": "SH",
+                                "breakdown_type": "event"
+                            },
+                            "url": "api/projects/1/persons/trends/?breakdown=%24geoip_country_code&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=-1m&display=WorldMap&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=signed_up&entity_type=events&breakdown_value=SH"
+                        },
+                        "breakdown_value": "SH"
+                    },
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up - SO",
+                        "count": 0,
+                        "data": [],
+                        "labels": [],
+                        "days": [
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "aggregated_value": 1,
+                        "filter": {
+                            "breakdown": "$geoip_country_code",
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "breakdown_type": "event",
+                            "date_from": "-1m",
+                            "display": "WorldMap",
+                            "events": "[{\"id\": \"signed_up\", \"type\": \"events\", \"order\": 0, \"name\": \"signed_up\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                            "insight": "TRENDS",
+                            "interval": "day",
+                            "smoothing_intervals": 1
+                        },
+                        "persons": {
+                            "filter": {
+                                "entity_id": "signed_up",
+                                "entity_type": "events",
+                                "breakdown_value": "SO",
+                                "breakdown_type": "event"
+                            },
+                            "url": "api/projects/1/persons/trends/?breakdown=%24geoip_country_code&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=-1m&display=WorldMap&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=signed_up&entity_type=events&breakdown_value=SO"
+                        },
+                        "breakdown_value": "SO"
+                    },
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up - TT",
+                        "count": 0,
+                        "data": [],
+                        "labels": [],
+                        "days": [
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "aggregated_value": 1,
+                        "filter": {
+                            "breakdown": "$geoip_country_code",
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "breakdown_type": "event",
+                            "date_from": "-1m",
+                            "display": "WorldMap",
+                            "events": "[{\"id\": \"signed_up\", \"type\": \"events\", \"order\": 0, \"name\": \"signed_up\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                            "insight": "TRENDS",
+                            "interval": "day",
+                            "smoothing_intervals": 1
+                        },
+                        "persons": {
+                            "filter": {
+                                "entity_id": "signed_up",
+                                "entity_type": "events",
+                                "breakdown_value": "TT",
+                                "breakdown_type": "event"
+                            },
+                            "url": "api/projects/1/persons/trends/?breakdown=%24geoip_country_code&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=-1m&display=WorldMap&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=signed_up&entity_type=events&breakdown_value=TT"
+                        },
+                        "breakdown_value": "TT"
+                    },
+                    {
+                        "action": {
+                            "id": "signed_up",
+                            "type": "events",
+                            "order": 0,
+                            "name": "signed_up",
+                            "custom_name": null,
+                            "math": null,
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "signed_up - UG",
+                        "count": 0,
+                        "data": [],
+                        "labels": [],
+                        "days": [
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "aggregated_value": 1,
+                        "filter": {
+                            "breakdown": "$geoip_country_code",
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "breakdown_type": "event",
+                            "date_from": "-1m",
+                            "display": "WorldMap",
+                            "events": "[{\"id\": \"signed_up\", \"type\": \"events\", \"order\": 0, \"name\": \"signed_up\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                            "insight": "TRENDS",
+                            "interval": "day",
+                            "smoothing_intervals": 1
+                        },
+                        "persons": {
+                            "filter": {
+                                "entity_id": "signed_up",
+                                "entity_type": "events",
+                                "breakdown_value": "UG",
+                                "breakdown_type": "event"
+                            },
+                            "url": "api/projects/1/persons/trends/?breakdown=%24geoip_country_code&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=-1m&display=WorldMap&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=signed_up&entity_type=events&breakdown_value=UG"
+                        },
+                        "breakdown_value": "UG"
+                    }
+                ],
+                "created_at": "2022-11-28T10:36:16.983858Z",
+                "created_by": null,
+                "description": null,
+                "updated_at": "2022-11-28T10:36:16.983885Z",
+                "favorited": false,
+                "saved": true,
+                "last_modified_at": "2022-11-22T10:35:59.100351Z",
+                "last_modified_by": {
+                    "id": 1,
+                    "uuid": "0184bdce-e55b-0000-7a1f-cff0c8a9fbdd",
+                    "distinct_id": "66DmhJ27SbenLic9Zb17i508LEmgSq6fQTJ0t5btBhw",
+                    "first_name": "Employee 427",
+                    "email": "test@posthog.com"
+                },
+                "is_sample": false,
+                "effective_restriction_level": 21,
+                "effective_privilege_level": 37,
+                "timezone": null,
+                "tags": []
+            },
+            "text": null,
+            "last_refresh": "2022-11-30T11:14:29.717689Z",
+            "is_cached": true,
+            "layouts": {
+                "sm": { "h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3 },
+                "xs": { "h": 5, "w": 1, "x": 0, "y": 5, "minH": 5, "minW": 3, "moved": false, "static": false }
+            },
+            "color": null,
+            "filters_hash": "cache_ceb3f58b5afdd69bd25c42f87b0359c9",
+            "refreshing": false,
+            "refresh_attempt": 0
+        },
+        {
+            "id": 4,
+            "insight": {
+                "id": 4,
+                "short_id": "H6Vw9ZiY",
+                "name": "New user retention",
+                "derived_name": null,
+                "filters": {
+                    "period": "Week",
+                    "display": "ActionsTable",
+                    "insight": "RETENTION",
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    { "key": "email", "type": "person", "value": "is_set", "operator": "is_set" }
+                                ]
+                            }
+                        ]
+                    },
+                    "target_entity": { "id": "signed_up", "name": "signed_up", "type": "events", "order": 0 },
+                    "retention_type": "retention_first_time",
+                    "total_intervals": 9,
+                    "returning_entity": { "id": 1, "name": "Interacted with file", "type": "actions", "order": 0 },
+                    "date_from": "-7d"
+                },
+                "filters_hash": "cache_6b4441baca5d5db6c136efe0e7e6b82b",
+                "order": null,
+                "deleted": false,
+                "dashboards": [1],
+                "last_refresh": "2022-11-30T11:14:29.709996Z",
+                "refreshing": false,
+                "result": [
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 0",
+                        "date": "2022-10-02T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B0%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 1",
+                        "date": "2022-10-09T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B1%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 2",
+                        "date": "2022-10-16T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B2%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 3",
+                        "date": "2022-10-23T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B3%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 4",
+                        "date": "2022-10-30T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B4%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 5",
+                        "date": "2022-11-06T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B5%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 6",
+                        "date": "2022-11-13T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B6%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [
+                            { "count": 0, "people": [] },
+                            { "count": 0, "people": [] }
+                        ],
+                        "label": "Week 7",
+                        "date": "2022-11-20T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B7%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    },
+                    {
+                        "values": [{ "count": 0, "people": [] }],
+                        "label": "Week 8",
+                        "date": "2022-11-27T00:00:00Z",
+                        "people_url": "/api/person/retention/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_values=%5B8%5D&date_from=-7d&display=ActionsTable&insight=RETENTION&period=Week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22email%22%2C+%22operator%22%3A+%22is_set%22%2C+%22type%22%3A+%22person%22%2C+%22value%22%3A+%22is_set%22%7D%5D%7D&retention_type=retention_first_time&returning_entity=%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+null%2C+%22name%22%3A+null%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&target_entity=%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+null%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D&total_intervals=9"
+                    }
+                ],
+                "created_at": "2022-11-28T10:36:17.028376Z",
+                "created_by": null,
+                "description": null,
+                "updated_at": "2022-11-28T10:36:17.028401Z",
+                "favorited": false,
+                "saved": true,
+                "last_modified_at": "2022-10-25T10:35:59.100351Z",
+                "last_modified_by": {
+                    "id": 1,
+                    "uuid": "0184bdce-e55b-0000-7a1f-cff0c8a9fbdd",
+                    "distinct_id": "66DmhJ27SbenLic9Zb17i508LEmgSq6fQTJ0t5btBhw",
+                    "first_name": "Employee 427",
+                    "email": "test@posthog.com"
+                },
+                "is_sample": false,
+                "effective_restriction_level": 21,
+                "effective_privilege_level": 37,
+                "timezone": null,
+                "tags": []
+            },
+            "text": null,
+            "last_refresh": "2022-11-30T11:14:29.709996Z",
+            "is_cached": true,
+            "layouts": {
+                "sm": { "h": 5, "w": 6, "x": 6, "y": 5, "minH": 5, "minW": 3 },
+                "xs": { "h": 5, "w": 1, "x": 0, "y": 15, "minH": 5, "minW": 3, "moved": false, "static": false }
+            },
+            "color": null,
+            "filters_hash": "cache_6b4441baca5d5db6c136efe0e7e6b82b",
+            "refreshing": false,
+            "refresh_attempt": 0
+        },
+        {
+            "id": 6,
+            "insight": {
+                "id": 6,
+                "short_id": "XbzObpS2",
+                "name": "Weekly file volume",
+                "derived_name": null,
+                "filters": {
+                    "events": [
+                        {
+                            "id": "uploaded_file",
+                            "math": "sum",
+                            "name": "uploaded_file",
+                            "type": "events",
+                            "order": 0,
+                            "custom_name": "Uploaded bytes",
+                            "math_property": "file_size_b"
+                        },
+                        {
+                            "id": "deleted_file",
+                            "math": "sum",
+                            "name": "deleted_file",
+                            "type": "events",
+                            "order": 1,
+                            "custom_name": "Deleted bytes",
+                            "math_property": "file_size_b"
+                        }
+                    ],
+                    "actions": [],
+                    "display": "ActionsLineGraph",
+                    "insight": "TRENDS",
+                    "interval": "week",
+                    "date_from": "-8w",
+                    "new_entity": [],
+                    "properties": [],
+                    "filter_test_accounts": true
+                },
+                "filters_hash": "cache_70ee46d0dc8508016c96227dca04de20",
+                "order": null,
+                "deleted": false,
+                "dashboards": [1],
+                "last_refresh": "2022-11-30T11:14:29.701189Z",
+                "refreshing": false,
+                "result": [
+                    {
+                        "action": {
+                            "id": "uploaded_file",
+                            "type": "events",
+                            "order": 0,
+                            "name": "uploaded_file",
+                            "custom_name": "Uploaded bytes",
+                            "math": "sum",
+                            "math_property": "file_size_b",
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "uploaded_file",
+                        "count": 107713728709.0,
+                        "data": [
+                            8336709041.0, 4652394241.0, 10392341872.0, 19979058414.0, 13433898126.0, 9862530349.0,
+                            21740713827.0, 14537223713.0, 4778859126.0
+                        ],
+                        "labels": [
+                            "2-Oct-2022",
+                            "9-Oct-2022",
+                            "16-Oct-2022",
+                            "23-Oct-2022",
+                            "30-Oct-2022",
+                            "6-Nov-2022",
+                            "13-Nov-2022",
+                            "20-Nov-2022",
+                            "27-Nov-2022"
+                        ],
+                        "days": [
+                            "2022-10-02",
+                            "2022-10-09",
+                            "2022-10-16",
+                            "2022-10-23",
+                            "2022-10-30",
+                            "2022-11-06",
+                            "2022-11-13",
+                            "2022-11-20",
+                            "2022-11-27"
+                        ],
+                        "persons_urls": [
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-02",
+                                    "date_to": "2022-10-02",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-02&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-10-02&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-09",
+                                    "date_to": "2022-10-09",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-09&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-10-09&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-16",
+                                    "date_to": "2022-10-16",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-16&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-10-16&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-23",
+                                    "date_to": "2022-10-23",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-23&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-10-23&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-30",
+                                    "date_to": "2022-10-30",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-30&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-10-30&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-06",
+                                    "date_to": "2022-11-06",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-06&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-11-06&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-13",
+                                    "date_to": "2022-11-13",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-13&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-11-13&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-20",
+                                    "date_to": "2022-11-20",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-20&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-11-20&entity_order=0"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "uploaded_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-27",
+                                    "date_to": "2022-11-27",
+                                    "entity_order": 0
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-27&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=uploaded_file&entity_type=events&entity_math=sum&date_to=2022-11-27&entity_order=0"
+                            }
+                        ],
+                        "filter": {
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "date_from": "-8w",
+                            "display": "ActionsLineGraph",
+                            "events": [
+                                {
+                                    "id": "uploaded_file",
+                                    "type": "events",
+                                    "order": 0,
+                                    "name": "uploaded_file",
+                                    "custom_name": "Uploaded bytes",
+                                    "math": "sum",
+                                    "math_property": "file_size_b",
+                                    "math_group_type_index": null,
+                                    "properties": {}
+                                },
+                                {
+                                    "id": "deleted_file",
+                                    "type": "events",
+                                    "order": 1,
+                                    "name": "deleted_file",
+                                    "custom_name": "Deleted bytes",
+                                    "math": "sum",
+                                    "math_property": "file_size_b",
+                                    "math_group_type_index": null,
+                                    "properties": {}
+                                }
+                            ],
+                            "insight": "TRENDS",
+                            "interval": "week",
+                            "properties": {
+                                "type": "AND",
+                                "values": [{ "key": "id", "type": "precalculated-cohort", "value": 2 }]
+                            },
+                            "smoothing_intervals": 1
+                        }
+                    },
+                    {
+                        "action": {
+                            "id": "deleted_file",
+                            "type": "events",
+                            "order": 1,
+                            "name": "deleted_file",
+                            "custom_name": "Deleted bytes",
+                            "math": "sum",
+                            "math_property": "file_size_b",
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "deleted_file",
+                        "count": 0.0,
+                        "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        "labels": [
+                            "2-Oct-2022",
+                            "9-Oct-2022",
+                            "16-Oct-2022",
+                            "23-Oct-2022",
+                            "30-Oct-2022",
+                            "6-Nov-2022",
+                            "13-Nov-2022",
+                            "20-Nov-2022",
+                            "27-Nov-2022"
+                        ],
+                        "days": [
+                            "2022-10-02",
+                            "2022-10-09",
+                            "2022-10-16",
+                            "2022-10-23",
+                            "2022-10-30",
+                            "2022-11-06",
+                            "2022-11-13",
+                            "2022-11-20",
+                            "2022-11-27"
+                        ],
+                        "persons_urls": [
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-02",
+                                    "date_to": "2022-10-02",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-02&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-10-02&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-09",
+                                    "date_to": "2022-10-09",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-09&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-10-09&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-16",
+                                    "date_to": "2022-10-16",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-16&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-10-16&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-23",
+                                    "date_to": "2022-10-23",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-23&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-10-23&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-10-30",
+                                    "date_to": "2022-10-30",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-10-30&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-10-30&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-06",
+                                    "date_to": "2022-11-06",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-06&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-11-06&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-13",
+                                    "date_to": "2022-11-13",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-13&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-11-13&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-20",
+                                    "date_to": "2022-11-20",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-20&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-11-20&entity_order=1"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": "deleted_file",
+                                    "entity_type": "events",
+                                    "entity_math": "sum",
+                                    "date_from": "2022-11-27",
+                                    "date_to": "2022-11-27",
+                                    "entity_order": 1
+                                },
+                                "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2022-11-27&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22uploaded_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22uploaded_file%22%2C+%22custom_name%22%3A+%22Uploaded+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22deleted_file%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22deleted_file%22%2C+%22custom_name%22%3A+%22Deleted+bytes%22%2C+%22math%22%3A+%22sum%22%2C+%22math_property%22%3A+%22file_size_b%22%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=week&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1&entity_id=deleted_file&entity_type=events&entity_math=sum&date_to=2022-11-27&entity_order=1"
+                            }
+                        ],
+                        "filter": {
+                            "breakdown_attribution_type": "first_touch",
+                            "breakdown_normalize_url": false,
+                            "date_from": "-8w",
+                            "display": "ActionsLineGraph",
+                            "events": [
+                                {
+                                    "id": "uploaded_file",
+                                    "type": "events",
+                                    "order": 0,
+                                    "name": "uploaded_file",
+                                    "custom_name": "Uploaded bytes",
+                                    "math": "sum",
+                                    "math_property": "file_size_b",
+                                    "math_group_type_index": null,
+                                    "properties": {}
+                                },
+                                {
+                                    "id": "deleted_file",
+                                    "type": "events",
+                                    "order": 1,
+                                    "name": "deleted_file",
+                                    "custom_name": "Deleted bytes",
+                                    "math": "sum",
+                                    "math_property": "file_size_b",
+                                    "math_group_type_index": null,
+                                    "properties": {}
+                                }
+                            ],
+                            "insight": "TRENDS",
+                            "interval": "week",
+                            "properties": {
+                                "type": "AND",
+                                "values": [{ "key": "id", "type": "precalculated-cohort", "value": 2 }]
+                            },
+                            "smoothing_intervals": 1
+                        }
+                    }
+                ],
+                "created_at": "2022-11-28T10:36:17.070150Z",
+                "created_by": null,
+                "description": null,
+                "updated_at": "2022-11-28T10:37:14.272692Z",
+                "favorited": false,
+                "saved": true,
+                "last_modified_at": "2022-11-10T10:35:59.100351Z",
+                "last_modified_by": {
+                    "id": 1,
+                    "uuid": "0184bdce-e55b-0000-7a1f-cff0c8a9fbdd",
+                    "distinct_id": "66DmhJ27SbenLic9Zb17i508LEmgSq6fQTJ0t5btBhw",
+                    "first_name": "Employee 427",
+                    "email": "test@posthog.com"
+                },
+                "is_sample": false,
+                "effective_restriction_level": 21,
+                "effective_privilege_level": 37,
+                "timezone": null,
+                "tags": []
+            },
+            "text": null,
+            "last_refresh": "2022-11-30T11:14:29.701189Z",
+            "is_cached": true,
+            "layouts": {
+                "sm": { "h": 5, "w": 6, "x": 6, "y": 10, "minH": 5, "minW": 3 },
+                "xs": { "h": 5, "w": 1, "x": 0, "y": 25, "minH": 5, "minW": 3, "moved": false, "static": false }
+            },
+            "color": null,
+            "filters_hash": "cache_70ee46d0dc8508016c96227dca04de20",
+            "refreshing": false,
+            "refresh_attempt": 0
+        },
+        {
+            "id": 3,
+            "insight": {
+                "id": 3,
+                "short_id": "g5Yz2ij1",
+                "name": "Activation",
+                "derived_name": null,
+                "filters": {
+                    "events": [
+                        {
+                            "id": "signed_up",
+                            "name": "signed_up",
+                            "type": "events",
+                            "order": 2,
+                            "custom_name": "Signed up"
+                        },
+                        {
+                            "id": "upgraded_plan",
+                            "name": "upgraded_plan",
+                            "type": "events",
+                            "order": 4,
+                            "custom_name": "Upgraded plan"
+                        }
+                    ],
+                    "actions": [{ "id": 1, "name": "Interacted with file", "type": "actions", "order": 3 }],
+                    "display": "FunnelViz",
+                    "insight": "FUNNELS",
+                    "interval": "day",
+                    "date_from": "-1m",
+                    "funnel_viz_type": "steps",
+                    "filter_test_accounts": true
+                },
+                "filters_hash": "cache_f80465780a58a5a48c547fb5b3a5812b",
+                "order": null,
+                "deleted": false,
+                "dashboards": [1],
+                "last_refresh": "2022-11-30T11:14:30.066278Z",
+                "refreshing": false,
+                "result": [
+                    {
+                        "action_id": "signed_up",
+                        "name": "signed_up",
+                        "custom_name": "Signed up",
+                        "order": 0,
+                        "people": [],
+                        "count": 32,
+                        "type": "events",
+                        "average_conversion_time": null,
+                        "median_conversion_time": null,
+                        "converted_people_url": "/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-1m&display=FunnelViz&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+%22Signed+up%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22upgraded_plan%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+4%2C+%22name%22%3A+%22upgraded_plan%22%2C+%22custom_name%22%3A+%22Upgraded+plan%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1",
+                        "dropped_people_url": null
+                    },
+                    {
+                        "action_id": 1,
+                        "name": "Interacted with file",
+                        "custom_name": null,
+                        "order": 1,
+                        "people": [],
+                        "count": 32,
+                        "type": "actions",
+                        "average_conversion_time": 71.34375,
+                        "median_conversion_time": 72.0,
+                        "converted_people_url": "/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-1m&display=FunnelViz&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+%22Signed+up%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22upgraded_plan%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+4%2C+%22name%22%3A+%22upgraded_plan%22%2C+%22custom_name%22%3A+%22Upgraded+plan%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1",
+                        "dropped_people_url": "/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-1m&display=FunnelViz&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+%22Signed+up%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22upgraded_plan%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+4%2C+%22name%22%3A+%22upgraded_plan%22%2C+%22custom_name%22%3A+%22Upgraded+plan%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1"
+                    },
+                    {
+                        "action_id": "upgraded_plan",
+                        "name": "upgraded_plan",
+                        "custom_name": "Upgraded plan",
+                        "order": 2,
+                        "people": [],
+                        "count": 0,
+                        "type": "events",
+                        "average_conversion_time": null,
+                        "median_conversion_time": null,
+                        "converted_people_url": "/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-1m&display=FunnelViz&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+%22Signed+up%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22upgraded_plan%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+4%2C+%22name%22%3A+%22upgraded_plan%22%2C+%22custom_name%22%3A+%22Upgraded+plan%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=3&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1",
+                        "dropped_people_url": "/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-1m&display=FunnelViz&events=%5B%7B%22id%22%3A+%22signed_up%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22signed_up%22%2C+%22custom_name%22%3A+%22Signed+up%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22upgraded_plan%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+4%2C+%22name%22%3A+%22upgraded_plan%22%2C+%22custom_name%22%3A+%22Upgraded+plan%22%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-3&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&smoothing_intervals=1"
+                    }
+                ],
+                "created_at": "2022-11-28T10:36:17.008241Z",
+                "created_by": null,
+                "description": null,
+                "updated_at": "2022-11-28T10:37:14.230100Z",
+                "favorited": false,
+                "saved": true,
+                "last_modified_at": "2022-11-09T10:35:59.100351Z",
+                "last_modified_by": {
+                    "id": 1,
+                    "uuid": "0184bdce-e55b-0000-7a1f-cff0c8a9fbdd",
+                    "distinct_id": "66DmhJ27SbenLic9Zb17i508LEmgSq6fQTJ0t5btBhw",
+                    "first_name": "Employee 427",
+                    "email": "test@posthog.com"
+                },
+                "is_sample": false,
+                "effective_restriction_level": 21,
+                "effective_privilege_level": 37,
+                "timezone": null,
+                "tags": []
+            },
+            "text": null,
+            "last_refresh": "2022-11-30T11:14:30.066278Z",
+            "is_cached": true,
+            "layouts": {
+                "sm": { "h": 5, "w": 6, "x": 0, "y": 5, "minH": 5, "minW": 3 },
+                "xs": { "h": 5, "w": 1, "x": 0, "y": 10, "minH": 5, "minW": 3, "moved": false, "static": false }
+            },
+            "color": null,
+            "filters_hash": "cache_f80465780a58a5a48c547fb5b3a5812b",
+            "refreshing": false,
+            "refresh_attempt": 0
+        },
+        {
+            "id": 5,
+            "insight": {
+                "id": 5,
+                "short_id": "Qcvds2lB",
+                "name": "Active user lifecycle",
+                "derived_name": null,
+                "filters": {
+                    "events": [],
+                    "actions": [
+                        { "id": 1, "math": "total", "name": "Interacted with file", "type": "actions", "order": 0 }
+                    ],
+                    "compare": false,
+                    "display": "ActionsLineGraph",
+                    "insight": "LIFECYCLE",
+                    "interval": "day",
+                    "shown_as": "Lifecycle",
+                    "date_from": "-8w",
+                    "new_entity": [],
+                    "properties": [],
+                    "filter_test_accounts": true
+                },
+                "filters_hash": "cache_beb8babf8ebf9370338881a5c7945d77",
+                "order": null,
+                "deleted": false,
+                "dashboards": [1],
+                "last_refresh": "2022-11-30T11:14:30.200219Z",
+                "refreshing": false,
+                "result": [
+                    {
+                        "action": {
+                            "id": 1,
+                            "type": "actions",
+                            "order": 0,
+                            "name": "Interacted with file",
+                            "custom_name": null,
+                            "math": "total",
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "Interacted with file - new",
+                        "count": 40.0,
+                        "data": [
+                            1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                            1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 4.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0,
+                            2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 4.0, 2.0, 1.0, 2.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+                            1.0, 0.0, 0.0
+                        ],
+                        "labels": [
+                            "5-Oct-2022",
+                            "6-Oct-2022",
+                            "7-Oct-2022",
+                            "8-Oct-2022",
+                            "9-Oct-2022",
+                            "10-Oct-2022",
+                            "11-Oct-2022",
+                            "12-Oct-2022",
+                            "13-Oct-2022",
+                            "14-Oct-2022",
+                            "15-Oct-2022",
+                            "16-Oct-2022",
+                            "17-Oct-2022",
+                            "18-Oct-2022",
+                            "19-Oct-2022",
+                            "20-Oct-2022",
+                            "21-Oct-2022",
+                            "22-Oct-2022",
+                            "23-Oct-2022",
+                            "24-Oct-2022",
+                            "25-Oct-2022",
+                            "26-Oct-2022",
+                            "27-Oct-2022",
+                            "28-Oct-2022",
+                            "29-Oct-2022",
+                            "30-Oct-2022",
+                            "31-Oct-2022",
+                            "1-Nov-2022",
+                            "2-Nov-2022",
+                            "3-Nov-2022",
+                            "4-Nov-2022",
+                            "5-Nov-2022",
+                            "6-Nov-2022",
+                            "7-Nov-2022",
+                            "8-Nov-2022",
+                            "9-Nov-2022",
+                            "10-Nov-2022",
+                            "11-Nov-2022",
+                            "12-Nov-2022",
+                            "13-Nov-2022",
+                            "14-Nov-2022",
+                            "15-Nov-2022",
+                            "16-Nov-2022",
+                            "17-Nov-2022",
+                            "18-Nov-2022",
+                            "19-Nov-2022",
+                            "20-Nov-2022",
+                            "21-Nov-2022",
+                            "22-Nov-2022",
+                            "23-Nov-2022",
+                            "24-Nov-2022",
+                            "25-Nov-2022",
+                            "26-Nov-2022",
+                            "27-Nov-2022",
+                            "28-Nov-2022",
+                            "29-Nov-2022",
+                            "30-Nov-2022"
+                        ],
+                        "days": [
+                            "2022-10-05",
+                            "2022-10-06",
+                            "2022-10-07",
+                            "2022-10-08",
+                            "2022-10-09",
+                            "2022-10-10",
+                            "2022-10-11",
+                            "2022-10-12",
+                            "2022-10-13",
+                            "2022-10-14",
+                            "2022-10-15",
+                            "2022-10-16",
+                            "2022-10-17",
+                            "2022-10-18",
+                            "2022-10-19",
+                            "2022-10-20",
+                            "2022-10-21",
+                            "2022-10-22",
+                            "2022-10-23",
+                            "2022-10-24",
+                            "2022-10-25",
+                            "2022-10-26",
+                            "2022-10-27",
+                            "2022-10-28",
+                            "2022-10-29",
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "status": "new",
+                        "persons_urls": [
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-05&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-06&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-07&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-08&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-09&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-10&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-11&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-12&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-13&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-14&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-15&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-16&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-17&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-18&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-19&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-20&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-21&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-22&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-23&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-24&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-25&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-26&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-27&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-28&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-29&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-30&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-31",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-31&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-01",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-01&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-02",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-02&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-03",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-03&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-04",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-04&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-05&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-06&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-07&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-08&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-09&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-10&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-11&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-12&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-13&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-14&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-15&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-16&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-17&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-18&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-19&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-20&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-21&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-22&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-23&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-24&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-25&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-26&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-27&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-28&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-29&entity_order=0&lifecycle_type=new"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "new"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-30&entity_order=0&lifecycle_type=new"
+                            }
+                        ]
+                    },
+                    {
+                        "action": {
+                            "id": 1,
+                            "type": "actions",
+                            "order": 0,
+                            "name": "Interacted with file",
+                            "custom_name": null,
+                            "math": "total",
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "Interacted with file - dormant",
+                        "count": -230.0,
+                        "data": [
+                            -2.0, -2.0, -2.0, -2.0, -2.0, -5.0, 0.0, -4.0, -2.0, -3.0, 0.0, -7.0, -1.0, 0.0, 0.0, -5.0,
+                            -2.0, -1.0, -5.0, -4.0, -4.0, -3.0, -7.0, -1.0, -6.0, -5.0, -2.0, -3.0, -3.0, -5.0, -4.0,
+                            -5.0, -5.0, -2.0, -8.0, -4.0, -5.0, -5.0, -1.0, -3.0, -3.0, -1.0, -2.0, -2.0, -6.0, -7.0,
+                            -7.0, -4.0, -5.0, -9.0, -6.0, -5.0, -5.0, -6.0, -9.0, -23.0, 0.0
+                        ],
+                        "labels": [
+                            "5-Oct-2022",
+                            "6-Oct-2022",
+                            "7-Oct-2022",
+                            "8-Oct-2022",
+                            "9-Oct-2022",
+                            "10-Oct-2022",
+                            "11-Oct-2022",
+                            "12-Oct-2022",
+                            "13-Oct-2022",
+                            "14-Oct-2022",
+                            "15-Oct-2022",
+                            "16-Oct-2022",
+                            "17-Oct-2022",
+                            "18-Oct-2022",
+                            "19-Oct-2022",
+                            "20-Oct-2022",
+                            "21-Oct-2022",
+                            "22-Oct-2022",
+                            "23-Oct-2022",
+                            "24-Oct-2022",
+                            "25-Oct-2022",
+                            "26-Oct-2022",
+                            "27-Oct-2022",
+                            "28-Oct-2022",
+                            "29-Oct-2022",
+                            "30-Oct-2022",
+                            "31-Oct-2022",
+                            "1-Nov-2022",
+                            "2-Nov-2022",
+                            "3-Nov-2022",
+                            "4-Nov-2022",
+                            "5-Nov-2022",
+                            "6-Nov-2022",
+                            "7-Nov-2022",
+                            "8-Nov-2022",
+                            "9-Nov-2022",
+                            "10-Nov-2022",
+                            "11-Nov-2022",
+                            "12-Nov-2022",
+                            "13-Nov-2022",
+                            "14-Nov-2022",
+                            "15-Nov-2022",
+                            "16-Nov-2022",
+                            "17-Nov-2022",
+                            "18-Nov-2022",
+                            "19-Nov-2022",
+                            "20-Nov-2022",
+                            "21-Nov-2022",
+                            "22-Nov-2022",
+                            "23-Nov-2022",
+                            "24-Nov-2022",
+                            "25-Nov-2022",
+                            "26-Nov-2022",
+                            "27-Nov-2022",
+                            "28-Nov-2022",
+                            "29-Nov-2022",
+                            "30-Nov-2022"
+                        ],
+                        "days": [
+                            "2022-10-05",
+                            "2022-10-06",
+                            "2022-10-07",
+                            "2022-10-08",
+                            "2022-10-09",
+                            "2022-10-10",
+                            "2022-10-11",
+                            "2022-10-12",
+                            "2022-10-13",
+                            "2022-10-14",
+                            "2022-10-15",
+                            "2022-10-16",
+                            "2022-10-17",
+                            "2022-10-18",
+                            "2022-10-19",
+                            "2022-10-20",
+                            "2022-10-21",
+                            "2022-10-22",
+                            "2022-10-23",
+                            "2022-10-24",
+                            "2022-10-25",
+                            "2022-10-26",
+                            "2022-10-27",
+                            "2022-10-28",
+                            "2022-10-29",
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "status": "dormant",
+                        "persons_urls": [
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-05&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-06&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-07&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-08&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-09&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-10&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-11&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-12&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-13&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-14&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-15&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-16&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-17&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-18&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-19&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-20&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-21&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-22&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-23&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-24&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-25&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-26&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-27&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-28&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-29&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-30&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-31",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-31&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-01",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-01&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-02",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-02&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-03",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-03&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-04",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-04&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-05&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-06&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-07&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-08&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-09&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-10&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-11&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-12&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-13&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-14&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-15&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-16&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-17&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-18&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-19&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-20&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-21&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-22&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-23&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-24&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-25&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-26&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-27&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-28&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-29&entity_order=0&lifecycle_type=dormant"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "dormant"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-30&entity_order=0&lifecycle_type=dormant"
+                            }
+                        ]
+                    },
+                    {
+                        "action": {
+                            "id": 1,
+                            "type": "actions",
+                            "order": 0,
+                            "name": "Interacted with file",
+                            "custom_name": null,
+                            "math": "total",
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "Interacted with file - resurrecting",
+                        "count": 179.0,
+                        "data": [
+                            1.0, 3.0, 2.0, 1.0, 2.0, 0.0, 7.0, 0.0, 1.0, 3.0, 4.0, 0.0, 1.0, 3.0, 5.0, 1.0, 3.0, 2.0,
+                            1.0, 5.0, 5.0, 5.0, 1.0, 4.0, 2.0, 3.0, 4.0, 2.0, 6.0, 1.0, 6.0, 3.0, 6.0, 3.0, 2.0, 7.0,
+                            3.0, 2.0, 5.0, 3.0, 2.0, 3.0, 3.0, 1.0, 3.0, 6.0, 4.0, 1.0, 5.0, 6.0, 5.0, 6.0, 4.0, 5.0,
+                            7.0, 0.0, 0.0
+                        ],
+                        "labels": [
+                            "5-Oct-2022",
+                            "6-Oct-2022",
+                            "7-Oct-2022",
+                            "8-Oct-2022",
+                            "9-Oct-2022",
+                            "10-Oct-2022",
+                            "11-Oct-2022",
+                            "12-Oct-2022",
+                            "13-Oct-2022",
+                            "14-Oct-2022",
+                            "15-Oct-2022",
+                            "16-Oct-2022",
+                            "17-Oct-2022",
+                            "18-Oct-2022",
+                            "19-Oct-2022",
+                            "20-Oct-2022",
+                            "21-Oct-2022",
+                            "22-Oct-2022",
+                            "23-Oct-2022",
+                            "24-Oct-2022",
+                            "25-Oct-2022",
+                            "26-Oct-2022",
+                            "27-Oct-2022",
+                            "28-Oct-2022",
+                            "29-Oct-2022",
+                            "30-Oct-2022",
+                            "31-Oct-2022",
+                            "1-Nov-2022",
+                            "2-Nov-2022",
+                            "3-Nov-2022",
+                            "4-Nov-2022",
+                            "5-Nov-2022",
+                            "6-Nov-2022",
+                            "7-Nov-2022",
+                            "8-Nov-2022",
+                            "9-Nov-2022",
+                            "10-Nov-2022",
+                            "11-Nov-2022",
+                            "12-Nov-2022",
+                            "13-Nov-2022",
+                            "14-Nov-2022",
+                            "15-Nov-2022",
+                            "16-Nov-2022",
+                            "17-Nov-2022",
+                            "18-Nov-2022",
+                            "19-Nov-2022",
+                            "20-Nov-2022",
+                            "21-Nov-2022",
+                            "22-Nov-2022",
+                            "23-Nov-2022",
+                            "24-Nov-2022",
+                            "25-Nov-2022",
+                            "26-Nov-2022",
+                            "27-Nov-2022",
+                            "28-Nov-2022",
+                            "29-Nov-2022",
+                            "30-Nov-2022"
+                        ],
+                        "days": [
+                            "2022-10-05",
+                            "2022-10-06",
+                            "2022-10-07",
+                            "2022-10-08",
+                            "2022-10-09",
+                            "2022-10-10",
+                            "2022-10-11",
+                            "2022-10-12",
+                            "2022-10-13",
+                            "2022-10-14",
+                            "2022-10-15",
+                            "2022-10-16",
+                            "2022-10-17",
+                            "2022-10-18",
+                            "2022-10-19",
+                            "2022-10-20",
+                            "2022-10-21",
+                            "2022-10-22",
+                            "2022-10-23",
+                            "2022-10-24",
+                            "2022-10-25",
+                            "2022-10-26",
+                            "2022-10-27",
+                            "2022-10-28",
+                            "2022-10-29",
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "status": "resurrecting",
+                        "persons_urls": [
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-05&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-06&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-07&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-08&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-09&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-10&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-11&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-12&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-13&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-14&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-15&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-16&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-17&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-18&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-19&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-20&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-21&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-22&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-23&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-24&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-25&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-26&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-27&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-28&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-29&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-30&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-31",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-31&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-01",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-01&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-02",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-02&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-03",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-03&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-04",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-04&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-05&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-06&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-07&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-08&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-09&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-10&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-11&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-12&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-13&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-14&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-15&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-16&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-17&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-18&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-19&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-20&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-21&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-22&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-23&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-24&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-25&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-26&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-27&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-28&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-29&entity_order=0&lifecycle_type=resurrecting"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "resurrecting"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-30&entity_order=0&lifecycle_type=resurrecting"
+                            }
+                        ]
+                    },
+                    {
+                        "action": {
+                            "id": 1,
+                            "type": "actions",
+                            "order": 0,
+                            "name": "Interacted with file",
+                            "custom_name": null,
+                            "math": "total",
+                            "math_property": null,
+                            "math_group_type_index": null,
+                            "properties": {}
+                        },
+                        "label": "Interacted with file - returning",
+                        "count": 849.0,
+                        "data": [
+                            9.0, 9.0, 10.0, 11.0, 11.0, 8.0, 8.0, 11.0, 10.0, 8.0, 12.0, 9.0, 9.0, 10.0, 13.0, 13.0,
+                            13.0, 16.0, 14.0, 12.0, 14.0, 17.0, 16.0, 16.0, 15.0, 12.0, 14.0, 15.0, 14.0, 19.0, 16.0,
+                            18.0, 16.0, 20.0, 15.0, 14.0, 17.0, 17.0, 18.0, 20.0, 20.0, 21.0, 23.0, 25.0, 21.0, 21.0,
+                            22.0, 23.0, 21.0, 19.0, 19.0, 20.0, 21.0, 19.0, 15.0, 0.0, 0.0
+                        ],
+                        "labels": [
+                            "5-Oct-2022",
+                            "6-Oct-2022",
+                            "7-Oct-2022",
+                            "8-Oct-2022",
+                            "9-Oct-2022",
+                            "10-Oct-2022",
+                            "11-Oct-2022",
+                            "12-Oct-2022",
+                            "13-Oct-2022",
+                            "14-Oct-2022",
+                            "15-Oct-2022",
+                            "16-Oct-2022",
+                            "17-Oct-2022",
+                            "18-Oct-2022",
+                            "19-Oct-2022",
+                            "20-Oct-2022",
+                            "21-Oct-2022",
+                            "22-Oct-2022",
+                            "23-Oct-2022",
+                            "24-Oct-2022",
+                            "25-Oct-2022",
+                            "26-Oct-2022",
+                            "27-Oct-2022",
+                            "28-Oct-2022",
+                            "29-Oct-2022",
+                            "30-Oct-2022",
+                            "31-Oct-2022",
+                            "1-Nov-2022",
+                            "2-Nov-2022",
+                            "3-Nov-2022",
+                            "4-Nov-2022",
+                            "5-Nov-2022",
+                            "6-Nov-2022",
+                            "7-Nov-2022",
+                            "8-Nov-2022",
+                            "9-Nov-2022",
+                            "10-Nov-2022",
+                            "11-Nov-2022",
+                            "12-Nov-2022",
+                            "13-Nov-2022",
+                            "14-Nov-2022",
+                            "15-Nov-2022",
+                            "16-Nov-2022",
+                            "17-Nov-2022",
+                            "18-Nov-2022",
+                            "19-Nov-2022",
+                            "20-Nov-2022",
+                            "21-Nov-2022",
+                            "22-Nov-2022",
+                            "23-Nov-2022",
+                            "24-Nov-2022",
+                            "25-Nov-2022",
+                            "26-Nov-2022",
+                            "27-Nov-2022",
+                            "28-Nov-2022",
+                            "29-Nov-2022",
+                            "30-Nov-2022"
+                        ],
+                        "days": [
+                            "2022-10-05",
+                            "2022-10-06",
+                            "2022-10-07",
+                            "2022-10-08",
+                            "2022-10-09",
+                            "2022-10-10",
+                            "2022-10-11",
+                            "2022-10-12",
+                            "2022-10-13",
+                            "2022-10-14",
+                            "2022-10-15",
+                            "2022-10-16",
+                            "2022-10-17",
+                            "2022-10-18",
+                            "2022-10-19",
+                            "2022-10-20",
+                            "2022-10-21",
+                            "2022-10-22",
+                            "2022-10-23",
+                            "2022-10-24",
+                            "2022-10-25",
+                            "2022-10-26",
+                            "2022-10-27",
+                            "2022-10-28",
+                            "2022-10-29",
+                            "2022-10-30",
+                            "2022-10-31",
+                            "2022-11-01",
+                            "2022-11-02",
+                            "2022-11-03",
+                            "2022-11-04",
+                            "2022-11-05",
+                            "2022-11-06",
+                            "2022-11-07",
+                            "2022-11-08",
+                            "2022-11-09",
+                            "2022-11-10",
+                            "2022-11-11",
+                            "2022-11-12",
+                            "2022-11-13",
+                            "2022-11-14",
+                            "2022-11-15",
+                            "2022-11-16",
+                            "2022-11-17",
+                            "2022-11-18",
+                            "2022-11-19",
+                            "2022-11-20",
+                            "2022-11-21",
+                            "2022-11-22",
+                            "2022-11-23",
+                            "2022-11-24",
+                            "2022-11-25",
+                            "2022-11-26",
+                            "2022-11-27",
+                            "2022-11-28",
+                            "2022-11-29",
+                            "2022-11-30"
+                        ],
+                        "status": "returning",
+                        "persons_urls": [
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-05&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-06&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-07&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-08&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-09&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-10&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-11&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-12&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-13&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-14&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-15&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-16&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-17&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-18&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-19&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-20&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-21&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-22&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-23&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-24&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-25&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-26&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-27&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-28&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-29&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-30&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-10-31",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-10-31&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-01",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-01&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-02",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-02&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-03",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-03&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-04",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-04&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-05",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-05&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-06",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-06&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-07",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-07&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-08",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-08&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-09",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-09&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-10",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-10&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-11",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-11&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-12",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-12&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-13",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-13&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-14",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-14&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-15",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-15&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-16",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-16&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-17",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-17&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-18",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-18&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-19",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-19&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-20",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-20&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-21",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-21&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-22",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-22&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-23",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-23&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-24",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-24&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-25",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-25&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-26",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-26&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-27",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-27&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-28",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-28&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-29",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-29&entity_order=0&lifecycle_type=returning"
+                            },
+                            {
+                                "filter": {
+                                    "entity_id": 1,
+                                    "entity_type": "actions",
+                                    "entity_math": "total",
+                                    "target_date": "2022-11-30",
+                                    "entity_order": 0,
+                                    "lifecycle_type": "returning"
+                                },
+                                "url": "api/person/lifecycle/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=-8w&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A+1%2C+%22type%22%3A+%22actions%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22Interacted+with+file%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+%22total%22%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=LIFECYCLE&interval=day&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&shown_as=Lifecycle&smoothing_intervals=1&entity_id=1&entity_type=actions&entity_math=total&target_date=2022-11-30&entity_order=0&lifecycle_type=returning"
+                            }
+                        ]
+                    }
+                ],
+                "created_at": "2022-11-28T10:36:17.046239Z",
+                "created_by": null,
+                "description": "An active user being defined by interaction with files.",
+                "updated_at": "2022-11-28T10:37:14.250792Z",
+                "favorited": false,
+                "saved": true,
+                "last_modified_at": "2022-10-25T10:35:59.100351Z",
+                "last_modified_by": {
+                    "id": 1,
+                    "uuid": "0184bdce-e55b-0000-7a1f-cff0c8a9fbdd",
+                    "distinct_id": "66DmhJ27SbenLic9Zb17i508LEmgSq6fQTJ0t5btBhw",
+                    "first_name": "Employee 427",
+                    "email": "test@posthog.com"
+                },
+                "is_sample": false,
+                "effective_restriction_level": 21,
+                "effective_privilege_level": 37,
+                "timezone": null,
+                "tags": []
+            },
+            "text": null,
+            "last_refresh": "2022-11-30T11:14:30.200219Z",
+            "is_cached": true,
+            "layouts": {
+                "sm": { "h": 5, "w": 6, "x": 0, "y": 10, "minH": 5, "minW": 3 },
+                "xs": { "h": 5, "w": 1, "x": 0, "y": 20, "minH": 5, "minW": 3, "moved": false, "static": false }
+            },
+            "color": null,
+            "filters_hash": "cache_beb8babf8ebf9370338881a5c7945d77",
+            "refreshing": false,
+            "refresh_attempt": 0
+        }
+    ],
     "restriction_level": 21,
     "effective_restriction_level": 21,
-    "effective_privilege_level": 37
+    "effective_privilege_level": 37,
+    "tags": []
 }


### PR DESCRIPTION
## Problem

The storybook story for "Dashboards > Show" was broken. It seems we've changed the api for dashboards and the mock for it got outdated.

## Changes

- Overwrites the existing mock with a new one based on generated demo data.
- Silences mock service worker to be able to see other console logs.

## How did you test this code?

Verified the story loads correctly.