### PR TITLE
fix(flags): replace nbsp in example python code with space

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -78,7 +78,7 @@ export function PythonSnippet({ flagKey }: { flagKey: string }): JSX.Element {
     return (
         <>
             <CodeSnippet language={Language.Python} wrap>
-                {`if posthog.feature_enabled("${flagKey}", "user_distinct_id"):
+                {`if posthog.feature_enabled("${flagKey}", "user_distinct_id"):
     runAwesomeFeature()
 `}
             </CodeSnippet>


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/1087 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/3998)

## Changes

Replaces NBSP with space so that users can copy it cleanly.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
