### PR TITLE
fix: cannot create project if user deletes last project

### DIFF
--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -20,6 +20,7 @@ import { teamLogic } from '../teamLogic'
 import { createDefaultPluginSource } from 'scenes/plugins/source/createDefaultPluginSource'
 import { frontendAppsLogic } from 'scenes/apps/frontendAppsLogic'
 import { urls } from 'scenes/urls'
+import { lemonToast } from 'lib/components/lemonToast'
 
 export type PluginForm = FormInstance
 
@@ -449,6 +450,12 @@ export const pluginsLogic = kea<pluginsLogicType>([
         installedPlugins: [
             (s) => [s.plugins, s.pluginConfigs, s.updateStatus],
             (plugins, pluginConfigs, updateStatus): PluginTypeWithConfig[] => {
+                const { currentTeam } = teamLogic.values
+                if (!currentTeam) {
+                    lemonToast.error("Can't list installed plugins with no user or team!")
+                    return []
+                }
+
                 const pluginValues = Object.values(plugins)
                 return pluginValues
                     .map((plugin, index) => {
@@ -460,10 +467,6 @@ export const pluginsLogic = kea<pluginsLogicType>([
                                     config[key] = def
                                 }
                             )
-                            const { currentTeam } = teamLogic.values
-                            if (!currentTeam) {
-                                throw new Error("Can't list installed plugins with no user or team!")
-                            }
                             pluginConfig = {
                                 id: undefined,
                                 team_id: currentTeam.id,


### PR DESCRIPTION
## Problem

Zendesk - https://posthoghelp.zendesk.com/agent/tickets/1076 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/3989)

If a user deletes their last project, they are blocked from creating a new project by this page:

<img width="949" alt="Screenshot 2022-12-01 at 12 33 00 PM" src="https://user-images.githubusercontent.com/13460330/205121214-71876866-0942-4498-9639-a40900a33e67.png">

## Changes

Don't block app on this error, instead throw lemon toast

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally
