### PR TITLE
chore(dashboards): remove unnecessary branch in dashboards API

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -166,20 +166,6 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
             except Dashboard.DoesNotExist:
                 raise serializers.ValidationError({"use_dashboard": "Invalid value provided"})
 
-        elif request.data.get("items"):
-            for item in request.data["items"]:
-                insight = Insight.objects.create(
-                    **{
-                        key: value
-                        for key, value in item.items()
-                        if key not in ("id", "deleted", "dashboard", "team", "layout", "color")
-                    },
-                    team=team,
-                )
-                DashboardTile.objects.create(
-                    dashboard=dashboard, insight=insight, layouts=item.get("layouts"), color=item.get("color")
-                )
-
         # Manual tag creation since this create method doesn't call super()
         self._attempt_set_tags(tags, dashboard)
 


### PR DESCRIPTION
## Problem

Was reading the API code and noticed this branch in dashboard creation still uses the deprecated items property

Without this branch

* all tests pass
* you can still create dashboards from templates
* you can still duplicate dashboards

## Changes

remove the branch

## How did you test this code?

ran developer tests, created and duplicated dashboards locally