### PR TITLE
fix(comment): fix location for trends util

### DIFF
--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -69,13 +69,13 @@ class EnterpriseColumnOptimizer(FOSSColumnOptimizer):
 
             # Math properties are also implicitly used.
             #
-            # See ee/clickhouse/queries/trends/util.py#process_math
+            # See postgog/queries/trends/util.py#process_math
             if entity.math_property:
                 counter[(entity.math_property, "event", None)] += 1
 
             # If groups are involved, they're also used
             #
-            # See ee/clickhouse/queries/trends/util.py#process_math
+            # See postgog/queries/trends/util.py#process_math
             if entity.math_group_type_index is not None:
                 counter[(f"$group_{entity.math_group_type_index}", "event", None)] += 1
 

--- a/posthog/queries/column_optimizer/foss_column_optimizer.py
+++ b/posthog/queries/column_optimizer/foss_column_optimizer.py
@@ -121,7 +121,7 @@ class FOSSColumnOptimizer:
 
             # Math properties are also implicitly used.
             #
-            # See ee/clickhouse/queries/trends/util.py#process_math
+            # See postgog/queries/trends/util.py#process_math
             if entity.math_property:
                 counter[(entity.math_property, "event", None)] += 1
 


### PR DESCRIPTION
## Problem

There is no `ee/clickhouse/queries/trends/util.py#process_math`.

## Changes

Replace `ee/clickhouse/queries/trends/util.py#process_math` with `postgog/queries/trends/util.py#process_math`.
