### PR TITLE
fix: leave toasts alone when unmounting insight logics

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -1080,7 +1080,6 @@ export const insightLogic = kea<insightLogicType>([
             if (values.timeout) {
                 clearTimeout(values.timeout)
             }
-            lemonToast.dismiss()
         },
     })),
 ])


### PR DESCRIPTION
## Problem

Sometimes when testing dashboard and insight interactions toasts would disappear unexpectedly.

I just noticed we dismiss toasts when unmounting `insightLogic`

## Changes

Don't do that

## How did you test this code?

I didn't. Opening PR rather than asking about it in Slack 🤣 