### PR TITLE
fix: Billing popup function can't use hooks

### DIFF
--- a/frontend/src/scenes/billing/v2/BillingPopup.tsx
+++ b/frontend/src/scenes/billing/v2/BillingPopup.tsx
@@ -3,7 +3,6 @@ import { BillingV2 } from './control/Billing'
 import { BillingV2 as BillingV2Test } from './test/Billing'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useValues } from 'kea'
 
 export type BillingPopupProps = {
     title?: string
@@ -14,16 +13,13 @@ export function openBillingPopupModal({
     title = 'Unlock premium features',
     description,
 }: BillingPopupProps = {}): void {
-    const { featureFlags } = useValues(featureFlagLogic)
+    const featureFlags = featureFlagLogic.findMounted()?.values?.featureFlags
+    const testExperiment = featureFlags?.[FEATURE_FLAGS.BILLING_FEATURES_EXPERIMENT] === 'test'
 
     LemonDialog.open({
         title: title,
         description: description,
-        content: (
-            <>
-                {featureFlags[FEATURE_FLAGS.BILLING_FEATURES_EXPERIMENT] === 'test' ? <BillingV2Test /> : <BillingV2 />}
-            </>
-        ),
+        content: <>{testExperiment ? <BillingV2Test /> : <BillingV2 />}</>,
         width: 800,
         primaryButton: {
             children: 'Maybe later...',


### PR DESCRIPTION
## Problem

The billing popup stopped working as we try to use a react hook in a standard function 🙈 

## Changes

* Changes this to access Kea logic the imperative way

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
