### PR TITLE
fix: cached dashboard items are not displayed

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -16,7 +16,8 @@ import { TextCard } from 'lib/components/Cards/TextCard/TextCard'
 
 export function DashboardItems(): JSX.Element {
     const {
-        allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
+        // dashboard but directly on dashboardLogic not via dashboardsModel
+        allItems: dashboard,
         tiles,
         layouts,
         dashboardMode,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -65,12 +65,12 @@ export const AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 300
 
 export type LoadDashboardItemsProps = { refresh?: boolean; action: string }
 
-interface InsightCachereloadProps {
+interface InsightCacheReloadProps {
     cachedInsight: InsightModel
     dashboardId: number
     refreshedInsight: InsightModel
 }
-function reloadCachedInsight({ cachedInsight, dashboardId, refreshedInsight }: InsightCachereloadProps): void {
+function reloadCachedInsight({ cachedInsight, dashboardId, refreshedInsight }: InsightCacheReloadProps): void {
     // reload the cached results inside the insight's logic
     // this is what causes the dashboard's tiles displayed data to change
     if (refreshedInsight.filters.insight) {
@@ -1086,7 +1086,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 const tilesWithNoResults = values.tiles?.filter((t) => !!t.insight && !t.insight.result) || []
                 const tilesWithResults = values.tiles?.filter((t) => !!t.insight && t.insight.result) || []
 
-                if (tilesWithNoResults && tilesWithNoResults?.length > 0) {
+                if (tilesWithNoResults.length) {
                     actions.refreshAllDashboardItems({
                         tiles: tilesWithNoResults,
                         action: 'load_missing',
@@ -1097,7 +1097,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 }
 
                 tilesWithResults
-                    ?.map((t) => t.insight)
+                    .map((t) => t.insight)
                     .filter((i): i is InsightModel => !!i)
                     .forEach((i) => {
                         reloadCachedInsight({ cachedInsight: i, dashboardId: dashboard.id, refreshedInsight: i })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -72,10 +72,10 @@ interface InsightCacheReloadProps {
 }
 
 /**
-  * :TRICKY: Changes in dashboards don't automatically propagate to already mounted insights!
-  * This function updates insightLogics individually.
-  *
-  * Call this whenever updating already rendered tiles within dashboardLogic
+ * :TRICKY: Changes in dashboards don't automatically propagate to already mounted insights!
+ * This function updates insightLogics individually.
+ *
+ * Call this whenever updating already rendered tiles within dashboardLogic
  */
 function updateExistingInsightState({ cachedInsight, dashboardId, refreshedInsight }: InsightCacheReloadProps): void {
     if (refreshedInsight.filters.insight) {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -71,24 +71,6 @@ interface InsightCacheReloadProps {
     refreshedInsight: InsightModel
 }
 
-/**
- *
- *
- *
- *    insightLogic new
- *    insightLogic specific
- *    insightLogic controlled
- *
- *    savedInsihts insightModel
- *
- *    dashboardsmOdel dashboardlogic
- *
- *
- * @param cachedInsight
- * @param dashboardId
- * @param refreshedInsight
- */
-
 function updateExistingInsightState({ cachedInsight, dashboardId, refreshedInsight }: InsightCacheReloadProps): void {
     // reload the cached results inside the insight's logic
     // this is what causes the dashboard's tiles displayed data to change

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -71,9 +71,11 @@ interface InsightCacheReloadProps {
     refreshedInsight: InsightModel
 }
 
+/**
+ * Update any existing mounted insightLogic
+ * This is what causes the dashboard's tiles displayed data to change
+ */
 function updateExistingInsightState({ cachedInsight, dashboardId, refreshedInsight }: InsightCacheReloadProps): void {
-    // reload the cached results inside the insight's logic
-    // this is what causes the dashboard's tiles displayed data to change
     if (refreshedInsight.filters.insight) {
         const itemResultLogic = insightLogic.findMounted({
             dashboardItemId: refreshedInsight.short_id,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -72,8 +72,10 @@ interface InsightCacheReloadProps {
 }
 
 /**
- * Update any existing mounted insightLogic
- * This is what causes the dashboard's tiles displayed data to change
+  * :TRICKY: Changes in dashboards don't automatically propagate to already mounted insights!
+  * This function updates insightLogics individually.
+  *
+  * Call this whenever updating already rendered tiles within dashboardLogic
  */
 function updateExistingInsightState({ cachedInsight, dashboardId, refreshedInsight }: InsightCacheReloadProps): void {
     if (refreshedInsight.filters.insight) {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1083,14 +1083,12 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 actions.refreshAllDashboardItems({ action: 'refresh_above_threshold', initialLoad, dashboardQueryId })
                 allLoaded = false
             } else {
-                const notYetLoadedItems =
-                    values.tiles?.filter((t): t is DashboardTile => !!t.insight && !t.insight.result) || []
-                const loadedItems =
-                    values.tiles?.filter((t): t is DashboardTile => !!t.insight && t.insight.result) || []
+                const tilesWithNoResults = values.tiles?.filter((t) => !!t.insight && !t.insight.result) || []
+                const tilesWithResults = values.tiles?.filter((t) => !!t.insight && t.insight.result) || []
 
-                if (notYetLoadedItems && notYetLoadedItems?.length > 0) {
+                if (tilesWithNoResults && tilesWithNoResults?.length > 0) {
                     actions.refreshAllDashboardItems({
-                        tiles: notYetLoadedItems,
+                        tiles: tilesWithNoResults,
                         action: 'load_missing',
                         initialLoad,
                         dashboardQueryId,
@@ -1098,7 +1096,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     allLoaded = false
                 }
 
-                loadedItems
+                tilesWithResults
                     ?.map((t) => t.insight)
                     .filter((i): i is InsightModel => !!i)
                     .forEach((i) => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -443,7 +443,6 @@ export const insightLogic = kea<insightLogicType>([
             }),
             setInsightMetadata: (state, { metadata }) => ({ ...state, ...metadata }),
             [dashboardsModel.actionTypes.updateDashboardInsight]: (state, { item, extraDashboardIds }) => {
-                // TODO when is this called without changes originating in this logic
                 const targetDashboards = (item?.dashboards || []).concat(extraDashboardIds || [])
                 const updateIsForThisDashboard =
                     item?.short_id === state.short_id &&


### PR DESCRIPTION
## Problem

following #12978 dashboards that returned results from the cache *that were already displayed and so had a loaded set of insight logics* would not update tiles' displayed data 

### before

![insights-not-updating](https://user-images.githubusercontent.com/984817/204932632-d45ffd6b-5165-48fb-8f09-934aaa372f25.gif)

## Changes

looks up the insight logic for any cached result and updates it with API results

### After

![insights-updating0whencached](https://user-images.githubusercontent.com/984817/204932607-680a063e-19ad-43ad-86d8-adf14e41d70f.gif)


## How did you test this code?

running it locally