### PR TITLE
fix: make sure demo snack and project title wrap properly

### DIFF
--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -14,14 +14,14 @@ import { navigationLogic } from './navigationLogic'
 
 export function ProjectName({ team }: { team: TeamBasicType }): JSX.Element {
     return (
-        <>
-            {team.name}
+        <div className="flex items-center">
+            <span className="mb-1">{team.name}</span>
             {team.is_demo ? (
-                <LemonSnack title="Demo" className="ml-3 text-xs" color="primary-extralight">
+                <LemonSnack title="Demo" className="ml-3 text-xs shrink-0" color="primary-extralight">
                     Demo
                 </LemonSnack>
             ) : null}
-        </>
+        </div>
     )
 }
 


### PR DESCRIPTION
## Problem

Fixes #13039 

## Changes

This should really matter for customer since all the demo projects will be called Hedgebox, and therefore not need to wrap, but at least now it won't drive _us_ insane seeing it in our own instance. And more future-proof.

It now wraps properly:

| Before  | After |
| ------------- | ------------- |
| <img width="337" alt="Screenshot 2022-11-30 at 16 36 18" src="https://user-images.githubusercontent.com/4550621/204841296-a0d407c4-cf9e-46ae-9314-736f284fd3bc.png">  | ![image](https://user-images.githubusercontent.com/18598166/204850615-e574277d-69a2-4985-a101-b3680995a49b.png)  |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I tried it with a bunch of different name lengths and it works well enough. There is still room for improvement here IMO. Showing the whole long name of a project looks ugly regardless of the Demo snack, but I'm not sure we want to truncate it.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
