### PR TITLE
feat(plugin-server): distribute scheduled tasks i.e. runEveryX

### DIFF
--- a/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
+++ b/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
@@ -1,0 +1,103 @@
+import Redis from 'ioredis'
+import { Consumer, Kafka, KafkaMessage, logLevel, Partitioners, Producer } from 'kafkajs'
+import { Pool } from 'pg'
+import { v4 as uuidv4 } from 'uuid'
+
+import { defaultConfig } from '../src/config/config'
+import { delayUntilEventIngested } from '../tests/helpers/clickhouse'
+
+let producer: Producer
+let postgres: Pool // NOTE: we use a Pool here but it's probably not necessary, but for instance `insertRow` uses a Pool.
+let kafka: Kafka
+let redis: Redis.Redis
+
+beforeAll(async () => {
+    // Setup connections to kafka, clickhouse, and postgres
+    postgres = new Pool({
+        connectionString: defaultConfig.DATABASE_URL!,
+        // We use a pool only for typings sake, but we don't actually need to,
+        // so set max connections to 1.
+        max: 1,
+    })
+    kafka = new Kafka({ brokers: [defaultConfig.KAFKA_HOSTS], logLevel: logLevel.NOTHING })
+    producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner })
+    await producer.connect()
+    redis = new Redis(defaultConfig.REDIS_URL)
+})
+
+afterAll(async () => {
+    await Promise.all([producer.disconnect(), postgres.end(), redis.disconnect()])
+})
+
+// Test out some error cases that we wouldn't be able to handle without
+// producing to the jobs queue directly.
+
+let dlq: KafkaMessage[]
+let dlqConsumer: Consumer
+
+beforeAll(async () => {
+    dlq = []
+    dlqConsumer = kafka.consumer({ groupId: 'scheduled-tasks-consumer-test' })
+    await dlqConsumer.subscribe({ topic: 'scheduled_tasks_dlq' })
+    await dlqConsumer.run({
+        eachMessage: ({ message }) => {
+            dlq.push(message)
+            return Promise.resolve()
+        },
+    })
+})
+
+afterAll(async () => {
+    await dlqConsumer.disconnect()
+})
+
+test.concurrent(`handles empty messages`, async () => {
+    const key = uuidv4()
+
+    await producer.send({
+        topic: 'jobs',
+        messages: [
+            {
+                key: key,
+                value: null,
+            },
+        ],
+    })
+
+    const messages = await delayUntilEventIngested(() => dlq.filter((message) => message.key?.toString() === key))
+    expect(messages.length).toBe(1)
+})
+
+test.concurrent(`handles invalid JSON`, async () => {
+    const key = uuidv4()
+
+    await producer.send({
+        topic: 'jobs',
+        messages: [
+            {
+                key: key,
+                value: 'invalid json',
+            },
+        ],
+    })
+
+    const messages = await delayUntilEventIngested(() => dlq.filter((message) => message.key?.toString() === key))
+    expect(messages.length).toBe(1)
+})
+
+test.concurrent(`handles invalid message schema`, async () => {
+    const key = uuidv4()
+
+    await producer.send({
+        topic: 'jobs',
+        messages: [
+            {
+                key: key,
+                value: JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 'abc' }),
+            },
+        ],
+    })
+
+    const messages = await delayUntilEventIngested(() => dlq.filter((message) => message.key?.toString() === key))
+    expect(messages.length).toBe(1)
+})

--- a/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
+++ b/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
@@ -85,7 +85,7 @@ test.concurrent(`handles invalid JSON`, async () => {
     expect(messages.length).toBe(1)
 })
 
-test.concurrent(`handles invalid message schema`, async () => {
+test.concurrent(`handles invalid taskType`, async () => {
     const key = uuidv4()
 
     await producer.send({
@@ -93,7 +93,24 @@ test.concurrent(`handles invalid message schema`, async () => {
         messages: [
             {
                 key: key,
-                value: JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 'abc' }),
+                value: JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 1 }),
+            },
+        ],
+    })
+
+    const messages = await delayUntilEventIngested(() => dlq.filter((message) => message.key?.toString() === key))
+    expect(messages.length).toBe(1)
+})
+
+test.concurrent(`handles invalid pluginConfigId`, async () => {
+    const key = uuidv4()
+
+    await producer.send({
+        topic: 'scheduled_tasks',
+        messages: [
+            {
+                key: key,
+                value: JSON.stringify({ taskType: 'runEveryMinute', pluginConfigId: 'asdf' }),
             },
         ],
     })

--- a/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
+++ b/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
@@ -55,7 +55,7 @@ test.concurrent(`handles empty messages`, async () => {
     const key = uuidv4()
 
     await producer.send({
-        topic: 'jobs',
+        topic: 'scheduled_tasks',
         messages: [
             {
                 key: key,
@@ -72,7 +72,7 @@ test.concurrent(`handles invalid JSON`, async () => {
     const key = uuidv4()
 
     await producer.send({
-        topic: 'jobs',
+        topic: 'scheduled_tasks',
         messages: [
             {
                 key: key,
@@ -89,7 +89,7 @@ test.concurrent(`handles invalid message schema`, async () => {
     const key = uuidv4()
 
     await producer.send({
-        topic: 'jobs',
+        topic: 'scheduled_tasks',
         messages: [
             {
                 key: key,

--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -19,4 +19,6 @@ export const KAFKA_INGESTION_WARNINGS = `${prefix}clickhouse_ingestion_warnings$
 export const KAFKA_APP_METRICS = `${prefix}clickhouse_app_metrics${suffix}`
 export const KAFKA_JOBS = `${prefix}jobs${suffix}`
 export const KAFKA_JOBS_DLQ = `${prefix}jobs_dlq${suffix}`
+export const KAFKA_SCHEDULED_TASKS = `${prefix}scheduled_tasks${suffix}`
+export const KAFKA_SCHEDULED_TASKS_DLQ = `${prefix}scheduled_tasks_dlq${suffix}`
 export const KAFKA_METRICS_TIME_TO_SEE_DATA = `${prefix}clickhouse_metrics_time_to_see_data${suffix}`

--- a/plugin-server/src/main/graphile-worker/worker-setup.ts
+++ b/plugin-server/src/main/graphile-worker/worker-setup.ts
@@ -52,7 +52,7 @@ export async function startGraphileWorker(hub: Hub, graphileWorker: GraphileWork
 
         jobHandlers = {
             ...jobHandlers,
-            ...getScheduledTaskHandlers(hub, piscina),
+            ...getScheduledTaskHandlers(hub),
         }
 
         status.info('🔄', 'Graphile Worker: set up scheduled task handlers...')
@@ -76,11 +76,11 @@ export function getPluginJobHandlers(hub: Hub, graphileWorker: GraphileWorker, p
     return pluginJobHandlers
 }
 
-export function getScheduledTaskHandlers(hub: Hub, piscina: Piscina): TaskList {
+export function getScheduledTaskHandlers(hub: Hub): TaskList {
     const scheduledTaskHandlers: TaskList = {
-        runEveryMinute: async () => await runScheduledTasks(hub, piscina, 'runEveryMinute'),
-        runEveryHour: async () => await runScheduledTasks(hub, piscina, 'runEveryHour'),
-        runEveryDay: async () => await runScheduledTasks(hub, piscina, 'runEveryDay'),
+        runEveryMinute: async () => await runScheduledTasks(hub, 'runEveryMinute'),
+        runEveryHour: async () => await runScheduledTasks(hub, 'runEveryHour'),
+        runEveryDay: async () => await runScheduledTasks(hub, 'runEveryDay'),
     }
 
     return scheduledTaskHandlers

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -77,6 +77,7 @@ export const startScheduledTasksConsumer = async ({
                     timestamp: message.timestamp,
                 })
                 resolveOffset(message.offset)
+                statsd?.increment('scheduled_tasks.skip_stale', { taskType: task.taskType })
                 continue
             }
 

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -7,7 +7,10 @@ import { DependencyUnavailableError } from '../../utils/db/error'
 import { status } from '../../utils/status'
 import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
 
-const taskTypes = ['runEveryMinute', 'runEveryHour', 'runEveryDay']
+// The valid task types that can be scheduled.
+// TODO: not sure if there is another place that defines these but it would be
+// good to unify.
+const taskTypes = ['runEveryMinute', 'runEveryHour', 'runEveryDay'] as const
 
 export const startScheduledTasksConsumer = async ({
     kafka,
@@ -44,7 +47,7 @@ export const startScheduledTasksConsumer = async ({
             }
 
             let task: {
-                taskType: 'runEveryMinute' | 'runEveryHour' | 'runEveryDay'
+                taskType: typeof taskTypes[number]
                 pluginConfigId: number
             }
 

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -68,9 +68,9 @@ export const startScheduledTasksConsumer = async ({
                 continue
             }
 
-            // If the messages is older than the interval, we ignore it. The
+            // If the messages is older than the grace period, we ignore it. The
             // Kafka timestamp should be epoch milliseconds.
-            if (Number.parseInt(message.timestamp) < Date.now() - gracePeriodSecondsByTaskType[task.taskType]) {
+            if (Number.parseInt(message.timestamp) < Date.now() - gracePeriodMilliSecondsByTaskType[task.taskType]) {
                 status.warn('🔁', 'Skip stale task', {
                     taskType: task.taskType,
                     pluginConfigId: task.pluginConfigId,
@@ -124,7 +124,7 @@ export const startScheduledTasksConsumer = async ({
     return consumer
 }
 
-const gracePeriodSecondsByTaskType = {
+const gracePeriodMilliSecondsByTaskType = {
     runEveryMinute: 60 * 1000,
     runEveryHour: 60 * 60 * 1000,
     runEveryDay: 24 * 60 * 60 * 1000,

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -37,7 +37,6 @@ export const startScheduledTasksConsumer = async ({
         status.debug('🔁', 'Processing batch', { size: batch.messages.length })
         for (const message of batch.messages) {
             if (!message.value) {
-                status.error('⚠️', 'asdf', { topic: 'zxcv' })
                 status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
                     value: message.value,
                 })

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -1,0 +1,93 @@
+import Piscina from '@posthog/piscina'
+import { StatsD } from 'hot-shots'
+import { EachBatchHandler, Kafka, Producer } from 'kafkajs'
+
+import { KAFKA_SCHEDULED_TASKS, KAFKA_SCHEDULED_TASKS_DLQ } from '../../config/kafka-topics'
+import { status } from '../../utils/status'
+import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
+
+export const startScheduledTasksConsumer = async ({
+    kafka,
+    piscina,
+    producer,
+    statsd,
+}: {
+    kafka: Kafka
+    piscina: Piscina
+    producer: Producer // NOTE: not using KafkaProducerWrapper here to avoid buffering logic
+    statsd?: StatsD
+}) => {
+    /*
+        Consumes from the tasks buffer topic, and enqueues the tasks for execution
+        at a later date.
+    */
+
+    const consumer = kafka.consumer({ groupId: 'scheduled-tasks-runner' })
+    setupEventHandlers(consumer)
+
+    status.info('🔁', 'Starting scheduled tasks consumer')
+
+    const eachBatch: EachBatchHandler = async ({ batch, resolveOffset, heartbeat }) => {
+        status.debug('🔁', 'Processing batch', { size: batch.messages.length })
+        for (const message of batch.messages) {
+            if (!message.value) {
+                status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
+                    value: message.value,
+                })
+                // TODO: handle resolving offsets asynchronously
+                await producer.send({ topic: KAFKA_SCHEDULED_TASKS_DLQ, messages: [message] })
+                resolveOffset(message.offset)
+                continue
+            }
+
+            let task: {
+                taskType: 'runEveryMinute' | 'runEveryHour' | 'runEveryDay'
+                pluginConfigId: number
+            }
+
+            try {
+                task = JSON.parse(message.value.toString())
+            } catch (error) {
+                status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
+                    error,
+                })
+                // TODO: handle resolving offsets asynchronously
+                await producer.send({ topic: KAFKA_SCHEDULED_TASKS_DLQ, messages: [message] })
+                resolveOffset(message.offset)
+                continue
+            }
+
+            status.debug('⬆️', 'Running scheduled task', {
+                task,
+            })
+
+            try {
+                await piscina.run({ task: task.taskType, args: { pluginConfigId: task.pluginConfigId } })
+                resolveOffset(message.offset)
+                statsd?.increment('tasks_consumer.enqueued')
+            } catch (error) {
+                status.error('⚠️', 'Failed to enqueue anonymous event for processing', { error })
+                statsd?.increment('tasks_consumer.enqueue_error')
+                throw error
+            }
+
+            // After processing each message, we need to heartbeat to ensure
+            // we don't get kicked out of the group. Note that although we call
+            // this for each message, it's actually a no-op if we're not over
+            // the heartbeatInterval.
+            await heartbeat()
+        }
+
+        status.info('✅', 'Processed batch', { size: batch.messages.length })
+    }
+
+    await consumer.connect()
+    await consumer.subscribe({ topic: KAFKA_SCHEDULED_TASKS })
+    await consumer.run({
+        eachBatch: async (payload) => {
+            return await instrumentEachBatch(KAFKA_SCHEDULED_TASKS, eachBatch, payload, statsd)
+        },
+    })
+
+    return consumer
+}

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -32,10 +32,10 @@ export const startScheduledTasksConsumer = async ({
         status.debug('🔁', 'Processing batch', { size: batch.messages.length })
         for (const message of batch.messages) {
             if (!message.value) {
+                status.error('⚠️', 'asdf', { topic: 'zxcv' })
                 status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
                     value: message.value,
                 })
-                // TODO: handle resolving offsets asynchronously
                 await producer.send({ topic: KAFKA_SCHEDULED_TASKS_DLQ, messages: [message] })
                 resolveOffset(message.offset)
                 continue
@@ -50,9 +50,8 @@ export const startScheduledTasksConsumer = async ({
                 task = JSON.parse(message.value.toString())
             } catch (error) {
                 status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
-                    error,
+                    error: error.stack ?? error,
                 })
-                // TODO: handle resolving offsets asynchronously
                 await producer.send({ topic: KAFKA_SCHEDULED_TASKS_DLQ, messages: [message] })
                 resolveOffset(message.offset)
                 continue

--- a/plugin-server/tests/main/jobs/schedule.test.ts
+++ b/plugin-server/tests/main/jobs/schedule.test.ts
@@ -1,5 +1,8 @@
+import { Producer } from 'kafkajs'
+
 import { runScheduledTasks } from '../../../src/main/graphile-worker/schedule'
 import { Hub } from '../../../src/types'
+import { KafkaProducerWrapper } from '../../../src/utils/db/kafka-producer-wrapper'
 import { UUID } from '../../../src/utils/utils'
 import { PromiseManager } from '../../../src/worker/vm/promise-manager'
 
@@ -26,25 +29,30 @@ describe('Graphile Worker schedule', () => {
                 runEveryHour: [4, 5, 6],
                 runEveryDay: [7, 8, 9],
             },
+            kafkaProducer: {
+                producer: {
+                    send: jest.fn(),
+                } as unknown as Producer,
+            } as KafkaProducerWrapper,
         }
 
-        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'iDontExist')
+        await runScheduledTasks(mockHubWithPluginSchedule, 'iDontExist')
         expect(mockPiscina.run).not.toHaveBeenCalled()
 
-        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryMinute')
+        await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryMinute')
 
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(1, { args: { pluginConfigId: 1 }, task: 'runEveryMinute' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(2, { args: { pluginConfigId: 2 }, task: 'runEveryMinute' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(3, { args: { pluginConfigId: 3 }, task: 'runEveryMinute' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(1, { pluginConfigId: 1, taskType: 'runEveryMinute' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(2, { pluginConfigId: 2, taskType: 'runEveryMinute' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(3, { pluginConfigId: 3, taskType: 'runEveryMinute' })
 
-        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryHour')
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(4, { args: { pluginConfigId: 4 }, task: 'runEveryHour' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(5, { args: { pluginConfigId: 5 }, task: 'runEveryHour' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(6, { args: { pluginConfigId: 6 }, task: 'runEveryHour' })
+        await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryHour')
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(4, { pluginConfigId: 4, taskType: 'runEveryHour' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(5, { pluginConfigId: 5, taskType: 'runEveryHour' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(6, { pluginConfigId: 6, taskType: 'runEveryHour' })
 
-        await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryDay')
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(7, { args: { pluginConfigId: 7 }, task: 'runEveryDay' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(8, { args: { pluginConfigId: 8 }, task: 'runEveryDay' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(9, { args: { pluginConfigId: 9 }, task: 'runEveryDay' })
+        await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryDay')
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(7, { pluginConfigId: 7, taskType: 'runEveryDay' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(8, { pluginConfigId: 8, taskType: 'runEveryDay' })
+        expect(mockPiscina.run).toHaveBeenNthCalledWith(9, { pluginConfigId: 9, taskType: 'runEveryDay' })
     })
 })

--- a/plugin-server/tests/main/jobs/schedule.test.ts
+++ b/plugin-server/tests/main/jobs/schedule.test.ts
@@ -44,8 +44,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '1',
                     value: JSON.stringify({
-                        pluginConfigId: 1,
                         taskType: 'runEveryMinute',
+                        pluginConfigId: 1,
                     }),
                 },
             ],
@@ -56,8 +56,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '2',
                     value: JSON.stringify({
-                        pluginConfigId: 2,
                         taskType: 'runEveryMinute',
+                        pluginConfigId: 2,
                     }),
                 },
             ],
@@ -68,8 +68,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '3',
                     value: JSON.stringify({
-                        pluginConfigId: 3,
                         taskType: 'runEveryMinute',
+                        pluginConfigId: 3,
                     }),
                 },
             ],
@@ -82,8 +82,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '4',
                     value: JSON.stringify({
-                        pluginConfigId: 4,
                         taskType: 'runEveryHour',
+                        pluginConfigId: 4,
                     }),
                 },
             ],
@@ -94,8 +94,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '5',
                     value: JSON.stringify({
-                        pluginConfigId: 5,
                         taskType: 'runEveryHour',
+                        pluginConfigId: 5,
                     }),
                 },
             ],
@@ -106,8 +106,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '6',
                     value: JSON.stringify({
-                        pluginConfigId: 6,
                         taskType: 'runEveryHour',
+                        pluginConfigId: 6,
                     }),
                 },
             ],
@@ -120,8 +120,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '7',
                     value: JSON.stringify({
-                        pluginConfigId: 7,
                         taskType: 'runEveryDay',
+                        pluginConfigId: 7,
                     }),
                 },
             ],
@@ -132,8 +132,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '8',
                     value: JSON.stringify({
-                        pluginConfigId: 8,
                         taskType: 'runEveryDay',
+                        pluginConfigId: 8,
                     }),
                 },
             ],
@@ -144,8 +144,8 @@ describe('Graphile Worker schedule', () => {
                 {
                     key: '9',
                     value: JSON.stringify({
-                        pluginConfigId: 9,
                         taskType: 'runEveryDay',
+                        pluginConfigId: 9,
                     }),
                 },
             ],

--- a/plugin-server/tests/main/jobs/schedule.test.ts
+++ b/plugin-server/tests/main/jobs/schedule.test.ts
@@ -42,6 +42,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '1',
                     value: JSON.stringify({
                         pluginConfigId: 1,
                         taskType: 'runEveryMinute',
@@ -53,6 +54,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '2',
                     value: JSON.stringify({
                         pluginConfigId: 2,
                         taskType: 'runEveryMinute',
@@ -64,6 +66,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '3',
                     value: JSON.stringify({
                         pluginConfigId: 3,
                         taskType: 'runEveryMinute',
@@ -77,6 +80,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '4',
                     value: JSON.stringify({
                         pluginConfigId: 4,
                         taskType: 'runEveryHour',
@@ -88,6 +92,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '5',
                     value: JSON.stringify({
                         pluginConfigId: 5,
                         taskType: 'runEveryHour',
@@ -99,6 +104,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '6',
                     value: JSON.stringify({
                         pluginConfigId: 6,
                         taskType: 'runEveryHour',
@@ -112,6 +118,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '7',
                     value: JSON.stringify({
                         pluginConfigId: 7,
                         taskType: 'runEveryDay',
@@ -123,6 +130,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '8',
                     value: JSON.stringify({
                         pluginConfigId: 8,
                         taskType: 'runEveryDay',
@@ -134,6 +142,7 @@ describe('Graphile Worker schedule', () => {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
+                    key: '9',
                     value: JSON.stringify({
                         pluginConfigId: 9,
                         taskType: 'runEveryDay',

--- a/plugin-server/tests/main/jobs/schedule.test.ts
+++ b/plugin-server/tests/main/jobs/schedule.test.ts
@@ -1,5 +1,6 @@
 import { Producer } from 'kafkajs'
 
+import { KAFKA_SCHEDULED_TASKS } from '../../../src/config/kafka-topics'
 import { runScheduledTasks } from '../../../src/main/graphile-worker/schedule'
 import { Hub } from '../../../src/types'
 import { KafkaProducerWrapper } from '../../../src/utils/db/kafka-producer-wrapper'
@@ -18,10 +19,6 @@ describe('Graphile Worker schedule', () => {
     })
 
     test('runScheduledTasks()', async () => {
-        const mockPiscina = {
-            run: jest.fn(),
-        }
-
         const mockHubWithPluginSchedule = {
             ...mockHub,
             pluginSchedule: {
@@ -37,22 +34,112 @@ describe('Graphile Worker schedule', () => {
         }
 
         await runScheduledTasks(mockHubWithPluginSchedule, 'iDontExist')
-        expect(mockPiscina.run).not.toHaveBeenCalled()
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).not.toHaveBeenCalled()
 
         await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryMinute')
 
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(1, { pluginConfigId: 1, taskType: 'runEveryMinute' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(2, { pluginConfigId: 2, taskType: 'runEveryMinute' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(3, { pluginConfigId: 3, taskType: 'runEveryMinute' })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(1, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 1,
+                        taskType: 'runEveryMinute',
+                    }),
+                },
+            ],
+        })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(2, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 2,
+                        taskType: 'runEveryMinute',
+                    }),
+                },
+            ],
+        })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(3, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 3,
+                        taskType: 'runEveryMinute',
+                    }),
+                },
+            ],
+        })
 
         await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryHour')
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(4, { pluginConfigId: 4, taskType: 'runEveryHour' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(5, { pluginConfigId: 5, taskType: 'runEveryHour' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(6, { pluginConfigId: 6, taskType: 'runEveryHour' })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(4, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 4,
+                        taskType: 'runEveryHour',
+                    }),
+                },
+            ],
+        })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(5, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 5,
+                        taskType: 'runEveryHour',
+                    }),
+                },
+            ],
+        })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(6, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 6,
+                        taskType: 'runEveryHour',
+                    }),
+                },
+            ],
+        })
 
         await runScheduledTasks(mockHubWithPluginSchedule, 'runEveryDay')
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(7, { pluginConfigId: 7, taskType: 'runEveryDay' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(8, { pluginConfigId: 8, taskType: 'runEveryDay' })
-        expect(mockPiscina.run).toHaveBeenNthCalledWith(9, { pluginConfigId: 9, taskType: 'runEveryDay' })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(7, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 7,
+                        taskType: 'runEveryDay',
+                    }),
+                },
+            ],
+        })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(8, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 8,
+                        taskType: 'runEveryDay',
+                    }),
+                },
+            ],
+        })
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(9, {
+            topic: KAFKA_SCHEDULED_TASKS,
+            messages: [
+                {
+                    value: JSON.stringify({
+                        pluginConfigId: 9,
+                        taskType: 'runEveryDay',
+                    }),
+                },
+            ],
+        })
     })
 })


### PR DESCRIPTION
At the moment we only run on which ever Graphile worker node picks up
the scheduled tasks. Tasks are run in sequence, running through each of
the associated pluginConfigIds.

We tried to spread the workload by creating a Graphile Worker job for
each pluginConfigId, but this caused a lot of load on the Graphile
Worker database.

One thing this PR doesn't tackle is what happens if we end up having the
jobs back up. There is probably some logic we should add to avoid really
old scheduled tasks from running.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
