### PR TITLE
ci(plugin-server): timeout waiting for server to stop after 30 seconds

### DIFF
--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -9,7 +9,7 @@
 # Context is this was originally written in the GitHub Actions workflow file,
 # but it's easier to debug in a script.
 
-set -ex -o pipefail
+set -e -o pipefail
 
 export WORKER_CONCURRENCY=1
 export CONVERSION_BUFFER_ENABLED=true

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -47,7 +47,11 @@ while kill -0 $SERVER_PID; do
     sleep 1
 done
 
-if [ $exit_code -ne 0 ]; then
+if kill -0 $SERVER_PID; then
+    echo 'WARNING: plugin-server did not exit in time'
+fi
+
+if [ $exit_code -ne 0 ] || [ kill -0 $SERVER_PID ]; then
     echo '::group::Plugin Server logs'
     cat $LOG_FILE
     echo '::endgroup::'

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -35,15 +35,15 @@ echo ''
 echo '::endgroup::'
 
 set +e
-yarn functional_tests --maxConcurrency=10 --verbose
+yarn functional_tests --maxConcurrency=10 --verbose -t "asdf"
 exit_code=$?
 set -e
 
 kill $SERVER_PID
 
 while kill -0 $SERVER_PID; do
-    echo "Waiting for plugin-server to exit..."
-    ((c++)) && ((c==30)) && break
+    echo "Waiting for plugin-server to exit, pid $SERVER_PID..."
+    ((c++)) && ((c==60)) && break
     sleep 1
 done
 
@@ -51,10 +51,8 @@ if kill -0 $SERVER_PID; then
     echo 'WARNING: plugin-server did not exit in time'
 fi
 
-if [ $exit_code -ne 0 ] || [ kill -0 $SERVER_PID ]; then
-    echo '::group::Plugin Server logs'
-    cat $LOG_FILE
-    echo '::endgroup::'
-fi
+echo '::group::Plugin Server logs'
+cat $LOG_FILE
+echo '::endgroup::'
 
 exit $exit_code

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -40,7 +40,7 @@ exit_code=$?
 set -e
 
 kill $SERVER_PID
-wait $SERVER_PID
+timeout --kill-after 30s 30s wait $SERVER_PID
 
 if [ $exit_code -ne 0 ]; then
     echo '::group::Plugin Server logs'

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -40,7 +40,12 @@ exit_code=$?
 set -e
 
 kill $SERVER_PID
-timeout --kill-after 30s 30s wait $SERVER_PID
+
+while kill -0 $SERVER_PID; do
+    echo "Waiting for plugin-server to exit..."
+    ((c++)) && ((c==30)) && break
+    sleep 1
+done
 
 if [ $exit_code -ne 0 ]; then
     echo '::group::Plugin Server logs'

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -35,7 +35,7 @@ echo ''
 echo '::endgroup::'
 
 set +e
-yarn functional_tests --maxConcurrency=10 --verbose -t "asdf"
+yarn functional_tests --maxConcurrency=10 --verbose
 exit_code=$?
 set -e
 
@@ -46,10 +46,6 @@ while kill -0 $SERVER_PID; do
     ((c++)) && ((c==60)) && break
     sleep 1
 done
-
-if kill -0 $SERVER_PID; then
-    echo 'WARNING: plugin-server did not exit in time'
-fi
 
 echo '::group::Plugin Server logs'
 cat $LOG_FILE


### PR DESCRIPTION
Sometimes the plugin server doesn't manage to stop. We should fix that
as there is obviously a bug there, but I'll do that separately. As a
failsafe I added a 30s timeout.

The downside of this atm is that if it doesn't stop cleanly, we will not get a 
coverage report.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
