### PR TITLE
feat(ingestion): add ingestion warning on time parsing errors

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -18,7 +18,7 @@ const WARNING_TYPE_TO_DESCRIPTION = {
     cannot_merge_already_identified: 'Refused to merge an already identified user',
     cannot_merge_with_illegal_distinct_id: 'Refused to merge with an illegal distinct id',
     skipping_event_invalid_uuid: 'Refused to process event with invalid uuid',
-    ignored_invalid_timestamp: 'Ingested an event with an invalid timestamp',
+    ignored_invalid_timestamp: 'Ignored an invalid timestamp, event was still ingested',
 }
 
 const WARNING_TYPE_RENDERER = {
@@ -68,8 +68,8 @@ const WARNING_TYPE_RENDERER = {
         }
         return (
             <>
-                Ingested an event with invalid value <code>{details.value}</code> in field <code>{details.field}</code>:{' '}
-                {details.reason}
+                Used server timestamp when ingesting event due to invalid value <code>{details.value}</code> in field{' '}
+                <code>{details.field}</code>: {details.reason}
             </>
         )
     },

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -18,6 +18,7 @@ const WARNING_TYPE_TO_DESCRIPTION = {
     cannot_merge_already_identified: 'Refused to merge an already identified user',
     cannot_merge_with_illegal_distinct_id: 'Refused to merge with an illegal distinct id',
     skipping_event_invalid_uuid: 'Refused to process event with invalid uuid',
+    ignored_invalid_timestamp: 'Ingested an event with an invalid timestamp',
 }
 
 const WARNING_TYPE_RENDERER = {
@@ -56,6 +57,19 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Refused to process event with invalid uuid: <code>{details.eventUuid}</code>.
+            </>
+        )
+    },
+    ignored_invalid_timestamp: function Render(warning: IngestionWarning): JSX.Element {
+        const details = warning.details as {
+            field: string
+            value: string
+            reason: string
+        }
+        return (
+            <>
+                Ingested an event with invalid value <code>{details.value}</code> in field <code>{details.field}</code>:{' '}
+                {details.reason}
             </>
         )
     },

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
@@ -12,12 +12,11 @@ export async function prepareEventStep(
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
     const { ip, site_url, team_id, uuid } = event
-    const invalidTimestampCallback = function (data: PluginEvent, reason: string) {
+    const invalidTimestampCallback = function (field: string, value: string, reason: string) {
         runner.hub.statsd?.increment('process_event_invalid_timestamp', { teamId: String(team_id) })
         captureIngestionWarning(runner.hub.db, team_id, 'ignored_invalid_timestamp', {
-            timestamp: data['timestamp'],
-            sentAt: data['sent_at'],
-            offset: data['offset'],
+            field: field,
+            value: value,
             reason: reason,
         })
     }

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
@@ -3,6 +3,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { PostIngestionEvent } from '../../../types'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { parseEventTimestamp } from '../timestamps'
+import { captureIngestionWarning } from '../utils'
 import { EventPipelineRunner, StepResult } from './runner'
 
 export async function prepareEventStep(
@@ -11,8 +12,14 @@ export async function prepareEventStep(
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
     const { ip, site_url, team_id, uuid } = event
-    const invalidTimestampCallback = function () {
+    const invalidTimestampCallback = function (data: PluginEvent, reason: string) {
         runner.hub.statsd?.increment('process_event_invalid_timestamp', { teamId: String(team_id) })
+        captureIngestionWarning(runner.hub.db, team_id, 'ignored_invalid_timestamp', {
+            timestamp: data['timestamp'],
+            sentAt: data['sent_at'],
+            offset: data['offset'],
+            reason: reason,
+        })
     }
     const preIngestionEvent = await runner.hub.eventsProcessor.processEvent(
         String(event.distinct_id),

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -13,14 +13,14 @@ export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimesta
     if (data['sent_at']) {
         sentAt = DateTime.fromISO(data['sent_at']).toUTC()
         if (!sentAt.isValid) {
-            callback?.('sent_at', data['sent_at'], sentAt.invalidExplanation ?? '')
+            callback?.('sent_at', data['sent_at'], sentAt.invalidExplanation || 'unknown error')
             sentAt = null
         }
     }
 
     const parsedTs = handleTimestamp(data, now, sentAt)
     if (!parsedTs.isValid) {
-        callback?.('timestamp', data['timestamp'] ?? '', parsedTs.invalidExplanation ?? '')
+        callback?.('timestamp', data['timestamp'] ?? '', parsedTs.invalidExplanation || 'unknown error')
         return DateTime.utc()
     }
     return parsedTs

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -4,18 +4,18 @@ import { DateTime, Duration } from 'luxon'
 
 import { status } from '../../utils/status'
 
-type InvalidTimestampCallback = () => void
+type InvalidTimestampCallback = (data: PluginEvent, reason: string) => void
 
 export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimestampCallback): DateTime {
     const now = DateTime.fromISO(data['now']).toUTC()
     const sentAt = data['sent_at'] ? DateTime.fromISO(data['sent_at']).toUTC() : null
 
     const parsedTs = handleTimestamp(data, now, sentAt)
-    const ts = parsedTs.isValid ? parsedTs : DateTime.utc()
     if (!parsedTs.isValid) {
-        callback?.()
+        callback?.(data, parsedTs.invalidExplanation ?? 'unknown')
+        return DateTime.utc()
     }
-    return ts
+    return parsedTs
 }
 
 function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | null): DateTime {

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -4,7 +4,7 @@ import { DateTime, Duration } from 'luxon'
 
 import { status } from '../../utils/status'
 
-type InvalidTimestampCallback = (data: PluginEvent, reason: string) => void
+type InvalidTimestampCallback = (field: string, value: string, reason: string) => void
 
 export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimestampCallback): DateTime {
     const now = DateTime.fromISO(data['now']).toUTC() // now is set by the capture endpoint and assumed valid
@@ -13,14 +13,14 @@ export function parseEventTimestamp(data: PluginEvent, callback?: InvalidTimesta
     if (data['sent_at']) {
         sentAt = DateTime.fromISO(data['sent_at']).toUTC()
         if (!sentAt.isValid) {
-            callback?.(data, sentAt.invalidExplanation ?? 'sent_at format invalid')
+            callback?.('sent_at', data['sent_at'], sentAt.invalidExplanation ?? '')
             sentAt = null
         }
     }
 
     const parsedTs = handleTimestamp(data, now, sentAt)
     if (!parsedTs.isValid) {
-        callback?.(data, parsedTs.invalidExplanation ?? 'timestamp format invalid')
+        callback?.('timestamp', data['timestamp'] ?? '', parsedTs.invalidExplanation ?? '')
         return DateTime.utc()
     }
     return parsedTs

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -61,7 +61,9 @@ describe('parseEventTimestamp()', () => {
 
         const callbackMock = jest.fn()
         const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls).toEqual([[event, 'the input "invalid" can\'t be parsed as ISO 8601']])
+        expect(callbackMock.mock.calls).toEqual([
+            ['sent_at', 'invalid', 'the input "invalid" can\'t be parsed as ISO 8601'],
+        ])
 
         expect(timestamp.toISO()).toEqual('2021-10-30T03:02:00.000Z')
     })
@@ -129,7 +131,9 @@ describe('parseEventTimestamp()', () => {
 
         const callbackMock = jest.fn()
         const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls).toEqual([[event, 'the input "notISO" can\'t be parsed as ISO 8601']])
+        expect(callbackMock.mock.calls).toEqual([
+            ['timestamp', 'notISO', 'the input "notISO" can\'t be parsed as ISO 8601'],
+        ])
 
         expect(timestamp.toUTC().toISO()).toEqual('2020-08-12T01:02:00.000Z')
     })

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -1,5 +1,4 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { DateTime } from 'luxon'
 import tk from 'timekeeper'
 
 import { parseDate, parseEventTimestamp } from '../../../src/worker/ingestion/timestamps'
@@ -32,115 +31,106 @@ describe('parseDate()', () => {
 
 describe('parseEventTimestamp()', () => {
     beforeEach(() => {
-        tk.freeze(1330688329321) // Back to 2012-03-02
+        tk.freeze('2020-08-12T01:02:00.000Z')
     })
     afterEach(() => {
         tk.reset()
     })
 
-    it('captures sent_at', () => {
-        const rightNow = DateTime.utc()
-        const tomorrow = rightNow.plus({ days: 1, hours: 2 })
-        const tomorrowSentAt = rightNow.plus({ days: 1, hours: 2, minutes: 10 })
-
+    it('captures sent_at to adjusts timestamp', () => {
         const event = {
-            timestamp: tomorrow.toISO(),
-            now: rightNow,
-            sent_at: tomorrowSentAt,
+            timestamp: '2021-10-30T03:02:00.000Z',
+            sent_at: '2021-10-30T03:12:00.000Z',
+            now: '2021-10-29T01:44:00.000Z',
         } as any as PluginEvent
 
-        const timestamp = parseEventTimestamp(event)
-        const eventSecondsBeforeNow = rightNow.diff(timestamp, 'seconds').seconds
+        const callbackMock = jest.fn()
+        const timestamp = parseEventTimestamp(event, callbackMock)
+        expect(callbackMock.mock.calls.length).toEqual(0)
 
-        expect(eventSecondsBeforeNow).toBeGreaterThan(590)
-        expect(eventSecondsBeforeNow).toBeLessThan(610)
+        expect(timestamp.toISO()).toEqual('2021-10-29T01:34:00.000Z')
     })
 
-    it('ignores invalid sent_at', () => {
-        const rightNow = DateTime.utc()
-        const tomorrow = rightNow.plus({ days: 1, hours: 2 })
-
+    it('ignores and reports invalid sent_at', () => {
+        const tomorrow = '2021-10-30T03:02:00.000Z'
         const event = {
-            timestamp: tomorrow.toISO(),
-            now: rightNow,
+            timestamp: tomorrow,
             sent_at: 'invalid',
+            now: '2021-10-29T01:44:00.000Z',
         } as any as PluginEvent
 
-        const timestamp = parseEventTimestamp(event)
-        expect(timestamp).toEqual(tomorrow)
+        const callbackMock = jest.fn()
+        const timestamp = parseEventTimestamp(event, callbackMock)
+        expect(callbackMock.mock.calls).toEqual([[event, 'the input "invalid" can\'t be parsed as ISO 8601']])
+
+        expect(timestamp.toISO()).toEqual('2021-10-30T03:02:00.000Z')
     })
 
-    it('captures sent_at with no timezones', () => {
-        const rightNow = DateTime.utc()
-        const tomorrow = rightNow.plus({ days: 1, hours: 2 }).setZone('UTC+4')
-        const tomorrowSentAt = rightNow.plus({ days: 1, hours: 2, minutes: 10 }).setZone('UTC+4')
-
-        // TODO: not sure if this is correct?
-        // tomorrow = tomorrow.replace(tzinfo=None)
-        // tomorrow_sent_at = tomorrow_sent_at.replace(tzinfo=None)
-
+    it('captures sent_at with timezone info', () => {
         const event = {
-            timestamp: tomorrow,
-            now: rightNow,
-            sent_at: tomorrowSentAt,
+            timestamp: '2021-10-30T03:02:00.000+04:00',
+            sent_at: '2021-10-30T03:12:00.000+04:00',
+            now: '2021-10-29T01:44:00.000Z',
         } as any as PluginEvent
 
-        const timestamp = parseEventTimestamp(event)
-        const eventSecondsBeforeNow = rightNow.diff(timestamp, 'seconds').seconds
+        const callbackMock = jest.fn()
+        const timestamp = parseEventTimestamp(event, callbackMock)
+        expect(callbackMock.mock.calls.length).toEqual(0)
 
-        expect(eventSecondsBeforeNow).toBeGreaterThan(590)
-        expect(eventSecondsBeforeNow).toBeLessThan(610)
+        expect(timestamp.toISO()).toEqual('2021-10-29T01:34:00.000Z')
     })
 
-    it('captures with no sent_at', () => {
-        const rightNow = DateTime.utc()
-        const tomorrow = rightNow.plus({ days: 1, hours: 2 })
-
+    it('captures timestamp with no sent_at', () => {
         const event = {
-            timestamp: tomorrow,
-            now: rightNow,
+            timestamp: '2021-10-30T03:02:00.000Z',
+            now: '2021-10-29T01:44:00.000Z',
         } as any as PluginEvent
 
-        const timestamp = parseEventTimestamp(event)
-        const difference = tomorrow.diff(timestamp, 'seconds').seconds
-        expect(difference).toBeLessThan(1)
+        const callbackMock = jest.fn()
+        const timestamp = parseEventTimestamp(event, callbackMock)
+        expect(callbackMock.mock.calls.length).toEqual(0)
+
+        expect(timestamp.toISO()).toEqual(event.timestamp)
     })
 
-    it('works with offset timestamp', () => {
-        const now = DateTime.fromISO('2020-01-01T12:00:05.200Z')
-
+    it('captures with time offset and ignores sent_at', () => {
         const event = {
-            offset: 150,
-            now,
-            sent_at: now,
+            offset: 6000, // 6 seconds
+            now: '2021-10-29T01:44:00.000Z',
+            sent_at: '2021-10-30T03:12:00.000+04:00', // ignored
         } as any as PluginEvent
 
-        const timestamp = parseEventTimestamp(event)
-        expect(timestamp.toUTC().toISO()).toEqual('2020-01-01T12:00:05.050Z')
+        const callbackMock = jest.fn()
+        const timestamp = parseEventTimestamp(event, callbackMock)
+        expect(callbackMock.mock.calls.length).toEqual(0)
+
+        expect(timestamp.toUTC().toISO()).toEqual('2021-10-29T01:43:54.000Z')
     })
 
-    it('works with offset timestamp and no sent_at', () => {
-        const now = DateTime.fromISO('2020-01-01T12:00:05.200Z')
-
+    it('captures with time offset', () => {
         const event = {
-            offset: 150,
-            now,
+            offset: 6000, // 6 seconds
+            now: '2021-10-29T01:44:00.000Z',
         } as any as PluginEvent
 
-        const timestamp = parseEventTimestamp(event)
-        expect(timestamp.toUTC().toISO()).toEqual('2020-01-01T12:00:05.050Z')
+        const callbackMock = jest.fn()
+        const timestamp = parseEventTimestamp(event, callbackMock)
+        expect(callbackMock.mock.calls.length).toEqual(0)
+
+        expect(timestamp.toUTC().toISO()).toEqual('2021-10-29T01:43:54.000Z')
     })
 
     it('reports timestamp parsing error and fallbacks to DateTime.utc', () => {
         const event = {
             team_id: 123,
-            timestamp: 'invalid',
-            now: DateTime.fromISO('2020-01-01T12:00:05.200Z'),
+            timestamp: 'notISO',
+            now: '2020-01-01T12:00:05.200Z',
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
         const timestamp = parseEventTimestamp(event, callbackMock)
-        expect(callbackMock.mock.calls).toEqual([[]])
-        expect(timestamp.toUTC().toISO()).toEqual('2012-03-02T11:38:49.321Z')
+        expect(callbackMock.mock.calls).toEqual([[event, 'the input "notISO" can\'t be parsed as ISO 8601']])
+
+        expect(timestamp.toUTC().toISO()).toEqual('2020-08-12T01:02:00.000Z')
     })
 })


### PR DESCRIPTION
## Problem

Part 2/3 of https://github.com/PostHog/posthog/issues/13015: now that we don't report it to sentry anymore, report to the user, for them to fix their client code.

## Changes

- Add a new `ignored_invalid_timestamp` ingestion warning type
- Emit it when we fail to correctly parse the `sent_at` and `timestamp` event fields. The event is still ingested, but its time might be off
- Update the tests

## How did you test this code?

Submitted events with malformed timestamps to local devenv:

![image](https://user-images.githubusercontent.com/6241083/205647530-df59369c-abf8-4ba3-ba9a-8e75310da2df.png)

I cannot currently send events with a malformed `sent_at` (as the capture endpoints enforces the data quality), but it's better to have it here in case we have a regression later on.