### PR TITLE
fix: speculative sprinkling of breakpoint in save layouts

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -898,6 +898,8 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 ? tilesToSave
                 : (values.allItems?.tiles || []).map((tile) => ({ id: tile.id, layouts: tile.layouts }))
 
+            breakpoint()
+
             return await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 tiles: layoutsToUpdate,
                 no_items_field: true,


### PR DESCRIPTION
## Problem

We appear to have out of order layouts being saved

Let's apply [the canonical fix](https://keajs.org/docs/core/listeners/#breakpoints) before we do anything else

## Changes

adds a `breakpoint` before saving layouts

## How did you test this code?

ran locally and saw I could still update dashboard layouts