### PR TITLE
fix(time-to-see-data): refresh tiles by their order in layout

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -281,52 +281,6 @@ describe('dashboardLogic', () => {
             logic = dashboardLogic({ id: 5 })
             logic.mount()
         })
-        it('updates layouts via API when starting with empty layouts', async () => {
-            await expectLogic(logic)
-                .toFinishAllListeners()
-                .toMatchValues({
-                    layouts: {
-                        // generates the default layouts because all the tiles start empty
-                        sm: [
-                            { h: 8, i: '0', minH: 5, minW: 3, w: 8, x: 0, y: 0 },
-                            { h: 5, i: '1', minH: 5, minW: 3, w: 6, x: 0, y: 8 },
-                            { h: 6, i: '4', minH: 5, minW: 3, w: 6, x: 6, y: 8 },
-                        ],
-                        xs: [
-                            { h: 8, i: '0', minH: 5, minW: 1, w: 1, x: 0, y: 0 },
-                            { h: 5, i: '1', minH: 5, minW: 1, w: 1, x: 0, y: 8 },
-                            { h: 6, i: '4', minH: 5, minW: 1, w: 1, x: 0, y: 13 },
-                        ],
-                    },
-                })
-                .toDispatchActions([
-                    // frustratingly the same properties are sent in a different order
-                    // and the matcher cares about the order
-                    logic.actionCreators.saveLayouts([
-                        {
-                            id: 0,
-                            layouts: {
-                                sm: { i: '0', x: 0, y: 0, w: 8, h: 8, minW: 3, minH: 5 },
-                                xs: { i: '0', x: 0, y: 0, w: 1, h: 8, minW: 1, minH: 5 },
-                            },
-                        },
-                        {
-                            id: 1,
-                            layouts: {
-                                sm: { i: '1', x: 0, y: 8, w: 6, h: 5, minW: 3, minH: 5 },
-                                xs: { i: '1', x: 0, y: 8, w: 1, h: 5, minW: 1, minH: 5 },
-                            },
-                        },
-                        {
-                            id: 4,
-                            layouts: {
-                                sm: { i: '4', x: 6, y: 8, w: 6, h: 6, minW: 3, minH: 5 },
-                                xs: { i: '4', x: 0, y: 13, w: 1, h: 6, minW: 1, minH: 5 },
-                            },
-                        },
-                    ]),
-                ])
-        })
 
         it('saving layouts with no provided tiles updates all tiles', async () => {
             jest.spyOn(api, 'update')
@@ -339,11 +293,11 @@ describe('dashboardLogic', () => {
                 no_items_field: true,
                 tiles: [
                     {
-                        id: 9,
+                        id: 0,
                         layouts: {},
                     },
                     {
-                        id: 10,
+                        id: 1,
                         layouts: {},
                     },
                     {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -822,11 +822,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (s) => [s.layoutForItem],
             (layoutForItem) => (tiles: Array<DashboardTile>) => {
                 return [...tiles].sort((a: DashboardTile, b: DashboardTile) => {
-                    const aPos = layoutForItem[a.id]
-                    const bPos = layoutForItem[b.id]
-                    if (aPos.x < bPos.x || (aPos.x == bPos.x && aPos.y < bPos.y)) {
+                    const ax = layoutForItem[a.id]?.x ?? 0
+                    const ay = layoutForItem[a.id]?.y ?? 0
+                    const bx = layoutForItem[b.id]?.x ?? 0
+                    const by = layoutForItem[b.id]?.y ?? 0
+                    if (ax < bx || (ax == bx && ay < by)) {
                         return -1
-                    } else if (aPos.x > bPos.x || (aPos.x == bPos.x && aPos.y > bPos.y)) {
+                    } else if (ax > bx || (ax == bx && by > by)) {
                         return 1
                     } else {
                         return 0

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -15,7 +15,7 @@ import {
 import api, { getJSONOrThrow } from 'lib/api'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { router, urlToAction } from 'kea-router'
-import { areObjectValuesEmpty, clearDOMTextSelection, isUserLoggedIn, toParams, uuid } from 'lib/utils'
+import { clearDOMTextSelection, isUserLoggedIn, toParams, uuid } from 'lib/utils'
 import { insightsModel } from '~/models/insightsModel'
 import {
     AUTO_REFRESH_DASHBOARD_THRESHOLD_HOURS,
@@ -578,7 +578,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
     })),
-    selectors(({ actions }) => ({
+    selectors(() => ({
         asDashboardTemplate: [
             (s) => [s.allItems],
             (dashboard: DashboardType): string => {
@@ -688,8 +688,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
         layouts: [
             (s) => [s.tiles],
             (tiles) => {
-                const tilesWithNoLayout = tiles.filter((t) => !t.layouts || areObjectValuesEmpty(t.layouts))
-
                 const allLayouts: Partial<Record<keyof typeof BREAKPOINT_COLUMN_COUNTS, Layout[]>> = {}
 
                 for (const col of Object.keys(BREAKPOINT_COLUMN_COUNTS) as (keyof typeof BREAKPOINT_COLUMN_COUNTS)[]) {
@@ -771,15 +769,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     allLayouts[col] = cleanLayouts
                 }
 
-                if (tilesWithNoLayout.length > 0) {
-                    const layoutsByTileId = layoutsByTile(allLayouts)
-                    actions.saveLayouts(
-                        tilesWithNoLayout.map((t) => ({
-                            id: t.id,
-                            layouts: layoutsByTileId[t.id],
-                        }))
-                    )
-                }
                 return allLayouts
             },
         ],

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -818,6 +818,22 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 },
             ],
         ],
+        sortTilesByLayout: [
+            (s) => [s.layoutForItem],
+            (layoutForItem) => (tiles: Array<DashboardTile>) => {
+                return [...tiles].sort((a: DashboardTile, b: DashboardTile) => {
+                    const aPos = layoutForItem[a.id]
+                    const bPos = layoutForItem[b.id]
+                    if (aPos.x < bPos.x || (aPos.x == bPos.x && aPos.y < bPos.y)) {
+                        return -1
+                    } else if (aPos.x > bPos.x || (aPos.x == bPos.x && aPos.y > bPos.y)) {
+                        return 1
+                    } else {
+                        return 0
+                    }
+                })
+            },
+        ],
     })),
     events(({ actions, cache, props }) => ({
         afterMount: () => {
@@ -961,7 +977,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
             const dashboardId: number = props.id
 
-            const insights = (tiles || values.insightTiles || [])
+            const insights = values
+                .sortTilesByLayout(tiles || values.insightTiles || [])
                 .map((t) => t.insight)
                 .filter((i): i is InsightModel => !!i)
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -826,9 +826,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     const ay = layoutForItem[a.id]?.y ?? 0
                     const bx = layoutForItem[b.id]?.x ?? 0
                     const by = layoutForItem[b.id]?.y ?? 0
-                    if (ax < bx || (ax == bx && ay < by)) {
+                    if (ay < by || (ay == by && ax < bx)) {
                         return -1
-                    } else if (ax > bx || (ax == bx && by > by)) {
+                    } else if (ay > by || (ay == by && ax > bx)) {
                         return 1
                     } else {
                         return 0


### PR DESCRIPTION
Previously, when reloading tiles on the dashboard, they would be reloaded in a random order. Now the order reflects the order they are shown in the UI.

This benefits perceived performance as things closer to the top will get reloaded faster.

## How did you test this code?

Only manually
