### PR TITLE
feat: Added seekbar hover tooltip

### DIFF
--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -8,7 +8,8 @@
     position: relative;
     display: flex;
 
-    &:hover {
+    &:hover,
+    &--scrubbing {
         --bar-height: 8px;
     }
 
@@ -78,6 +79,41 @@
             border: 2px solid var(--bg-light);
             background-color: var(--recording-seekbar-red);
             transition: top 150ms ease-in-out;
+        }
+    }
+
+    .PlayerSeekBarInspector {
+        position: absolute;
+        z-index: 6;
+        bottom: 100%;
+        width: 100%;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 150ms ease-in-out;
+
+        .PlayerSeekBarInspector__tooltip {
+            width: 100%;
+
+            .PlayerSeekBarInspector__tooltip__content {
+                display: inline-block;
+                border-radius: var(--radius);
+                padding: 0.25rem 0.4rem;
+                font-size: 0.8rem;
+                font-weight: 600;
+                color: var(--white);
+                background-color: var(--muted-dark);
+
+                transform: translateX(-50%);
+                margin-bottom: 0.25rem;
+            }
+        }
+    }
+
+    .PlayerSeekbar__slider:hover,
+    &--scrubbing {
+        .PlayerSeekBarInspector {
+            pointer-events: all;
+            opacity: 1;
         }
     }
 

--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -112,7 +112,6 @@
     .PlayerSeekbar__slider:hover,
     &--scrubbing {
         .PlayerSeekBarInspector {
-            pointer-events: all;
             opacity: 1;
         }
     }

--- a/frontend/src/scenes/session-recordings/player/Seekbar.tsx
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.tsx
@@ -22,11 +22,8 @@ interface TickProps extends SessionRecordingPlayerLogicProps {
 
 function PlayerSeekbarInspector({ minMs, maxMs }: { minMs: number; maxMs: number }): JSX.Element {
     const [percentage, setPercentage] = useState<number>(0)
-
     const ref = useRef<HTMLDivElement>(null)
-
     const fixedUnits = maxMs / 1000 > 3600 ? 3 : 2
-
     const content = colonDelimitedDuration(minMs / 1000 + ((maxMs - minMs) / 1000) * percentage, fixedUnits)
 
     useEffect(() => {


### PR DESCRIPTION
## Problem

We don't indicate the timestamp on hover or when dragging the thumb which we easily could!

## Changes

* Adds a floating timestamp indicator when hovering or dragging.

![2022-12-01 15 20 31](https://user-images.githubusercontent.com/2536520/205076909-323fae44-419e-4bf4-bc20-06931f1a967b.gif)

## Known issue
* When moved to the end of the video it is partially clipped. I think its worth ignoring this for now and getting it in as it's considerably more effort to account for this case...

## How did you test this code?

Gif