### PR TITLE
feat(data-exploration): Replace event tables

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -816,7 +816,7 @@ const api = {
         async update(id: number, person: Partial<PersonType>): Promise<PersonType> {
             return new ApiRequest().person(id).update({ data: person })
         },
-        async updateProperty(id: number, property: string, value: any): Promise<void> {
+        async updateProperty(id: string, property: string, value: any): Promise<void> {
             return new ApiRequest()
                 .person(id)
                 .withAction('update_property')
@@ -827,7 +827,7 @@ const api = {
                     },
                 })
         },
-        async deleteProperty(id: number, property: string): Promise<void> {
+        async deleteProperty(id: string, property: string): Promise<void> {
             return new ApiRequest()
                 .person(id)
                 .withAction('delete_property')

--- a/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
+++ b/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
@@ -427,7 +427,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                 type: 'Person',
                 source: [
                     {
-                        id: '502746582',
+                        id: '01819231-75a0-0000-467e-a4be57b44a37',
                         name: '1819231753016b-0b04ab5a3ab143-3297640-75300-181923175313d4',
                         uuid: '01819231-75a0-0000-467e-a4be57b44a37',
                         created_at: '2022-06-23T20:12:03.828000Z',
@@ -462,7 +462,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                         distinct_ids: ['1819231753016b-0b04ab5a3ab143-3297640-75300-181923175313d4'],
                     },
                     {
-                        id: '502725471',
+                        id: '01819220-aa0b-0000-6992-fad9de0ea4dc',
                         name: '1819220a99e5ec-0005fee037f8d2-3297640-75300-1819220a99f6b7',
                         uuid: '01819220-aa0b-0000-6992-fad9de0ea4dc',
                         created_at: '2022-06-23T19:53:43.137000Z',
@@ -497,7 +497,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                         distinct_ids: ['1819220a99e5ec-0005fee037f8d2-3297640-75300-1819220a99f6b7'],
                     },
                     {
-                        id: '502715718',
+                        id: '01819218-92f2-0000-7132-90a079001dc9',
                         name: '18192189287517-0e66a695611002-3297640-75300-18192189288790',
                         uuid: '01819218-92f2-0000-7132-90a079001dc9',
                         created_at: '2022-06-23T19:44:52.944000Z',
@@ -532,7 +532,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                         distinct_ids: ['18192189287517-0e66a695611002-3297640-75300-18192189288790'],
                     },
                     {
-                        id: '502696118',
+                        id: '01819208-c74f-0000-75e7-7d3dc16da26b',
                         name: '1819208c6ed32c-0e427ef09bbae-3297640-75300-1819208c6ee74b',
                         uuid: '01819208-c74f-0000-75e7-7d3dc16da26b',
                         created_at: '2022-06-23T19:27:37.771000Z',

--- a/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
+++ b/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
@@ -427,7 +427,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                 type: 'Person',
                 source: [
                     {
-                        id: 502746582,
+                        id: '502746582',
                         name: '1819231753016b-0b04ab5a3ab143-3297640-75300-181923175313d4',
                         uuid: '01819231-75a0-0000-467e-a4be57b44a37',
                         created_at: '2022-06-23T20:12:03.828000Z',
@@ -462,7 +462,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                         distinct_ids: ['1819231753016b-0b04ab5a3ab143-3297640-75300-181923175313d4'],
                     },
                     {
-                        id: 502725471,
+                        id: '502725471',
                         name: '1819220a99e5ec-0005fee037f8d2-3297640-75300-1819220a99f6b7',
                         uuid: '01819220-aa0b-0000-6992-fad9de0ea4dc',
                         created_at: '2022-06-23T19:53:43.137000Z',
@@ -497,7 +497,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                         distinct_ids: ['1819220a99e5ec-0005fee037f8d2-3297640-75300-1819220a99f6b7'],
                     },
                     {
-                        id: 502715718,
+                        id: '502715718',
                         name: '18192189287517-0e66a695611002-3297640-75300-18192189288790',
                         uuid: '01819218-92f2-0000-7132-90a079001dc9',
                         created_at: '2022-06-23T19:44:52.944000Z',
@@ -532,7 +532,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                         distinct_ids: ['18192189287517-0e66a695611002-3297640-75300-18192189288790'],
                     },
                     {
-                        id: 502696118,
+                        id: '502696118',
                         name: '1819208c6ed32c-0e427ef09bbae-3297640-75300-1819208c6ee74b',
                         uuid: '01819208-c74f-0000-75e7-7d3dc16da26b',
                         created_at: '2022-06-23T19:27:37.771000Z',
@@ -568,7 +568,7 @@ export const personActivityResponseJson: ActivityLogItem[] = [
                     },
                 ],
                 target: {
-                    id: 502792727,
+                    id: '502792727',
                     name: '1819220a99e5ec-0005fee037f8d2-3297640-75300-1819220a99f6b7',
                     uuid: '01819256-1d25-0000-4ed7-ea437589ada7',
                     created_at: '2022-06-23T20:52:06.053733Z',

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1191,10 +1191,10 @@ export function roundToDecimal(value: number | null, places: number = 2): string
     return (Math.round(value * 100) / 100).toFixed(places)
 }
 
-export function sortedKeys(object: Record<string, any>): Record<string, any> {
-    const newObject: Record<string, any> = {}
+export function sortedKeys<T extends Record<string, any> = Record<string, any>>(object: T): T {
+    const newObject: T = {} as T
     for (const key of Object.keys(object).sort()) {
-        newObject[key] = object[key]
+        newObject[key as keyof T] = object[key]
     }
     return newObject
 }

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -1,7 +1,7 @@
 import { isDataNode, isDataTableNode, isLegacyQuery, isInsightQueryNode } from '../utils'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { DataNode } from '~/queries/nodes/DataNode/DataNode'
-import { Node, QueryCustom, QuerySchema } from '~/queries/schema'
+import { Node, QueryContext, QuerySchema } from '~/queries/schema'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { LegacyInsightQuery } from '~/queries/nodes/LegacyInsightQuery/LegacyInsightQuery'
 import { InsightQuery } from '~/queries/nodes/InsightQuery/InsightQuery'
@@ -14,12 +14,12 @@ export interface QueryProps<T extends Node = QuerySchema | Node> {
     setQuery?: (node: T) => void
     /** Does not call setQuery, not even locally */
     readOnly?: boolean
-    /** Custom components passed down to query nodes (e.g. custom table columns) */
-    custom?: QueryCustom
+    /** Custom components passed down to a few query nodes (e.g. custom table columns) */
+    context?: QueryContext
 }
 
 export function Query(props: QueryProps): JSX.Element {
-    const { query: globalQuery, setQuery: globalSetQuery, readOnly, custom } = props
+    const { query: globalQuery, setQuery: globalSetQuery, readOnly, context } = props
     const [localQuery, localSetQuery] = useState(globalQuery)
     useEffect(() => {
         if (globalQuery !== localQuery) {
@@ -40,7 +40,7 @@ export function Query(props: QueryProps): JSX.Element {
     if (isLegacyQuery(query)) {
         component = <LegacyInsightQuery query={query} />
     } else if (isDataTableNode(query)) {
-        component = <DataTable query={query} setQuery={setQuery} custom={custom} />
+        component = <DataTable query={query} setQuery={setQuery} context={context} />
     } else if (isDataNode(query)) {
         component = <DataNode query={query} />
     } else if (isInsightQueryNode(query)) {

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -1,14 +1,14 @@
 import { isDataNode, isDataTableNode, isLegacyQuery, isInsightQueryNode } from '../utils'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { DataNode } from '~/queries/nodes/DataNode/DataNode'
-import { Node } from '~/queries/schema'
+import { Node, QuerySchema } from '~/queries/schema'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { LegacyInsightQuery } from '~/queries/nodes/LegacyInsightQuery/LegacyInsightQuery'
 import { InsightQuery } from '~/queries/nodes/InsightQuery/InsightQuery'
 
-export interface QueryProps {
-    query: Node | string
-    setQuery?: (node: Node) => void
+export interface QueryProps<T extends Node = QuerySchema | Node> {
+    query: T | string
+    setQuery?: (node: T) => void
 }
 
 export function Query(props: QueryProps): JSX.Element {

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -1,18 +1,22 @@
 import { isDataNode, isDataTableNode, isLegacyQuery, isInsightQueryNode } from '../utils'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { DataNode } from '~/queries/nodes/DataNode/DataNode'
-import { Node, QuerySchema } from '~/queries/schema'
+import { Node, QueryCustom, QuerySchema } from '~/queries/schema'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { LegacyInsightQuery } from '~/queries/nodes/LegacyInsightQuery/LegacyInsightQuery'
 import { InsightQuery } from '~/queries/nodes/InsightQuery/InsightQuery'
 
 export interface QueryProps<T extends Node = QuerySchema | Node> {
+    /** The query to render */
     query: T | string
+    /** Set this if the user can update the query */
     setQuery?: (node: T) => void
+    /** Custom components passed down to query nodes (e.g. custom table columns) */
+    custom?: QueryCustom
 }
 
 export function Query(props: QueryProps): JSX.Element {
-    const { query, setQuery } = props
+    const { query, setQuery, custom } = props
     if (typeof query === 'string') {
         try {
             return <Query {...props} query={JSON.parse(query)} />
@@ -24,7 +28,7 @@ export function Query(props: QueryProps): JSX.Element {
     if (isLegacyQuery(query)) {
         component = <LegacyInsightQuery query={query} />
     } else if (isDataTableNode(query)) {
-        component = <DataTable query={query} setQuery={setQuery} />
+        component = <DataTable query={query} setQuery={setQuery} custom={custom} />
     } else if (isDataNode(query)) {
         component = <DataNode query={query} />
     } else if (isInsightQueryNode(query)) {

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -5,18 +5,25 @@ import { Node, QueryCustom, QuerySchema } from '~/queries/schema'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { LegacyInsightQuery } from '~/queries/nodes/LegacyInsightQuery/LegacyInsightQuery'
 import { InsightQuery } from '~/queries/nodes/InsightQuery/InsightQuery'
+import { useState } from 'react'
 
 export interface QueryProps<T extends Node = QuerySchema | Node> {
     /** The query to render */
     query: T | string
     /** Set this if the user can update the query */
     setQuery?: (node: T) => void
+    /** Can the query can still be edited locally if there is `setQuery` */
+    setQueryLocally?: boolean
     /** Custom components passed down to query nodes (e.g. custom table columns) */
     custom?: QueryCustom
 }
 
 export function Query(props: QueryProps): JSX.Element {
-    const { query, setQuery, custom } = props
+    const { query: globalQuery, setQuery: globalSetQuery, setQueryLocally, custom } = props
+    const [localQuery, localSetQuery] = useState(globalQuery)
+    const query = setQueryLocally ? localQuery : globalQuery
+    const setQuery = setQueryLocally ? localSetQuery : globalSetQuery
+
     if (typeof query === 'string') {
         try {
             return <Query {...props} query={JSON.parse(query)} />

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -5,24 +5,29 @@ import { Node, QueryCustom, QuerySchema } from '~/queries/schema'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { LegacyInsightQuery } from '~/queries/nodes/LegacyInsightQuery/LegacyInsightQuery'
 import { InsightQuery } from '~/queries/nodes/InsightQuery/InsightQuery'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export interface QueryProps<T extends Node = QuerySchema | Node> {
     /** The query to render */
     query: T | string
-    /** Set this if the user can update the query */
+    /** Set this if you're controlling the query parameter */
     setQuery?: (node: T) => void
-    /** Can the query can still be edited locally if there is `setQuery` */
-    setQueryLocally?: boolean
+    /** Does not call setQuery, not even locally */
+    readOnly?: boolean
     /** Custom components passed down to query nodes (e.g. custom table columns) */
     custom?: QueryCustom
 }
 
 export function Query(props: QueryProps): JSX.Element {
-    const { query: globalQuery, setQuery: globalSetQuery, setQueryLocally, custom } = props
+    const { query: globalQuery, setQuery: globalSetQuery, readOnly, custom } = props
     const [localQuery, localSetQuery] = useState(globalQuery)
-    const query = setQueryLocally ? localQuery : globalQuery
-    const setQuery = setQueryLocally ? localSetQuery : globalSetQuery
+    useEffect(() => {
+        if (globalQuery !== localQuery) {
+            localSetQuery(globalQuery)
+        }
+    }, [globalQuery])
+    const query = readOnly ? globalQuery : localQuery
+    const setQuery = readOnly ? undefined : globalSetQuery ?? localSetQuery
 
     if (typeof query === 'string') {
         try {

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -6,6 +6,7 @@ import { query } from '~/queries/query'
 import { isEventsNode } from '~/queries/utils'
 import { subscriptions } from 'kea-subscriptions'
 import { objectsEqual } from 'lib/utils'
+import clsx from 'clsx'
 
 export interface DataNodeLogicProps {
     key: string
@@ -89,11 +90,10 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             // store the autoload toggle's state in localstorage, separately for each data node kind
             {
                 persist: true,
-                storageKey: [
-                    'queries.nodes.dataNodeLogic.autoLoadToggled',
-                    props.query.kind,
-                    isEventsNode(props.query) && props.query.actionId ? 'action' : '',
-                ].join('.'),
+                storageKey: clsx('queries.nodes.dataNodeLogic.autoLoadToggled', props.query.kind, {
+                    action: isEventsNode(props.query) && props.query.actionId,
+                    person: isEventsNode(props.query) && props.query.personId,
+                }),
             },
             { toggleAutoLoad: (state) => !state },
         ],

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -87,7 +87,14 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         autoLoadToggled: [
             false,
             // store the autoload toggle's state in localstorage, separately for each data node kind
-            { persist: true, storageKey: `queries.nodes.dataNodeLogic.autoLoadToggled.${props.query.kind}` },
+            {
+                persist: true,
+                storageKey: [
+                    'queries.nodes.dataNodeLogic.autoLoadToggled',
+                    props.query.kind,
+                    isEventsNode(props.query) && props.query.actionId ? 'action' : '',
+                ].join('.'),
+            },
             { toggleAutoLoad: (state) => !state },
         ],
         autoLoadStarted: [false, { startAutoLoad: () => true, stopAutoLoad: () => false }],

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -1,5 +1,5 @@
 import './DataTable.scss'
-import { DataTableNode, EventsNode, Node, QueryCustom } from '~/queries/schema'
+import { DataTableNode, EventsNode, Node, QueryContext } from '~/queries/schema'
 import { useState } from 'react'
 import { useValues, BindLogic } from 'kea'
 import { dataNodeLogic, DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -29,12 +29,12 @@ interface DataTableProps {
     query: DataTableNode
     setQuery?: (node: DataTableNode) => void
     /** Custom table columns */
-    custom?: QueryCustom
+    context?: QueryContext
 }
 
 let uniqueNode = 0
 
-export function DataTable({ query, setQuery, custom }: DataTableProps): JSX.Element {
+export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Element {
     const [key] = useState(() => `DataTable.${uniqueNode++}`)
 
     const dataNodeLogicProps: DataNodeLogicProps = { query: query.source, key }
@@ -68,9 +68,9 @@ export function DataTable({ query, setQuery, custom }: DataTableProps): JSX.Elem
     const lemonColumns: LemonTableColumn<EventType, keyof EventType | undefined>[] = [
         ...columns.map((key) => ({
             dataIndex: key as any,
-            title: renderTitle(key, custom),
+            title: renderTitle(key, context),
             render: function RenderDataTableColumn(_: any, record: EventType) {
-                return renderColumn(key, record, query, setQuery, custom)
+                return renderColumn(key, record, query, setQuery, context)
             },
         })),
         ...(showActions

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -1,5 +1,5 @@
 import './DataTable.scss'
-import { DataTableNode, EventsNode, Node } from '~/queries/schema'
+import { DataTableNode, EventsNode, Node, QueryCustom } from '~/queries/schema'
 import { useState } from 'react'
 import { useValues, BindLogic } from 'kea'
 import { dataNodeLogic, DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -28,11 +28,13 @@ import { InlineEditor } from '~/queries/nodes/Node/InlineEditor'
 interface DataTableProps {
     query: DataTableNode
     setQuery?: (node: DataTableNode) => void
+    /** Custom table columns */
+    custom?: QueryCustom
 }
 
 let uniqueNode = 0
 
-export function DataTable({ query, setQuery }: DataTableProps): JSX.Element {
+export function DataTable({ query, setQuery, custom }: DataTableProps): JSX.Element {
     const [key] = useState(() => `DataTable.${uniqueNode++}`)
 
     const dataNodeLogicProps: DataNodeLogicProps = { query: query.source, key }
@@ -66,9 +68,9 @@ export function DataTable({ query, setQuery }: DataTableProps): JSX.Element {
     const lemonColumns: LemonTableColumn<EventType, keyof EventType | undefined>[] = [
         ...columns.map((key) => ({
             dataIndex: key as any,
-            title: renderTitle(key),
+            title: renderTitle(key, custom),
             render: function RenderDataTableColumn(_: any, record: EventType) {
-                return renderColumn(key, record, query, setQuery)
+                return renderColumn(key, record, query, setQuery, custom)
             },
         })),
         ...(showActions

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -27,7 +27,12 @@ export const dataTableLogic = kea<dataTableLogicType>([
                 // This makes old stored columns (e.g. on the Team model) compatible with the new view that prepends 'properties.'
                 const topLevelFields = ['event', 'timestamp', 'id', 'distinct_id', 'person', 'url']
                 return storedColumns.map((column) => {
-                    if (topLevelFields.includes(column) || column.includes('properties.')) {
+                    if (
+                        topLevelFields.includes(column) ||
+                        column.startsWith('person.properties.') ||
+                        column.startsWith('properties.') ||
+                        column.startsWith('custom.')
+                    ) {
                         return column
                     } else {
                         return `properties.${column}`

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -2,6 +2,7 @@ import { actions, kea, key, path, props, propsChanged, reducers, selectors } fro
 import type { dataTableLogicType } from './dataTableLogicType'
 import { DataTableNode, DataTableStringColumn } from '~/queries/schema'
 import { defaultDataTableStringColumns } from './defaults'
+import { sortedKeys } from 'lib/utils'
 
 export interface DataTableLogicProps {
     key: string
@@ -42,19 +43,26 @@ export const dataTableLogic = kea<dataTableLogicType>([
         ],
         queryWithDefaults: [
             (s) => [(_, props) => props.query, s.columns],
-            (query: DataTableNode, columns): Required<DataTableNode> => ({
-                ...query,
-                columns: columns,
-                showPropertyFilter: query.showPropertyFilter ?? false,
-                showEventFilter: query.showEventFilter ?? false,
-                showActions: query.showActions ?? true,
-                showExport: query.showExport ?? false,
-                showReload: query.showReload ?? false,
-                showColumnConfigurator: query.showColumnConfigurator ?? false,
-                showEventsBufferWarning: query.showEventsBufferWarning ?? false,
-                expandable: query.expandable ?? true,
-                propertiesViaUrl: query.propertiesViaUrl ?? false,
-            }),
+            (query: DataTableNode, columns): Required<DataTableNode> => {
+                const { kind, columns: _columns, source, ...rest } = query
+                return {
+                    kind,
+                    columns: columns,
+                    source,
+                    ...sortedKeys({
+                        ...rest,
+                        expandable: query.expandable ?? true,
+                        propertiesViaUrl: query.propertiesViaUrl ?? false,
+                        showPropertyFilter: query.showPropertyFilter ?? false,
+                        showEventFilter: query.showEventFilter ?? false,
+                        showActions: query.showActions ?? true,
+                        showExport: query.showExport ?? false,
+                        showReload: query.showReload ?? false,
+                        showColumnConfigurator: query.showColumnConfigurator ?? false,
+                        showEventsBufferWarning: query.showEventsBufferWarning ?? false,
+                    }),
+                }
+            },
         ],
     }),
     propsChanged(({ actions, props }, oldProps) => {

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -32,7 +32,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
                         topLevelFields.includes(column) ||
                         column.startsWith('person.properties.') ||
                         column.startsWith('properties.') ||
-                        column.startsWith('custom.')
+                        column.startsWith('context.')
                     ) {
                         return column
                     } else {

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -6,7 +6,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { Property } from 'lib/components/Property'
 import { urls } from 'scenes/urls'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
-import { DataTableNode, QueryCustom } from '~/queries/schema'
+import { DataTableNode, QueryContext } from '~/queries/schema'
 import { isEventsNode } from '~/queries/utils'
 import { combineUrl, router } from 'kea-router'
 
@@ -15,7 +15,7 @@ export function renderColumn(
     record: EventType,
     query: DataTableNode,
     setQuery?: (node: DataTableNode) => void,
-    custom?: QueryCustom
+    context?: QueryContext
 ): JSX.Element | string {
     if (key === 'event') {
         if (record.event === '$autocapture') {
@@ -130,8 +130,8 @@ export function renderColumn(
                 <PersonHeader noLink withIcon person={record.person} />
             </Link>
         )
-    } else if (key.startsWith('custom.')) {
-        const Component = custom?.[key.substring(7)]?.render
+    } else if (key.startsWith('context.columns.')) {
+        const Component = context?.columns?.[key.substring(16)]?.render
         return Component ? <Component record={record} /> : ''
     } else {
         return String(record[key])

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -6,7 +6,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { Property } from 'lib/components/Property'
 import { urls } from 'scenes/urls'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
-import { DataTableNode } from '~/queries/schema'
+import { DataTableNode, QueryCustom } from '~/queries/schema'
 import { isEventsNode } from '~/queries/utils'
 import { combineUrl, router } from 'kea-router'
 
@@ -14,7 +14,8 @@ export function renderColumn(
     key: string,
     record: EventType,
     query: DataTableNode,
-    setQuery?: (node: DataTableNode) => void
+    setQuery?: (node: DataTableNode) => void,
+    custom?: QueryCustom
 ): JSX.Element | string {
     if (key === 'event') {
         if (record.event === '$autocapture') {
@@ -129,6 +130,9 @@ export function renderColumn(
                 <PersonHeader noLink withIcon person={record.person} />
             </Link>
         )
+    } else if (key.startsWith('custom.')) {
+        const Component = custom?.[key.substring(7)]?.render
+        return Component ? <Component record={record} /> : ''
     } else {
         return String(record[key])
     }

--- a/frontend/src/queries/nodes/DataTable/renderTitle.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderTitle.tsx
@@ -1,7 +1,8 @@
 import { PropertyFilterType } from '~/types'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { QueryCustom } from '~/queries/schema'
 
-export function renderTitle(key: string): JSX.Element | string {
+export function renderTitle(key: string, custom?: QueryCustom): JSX.Element | string {
     if (key === 'timestamp') {
         return 'Time'
     } else if (key === 'event') {
@@ -12,6 +13,8 @@ export function renderTitle(key: string): JSX.Element | string {
         return 'URL / Screen'
     } else if (key.startsWith('properties.')) {
         return <PropertyKeyInfo value={key.substring(11)} type={PropertyFilterType.Event} disableIcon />
+    } else if (key.startsWith('custom.')) {
+        return custom?.[key.substring(7)]?.title ?? key.substring(7).replace('_', ' ')
     } else if (key.startsWith('person.properties.')) {
         // NOTE: PropertyFilterType.Event is not a mistake. PropertyKeyInfo only knows events vs elements ¯\_(ツ)_/¯
         return <PropertyKeyInfo value={key.substring(18)} type={PropertyFilterType.Event} disableIcon />

--- a/frontend/src/queries/nodes/DataTable/renderTitle.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderTitle.tsx
@@ -1,8 +1,9 @@
 import { PropertyFilterType } from '~/types'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { QueryCustom } from '~/queries/schema'
+import { QueryContext } from '~/queries/schema'
 
-export function renderTitle(key: string, custom?: QueryCustom): JSX.Element | string {
+export function renderTitle(key: string, context?: QueryContext): JSX.Element | string {
+    console.log(key)
     if (key === 'timestamp') {
         return 'Time'
     } else if (key === 'event') {
@@ -13,8 +14,8 @@ export function renderTitle(key: string, custom?: QueryCustom): JSX.Element | st
         return 'URL / Screen'
     } else if (key.startsWith('properties.')) {
         return <PropertyKeyInfo value={key.substring(11)} type={PropertyFilterType.Event} disableIcon />
-    } else if (key.startsWith('custom.')) {
-        return custom?.[key.substring(7)]?.title ?? key.substring(7).replace('_', ' ')
+    } else if (key.startsWith('context.columns.')) {
+        return context?.columns?.[key.substring(16)]?.title ?? key.substring(16).replace('_', ' ')
     } else if (key.startsWith('person.properties.')) {
         // NOTE: PropertyFilterType.Event is not a mistake. PropertyKeyInfo only knows events vs elements ¯\_(ツ)_/¯
         return <PropertyKeyInfo value={key.substring(18)} type={PropertyFilterType.Event} disableIcon />

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -22,8 +22,9 @@ export async function query<N extends DataNode = DataNode>(
     if (isEventsNode(query)) {
         return await api.events.list(
             {
-                properties: query.properties,
+                properties: [...(query.fixedProperties || []), ...(query.properties || [])],
                 ...(query.event ? { event: query.event } : {}),
+                ...(query.actionId ? { action_id: query.actionId } : {}),
                 before: query.before,
                 after: query.after,
             },

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -25,6 +25,7 @@ export async function query<N extends DataNode = DataNode>(
                 properties: [...(query.fixedProperties || []), ...(query.properties || [])],
                 ...(query.event ? { event: query.event } : {}),
                 ...(query.actionId ? { action_id: query.actionId } : {}),
+                ...(query.personId ? { person_id: query.personId } : {}),
                 before: query.before,
                 after: query.after,
             },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1484,6 +1484,10 @@
                 "name": {
                     "type": "string"
                 },
+                "personId": {
+                    "description": "Show events for a given person",
+                    "type": "string"
+                },
                 "properties": {
                     "description": "Properties configurable in the interface",
                     "items": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8,6 +8,13 @@
                 "custom_name": {
                     "type": "string"
                 },
+                "fixedProperties": {
+                    "description": "Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)",
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
+                },
                 "id": {
                     "type": "number"
                 },
@@ -39,6 +46,7 @@
                     "type": "string"
                 },
                 "properties": {
+                    "description": "Properties configurable in the interface",
                     "items": {
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },
@@ -1421,6 +1429,10 @@
         "EventsNode": {
             "additionalProperties": false,
             "properties": {
+                "actionId": {
+                    "description": "Show events matching a given action",
+                    "type": "number"
+                },
                 "after": {
                     "description": "Only fetch events that happened after this timestamp",
                     "type": "string"
@@ -1434,6 +1446,13 @@
                 },
                 "event": {
                     "type": "string"
+                },
+                "fixedProperties": {
+                    "description": "Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)",
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
                 },
                 "kind": {
                     "const": "EventsNode",
@@ -1466,6 +1485,7 @@
                     "type": "string"
                 },
                 "properties": {
+                    "description": "Properties configurable in the interface",
                     "items": {
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -72,13 +72,18 @@ export interface EntityNode extends DataNode {
     math?: BaseMathType | PropertyMathType | CountPerActorMathType
     math_property?: string
     math_group_type_index?: 0 | 1 | 2 | 3 | 4
+    /** Properties configurable in the interface */
     properties?: AnyPropertyFilter[]
+    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
+    fixedProperties?: AnyPropertyFilter[]
 }
 
 export interface EventsNode extends EntityNode {
     kind: NodeKind.EventsNode
     event?: string
     limit?: number
+    /** Show events matching a given action */
+    actionId?: number
     /** Only fetch events that happened before this timestamp */
     before?: string
     /** Only fetch events that happened after this timestamp */

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -225,3 +225,6 @@ export interface BreakdownFilter {
     breakdown_group_type_index?: number | null
     aggregation_group_type_index?: number | undefined // Groups aggregation
 }
+
+/** Pass custom templates and other metadata to queries. Used for e.g. custom columns in the DataTable. */
+export type QueryCustom = Record<string, { title?: string; render?: (props: { record: any }) => JSX.Element }>

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -228,5 +228,13 @@ export interface BreakdownFilter {
     aggregation_group_type_index?: number | undefined // Groups aggregation
 }
 
-/** Pass custom templates and other metadata to queries. Used for e.g. custom columns in the DataTable. */
-export type QueryCustom = Record<string, { title?: string; render?: (props: { record: any }) => JSX.Element }>
+/** Pass custom metadata to queries. Used for e.g. custom columns in the DataTable. */
+export interface QueryContext {
+    /** Column templates for the DataTable */
+    columns: Record<string, QueryContextColumn>
+}
+
+interface QueryContextColumn {
+    title?: string
+    render?: (props: { record: any }) => JSX.Element
+}

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -84,6 +84,8 @@ export interface EventsNode extends EntityNode {
     limit?: number
     /** Show events matching a given action */
     actionId?: number
+    /** Show events for a given person */
+    personId?: string
     /** Only fetch events that happened before this timestamp */
     before?: string
     /** Only fetch events that happened after this timestamp */

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -8,6 +8,10 @@ import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
 import { SceneExport } from 'scenes/sceneTypes'
 import { actionLogic, ActionLogicProps } from 'scenes/actions/actionLogic'
+import { Query } from '~/queries/Query/Query'
+import { NodeKind } from '~/queries/schema'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export const scene: SceneExport = {
     logic: actionLogic,
@@ -22,6 +26,9 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
 
     const { action, isComplete } = useValues(actionLogic)
     const { loadAction } = useActions(actionLogic)
+
+    const { featureFlags } = useValues(featureFlagLogic)
+    const featureDataExploration = featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_LIVE_EVENTS]
 
     return (
         <>
@@ -53,13 +60,25 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
                             )}
                         </p>
                         <div className="pt-4 border-t" />
-                        <EventsTable
-                            fixedFilters={fixedFilters}
-                            sceneUrl={urls.action(id)}
-                            fetchMonths={3}
-                            pageKey={`action-${id}-${JSON.stringify(fixedFilters)}`}
-                            showEventFilter={false}
-                        />
+                        {featureDataExploration ? (
+                            <Query
+                                query={{
+                                    kind: NodeKind.DataTableNode,
+                                    source: { kind: NodeKind.EventsNode, actionId: id },
+                                    showReload: true,
+                                    showColumnConfigurator: true,
+                                    showExport: true,
+                                }}
+                            />
+                        ) : (
+                            <EventsTable
+                                fixedFilters={fixedFilters}
+                                sceneUrl={urls.action(id)}
+                                fetchMonths={3}
+                                pageKey={`action-${id}-${JSON.stringify(fixedFilters)}`}
+                                showEventFilter={false}
+                            />
+                        )}
                     </div>
                 ) : (
                     <div>

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -472,11 +472,11 @@ export function EventsTable({
             person: ['person.distinct_ids.0', 'person.properties.email'],
         }
 
-        return (selectedColumns === 'DEFAULT' ? defaultColumns.map((e) => e.key || '') : selectedColumns).flatMap(
-            (x) => {
+        return (selectedColumns === 'DEFAULT' ? defaultColumns.map((e) => e.key || '') : selectedColumns)
+            .flatMap((x) => {
                 return columnMapping[x] || `properties.${x}`
-            }
-        )
+            })
+            .filter((c) => !c.startsWith('custom.'))
     }, [defaultColumns, selectedColumns])
 
     return (

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -58,6 +58,8 @@ import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/uti
 import { featureFlagPermissionsLogic } from './featureFlagPermissionsLogic'
 import { ResourcePermission } from 'scenes/ResourcePermissionModal'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
+import { NodeKind } from '~/queries/schema'
+import { Query } from '~/queries/Query/Query'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
@@ -439,7 +441,24 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
 }
 
 function ExposureTab({ id, featureFlagKey }: { id: string; featureFlagKey: string }): JSX.Element {
-    return (
+    const { featureFlags } = useValues(enabledFeaturesLogic)
+    const featureDataExploration = featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_LIVE_EVENTS]
+
+    return featureDataExploration ? (
+        <Query
+            query={{
+                kind: NodeKind.DataTableNode,
+                source: {
+                    kind: NodeKind.EventsNode,
+                    event: '$feature_flag_called',
+                    properties: defaultPropertyOnFlag(featureFlagKey),
+                },
+                showReload: true,
+                showColumnConfigurator: true,
+                showExport: true,
+            }}
+        />
+    ) : (
         <EventsTable
             fixedFilters={{
                 event_filter: '$feature_flag_called',

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -90,6 +90,7 @@ export function Group(): JSX.Element {
                                 showEventFilter: true,
                                 showPropertyFilter: true,
                             }}
+                            setQueryLocally
                         />
                     ) : (
                         <EventsTable

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -90,7 +90,6 @@ export function Group(): JSX.Element {
                                 showEventFilter: true,
                                 showPropertyFilter: true,
                             }}
-                            setQueryLocally
                         />
                     ) : (
                         <EventsTable

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -10,6 +10,10 @@ import { useActions, useValues } from 'kea'
 import { WebPerformanceWaterfallChart } from 'scenes/performance/WebPerformanceWaterfallChart'
 import { IconPlay } from 'lib/components/icons'
 import { LemonButton } from '@posthog/lemon-ui'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { Query } from '~/queries/Query/Query'
+import { EventsNode, NodeKind } from '~/queries/schema'
 
 /*
  * link to SessionRecording from table and chart
@@ -27,53 +31,99 @@ export const webPerformancePropertyFilters: AnyPropertyFilter[] = [
 
 const EventsWithPerformanceTable = (): JSX.Element => {
     const { setEventToDisplay } = useActions(webPerformanceLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const featureDataExploration = featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_LIVE_EVENTS]
 
     return (
         <>
             <div className="pt-4 border-t" />
-            <EventsTable
-                fixedFilters={{
-                    properties: webPerformancePropertyFilters,
-                }}
-                sceneUrl={urls.webPerformance()}
-                fetchMonths={1}
-                pageKey={`webperformance-${JSON.stringify(webPerformancePropertyFilters)}`}
-                showPersonColumn={false}
-                showCustomizeColumns={false}
-                showExport={false}
-                showAutoload={false}
-                showEventFilter={false}
-                showPropertyFilter={true}
-                showRowExpanders={false}
-                showActionsButton={false}
-                linkPropertiesToFilters={false}
-                data-attr="waterfall-events-table"
-                startingColumns={['$current_url', '$performance_page_loaded']}
-                fixedColumns={[
-                    {
-                        render: function RenderViewButton(_: any, { event }: EventsTableRowItem) {
-                            if (!event) {
-                                return { props: { colSpan: 0 } }
-                            }
-                            return (
-                                <div>
-                                    <LemonButton
-                                        data-attr={`view-waterfall-button-${event?.id}`}
-                                        icon={<IconPlay />}
-                                        type="secondary"
-                                        size="small"
-                                        onClick={() => {
-                                            setEventToDisplay(event)
-                                        }}
-                                    >
-                                        View waterfall chart
-                                    </LemonButton>
-                                </div>
-                            )
+            {featureDataExploration ? (
+                <Query
+                    query={{
+                        kind: NodeKind.DataTableNode,
+                        source: {
+                            kind: NodeKind.EventsNode,
+                            fixedProperties: webPerformancePropertyFilters,
                         },
-                    },
-                ]}
-            />
+                        columns: ['properties.$current_url', 'properties.$lib', 'timestamp', 'custom.waterfallButton'],
+                        showReload: true,
+                        showColumnConfigurator: false,
+                        showExport: true,
+                        showEventFilter: false,
+                        showPropertyFilter: true,
+                        showActions: false,
+                        expandable: false,
+                    }}
+                    custom={{
+                        waterfallButton: {
+                            title: '',
+                            render: function RenderWaterfallButton({
+                                record: event,
+                            }: {
+                                record: Required<EventsNode>['response']['results'][0]
+                            }) {
+                                return (
+                                    <div>
+                                        <LemonButton
+                                            data-attr={`view-waterfall-button-${event?.id}`}
+                                            icon={<IconPlay />}
+                                            type="secondary"
+                                            size="small"
+                                            onClick={() => setEventToDisplay(event)}
+                                        >
+                                            View waterfall chart
+                                        </LemonButton>
+                                    </div>
+                                )
+                            },
+                        },
+                    }}
+                />
+            ) : (
+                <EventsTable
+                    fixedFilters={{
+                        properties: webPerformancePropertyFilters,
+                    }}
+                    sceneUrl={urls.webPerformance()}
+                    fetchMonths={1}
+                    pageKey={`webperformance-${JSON.stringify(webPerformancePropertyFilters)}`}
+                    showPersonColumn={false}
+                    showCustomizeColumns={false}
+                    showExport={false}
+                    showAutoload={false}
+                    showEventFilter={false}
+                    showPropertyFilter={true}
+                    showRowExpanders={false}
+                    showActionsButton={false}
+                    linkPropertiesToFilters={false}
+                    data-attr="waterfall-events-table"
+                    startingColumns={['$current_url', '$performance_page_loaded']}
+                    fixedColumns={[
+                        {
+                            render: function RenderViewButton(_: any, { event }: EventsTableRowItem) {
+                                if (!event) {
+                                    return { props: { colSpan: 0 } }
+                                }
+                                return (
+                                    <div>
+                                        <LemonButton
+                                            data-attr={`view-waterfall-button-${event?.id}`}
+                                            icon={<IconPlay />}
+                                            type="secondary"
+                                            size="small"
+                                            onClick={() => {
+                                                setEventToDisplay(event)
+                                            }}
+                                        >
+                                            View waterfall chart
+                                        </LemonButton>
+                                    </div>
+                                )
+                            },
+                        },
+                    ]}
+                />
+            )}
         </>
     )
 }

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -54,6 +54,7 @@ const EventsWithPerformanceTable = (): JSX.Element => {
                         showActions: false,
                         expandable: false,
                     }}
+                    setQueryLocally
                     custom={{
                         waterfallButton: {
                             title: '',

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -54,7 +54,6 @@ const EventsWithPerformanceTable = (): JSX.Element => {
                         showActions: false,
                         expandable: false,
                     }}
-                    setQueryLocally
                     custom={{
                         waterfallButton: {
                             title: '',

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -45,7 +45,12 @@ const EventsWithPerformanceTable = (): JSX.Element => {
                             kind: NodeKind.EventsNode,
                             fixedProperties: webPerformancePropertyFilters,
                         },
-                        columns: ['properties.$current_url', 'properties.$lib', 'timestamp', 'custom.waterfallButton'],
+                        columns: [
+                            'properties.$current_url',
+                            'properties.$lib',
+                            'timestamp',
+                            'context.columns.waterfallButton',
+                        ],
                         showReload: true,
                         showColumnConfigurator: false,
                         showExport: true,
@@ -54,27 +59,29 @@ const EventsWithPerformanceTable = (): JSX.Element => {
                         showActions: false,
                         expandable: false,
                     }}
-                    custom={{
-                        waterfallButton: {
-                            title: '',
-                            render: function RenderWaterfallButton({
-                                record: event,
-                            }: {
-                                record: Required<EventsNode>['response']['results'][0]
-                            }) {
-                                return (
-                                    <div>
-                                        <LemonButton
-                                            data-attr={`view-waterfall-button-${event?.id}`}
-                                            icon={<IconPlay />}
-                                            type="secondary"
-                                            size="small"
-                                            onClick={() => setEventToDisplay(event)}
-                                        >
-                                            View waterfall chart
-                                        </LemonButton>
-                                    </div>
-                                )
+                    context={{
+                        columns: {
+                            waterfallButton: {
+                                title: '',
+                                render: function RenderWaterfallButton({
+                                    record: event,
+                                }: {
+                                    record: Required<EventsNode>['response']['results'][0]
+                                }) {
+                                    return (
+                                        <div>
+                                            <LemonButton
+                                                data-attr={`view-waterfall-button-${event?.id}`}
+                                                icon={<IconPlay />}
+                                                type="secondary"
+                                                size="small"
+                                                onClick={() => setEventToDisplay(event)}
+                                            >
+                                                View waterfall chart
+                                            </LemonButton>
+                                        </div>
+                                    )
+                                },
                             },
                         },
                     }}

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -177,7 +177,6 @@ export function Person(): JSX.Element | null {
                                 showEventFilter: true,
                                 showPropertyFilter: true,
                             }}
-                            setQueryLocally
                         />
                     ) : (
                         <EventsTable

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -642,7 +642,7 @@ export interface FunnelStepRangeEntityFilter {
 export type EntityFilterTypes = EntityFilter | ActionFilter | null
 
 export interface PersonType {
-    id?: number
+    id?: string
     uuid?: string
     name?: string
     distinct_ids: string[]


### PR DESCRIPTION
## Problem

Followup to https://github.com/PostHog/posthog/pull/12950

## Changes

Replaces a few more events tables with data exploration queries.

- Feature flag exposures
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/53387/205623026-ab4de313-c38b-4605-a12d-802d15483a92.png">

- Data management matched events
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/53387/205623115-dffadb74-2a6c-49ae-8b51-b22cd0082dca.png">

- Actions
<img width="1719" alt="image" src="https://user-images.githubusercontent.com/53387/205623199-146045ee-8dc3-428a-9f5e-98684aa99a0f.png">

- Groups
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/53387/205623294-bcf53211-15fa-4c4c-aa77-cbd572c98603.png">

- Persons
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/53387/205625911-a65a3d27-9997-494e-8993-d985cb602062.png">

- Web Performance (featuring custom columns)
![2022-12-05 12 05 50](https://user-images.githubusercontent.com/53387/205622912-c67bf18a-6d91-41be-8b0c-88e26479bf36.gif)


## How did you test this code?

Clicked around in the interface.