### PR TITLE
fix(rba): Allow new feature flags to always have permissions editing

### DIFF
--- a/frontend/src/scenes/ResourcePermissionModal.tsx
+++ b/frontend/src/scenes/ResourcePermissionModal.tsx
@@ -14,7 +14,6 @@ import {
     ResourcePermissionMapping,
 } from './organization/Settings/Permissions/permissionsLogic'
 import { rolesLogic } from './organization/Settings/Roles/rolesLogic'
-import { organizationLogic } from './organizationLogic'
 import { urls } from './urls'
 
 interface ResourcePermissionProps {
@@ -27,6 +26,7 @@ interface ResourcePermissionProps {
     deleteAssociatedRole: (id: RoleType['id']) => void
     isNewResource: boolean
     resourceType: Resource
+    canEdit: boolean
 }
 
 interface ResourcePermissionModalProps extends ResourcePermissionProps {
@@ -59,6 +59,7 @@ export function ResourcePermissionModal({
     roles,
     deleteAssociatedRole,
     isNewResource,
+    canEdit,
 }: ResourcePermissionModalProps): JSX.Element {
     return (
         <>
@@ -73,6 +74,7 @@ export function ResourcePermissionModal({
                     onAdd={onAdd}
                     roles={roles}
                     deleteAssociatedRole={deleteAssociatedRole}
+                    canEdit={canEdit}
                 />
             </LemonModal>
         </>
@@ -89,11 +91,10 @@ export function ResourcePermission({
     deleteAssociatedRole,
     isNewResource,
     resourceType,
+    canEdit,
 }: ResourcePermissionProps): JSX.Element {
     const { allPermissions, shouldShowPermissionsTable } = useValues(permissionsLogic)
     const { roles: possibleRolesWithAccess } = useValues(rolesLogic)
-    const { isAdminOrOwner } = useValues(organizationLogic)
-
     const resourceLevel = allPermissions.find((permission) => permission.resource === resourceType)
     // TODO: feature_flag_access_level should eventually be generic in this component
     const rolesWithAccess = possibleRolesWithAccess.filter(
@@ -163,7 +164,7 @@ export function ResourcePermission({
                     {<OrganizationResourcePermissionRoles roles={rolesWithAccess} />}
                 </>
             )}
-            {isAdminOrOwner && (
+            {(isNewResource || canEdit) && (
                 <>
                     <h5 className="mt-4">Custom edit roles</h5>
                     <div className="flex gap-2">

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -254,6 +254,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                 onAdd={() => addAssociatedRoles()}
                                                 roles={derivedRoles}
                                                 deleteAssociatedRole={(id) => deleteAssociatedRole({ roleId: id })}
+                                                canEdit={featureFlag.can_edit}
                                             />
                                         </PayGateMini>
                                     </Card>
@@ -414,6 +415,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                     onAdd={() => addAssociatedRoles()}
                                                     roles={derivedRoles}
                                                     deleteAssociatedRole={(id) => deleteAssociatedRole({ roleId: id })}
+                                                    canEdit={featureFlag.can_edit}
                                                 />
                                             </PayGateMini>
                                         </Tabs.TabPane>

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -18,6 +18,7 @@ from posthog.models.experiment import Experiment
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models.organization import OrganizationMembership
 from posthog.models.property import GroupTypeIndex, GroupTypeName
 from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.signals import mutable_receiver
@@ -701,7 +702,11 @@ def can_user_edit_feature_flag(request, feature_flag):
     else:
         if feature_flag.created_by == request.user:
             return True
-
+        if (
+            request.user.organization_memberships.get(organization=request.user.organization).level
+            >= OrganizationMembership.Level.ADMIN
+        ):
+            return True
         all_role_memberships = request.user.role_memberships.select_related("role").all()
         try:
             feature_flag_resource_access = OrganizationResourceAccess.objects.get(


### PR DESCRIPTION
## Problem

Only users with admin+ org membership level was able to set permissions on a feature flag

## Changes

Users who are the creator of their feature flags should be able to set permissions on it, or if they have the appropriate access level.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
