### PR TITLE
fix: default sort experiments by created_at

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -196,6 +196,7 @@ class ClickhouseExperimentsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet
         TeamMemberAccessPermission,
     ]
     premium_feature = AvailableFeature.EXPERIMENTATION
+    ordering = "-created_at"
 
     def get_queryset(self):
         return super().get_queryset().prefetch_related("feature_flag", "created_by")


### PR DESCRIPTION
## Problem
The experiments page is now default sorted by "created_at", we want it to be sorted by "-created_at" by default (most recent first)

## Changes
- Adds a default ordering to the experiments queryset

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- Tested locally
