### PR TITLE
feat(cohorts): add number of matching cohort users to cohort detail section

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -25,6 +25,7 @@ import { Persons } from 'scenes/persons/Persons'
 import { LemonLabel } from 'lib/components/LemonLabel/LemonLabel'
 import { Form } from 'kea-forms'
 import { NotFound } from 'lib/components/NotFound'
+import { pluralize } from 'lib/utils'
 
 export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const logicProps = { id }
@@ -197,7 +198,18 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                     <>
                         <Divider />
                         <div>
-                            <h3 className="l3">Persons in this cohort</h3>
+                            <h3 className="l3 mb-4">
+                                Persons in this cohort
+                                <span className="text-muted ml-2">
+                                    {!cohort.is_calculating &&
+                                        `(${cohort.count} matching ${pluralize(
+                                            cohort.count ?? 0,
+                                            'user',
+                                            'users',
+                                            false
+                                        )})`}
+                                </span>
+                            </h3>
                             {cohort.is_calculating ? (
                                 <div className="cohort-recalculating flex items-center">
                                     <Spinner className="mr-4" />

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -204,8 +204,8 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                     {!cohort.is_calculating &&
                                         `(${cohort.count} matching ${pluralize(
                                             cohort.count ?? 0,
-                                            'user',
-                                            'users',
+                                            'person',
+                                            'persons',
                                             false
                                         )})`}
                                 </span>


### PR DESCRIPTION
## Problem

https://posthogusers.slack.com/archives/C01GLBKHKQT/p1669902815625789

## Changes

Cohort detail page

<img width="352" alt="Screenshot 2022-12-01 at 11 07 50 AM" src="https://user-images.githubusercontent.com/13460330/205102127-40702ad1-e3cf-431f-a71f-df749a656616.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👁️ 
