### PR TITLE
chore: no need to explicitly set date when loading a dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -282,6 +282,7 @@ describe('dashboardLogic', () => {
 
             await expectLogic(logic)
                 .toFinishAllListeners()
+                .toNotHaveDispatchedActions(['setDates'])
                 .toMatchValues({ filters: { date_from: '-24h', date_to: null } })
         })
     })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -155,8 +155,6 @@ export const dashboardLogic = kea<dashboardLogicType>({
 
                         actions.setInitialLoadResponseBytes(getResponseBytes(dashboardResponse))
 
-                        actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
-
                         return dashboard
                     } catch (error: any) {
                         if (error.status === 404) {
@@ -257,6 +255,11 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 setProperties: (state, { properties }) => ({
                     ...state,
                     properties: properties || null,
+                }),
+                loadDashboardItemsSuccess: (state, { allItems }) => ({
+                    ...state,
+                    date_from: allItems?.filters.date_from || null,
+                    date_to: allItems?.filters.date_to || null,
                 }),
             },
         ],


### PR DESCRIPTION
## Problem

When loading a dashboard we call `setDates` so that the correct reducer is updated and the UI correctly reflects the date range of the dashboard.

If we don't do this then the dashboard always shows as `custom` even if the date is set.

This sends us analytics as if the dashboard date range was changed. Which it wasn't. Very misleading, a horror 🙀 

## Changes

Listen to the loading success action in the reducer so the date range is set without sending analytics

## How did you test this code?

Added a developer test
