### PR TITLE
chore(insights): Improve chart type selector UX

### DIFF
--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -15,9 +15,9 @@ import { navigationLogic } from './navigationLogic'
 export function ProjectName({ team }: { team: TeamBasicType }): JSX.Element {
     return (
         <div className="flex items-center">
-            <span className="mb-1">{team.name}</span>
+            <span>{team.name}</span>
             {team.is_demo ? (
-                <LemonSnack title="Demo" className="ml-3 text-xs shrink-0" color="primary-extralight">
+                <LemonSnack className="ml-2 text-xs shrink-0" color="primary-extralight">
                     Demo
                 </LemonSnack>
             ) : null}

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -236,14 +236,19 @@ function LemonSelectOptionRow<T>({
 
     let tooltipContent: string | JSX.Element | undefined
     if (option.tooltip && option.disabledReason) {
+        // TODO: Pull this logic into LemonButton, so that `disabledReason` is a thing in the entire design system
         tooltipContent = (
             <>
                 {option.tooltip}
-                <div className="mt-1">{option.disabledReason}</div>
+                <div className="mt-1 italic">{option.disabledReason}</div>
             </>
         )
     } else {
-        tooltipContent = option.disabledReason || option.tooltip
+        tooltipContent = option.disabledReason ? (
+            <span className="italic">{option.disabledReason}</span>
+        ) : (
+            option.tooltip
+        )
     }
 
     return 'options' in option ? (

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -12,7 +12,8 @@ interface LemonSelectOptionBase {
     label: string | JSX.Element
     icon?: React.ReactElement
     sideIcon?: React.ReactElement
-    disabled?: boolean
+    /** Like plain `disabled`, except we enforce a reason to be shown in the tooltip. */
+    disabledReason?: string
     tooltip?: string | JSX.Element
     'data-attr'?: string
 }
@@ -231,14 +232,28 @@ function LemonSelectOptionRow<T>({
     onSelect: (value: T) => void
     tooltipPlacement: TooltipPlacement | undefined
 }): JSX.Element {
+    const disabled = !!option.disabledReason
+
+    let tooltipContent: string | JSX.Element | undefined
+    if (option.tooltip && option.disabledReason) {
+        tooltipContent = (
+            <>
+                {option.tooltip}
+                <div className="mt-1">{option.disabledReason}</div>
+            </>
+        )
+    } else {
+        tooltipContent = option.disabledReason || option.tooltip
+    }
+
     return 'options' in option ? (
         <LemonButtonWithPopup
             icon={option.icon}
             sideIcon={option.sideIcon}
-            tooltip={option.tooltip}
+            tooltip={tooltipContent}
             tooltipPlacement={tooltipPlacement}
             status="stealth"
-            disabled={option.disabled}
+            disabled={disabled}
             fullWidth
             data-attr={option['data-attr']}
             active={doOptionsContainActiveValue(option.options, activeValue)}
@@ -267,10 +282,10 @@ function LemonSelectOptionRow<T>({
         <LemonButton
             icon={option.icon}
             sideIcon={option.sideIcon}
-            tooltip={option.tooltip}
+            tooltip={tooltipContent}
             tooltipPlacement={tooltipPlacement}
             status="stealth"
-            disabled={option.disabled}
+            disabled={disabled}
             fullWidth
             data-attr={option['data-attr']}
             active={option.value === activeValue}

--- a/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerListRow.tsx
@@ -9,8 +9,7 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 import { PlayerListExpandableConfig } from 'scenes/session-recordings/player/list/PlayerList'
 import { LemonSelectOptionLeaf } from '@posthog/lemon-ui'
 
-export interface ListRowOption<T>
-    extends Pick<LemonSelectOptionLeaf<T>, 'value' | 'label' | 'tooltip' | 'disabled' | 'data-attr'> {
+export interface ListRowOption<T> extends Pick<LemonSelectOptionLeaf<T>, 'value' | 'label' | 'tooltip' | 'data-attr'> {
     onClick?: (record: T) => void
 }
 
@@ -141,7 +140,6 @@ function PlayerListRowRaw<T extends Record<string, any>>({
                                                         ;(option as ListRowOption<T> | undefined)?.onClick?.(record)
                                                     }}
                                                     status="stealth"
-                                                    disabled={option.disabled}
                                                     fullWidth
                                                     data-attr={option['data-attr']}
                                                 >


### PR DESCRIPTION
## Problem

I initially wanted to solve #12986 frontend-side (by disabling the faulty combination), which is when I noticed there are a few issues with our `ChartFilter` component:
1. it used a custom `Label` component for showing icons and tooltips instead of using `LemonSelect`'s built-in features
2. it had some special cases for Retention insights, but this component isn't used there
3. if an option was disabled, it wasn't clear why


## Changes

This:
1. makes use of all `LemonSelect` features for a smoother experience and more cohesive look
2. removed Retention special cases
3. I made it impossible to disable an option without providing a user-facing reason – those reasons are shown in a tooltip

| Before | After |
| --- | --- |
| <img width="197" alt="before" src="https://user-images.githubusercontent.com/4550621/205154519-37697996-f694-4172-b5e6-7a8ff2de2d1d.png"> | <img width="567" alt="after" src="https://user-images.githubusercontent.com/4550621/205156267-1fd6aa0e-b326-4b9a-8322-8e6236a3ddf8.png"> |
