### PR TITLE
fix(shared insights): shared pie chart layout

### DIFF
--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -37,6 +37,10 @@
             > * {
                 flex: 1;
             }
+
+            .ActionsPie {
+                position: absolute;
+            }
         }
     }
 

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -30,6 +30,7 @@
         }
 
         .InsightViz {
+            position: relative;
             display: flex;
             min-height: 50vw;
 

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -30,12 +30,19 @@
         }
 
         .InsightViz {
-            position: relative;
             display: flex;
             min-height: 50vw;
 
             > * {
                 flex: 1;
+            }
+
+            > :last-child {
+                margin-bottom: 0;
+            }
+
+            > :first-child {
+                margin-top: 0;
             }
         }
     }

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -36,14 +36,6 @@
             > * {
                 flex: 1;
             }
-
-            > :last-child {
-                margin-bottom: 0;
-            }
-
-            > :first-child {
-                margin-top: 0;
-            }
         }
     }
 

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -76,7 +76,7 @@ export function ExportedInsight({
                         'ExportedInsight__content--with-watermark': showWatermark,
                     })}
                 >
-                    <InsightViz insight={insight as any} style={{ top: 0, left: 0, position: 'relative' }} />
+                    <InsightViz insight={insight as any} style={{ top: 0, left: 0 }} />
                     {showLegend ? (
                         <div className="p-4">
                             <InsightLegend horizontal readOnly />

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -21,6 +21,11 @@ export function ExportedInsight({
     exportOptions: ExportOptions
     type: ExportType
 }): JSX.Element {
+    if (isTrendsFilter(insight.filters) && insight.filters.show_legend) {
+        // legend is always shown so don't show it alongside the insight
+        insight.filters.show_legend = false
+    }
+
     const insightLogicProps: InsightLogicProps = {
         dashboardItemId: insight.short_id,
         cachedInsight: insight,

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -76,7 +76,7 @@ export function ExportedInsight({
                         'ExportedInsight__content--with-watermark': showWatermark,
                     })}
                 >
-                    <InsightViz insight={insight as any} style={{ top: 0, left: 0 }} />
+                    <InsightViz insight={insight as any} style={{ top: 0, left: 0, position: 'relative' }} />
                     {showLegend ? (
                         <div className="p-4">
                             <InsightLegend horizontal readOnly />

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -49,7 +49,13 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
 
     return data ? (
         data[0] && data[0].labels ? (
-            <div className={clsx('w-full', inCardView && 'flex flex-row pr-4 h-full items-center')}>
+            <div
+                className={clsx(
+                    'w-full',
+                    inCardView && 'flex flex-row h-full items-center',
+                    isTrendsFilter(filters) && filters.show_legend && 'pr-4'
+                )}
+            >
                 <div className={clsx('actions-pie-component', inCardView && 'grow')}>
                     <div className="pie-chart">
                         <PieChart

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -51,7 +51,7 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
         data[0] && data[0].labels ? (
             <div
                 className={clsx(
-                    'w-full',
+                    'ActionsPie w-full',
                     inCardView && 'flex flex-row h-full items-center',
                     isTrendsFilter(filters) && filters.show_legend && 'pr-4'
                 )}


### PR DESCRIPTION
## Problem

Spotted that the piechart was showing incorrectly but only when an insight was shared or exported

<img width="790" alt="Screenshot 2022-12-05 at 10 06 50" src="https://user-images.githubusercontent.com/984817/205610244-0a0a903e-a7ab-4d64-939d-cff94831e918.png">

(I assume this was broken in #13018 )

## Changes

* corrects that layout 
* fly-by only add right padding to the pie when showing the legend

<img width="794" alt="Screenshot 2022-12-05 at 09 58 04" src="https://user-images.githubusercontent.com/984817/205608338-01c6095d-ed39-47e8-8a26-ada484efe80b.png">

## How did you test this code?

* sharing a pie locally and seeing it display correctly
* switching it to each of the other insight types and seeing it display correctly
