### PR TITLE
feat: Added filtering by date support for persons API

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -7,7 +7,7 @@
               WHERE team_id = %(team_id)s
               GROUP BY id
               HAVING max(is_deleted) = 0
-                 
+                  
               
               
           
@@ -27,7 +27,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
+              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)    
               
               
           
@@ -47,7 +47,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND ((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
+              AND ((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))    
               
               
           
@@ -67,7 +67,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s  AND has(%(vpersonquery_grouped_filters__1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__1)s), '^"|"$', ''))  AND has(%(vpersonquery_grouped_filters__2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__2)s), '^"|"$', '')))   
+              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s  AND has(%(vpersonquery_grouped_filters__1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__1)s), '^"|"$', ''))  AND has(%(vpersonquery_grouped_filters__2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__2)s), '^"|"$', '')))    
               
               
           
@@ -82,7 +82,7 @@
               WHERE team_id = %(team_id)s
               GROUP BY id
               HAVING max(is_deleted) = 0
-                 
+                  
               
               
           
@@ -102,7 +102,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
+              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)    
               
               
           
@@ -122,7 +122,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND ((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
+              AND ((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))    
               
               
           
@@ -142,7 +142,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_0_1)s))AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__1_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__1_1)s))   
+              AND (((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_0_1)s))AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__1_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__1_1)s))    
               
               
           
@@ -162,7 +162,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
+              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)    
               
               
           
@@ -182,7 +182,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
+              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)    
               
               
           
@@ -202,7 +202,7 @@
               )
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
+              AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)    
               
               
           

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -176,6 +176,16 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
                 OpenApiTypes.STR,
                 description="Search persons, either by email (full text search) or distinct_id (exact match).",
             ),
+            OpenApiParameter(
+                "date_from",
+                OpenApiTypes.DATETIME,
+                description="Filter persons by date they were first seen on or after this date.",
+            ),
+            OpenApiParameter(
+                "date_to",
+                OpenApiTypes.DATETIME,
+                description="Filter persons by date they were first seen on or before this date. If only the date is specified without a time then it is inclusive (i.e. to the end of the day).",
+            ),
             PersonPropertiesSerializer(required=False),
         ],
     )

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -12,10 +12,11 @@ from typing import (
     cast,
 )
 
+import pytz
+from dateutil.parser import isoparse
 from django.db.models import Prefetch
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter
-import pytz
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
@@ -25,7 +26,6 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 from statshog.defaults.django import statsd
-from dateutil.parser import isoparse
 
 from posthog.api.capture import capture_internal
 from posthog.api.documentation import PersonPropertiesSerializer, extend_schema

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -99,8 +99,6 @@ def get_person_name(person: Person) -> str:
 
 class PersonSerializer(serializers.HyperlinkedModelSerializer):
     name = serializers.SerializerMethodField()
-    created_at_from = serializers.DateTimeField(required=False, allow_null=True)
-    created_at_to = serializers.DateTimeField(required=False, allow_null=True)
 
     class Meta:
         model = Person

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -579,6 +579,18 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         created_ids.reverse()  # ids are returned in desc order
         self.assertEqual(returned_ids, created_ids, returned_ids)
 
+    def test_date_filters(self):
+        with freeze_time("2022-12-01T12:00:00.000Z"):
+            _create_person(team=self.team, distinct_ids=["id1"], properties={})
+        with freeze_time("2022-12-02T12:00:00.000Z"):
+            _create_person(team=self.team, distinct_ids=["id2"], properties={})
+        with freeze_time("2022-12-03T12:00:00.000Z"):
+            _create_person(team=self.team, distinct_ids=["id3"], properties={})
+
+        # Get all
+        response = self.client.get("/api/person/?date_from=2022-12-01&date_to=2022-12-03").json()
+        self.assertEqual(len(response["results"]), 3)
+
     def _get_person_activity(self, person_id: Optional[str] = None, expected_status: int = status.HTTP_200_OK):
         if person_id:
             url = f"/api/person/{person_id}/activity"

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -591,6 +591,23 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get("/api/person/?date_from=2022-12-01&date_to=2022-12-03").json()
         self.assertEqual(len(response["results"]), 3)
 
+        # Get older inclusive date
+        response = self.client.get("/api/person/?date_to=2022-12-02").json()
+        self.assertEqual(len(response["results"]), 2)
+        assert response["results"][0]["distinct_ids"][0] == "id2"
+        assert response["results"][1]["distinct_ids"][0] == "id1"
+
+        # Get only newer
+        response = self.client.get("/api/person/?date_from=2022-12-02").json()
+        self.assertEqual(len(response["results"]), 2)
+        assert response["results"][0]["distinct_ids"][0] == "id3"
+        assert response["results"][1]["distinct_ids"][0] == "id2"
+
+        # Get older specific time
+        response = self.client.get("/api/person/?date_to=2022-12-02T02:00:00").json()
+        self.assertEqual(len(response["results"]), 1)
+        assert response["results"][0]["distinct_ids"][0] == "id1"
+
     def _get_person_activity(self, person_id: Optional[str] = None, expected_status: int = status.HTTP_200_OK):
         if person_id:
             url = f"/api/person/{person_id}/activity"

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -588,23 +588,23 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             _create_person(team=self.team, distinct_ids=["id3"], properties={})
 
         # Get all
-        response = self.client.get("/api/person/?date_from=2022-12-01&date_to=2022-12-03").json()
+        response = self.client.get("/api/person/?created_at_from=2022-12-01&created_at_to=2022-12-03").json()
         self.assertEqual(len(response["results"]), 3)
 
         # Get older inclusive date
-        response = self.client.get("/api/person/?date_to=2022-12-02").json()
+        response = self.client.get("/api/person/?created_at_to=2022-12-02").json()
         self.assertEqual(len(response["results"]), 2)
         assert response["results"][0]["distinct_ids"][0] == "id2"
         assert response["results"][1]["distinct_ids"][0] == "id1"
 
         # Get only newer
-        response = self.client.get("/api/person/?date_from=2022-12-02").json()
+        response = self.client.get("/api/person/?created_at_from=2022-12-02").json()
         self.assertEqual(len(response["results"]), 2)
         assert response["results"][0]["distinct_ids"][0] == "id3"
         assert response["results"][1]["distinct_ids"][0] == "id2"
 
         # Get older specific time
-        response = self.client.get("/api/person/?date_to=2022-12-02T02:00:00").json()
+        response = self.client.get("/api/person/?created_at_to=2022-12-02T02:00:00").json()
         self.assertEqual(len(response["results"]), 1)
         assert response["results"][0]["distinct_ids"][0] == "id1"
 

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -233,7 +233,6 @@ class PersonQuery:
         clause = ""
         params = {}
 
-        print(self._created_at_range)
         if self._created_at_range and self._created_at_range[0]:
             clause += " AND created_at >= %(created_at_from)s"
             params.update({"created_at_from": self._created_at_range[0]})

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -1,5 +1,5 @@
-from typing import Dict, List, Optional, Set, Tuple, Union
 from datetime import datetime
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from posthog.clickhouse.materialized_columns import ColumnName
 from posthog.constants import PropertyOperatorType


### PR DESCRIPTION
## Problem

Related to https://github.com/PostHog/posthog/issues/12962

Customer requested the ability to filter persons based on the creation date via the API. We support for our other 
primitives so why not here.

## Changes

* Extends the list persons endpoint to filter on `created_at_from` and `created_at_to` 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests