### PR TITLE
fix: Buttons overlapping on recordings modal

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
@@ -36,6 +36,12 @@
                 height: 0px;
             }
         }
+
+        .LemonModal & {
+            .PlayerMeta__top {
+                padding-right: 3.5rem;
+            }
+        }
     }
 
     &--fullscreen {
@@ -71,12 +77,6 @@
             &--exit-active {
                 transform: translateX(-100%);
             }
-        }
-    }
-
-    .LemonModal & {
-        .PlayerMeta__expander {
-            margin-right: 3rem;
         }
     }
 

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -61,7 +61,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
             )}
 
             <div
-                className={clsx('flex items-center gap-2 shrink-0', {
+                className={clsx('PlayerMeta__top flex items-center gap-2 shrink-0', {
                     'p-3 border-b': !isFullScreen,
                     'px-3 p-1 text-xs': isFullScreen,
                 })}
@@ -170,10 +170,13 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                 </CSSTransition>
             )}
             <div
-                className={clsx('flex items-center justify-between gap-2 whitespace-nowrap overflow-hidden', {
-                    'p-3': !isFullScreen,
-                    'p-1 px-3 text-xs h-12': isFullScreen,
-                })}
+                className={clsx(
+                    'PlayerMeta__bottom flex items-center justify-between gap-2 whitespace-nowrap overflow-hidden',
+                    {
+                        'p-3': !isFullScreen,
+                        'p-1 px-3 text-xs h-12': isFullScreen,
+                    }
+                )}
             >
                 {sessionPlayerMetaDataLoading || currentWindowIndex === -1 ? (
                     <LemonSkeleton className="w-1/3 my-1" />

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.scss
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.scss
@@ -82,11 +82,6 @@
     }
 }
 
-.SessionPlayerModal {
-    width: 100%;
-    padding: 0;
-}
-
 .PlayerControlSeekIcon {
     position: relative;
     display: flex;

--- a/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
+++ b/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
@@ -27,17 +27,15 @@ export function SessionPlayerModal(): JSX.Element | null {
                 ) : null}
             </header>
             <LemonModal.Content embedded>
-                <div className="SessionPlayerModal">
-                    {activeSessionRecording?.id && (
-                        <SessionRecordingPlayer
-                            playerKey="modal"
-                            sessionRecordingId={activeSessionRecording?.id}
-                            matching={activeSessionRecording?.matching_events}
-                            includeMeta={false}
-                            noBorder
-                        />
-                    )}
-                </div>
+                {activeSessionRecording?.id && (
+                    <SessionRecordingPlayer
+                        playerKey="modal"
+                        sessionRecordingId={activeSessionRecording?.id}
+                        matching={activeSessionRecording?.matching_events}
+                        includeMeta={false}
+                        noBorder
+                    />
+                )}
             </LemonModal.Content>
         </LemonModal>
     )


### PR DESCRIPTION
## Problem

Fixes a regression where the buttons in the meta area overlap with the modal close

## Changes

* Apply padding to the top area instead of the individual element (more reliable approach)

<img width="263" alt="Screenshot 2022-12-01 at 08 42 32" src="https://user-images.githubusercontent.com/2536520/204994746-8872cec6-5286-4845-b544-790692df6b39.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 