### PR TITLE
fix(bin): Format `hobby-ci.py` and run black in CI for `bin/*.py`

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -60,6 +60,7 @@ jobs:
                         # code completely
                         - 'ee/**/*'
                         - 'posthog/**/*'
+                        - 'bin/*.py'
                         - requirements.txt
                         - requirements-dev.txt
                         - mypy.ini

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -30,7 +30,7 @@ user_data = (
     "cd hobby \n"
     "sed -i \"s/#\\$nrconf{restart} = 'i';/\\$nrconf{restart} = 'a';/g\" /etc/needrestart/needrestart.conf \n"
     "git clone https://github.com/PostHog/posthog.git \n"
-    "cd posthog \n" 
+    "cd posthog \n"
     f"git checkout {branch} \n"
     "cd .. \n"
     f"chmod +x posthog/bin/deploy-hobby \n"


### PR DESCRIPTION
## Problem

"Python code quality checks" are failing on master because they didn't run in #13085, which changed `bin/hobby-ci.py`.

## Changes

Fixes the above.