### PR TITLE
feat(plugin-server): track person creation event uuid

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -331,6 +331,11 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Plugin Metric',
             description: 'Performance metrics for a given plugin.',
         },
+        $creator_event_uuid: {
+            label: 'Creator Event ID',
+            description: 'Unique ID for the event, which created this person.',
+            examples: ['16ff262c4301e5-0aa346c03894bc-39667c0e-1aeaa0-16ff262c431767'],
+        },
 
         // UTM tags
         utm_source: {

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -148,6 +148,7 @@ test.concurrent(`event ingestion: can $set and update person properties`, async 
     expect(firstEvent).toEqual(
         expect.objectContaining({
             person_properties: {
+                $creator_event_uuid: personEventUuid,
                 prop: 'value',
             },
         })
@@ -171,6 +172,7 @@ test.concurrent(`event ingestion: can $set and update person properties`, async 
     expect(secondEvent).toEqual(
         expect.objectContaining({
             person_properties: {
+                $creator_event_uuid: personEventUuid,
                 prop: 'updated value',
             },
         })
@@ -199,6 +201,7 @@ test.concurrent(`event ingestion: can $set_once person properties but not update
     expect(firstEvent).toEqual(
         expect.objectContaining({
             person_properties: {
+                $creator_event_uuid: personEventUuid,
                 prop: 'value',
             },
         })
@@ -221,6 +224,7 @@ test.concurrent(`event ingestion: can $set_once person properties but not update
     expect(secondEvent).toEqual(
         expect.objectContaining({
             person_properties: {
+                $creator_event_uuid: personEventUuid,
                 prop: 'value',
             },
         })

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -128,6 +128,7 @@ export class PersonState {
                     // :NOTE: This should never be set in this branch, but adding this for logical consistency
                     this.updateIsIdentified,
                     this.newUuid,
+                    this.event.uuid,
                     [this.distinctId]
                 )
                 // :TRICKY: Avoid subsequent queries re-fetching person
@@ -161,9 +162,10 @@ export class PersonState {
         isUserId: number | null,
         isIdentified: boolean,
         uuid: string,
+        creatorEventUuid: string,
         distinctIds?: string[]
     ): Promise<Person> {
-        const props = { ...propertiesOnce, ...properties }
+        const props = { ...propertiesOnce, ...properties, ...{ $creator_event_uuid: creatorEventUuid } }
         const propertiesLastOperation: Record<string, any> = {}
         const propertiesLastUpdatedAt: Record<string, any> = {}
         Object.keys(propertiesOnce).forEach((key) => {
@@ -380,6 +382,7 @@ export class PersonState {
                     null,
                     true,
                     this.newUuid,
+                    this.event.uuid,
                     [distinctId, previousDistinctId]
                 )
                 // :KLUDGE: Avoid unneeded fetches in updateProperties()

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -287,6 +287,7 @@ test('capture new person', async () => {
         ],
     })
 
+    const uuid = new UUIDT().toString()
     await processEvent(
         '2',
         '127.0.0.1',
@@ -297,13 +298,14 @@ test('capture new person', async () => {
         } as any as PluginEvent,
         team.id,
         now,
-        new UUIDT().toString()
+        uuid
     )
 
     let persons = await hub.db.fetchPersons()
     expect(persons[0].version).toEqual(0)
     expect(persons[0].created_at).toEqual(now)
     let expectedProps = {
+        $creator_event_uuid: uuid,
         $initial_browser: 'Chrome',
         $initial_browser_version: '95',
         $initial_utm_medium: 'twitter',
@@ -382,6 +384,7 @@ test('capture new person', async () => {
     expect(persons.length).toEqual(1)
     expect(persons[0].version).toEqual(1)
     expectedProps = {
+        $creator_event_uuid: uuid,
         $initial_browser: 'Chrome',
         $initial_browser_version: '95',
         $initial_utm_medium: 'twitter',
@@ -1891,6 +1894,8 @@ test('any event can do $set on props (user exists)', async () => {
 })
 
 test('any event can do $set on props (new user)', async () => {
+    const uuid = new UUIDT().toString()
+
     await processEvent(
         'distinct_id1',
         '',
@@ -1905,7 +1910,7 @@ test('any event can do $set on props (new user)', async () => {
         } as any as PluginEvent,
         team.id,
         now,
-        new UUIDT().toString()
+        uuid
     )
 
     expect((await hub.db.fetchEvents()).length).toBe(1)
@@ -1915,7 +1920,7 @@ test('any event can do $set on props (new user)', async () => {
 
     const [person] = await hub.db.fetchPersons()
     expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
-    expect(person.properties).toEqual({ a_prop: 'test-1', c_prop: 'test-1' })
+    expect(person.properties).toEqual({ $creator_event_uuid: uuid, a_prop: 'test-1', c_prop: 'test-1' })
 })
 
 test('any event can do $set_once on props', async () => {
@@ -1969,6 +1974,7 @@ test('any event can do $set_once on props', async () => {
 })
 
 test('$set and $set_once', async () => {
+    const uuid = new UUIDT().toString()
     await processEvent(
         'distinct_id1',
         '',
@@ -1984,7 +1990,7 @@ test('$set and $set_once', async () => {
         } as any as PluginEvent,
         team.id,
         now,
-        new UUIDT().toString()
+        uuid
     )
 
     expect((await hub.db.fetchEvents()).length).toBe(1)
@@ -1992,6 +1998,7 @@ test('$set and $set_once', async () => {
     const [person] = await hub.db.fetchPersons()
     expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
     expect(person.properties).toEqual({
+        $creator_event_uuid: uuid,
         key1: 'value1',
         key2: 'value2',
         key3: 'value4',

--- a/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
@@ -97,6 +97,7 @@ describe('Event Pipeline integration test', () => {
         expect(persons.length).toEqual(1)
         expect(persons[0].version).toEqual(0)
         expect(persons[0].properties).toEqual({
+            $creator_event_uuid: event.uuid,
             $initial_browser: 'Chrome',
             personProp: 'value',
             anotherValue: 2,
@@ -187,7 +188,9 @@ describe('Event Pipeline integration test', () => {
                     id: expect.any(Number),
                     created_at: expect.any(String),
                     team_id: 2,
-                    properties: {},
+                    properties: {
+                        $creator_event_uuid: event.uuid,
+                    },
                     uuid: expect.any(String),
                 },
             },

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -95,7 +95,12 @@ describe('PersonState.update()', () => {
 
     describe('on person creation', () => {
         it('creates person if they are new', async () => {
-            const personContainer = await personState({ event: '$pageview', distinct_id: 'new-user' }).update()
+            const event_uuid = new UUIDT().toString()
+            const personContainer = await personState({
+                event: '$pageview',
+                distinct_id: 'new-user',
+                uuid: event_uuid,
+            }).update()
             await hub.db.kafkaProducer.flush()
 
             expect(hub.personManager.isNewPerson).toHaveBeenCalledTimes(1)
@@ -109,7 +114,7 @@ describe('PersonState.update()', () => {
                 expect.objectContaining({
                     id: expect.any(Number),
                     uuid: uuid.toString(),
-                    properties: {},
+                    properties: { $creator_event_uuid: event_uuid },
                     created_at: timestamp,
                     version: 0,
                     is_identified: false,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Persons are getting created somewhere they shouldn't be and we don't know why. This would help debug it, and also in the future for anyone having person_ids not tagged to the right person.

Note that when we do a merge we use the person_id from the same person as the properties, so this value is always tied to this person_id first created uuid. For merged persons we can look at the deleted persons in CH and see in properties which event created the person.

We could gate this if we want to be safe / not have it for everyone, but I think it could be useful in future debugging too of various data problems.

## Changes

Note this PR is stacked on top of https://github.com/PostHog/posthog/pull/13101
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

unittest updated
+ locally  - just sent a random event
<img width="982" alt="Screenshot 2022-12-02 at 15 21 56" src="https://user-images.githubusercontent.com/890921/205365203-920f7087-5a80-46db-a551-16f5139605e4.png">

