### PR TITLE
fix(hobby): fix hobby install compose

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -54,7 +54,7 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
-            SECRET_KEY: $POSTHOG_SERET
+            SECRET_KEY: $POSTHOG_SECRET
         image: posthog/posthog:$POSTHOG_APP_TAG
     web:
         extends:
@@ -66,7 +66,7 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
-            SECRET_KEY: $POSTHOG_SERET
+            SECRET_KEY: $POSTHOG_SECRET
     plugins:
         extends:
             file: docker-compose.base.yml
@@ -75,7 +75,7 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
-            SECRET_KEY: $POSTHOG_SERET
+            SECRET_KEY: $POSTHOG_SECRET
 
     caddy:
         image: caddy:2.6.1
@@ -103,7 +103,7 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
-            SECRET_KEY: $POSTHOG_SERET
+            SECRET_KEY: $POSTHOG_SECRET
 
 volumes:
     zookeeper-data:


### PR DESCRIPTION
## Problem

A typo was introduced in #13025, breaking the hobby deploy. The django container is started with an empty `SECRET_KEY`, and fails with:

> [ERROR] Default SECRET_KEY in production. Stopping Django server…

## Changes

Fix the typo in the compose file.

## How did you test this code?

Tried out on a DO droplet, by checking out this branch in the instance's `posthog` checkout and re-running the `deploy-hobby` script. Stack starts up fine now.