### PR TITLE
chore(build): push amd64 and arm64 images

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Update git sha
-              run: echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py
+              run: echo "GIT_SHA = '${GITHUB_SHA}'" > posthog/gitsha.py
 
             - name: Set up Depot CLI
               uses: depot/setup-action@v1
@@ -38,6 +38,7 @@ jobs:
               with:
                   context: .
                   push: true
+                  platforms: linux/amd64,linux/arm64
                   tags: posthog/posthog:latest
                   buildx-fallback: true # if Depot builder is unavailable, fall back to local buildx
 


### PR DESCRIPTION
## Problem
We currently build and push `amd64` images only but the future is bright and it's called ARM!  

## Changes
Add `arm64` images to DockerHub.

## How did you test this code?
I didn't