### PR TITLE
fix: feature flag autorollback

### DIFF
--- a/ee/tasks/auto_rollback_feature_flag.py
+++ b/ee/tasks/auto_rollback_feature_flag.py
@@ -32,13 +32,12 @@ def check_feature_flag_rollback_conditions(feature_flag_id: int) -> None:
 def calculate_rolling_average(rollback_condition: Dict, team_id: int, timezone: str) -> float:
     curr = datetime.now(tz=pytz.timezone(timezone))
 
-    days = 7
+    rolling_average_days = 7
 
-    # rolling average last 7 days
     filter = Filter(
         data={
             **rollback_condition["threshold_metric"],
-            "date_from": (curr - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+            "date_from": (curr - timedelta(days=rolling_average_days)).strftime("%Y-%m-%d %H:%M:%S.%f"),
             "date_to": curr.strftime("%Y-%m-%d %H:%M:%S.%f"),
         },
         team=team_id,
@@ -51,7 +50,7 @@ def calculate_rolling_average(rollback_condition: Dict, team_id: int, timezone: 
 
     data = result[0]["data"]
 
-    return sum(data) / days
+    return sum(data) / rolling_average_days
 
 
 def check_condition(rollback_condition: Dict, feature_flag: FeatureFlag) -> bool:

--- a/ee/tasks/auto_rollback_feature_flag.py
+++ b/ee/tasks/auto_rollback_feature_flag.py
@@ -7,6 +7,7 @@ from celery import shared_task
 from ee.api.sentry_stats import get_stats_for_timerange
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
+from posthog.models.team import Team
 from posthog.queries.trends.trends import Trends
 
 
@@ -29,7 +30,7 @@ def check_feature_flag_rollback_conditions(feature_flag_id: int) -> None:
         flag.save()
 
 
-def calculate_rolling_average(threshold_metric: Dict, team_id: int, timezone: str) -> float:
+def calculate_rolling_average(threshold_metric: Dict, team: Team, timezone: str) -> float:
     curr = datetime.now(tz=pytz.timezone(timezone))
 
     rolling_average_days = 7
@@ -40,10 +41,10 @@ def calculate_rolling_average(threshold_metric: Dict, team_id: int, timezone: st
             "date_from": (curr - timedelta(days=rolling_average_days)).strftime("%Y-%m-%d %H:%M:%S.%f"),
             "date_to": curr.strftime("%Y-%m-%d %H:%M:%S.%f"),
         },
-        team=team_id,
+        team=team,
     )
     trends_query = Trends()
-    result = trends_query.run(filter, team_id)
+    result = trends_query.run(filter, team)
 
     if not len(result):
         return False

--- a/ee/tasks/test/test_auto_rollback_feature_flag.py
+++ b/ee/tasks/test/test_auto_rollback_feature_flag.py
@@ -2,12 +2,47 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from ee.tasks.auto_rollback_feature_flag import check_condition, check_feature_flag_rollback_conditions
+from ee.tasks.auto_rollback_feature_flag import (
+    calculate_rolling_average,
+    check_condition,
+    check_feature_flag_rollback_conditions,
+)
 from posthog.models.feature_flag import FeatureFlag
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event
 
 
 class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
+    def test_calculate_rolling_average(self):
+        # rollback_condition: Dict, team_id: int, timezone
+        rollback_condition = {
+            "threshold": 10,
+            "threshold_metric": {
+                "insight": "trends",
+                "events": [{"order": 0, "id": "$pageview"}],
+            },
+            "operator": "lt",
+            "threshold_type": "insight",
+        }
+
+        with freeze_time("2021-08-21T20:00:00.000Z"):
+            for _ in range(70):
+                _create_event(
+                    event="$pageview",
+                    distinct_id="1",
+                    team=self.team,
+                    timestamp="2021-08-21 00:00:00",
+                    properties={"prop": 1},
+                )
+
+            self.assertEqual(
+                calculate_rolling_average(
+                    rollback_condition=rollback_condition,
+                    team_id=self.team,
+                    timezone="UTC",
+                ),
+                10,
+            )
+
     def test_check_condition(self):
         rollback_condition = {
             "threshold": 10,
@@ -31,16 +66,16 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
 
     def test_check_condition_valid(self):
         rollback_condition = {
-            "threshold": 3,
+            "threshold": 15,
             "threshold_metric": {
                 "insight": "trends",
                 "events": [{"order": 0, "id": "$pageview"}],
             },
-            "operator": "lt",
+            "operator": "gt",
             "threshold_type": "insight",
         }
 
-        for _ in range(10):
+        for _ in range(70):
             _create_event(
                 event="$pageview",
                 distinct_id="1",
@@ -53,15 +88,6 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                 distinct_id="1",
                 team=self.team,
                 timestamp="2021-08-22 00:00:00",
-                properties={"prop": 1},
-            )
-
-        for _ in range(20):
-            _create_event(
-                event="$pageview",
-                distinct_id="1",
-                team=self.team,
-                timestamp="2021-08-23 00:00:00",
                 properties={"prop": 1},
             )
 
@@ -74,25 +100,25 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                 rollback_conditions=[rollback_condition],
             )
 
-        with freeze_time("2021-08-23T20:00:00.000Z"):
-            self.assertEqual(check_condition(rollback_condition, flag), True)
+        with freeze_time("2021-08-21T20:00:00.000Z"):
+            self.assertEqual(check_condition(rollback_condition, flag), False)
 
         # Go another day with 0 events
-        with freeze_time("2021-08-26T20:00:00.000Z"):
-            self.assertEqual(check_condition(rollback_condition, flag), False)
+        with freeze_time("2021-08-22T20:00:00.000Z"):
+            self.assertEqual(check_condition(rollback_condition, flag), True)
 
     def test_feature_flag_rolledback(self):
         rollback_condition = {
-            "threshold": 3,
+            "threshold": 15,
             "threshold_metric": {
                 "insight": "trends",
                 "events": [{"order": 0, "id": "$pageview"}],
             },
-            "operator": "lt",
+            "operator": "gt",
             "threshold_type": "insight",
         }
 
-        for _ in range(10):
+        for _ in range(70):
             _create_event(
                 event="$pageview",
                 distinct_id="1",
@@ -108,16 +134,7 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                 properties={"prop": 1},
             )
 
-        for _ in range(20):
-            _create_event(
-                event="$pageview",
-                distinct_id="1",
-                team=self.team,
-                timestamp="2021-08-23 00:00:00",
-                properties={"prop": 1},
-            )
-
-        with freeze_time("2021-08-21T20:00:00.000Z"):
+        with freeze_time("2021-08-21T00:00:00.000Z"):
             flag = FeatureFlag.objects.create(
                 team=self.team,
                 created_by=self.user,

--- a/ee/tasks/test/test_auto_rollback_feature_flag.py
+++ b/ee/tasks/test/test_auto_rollback_feature_flag.py
@@ -39,7 +39,7 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(
                 calculate_rolling_average(
                     threshold_metric=threshold_metric,
-                    team_id=self.team,
+                    team=self.team,
                     timezone="UTC",
                 ),
                 10,  # because we have 70 events in the last 7 days
@@ -49,7 +49,7 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(
                 calculate_rolling_average(
                     threshold_metric=threshold_metric,
-                    team_id=self.team,
+                    team=self.team,
                     timezone="UTC",
                 ),
                 20,  # because we have 140 events in the last 7 days

--- a/ee/tasks/test/test_auto_rollback_feature_flag.py
+++ b/ee/tasks/test/test_auto_rollback_feature_flag.py
@@ -40,7 +40,7 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                     team_id=self.team,
                     timezone="UTC",
                 ),
-                10,
+                10,  # because we have 70 events in the last 7 days
             )
 
     def test_check_condition(self):

--- a/ee/tasks/test/test_auto_rollback_feature_flag.py
+++ b/ee/tasks/test/test_auto_rollback_feature_flag.py
@@ -24,7 +24,7 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                     event="$pageview",
                     distinct_id="1",
                     team=self.team,
-                    timestamp="2021-08-21 00:00:00",
+                    timestamp="2021-08-21 05:00:00",
                     properties={"prop": 1},
                 )
 
@@ -32,7 +32,7 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                     event="$pageview",
                     distinct_id="1",
                     team=self.team,
-                    timestamp="2021-08-22 00:00:00",
+                    timestamp="2021-08-22 05:00:00",
                     properties={"prop": 1},
                 )
         with freeze_time("2021-08-21T21:00:00.000Z"):

--- a/ee/tasks/test/test_auto_rollback_feature_flag.py
+++ b/ee/tasks/test/test_auto_rollback_feature_flag.py
@@ -13,15 +13,9 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event
 
 class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
     def test_calculate_rolling_average(self):
-        # rollback_condition: Dict, team_id: int, timezone
-        rollback_condition = {
-            "threshold": 10,
-            "threshold_metric": {
-                "insight": "trends",
-                "events": [{"order": 0, "id": "$pageview"}],
-            },
-            "operator": "lt",
-            "threshold_type": "insight",
+        threshold_metric = {
+            "insight": "trends",
+            "events": [{"order": 0, "id": "$pageview"}],
         }
 
         with freeze_time("2021-08-21T20:00:00.000Z"):
@@ -36,7 +30,7 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
 
             self.assertEqual(
                 calculate_rolling_average(
-                    rollback_condition=rollback_condition,
+                    threshold_metric=threshold_metric,
                     team_id=self.team,
                     timezone="UTC",
                 ),

--- a/ee/tasks/test/test_auto_rollback_feature_flag.py
+++ b/ee/tasks/test/test_auto_rollback_feature_flag.py
@@ -28,6 +28,14 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                     properties={"prop": 1},
                 )
 
+                _create_event(
+                    event="$pageview",
+                    distinct_id="1",
+                    team=self.team,
+                    timestamp="2021-08-22 00:00:00",
+                    properties={"prop": 1},
+                )
+        with freeze_time("2021-08-21T21:00:00.000Z"):
             self.assertEqual(
                 calculate_rolling_average(
                     threshold_metric=threshold_metric,
@@ -35,6 +43,16 @@ class AutoRollbackTest(ClickhouseTestMixin, APIBaseTest):
                     timezone="UTC",
                 ),
                 10,  # because we have 70 events in the last 7 days
+            )
+
+        with freeze_time("2021-08-22T21:00:00.000Z"):
+            self.assertEqual(
+                calculate_rolling_average(
+                    threshold_metric=threshold_metric,
+                    team_id=self.team,
+                    timezone="UTC",
+                ),
+                20,  # because we have 140 events in the last 7 days
             )
 
     def test_check_condition(self):

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -471,8 +471,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                     )}`
                 )
                 const counts = response.result?.[0]?.data
-                const firstWeek = counts.slice(0, 7)
-                const avg = Math.round(sum(firstWeek) / 7)
+                console.log(counts)
+                const avg = Math.round(sum(counts) / 7)
                 actions.setInsightResultAtIndex(index, avg)
             }
         },

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -471,7 +471,6 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                     )}`
                 )
                 const counts = response.result?.[0]?.data
-                console.log(counts)
                 const avg = Math.round(sum(counts) / 7)
                 actions.setInsightResultAtIndex(index, avg)
             }


### PR DESCRIPTION
## Problem

The autorollback code was cutting off the current day.

Previously, if the current time is 7pm, it would get the pageviews from 7 days ago at 7pm to now at 7pm and then remove the pageview from today. Now it includes the current day in the average

This then resulted in some of the tests wrongly failing, so I updated them

I also refactored out `calculate_rolling_average` and added a test

Fixing this should give me what I need to get the user interview app live :)

## Changes

- fixed autorollback to include the events of the current day
- refactored out `calculate_rolling_average`
- added failing test which now passes

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test for a refactored calculate_rolling_average
