### PR TITLE
feat(insights-caching): sync models, add business logic for new caching

### DIFF
--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -69,29 +69,6 @@
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.10
   '
-  SELECT "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared"
-  FROM "posthog_dashboard"
-  INNER JOIN "posthog_dashboardtile" ON ("posthog_dashboard"."id" = "posthog_dashboardtile"."dashboard_id")
-  WHERE "posthog_dashboardtile"."insight_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.11
-  '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
          "posthog_team"."organization_id",
@@ -133,7 +110,7 @@
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.12
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.11
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -154,7 +131,7 @@
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.13
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.12
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_dashboard"
@@ -162,7 +139,7 @@
   WHERE "posthog_dashboardtile"."insight_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.14
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.13
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -185,7 +162,7 @@
   WHERE "posthog_dashboardtile"."insight_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.15
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.14
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -228,7 +205,7 @@
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.16
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.15
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -249,7 +226,7 @@
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.17
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.16
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -275,7 +252,7 @@
   LIMIT 21 /**/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.18
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.17
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -318,7 +295,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.19
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.18
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -344,6 +321,27 @@
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
   WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
          AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.19
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
@@ -377,27 +375,6 @@
   '
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.20
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.21
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -494,7 +471,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.22
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.21
   '
   SELECT "posthog_sharingconfiguration"."id",
          "posthog_sharingconfiguration"."team_id",
@@ -511,7 +488,7 @@
                                                           5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.23
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.22
   '
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -650,7 +627,7 @@
   ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.24
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.23
   '
   SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
          "posthog_dashboard"."id",
@@ -736,7 +713,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.25
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.24
   '
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -749,22 +726,6 @@
          "posthog_dashboardtile"."refreshing",
          "posthog_dashboardtile"."refresh_attempt",
          "posthog_dashboardtile"."deleted",
-         "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared",
          "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."name",
          "posthog_dashboarditem"."derived_name",
@@ -791,11 +752,188 @@
          "posthog_dashboarditem"."dive_dashboard_id",
          "posthog_dashboarditem"."updated_at",
          "posthog_dashboarditem"."deprecated_tags",
-         "posthog_dashboarditem"."tags"
+         "posthog_dashboarditem"."tags",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config",
+         T6."id",
+         T6."password",
+         T6."last_login",
+         T6."first_name",
+         T6."last_name",
+         T6."is_staff",
+         T6."is_active",
+         T6."date_joined",
+         T6."uuid",
+         T6."current_organization_id",
+         T6."current_team_id",
+         T6."email",
+         T6."temporary_token",
+         T6."distinct_id",
+         T6."email_opt_in",
+         T6."partial_notification_settings",
+         T6."anonymize_data",
+         T6."toolbar_mode",
+         T6."events_column_config",
+         "posthog_text"."id",
+         "posthog_text"."body",
+         "posthog_text"."created_by_id",
+         "posthog_text"."last_modified_at",
+         "posthog_text"."last_modified_by_id",
+         "posthog_text"."team_id"
   FROM "posthog_dashboardtile"
-  INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_dashboardtile"."insight_id" = "posthog_dashboarditem"."id")
-  WHERE "posthog_dashboardtile"."dashboard_id" = 2 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  LEFT OUTER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_dashboarditem"."created_by_id" = "posthog_user"."id")
+  LEFT OUTER JOIN "posthog_user" T6 ON ("posthog_dashboarditem"."last_modified_by_id" = T6."id")
+  LEFT OUTER JOIN "posthog_text" ON ("posthog_dashboardtile"."text_id" = "posthog_text"."id")
+  WHERE (NOT ("posthog_dashboardtile"."deleted"
+              AND "posthog_dashboardtile"."deleted" IS NOT NULL)
+         AND (NOT "posthog_dashboarditem"."deleted"
+              OR "posthog_dashboardtile"."insight_id" IS NULL)
+         AND "posthog_dashboardtile"."dashboard_id" = 2
+         AND "posthog_dashboardtile"."dashboard_id" = 2
+         AND (NOT "posthog_dashboarditem"."deleted"
+              OR "posthog_dashboardtile"."insight_id" IS NULL))
+  ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.25
+  '
+  SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
+         "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_dashboard"
+  INNER JOIN "posthog_dashboardtile" ON ("posthog_dashboard"."id" = "posthog_dashboardtile"."dashboard_id")
+  INNER JOIN "posthog_team" ON ("posthog_dashboard"."team_id" = "posthog_team"."id")
+  INNER JOIN "posthog_organization" ON ("posthog_team"."organization_id" = "posthog_organization"."id")
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."id" IN
+           (SELECT U0."dashboard_id"
+            FROM "posthog_dashboardtile" U0
+            WHERE NOT (U0."deleted"
+                       AND U0."deleted" IS NOT NULL))
+         AND "posthog_dashboardtile"."insight_id" IN (1,
+                                                      2,
+                                                      3,
+                                                      4,
+                                                      5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.26
@@ -1218,68 +1356,6 @@
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.5
   '
-  SELECT "posthog_dashboardtile"."id",
-         "posthog_dashboardtile"."dashboard_id",
-         "posthog_dashboardtile"."insight_id",
-         "posthog_dashboardtile"."text_id",
-         "posthog_dashboardtile"."layouts",
-         "posthog_dashboardtile"."color",
-         "posthog_dashboardtile"."filters_hash",
-         "posthog_dashboardtile"."last_refresh",
-         "posthog_dashboardtile"."refreshing",
-         "posthog_dashboardtile"."refresh_attempt",
-         "posthog_dashboardtile"."deleted",
-         "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared",
-         "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."derived_name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt",
-         "posthog_dashboarditem"."last_modified_at",
-         "posthog_dashboarditem"."last_modified_by_id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."updated_at",
-         "posthog_dashboarditem"."deprecated_tags",
-         "posthog_dashboarditem"."tags"
-  FROM "posthog_dashboardtile"
-  INNER JOIN "posthog_dashboarditem" ON ("posthog_dashboardtile"."insight_id" = "posthog_dashboarditem"."id")
-  INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
-  WHERE "posthog_dashboardtile"."insight_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.6
-  '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
          "posthog_dashboard"."description",
@@ -1304,7 +1380,7 @@
                                      5 /* ... */) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.7
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.6
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1347,7 +1423,7 @@
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.8
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.7
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -1366,6 +1442,29 @@
   FROM "posthog_organization"
   WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.8
+  '
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared"
+  FROM "posthog_dashboard"
+  INNER JOIN "posthog_dashboardtile" ON ("posthog_dashboard"."id" = "posthog_dashboardtile"."dashboard_id")
+  WHERE "posthog_dashboardtile"."insight_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.9

--- a/posthog/api/test/dashboards/test_dashboard_text_tiles.py
+++ b/posthog/api/test/dashboards/test_dashboard_text_tiles.py
@@ -165,10 +165,10 @@ class TestDashboardTiles(APIBaseTest, QueryMatchingTest):
         dashboard_id, dashboard_json = self.dashboard_api.update_text_tile(dashboard_id, updated_tile)
 
         assert len(dashboard_json["tiles"]) == 2
-        assert [(t["id"], t["color"]) for t in dashboard_json["tiles"]] == [
+        assert set((t["id"], t["color"]) for t in dashboard_json["tiles"]) == {
             (tile_ids[0], "purple"),
             (tile_ids[1], None),
-        ]
+        }
 
     def test_can_remove_text_tiles_from_dashboard(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,9 +1,10 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import structlog
 from sentry_sdk import capture_exception
 
 from posthog.caching.utils import ensure_is_date
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.constants import (
     INSIGHT_FUNNELS,
     INSIGHT_PATHS,
@@ -15,9 +16,11 @@ from posthog.constants import (
 )
 from posthog.decorators import CacheType
 from posthog.logging.timing import timed
-from posthog.models import EventDefinition, Filter, RetentionFilter, Team
+from posthog.models import Dashboard, EventDefinition, Filter, Insight, RetentionFilter, Team
 from posthog.models.filters import PathFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
+from posthog.models.filters.utils import get_filter
+from posthog.models.insight import generate_insight_cache_key
 from posthog.queries.funnels import ClickhouseFunnelTimeToConvert, ClickhouseFunnelTrends
 from posthog.queries.funnels.utils import get_funnel_order_class
 from posthog.queries.paths import Paths
@@ -53,15 +56,26 @@ def get_cache_type(filter: FilterType) -> CacheType:
         return CacheType.TRENDS
 
 
-def calculate_result_by_cache_type(cache_type: CacheType, filter: Filter, key: str, team: Team) -> List[Dict[str, Any]]:
+def calculate_result_by_insight(
+    team: Team, insight: Insight, dashboard: Optional[Dashboard]
+) -> Tuple[str, str, List[Dict[str, Any]]]:
+    filter = get_filter(data=insight.dashboard_filters(dashboard), team=team)
+    cache_key = generate_insight_cache_key(insight, dashboard)
+    cache_type = get_cache_type(filter)
+
+    tag_queries(team_id=team.pk, insight_id=insight.pk, cache_type=cache_type, cache_key=cache_key)
+    return cache_key, cache_type, calculate_result_by_cache_type(cache_type, filter, team)
+
+
+def calculate_result_by_cache_type(cache_type: CacheType, filter: Filter, team: Team) -> List[Dict[str, Any]]:
     if cache_type == CacheType.FUNNEL:
-        return _calculate_funnel(filter, key, team)
+        return _calculate_funnel(filter, team)
     else:
-        return _calculate_by_filter(filter, key, team, cache_type)
+        return _calculate_by_filter(filter, team, cache_type)
 
 
 @timed("update_cache_item_timer.calculate_by_filter")
-def _calculate_by_filter(filter: FilterType, key: str, team: Team, cache_type: CacheType) -> List[Dict[str, Any]]:
+def _calculate_by_filter(filter: FilterType, team: Team, cache_type: CacheType) -> List[Dict[str, Any]]:
     insight_class = CACHE_TYPE_TO_INSIGHT_CLASS[cache_type]
 
     if cache_type == CacheType.PATHS:
@@ -72,7 +86,7 @@ def _calculate_by_filter(filter: FilterType, key: str, team: Team, cache_type: C
 
 
 @timed("update_cache_item_timer.calculate_funnel")
-def _calculate_funnel(filter: Filter, key: str, team: Team) -> List[Dict[str, Any]]:
+def _calculate_funnel(filter: Filter, team: Team) -> List[Dict[str, Any]]:
     if filter.funnel_viz_type == FunnelVizType.TRENDS:
         result = ClickhouseFunnelTrends(team=team, filter=filter).run()
     elif filter.funnel_viz_type == FunnelVizType.TIME_TO_CONVERT:

--- a/posthog/caching/insight_cache.py
+++ b/posthog/caching/insight_cache.py
@@ -1,0 +1,166 @@
+from datetime import datetime, timedelta
+from time import perf_counter
+from typing import Any, Dict, List, Optional, Tuple, cast
+from uuid import UUID
+
+import structlog
+from django.conf import settings
+from django.core.cache import cache
+from django.db import connection
+from django.utils.timezone import now
+from sentry_sdk.api import capture_exception
+from statshog.defaults.django import statsd
+
+from posthog.caching.calculate_results import calculate_result_by_insight
+from posthog.models import Dashboard, Insight, InsightCachingState, Team
+from posthog.models.instance_setting import get_instance_setting
+
+logger = structlog.get_logger(__name__)
+
+REQUEUE_DELAY = timedelta(hours=2)
+MAX_ATTEMPTS = 3
+
+
+def schedule_cache_updates():
+    from posthog.celery import update_cache_task
+
+    # :TODO: Separate celery queue for updates rather than limiting via this method
+    PARALLEL_INSIGHT_CACHE = get_instance_setting("PARALLEL_DASHBOARD_ITEM_CACHE")
+
+    to_update = fetch_states_in_need_of_updating(limit=PARALLEL_INSIGHT_CACHE)
+    # :TRICKY: Schedule tasks and deduplicate by ID to avoid clashes
+    representative_by_cache_key = set()
+    for team_id, cache_key, caching_state_id in to_update:
+        if (team_id, cache_key) not in representative_by_cache_key:
+            representative_by_cache_key.add((team_id, cache_key))
+            update_cache_task.delay(caching_state_id)
+
+    InsightCachingState.objects.filter(pk__in=(id for _, _, id in to_update)).update(last_refresh_queued_at=now())
+
+    if len(representative_by_cache_key) > 0:
+        logger.info(
+            "Scheduled caches to be updated", candidates=len(to_update), tasks_created=len(representative_by_cache_key)
+        )
+    else:
+        logger.info("No caches were found to be updated")
+
+
+def fetch_states_in_need_of_updating(limit: int) -> List[Tuple[int, str, UUID]]:
+    current_time = now()
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT team_id, cache_key, id
+            FROM posthog_insightcachingstate
+            WHERE target_cache_age_seconds IS NOT NULL
+            AND refresh_attempt < %(max_attempts)s
+            AND (
+                last_refresh IS NULL OR
+                last_refresh < %(current_time)s - target_cache_age_seconds * interval '1' second
+            )
+            AND (
+                last_refresh_queued_at IS NULL OR
+                last_refresh_queued_at < %(last_refresh_queued_at_threshold)s
+            )
+            ORDER BY last_refresh ASC NULLS FIRST
+            LIMIT %(limit)s
+            """,
+            {
+                "max_attempts": MAX_ATTEMPTS,
+                "current_time": current_time,
+                "last_refresh_queued_at_threshold": current_time - REQUEUE_DELAY,
+                "limit": limit,
+            },
+        )
+        return cursor.fetchall()
+
+
+def update_cache(caching_state_id: UUID):
+    caching_state = InsightCachingState.objects.get(pk=caching_state_id)
+
+    if caching_state.target_cache_age_seconds is None or (
+        caching_state.last_refresh is not None
+        and now() - caching_state.last_refresh < timedelta(seconds=caching_state.target_cache_age_seconds)
+    ):
+        statsd.incr("caching_state_update_skipped")
+        return
+
+    insight, dashboard = _extract_insight_dashboard(caching_state)
+    team: Team = insight.team
+    start_time = perf_counter()
+
+    exception = cache_key = cache_type = None
+
+    metadata = {
+        "team_id": team.pk,
+        "insight_id": insight.pk,
+        "dashboard_id": dashboard.pk if dashboard else None,
+        "last_refresh": caching_state.last_refresh,
+        "last_refresh_queued_at": caching_state.last_refresh_queued_at,
+    }
+
+    try:
+        cache_key, cache_type, result = calculate_result_by_insight(team=team, insight=insight, dashboard=dashboard)
+    except Exception as err:
+        capture_exception(err, metadata)
+        exception = err
+
+    duration = perf_counter() - start_time
+    if exception is None:
+        timestamp = now()
+        rows_updated = update_cached_state(
+            caching_state.team_id,
+            cast(str, cache_key),
+            timestamp,
+            {"result": result, "type": cache_type, "last_refresh": timestamp},
+        )
+        statsd.incr("caching_state_update_success")
+        statsd.incr("caching_state_update_rows_updated", rows_updated)
+        statsd.timing("caching_state_update_success_timing", duration)
+        logger.info("Re-calculated insight cache", rows_updated=rows_updated, duration=duration, **metadata)
+    else:
+        logger.warn(
+            "Failed to re-calculate insight cache",
+            exception=exception,
+            duration=duration,
+            **metadata,
+            refresh_attempt=caching_state.refresh_attempt,
+        )
+        statsd.incr("caching_state_update_errors")
+
+        if caching_state.refresh_attempt < MAX_ATTEMPTS:
+            from posthog.celery import update_cache_task
+
+            update_cache_task.apply_async(args=[caching_state_id], countdown=timedelta(minutes=10).total_seconds())
+
+        InsightCachingState.objects.filter(pk=caching_state.pk).update(
+            refresh_attempt=caching_state.refresh_attempt + 1, last_refresh_queued_at=now()
+        )
+
+
+def update_cached_state(team_id: int, cache_key: str, timestamp: datetime, result: Any):
+    cache.set(cache_key, result, settings.CACHED_RESULTS_TTL)
+
+    # :TRICKY: We update _all_ states with same cache_key to avoid needless re-calculations and
+    #   handle race conditions around cache_key changing.
+    return InsightCachingState.objects.filter(team_id=team_id, cache_key=cache_key).update(
+        last_refresh=timestamp, refresh_attempt=0
+    )
+
+
+def synchronously_update_cache(insight: Insight, dashboard: Optional[Dashboard]) -> List[Dict[str, Any]]:
+    cache_key, cache_type, result = calculate_result_by_insight(team=insight.team, insight=insight, dashboard=dashboard)
+    timestamp = now()
+    update_cached_state(
+        insight.team_id, cache_key, timestamp, {"result": result, "type": cache_type, "last_refresh": timestamp}
+    )
+    return result
+
+
+def _extract_insight_dashboard(caching_state: InsightCachingState) -> Tuple[Insight, Optional[Dashboard]]:
+    if caching_state.dashboard_tile is not None:
+        assert caching_state.dashboard_tile.insight is not None
+
+        return caching_state.dashboard_tile.insight, caching_state.dashboard_tile.dashboard
+    else:
+        return caching_state.insight, None

--- a/posthog/caching/insight_caching_state.py
+++ b/posthog/caching/insight_caching_state.py
@@ -3,6 +3,8 @@ from enum import Enum
 from functools import cached_property
 from typing import Optional, Union
 
+import structlog
+from django.core.paginator import Paginator
 from django.utils.timezone import now
 
 from posthog.caching.utils import active_teams
@@ -13,8 +15,8 @@ from posthog.models.team import Team
 
 VERY_RECENTLY_VIEWED_THRESHOLD = timedelta(hours=48)
 GENERALLY_VIEWED_THRESHOLD = timedelta(weeks=2)
-MAX_ATTEMPTS = 3
 
+logger = structlog.get_logger(__name__)
 
 # :TODO: Make these configurable
 class TargetCacheAge(Enum):
@@ -36,6 +38,22 @@ class LazyLoader:
             last_viewed_at__gte=now() - VERY_RECENTLY_VIEWED_THRESHOLD
         ).distinct("insight_id")
         return set(recently_viewed_insights.values_list("insight_id", flat=True))
+
+
+def sync_insight_cache_states():
+    lazy_loader = LazyLoader()
+
+    insights = Insight.objects.all().prefetch_related("team", "sharingconfiguration_set").order_by("pk")
+    for insight in _iterate_large_queryset(insights, 1000):
+        upsert(insight.team, insight, lazy_loader)
+
+    tiles = (
+        DashboardTile.objects.all()
+        .prefetch_related("dashboard", "dashboard__team", "dashboard__sharingconfiguration_set", "insight")
+        .order_by("pk")
+    )
+    for tile in _iterate_large_queryset(tiles, 1000):
+        upsert(tile.dashboard.team, tile, lazy_loader)
 
 
 def upsert(
@@ -60,20 +78,16 @@ def upsert(
     return caching_state
 
 
-def fetch_states_in_need_of_updating():
-    return InsightCachingState.objects.raw(
-        """
-        SELECT *
-        FROM posthog_insightcachingstate
-        WHERE target_cache_age_seconds IS NOT NULL
-          AND refresh_attempt < %(max_attempts)s
-          AND (
-            last_refresh IS NULL OR
-            last_refresh < %(timestamp)s - target_cache_age_seconds * interval '1' second
-          )
-        """,
-        {"max_attempts": MAX_ATTEMPTS, "timestamp": now()},
-    )
+def sync_insight_caching_state(team_id: int, insight_id: Optional[int] = None, dashboard_tile_id: Optional[int] = None):
+    try:
+        team = Team.objects.get(pk=team_id)
+        if dashboard_tile_id is not None:
+            upsert(team, DashboardTile.objects.get(pk=dashboard_tile_id))
+        elif insight_id is not None:
+            upsert(team, Insight.objects.get(pk=insight_id))
+    except Exception as err:
+        # This is a best-effort kind synchronization, safe to ignore errors
+        logger.warn("Failed to sync InsightCachingState, ignoring", exception=err)
 
 
 def calculate_cache_key(team: Team, target: Union[DashboardTile, Insight]) -> Optional[str]:
@@ -98,11 +112,13 @@ def calculate_target_age_insight(team: Team, insight: Insight, lazy_loader: Lazy
     if insight.deleted or len(insight.filters) == 0:
         return TargetCacheAge.NO_CACHING
 
-    # :TODO: Only cache insights that are shared
     if insight.pk not in lazy_loader.recently_viewed_insights:
         return TargetCacheAge.NO_CACHING
 
-    return TargetCacheAge.MID_PRIORITY
+    if insight.is_sharing_enabled:
+        return TargetCacheAge.MID_PRIORITY
+
+    return TargetCacheAge.NO_CACHING
 
 
 def calculate_target_age_dashboard_tile(
@@ -120,8 +136,6 @@ def calculate_target_age_dashboard_tile(
     if dashboard_tile.dashboard_id == team.primary_dashboard_id:
         return TargetCacheAge.HIGH_PRIORITY
 
-    # :TODO: If shared, MID_PRIORITY
-
     since_last_viewed = (
         now() - dashboard_tile.dashboard.last_accessed_at
         if dashboard_tile.dashboard.last_accessed_at
@@ -133,4 +147,16 @@ def calculate_target_age_dashboard_tile(
     if since_last_viewed < GENERALLY_VIEWED_THRESHOLD:
         return TargetCacheAge.MID_PRIORITY
 
-    return TargetCacheAge.LOW_PRIORITY
+    if dashboard_tile.dashboard.is_sharing_enabled:
+        return TargetCacheAge.LOW_PRIORITY
+
+    return TargetCacheAge.NO_CACHING
+
+
+def _iterate_large_queryset(queryset, page_size):
+    paginator = Paginator(queryset, page_size)
+    for page_number in paginator.page_range:
+        page = paginator.page(page_number)
+
+        for item in page.object_list:
+            yield item

--- a/posthog/caching/test/test_insight_cache.py
+++ b/posthog/caching/test/test_insight_cache.py
@@ -1,0 +1,164 @@
+from datetime import timedelta
+from typing import Optional, cast
+from unittest.mock import call, patch
+
+import pytest
+from django.utils.timezone import now
+from freezegun import freeze_time
+
+from posthog.caching.insight_cache import fetch_states_in_need_of_updating, schedule_cache_updates, update_cache
+from posthog.caching.insight_caching_state import upsert
+from posthog.caching.test.test_insight_caching_state import create_insight, filter_dict
+from posthog.decorators import CacheType
+from posthog.models import InsightCachingState, Team, User
+from posthog.models.signals import mute_selected_signals
+from posthog.utils import get_safe_cache
+
+
+def create_insight_caching_state(
+    team: Team,
+    user: User,
+    last_refresh: Optional[timedelta] = timedelta(days=14),  # noqa
+    last_refresh_queued_at: Optional[timedelta] = None,  # noqa
+    target_cache_age: Optional[timedelta] = timedelta(days=1),  # noqa
+    refresh_attempt: int = 0,
+    filters=filter_dict,
+    **kw,
+):
+    with mute_selected_signals():
+        insight = create_insight(team, user, filters=filters)
+
+    model = cast(InsightCachingState, upsert(team, insight))
+    model.last_refresh = now() - last_refresh if last_refresh is not None else None
+    model.last_refresh_queued_at = now() - last_refresh_queued_at if last_refresh_queued_at is not None else None
+    model.target_cache_age_seconds = target_cache_age.total_seconds() if target_cache_age is not None else None
+    model.refresh_attempt = refresh_attempt
+    model.save()
+    return model
+
+
+# Reaching into the internals of LocMemCache
+def cache_keys(cache):
+    return set(key.split(":", 2)[-1] for key in cache._cache.keys())
+
+
+@pytest.mark.django_db
+@patch("posthog.celery.update_cache_task")
+def test_schedule_cache_updates(update_cache_task, team: Team, user: User):
+    caching_state1 = create_insight_caching_state(team, user, filters=filter_dict, last_refresh=None)
+    create_insight_caching_state(team, user, filters=filter_dict)
+    caching_state3 = create_insight_caching_state(
+        team,
+        user,
+        filters={
+            **filter_dict,
+            "events": [{"id": "$pageleave"}],
+        },
+    )
+
+    schedule_cache_updates()
+
+    assert update_cache_task.delay.call_args_list == [call(caching_state1.pk), call(caching_state3.pk)]
+
+    last_refresh_queued_at = InsightCachingState.objects.filter(team=team).values_list(
+        "last_refresh_queued_at", flat=True
+    )
+    assert len(last_refresh_queued_at) == 3
+    assert None not in last_refresh_queued_at
+
+
+@pytest.mark.parametrize(
+    "params,expected_matches",
+    [
+        ({}, 1),
+        ({"limit": 0}, 0),
+        ({"last_refresh": None}, 1),
+        ({"target_cache_age": None, "last_refresh": None}, 0),
+        ({"target_cache_age": timedelta(days=1), "last_refresh": timedelta(days=2)}, 1),
+        ({"target_cache_age": timedelta(days=1), "last_refresh": timedelta(hours=23)}, 0),
+        ({"target_cache_age": timedelta(days=1), "last_refresh_queued_at": timedelta(hours=23)}, 1),
+        ({"target_cache_age": timedelta(days=1), "last_refresh_queued_at": timedelta(minutes=5)}, 0),
+        ({"refresh_attempt": 2}, 1),
+        ({"refresh_attempt": 3}, 0),
+    ],
+)
+@pytest.mark.django_db
+def test_fetch_states_in_need_of_updating(team: Team, user: User, params, expected_matches):
+    create_insight_caching_state(team, user, **params)
+
+    results = fetch_states_in_need_of_updating(params.get("limit", 10))
+    assert len(results) == expected_matches
+
+
+@pytest.mark.django_db
+@freeze_time("2020-01-04T13:01:01Z")
+def test_update_cache(cache, team: Team, user: User):
+    caching_state = create_insight_caching_state(team, user, refresh_attempt=1)
+
+    update_cache(caching_state.pk)
+
+    assert cache_keys(cache) == {caching_state.cache_key}
+    cached_result = get_safe_cache(caching_state.cache_key)
+    assert cached_result["result"] is not None
+    assert cached_result["type"] == CacheType.TRENDS
+    assert cached_result["last_refresh"] == now()
+
+    updated_caching_state = InsightCachingState.objects.get(team=team)
+    assert updated_caching_state.last_refresh == now()
+    assert updated_caching_state.refresh_attempt == 0
+
+
+@pytest.mark.django_db
+@freeze_time("2020-01-04T13:01:01Z")
+def test_update_cache_updates_identical_cache_keys(cache, team: Team, user: User):
+    caching_state1 = create_insight_caching_state(team, user, refresh_attempt=1)
+    caching_state2 = create_insight_caching_state(team, user, refresh_attempt=2)
+
+    assert caching_state1.cache_key == caching_state2.cache_key
+
+    update_cache(caching_state1.pk)
+
+    assert cache_keys(cache) == {caching_state1.cache_key}
+
+    updated_caching_states = InsightCachingState.objects.filter(team=team)
+    assert all(state.cache_key == caching_state1.cache_key for state in updated_caching_states)
+    assert all(state.last_refresh == now() for state in updated_caching_states)
+    assert all(state.refresh_attempt == 0 for state in updated_caching_states)
+
+
+@pytest.mark.django_db
+@freeze_time("2020-01-04T13:01:01Z")
+@patch("posthog.celery.update_cache_task")
+@patch("posthog.caching.insight_cache.calculate_result_by_insight")
+def test_update_cache_when_calculation_fails(
+    spy_calculate_result_by_insight, spy_update_cache_task, cache, team: Team, user: User
+):
+    caching_state = create_insight_caching_state(team, user, refresh_attempt=1)
+    spy_calculate_result_by_insight.side_effect = Exception()
+
+    update_cache(caching_state.pk)
+
+    assert cache_keys(cache) == set()
+
+    updated_caching_state = InsightCachingState.objects.get(team=team)
+    assert updated_caching_state.last_refresh == caching_state.last_refresh
+    assert updated_caching_state.refresh_attempt == 2
+    assert updated_caching_state.last_refresh_queued_at == now()
+
+    assert spy_update_cache_task.apply_async.call_count == 1
+
+
+@pytest.mark.django_db
+@freeze_time("2020-01-04T13:01:01Z")
+@patch("posthog.caching.insight_cache.calculate_result_by_insight")
+def test_update_cache_when_recently_refreshed(spy_calculate_result_by_insight, team: Team, user: User):
+    caching_state = create_insight_caching_state(
+        team, user, last_refresh=timedelta(hours=1), target_cache_age=timedelta(days=1)
+    )
+
+    update_cache(caching_state.pk)
+
+    updated_caching_state = InsightCachingState.objects.get(team=team)
+
+    assert spy_calculate_result_by_insight.call_count == 0
+    assert updated_caching_state.last_refresh == caching_state.last_refresh

--- a/posthog/caching/test/test_insight_caching_state.py
+++ b/posthog/caching/test/test_insight_caching_state.py
@@ -10,7 +10,7 @@ from posthog.caching.insight_caching_state import (
     LazyLoader,
     TargetCacheAge,
     calculate_target_age,
-    fetch_states_in_need_of_updating,
+    sync_insight_cache_states,
     upsert,
 )
 from posthog.models import (
@@ -19,10 +19,12 @@ from posthog.models import (
     Insight,
     InsightCachingState,
     InsightViewed,
+    SharingConfiguration,
     Team,
     Text,
     User,
 )
+from posthog.models.signals import mute_selected_signals
 from posthog.test.base import BaseTest
 
 filter_dict = {
@@ -37,6 +39,7 @@ def create_insight(
     mock_active_teams: Any = None,
     team_should_be_active=True,
     viewed_at_delta: Optional[timedelta] = timedelta(hours=1),  # noqa
+    is_shared=True,
     filters=filter_dict,
     deleted=False,
 ) -> Insight:
@@ -46,6 +49,8 @@ def create_insight(
     insight = Insight.objects.create(team=team, filters=filters, deleted=deleted)
     if viewed_at_delta is not None:
         InsightViewed.objects.create(insight=insight, last_viewed_at=now() - viewed_at_delta, user=user, team=team)
+    if is_shared:
+        SharingConfiguration.objects.create(team=team, insight=insight, enabled=True)
 
     return insight
 
@@ -61,6 +66,7 @@ def create_tile(
     insight_deleted=False,
     dashboard_deleted=False,
     dashboard_tile_deleted=False,
+    is_dashboard_shared=True,
     text_tile=False,
 ) -> DashboardTile:
     if mock_active_teams:
@@ -73,6 +79,9 @@ def create_tile(
     if on_home_dashboard:
         team.primary_dashboard_id = dashboard.pk
         team.save()
+
+    if is_dashboard_shared:
+        SharingConfiguration.objects.create(team=team, dashboard=dashboard, enabled=True)
 
     insight = text = None
     if text_tile:
@@ -88,28 +97,12 @@ def create_tile(
     )
 
 
-def create_insight_caching_state(
-    team: Team,
-    user: User,
-    last_refreshed: Optional[timedelta] = timedelta(days=14),  # noqa
-    target_cache_age: Optional[timedelta] = timedelta(days=1),  # noqa
-    refresh_attempt: int = 0,
-):
-    insight = create_insight(team, user)
-    InsightCachingState.objects.create(
-        team=team,
-        insight=insight,
-        last_refresh=now() - last_refreshed if last_refreshed is not None else None,
-        target_cache_age_seconds=target_cache_age.total_seconds() if target_cache_age is not None else None,
-        refresh_attempt=refresh_attempt,
-    )
-
-
 @pytest.mark.parametrize(
     "create_item,create_item_kw,expected_target_age",
     [
         # Insight test cases
-        pytest.param(create_insight, {}, TargetCacheAge.MID_PRIORITY, id="insight base"),
+        pytest.param(create_insight, {}, TargetCacheAge.MID_PRIORITY, id="shared insight (base)"),
+        pytest.param(create_insight, {"is_shared": False}, TargetCacheAge.NO_CACHING, id="not shared insight"),
         pytest.param(
             create_insight, {"team_should_be_active": False}, TargetCacheAge.NO_CACHING, id="insight with inactive team"
         ),
@@ -123,7 +116,8 @@ def create_insight_caching_state(
         pytest.param(create_insight, {"filters": {}}, TargetCacheAge.NO_CACHING, id="insight with no filters"),
         pytest.param(create_insight, {"deleted": True}, TargetCacheAge.NO_CACHING, id="deleted insight"),
         # Dashboard tile test cases
-        pytest.param(create_tile, {}, TargetCacheAge.LOW_PRIORITY, id="tile base"),
+        pytest.param(create_tile, {}, TargetCacheAge.LOW_PRIORITY, id="shared tile (base)"),
+        pytest.param(create_tile, {"is_dashboard_shared": False}, TargetCacheAge.NO_CACHING, id="not shared tile"),
         pytest.param(
             create_tile, {"team_should_be_active": False}, TargetCacheAge.NO_CACHING, id="tile with inactive team"
         ),
@@ -184,7 +178,8 @@ def test_calculate_target_age(
 @pytest.mark.django_db
 @patch("posthog.caching.insight_caching_state.active_teams")
 def test_upsert_new_insight(mock_active_teams, team: Team, user: User):
-    insight = create_insight(team=team, user=user, mock_active_teams=mock_active_teams)
+    with mute_selected_signals():
+        insight = create_insight(team=team, user=user, mock_active_teams=mock_active_teams)
     caching_state = upsert(team, insight)
 
     assert InsightCachingState.objects.filter(team=team).count() == 1
@@ -203,7 +198,8 @@ def test_upsert_new_insight(mock_active_teams, team: Team, user: User):
 @pytest.mark.django_db
 @patch("posthog.caching.insight_caching_state.active_teams")
 def test_upsert_update_insight(mock_active_teams, team: Team, user: User):
-    insight = create_insight(team=team, user=user, mock_active_teams=mock_active_teams)
+    with mute_selected_signals():
+        insight = create_insight(team=team, user=user, mock_active_teams=mock_active_teams)
     caching_state = upsert(team, insight)
     assert caching_state is not None
 
@@ -225,7 +221,8 @@ def test_upsert_update_insight(mock_active_teams, team: Team, user: User):
 @pytest.mark.django_db
 @patch("posthog.caching.insight_caching_state.active_teams")
 def test_upsert_new_tile(mock_active_teams, team: Team, user: User):
-    tile = create_tile(team=team, user=user, mock_active_teams=mock_active_teams)
+    with mute_selected_signals():
+        tile = create_tile(team=team, user=user, mock_active_teams=mock_active_teams)
     caching_state = upsert(team, tile)
 
     assert InsightCachingState.objects.filter(team=team).count() == 1
@@ -248,27 +245,19 @@ def test_upsert_text_tile_does_not_create_record(mock_active_teams, team: Team, 
     caching_state = upsert(team, tile)
 
     assert caching_state is None
-    assert not InsightCachingState.objects.filter(team=team).exists()
+    assert InsightCachingState.objects.filter(team=team).count() == 0
 
 
-@pytest.mark.parametrize(
-    "params,expected_matches",
-    [
-        ({}, 1),
-        ({"last_refreshed": None}, 1),
-        ({"target_cache_age": None, "last_refreshed": None}, 0),
-        ({"target_cache_age": timedelta(days=1), "last_refreshed": timedelta(days=2)}, 1),
-        ({"target_cache_age": timedelta(days=1), "last_refreshed": timedelta(hours=23)}, 0),
-        ({"refresh_attempt": 2}, 1),
-        ({"refresh_attempt": 3}, 0),
-    ],
-)
 @pytest.mark.django_db
-def test_fetch_states_in_need_of_updating(team: Team, user: User, params, expected_matches):
-    create_insight_caching_state(team, user, **params)
+@freeze_time("2020-01-04T13:01:01Z")
+def test_sync_insight_cache_states(team: Team, user: User):
+    with mute_selected_signals():
+        create_insight(team=team, user=user)
+        create_tile(team=team, user=user)
 
-    results = fetch_states_in_need_of_updating()
-    assert len(results) == expected_matches
+    sync_insight_cache_states()
+
+    assert InsightCachingState.objects.filter(team=team).count() == 3
 
 
 class TestLazyLoader(BaseTest):

--- a/posthog/caching/test/test_update_cache.py
+++ b/posthog/caching/test/test_update_cache.py
@@ -967,27 +967,6 @@ class TestUpdateCache(APIBaseTest):
             assert insight_one.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
             assert insight_two.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
 
-    @patch("posthog.caching.update_cache.cache.set")
-    @patch("posthog.caching.calculate_results._calculate_by_filter")
-    @patch("posthog.caching.update_cache.group.apply_async")
-    @patch("posthog.celery.update_cache_item_task.s")
-    @patch("posthog.caching.update_cache.statsd.incr")
-    def test_update_insight_cache_reports_zero_filters_hashes_updated_when_tile_has_correct_filters_hash(
-        self,
-        statsd_incr: MagicMock,
-        patch_update_cache_item: MagicMock,
-        _patch_apply_async: MagicMock,
-        _patch_generate_results: MagicMock,
-        _patched_cache_set: MagicMock,
-    ) -> None:
-        # a tile with the correct filters hash
-        _a_dashboard_tile_with_known_last_refresh(self.team, last_refresh_date=None, filters={"date_from": "-90d"})
-
-        run_cache_update(patch_update_cache_item)
-
-        # received update_cache_item_success and did not receive update_cache_item_set_new_cache_key_on_tile
-        assert [mock_call.args[0] for mock_call in statsd_incr.mock_calls] == ["update_cache_item_success"]
-
     @freeze_time("2021-08-25T22:09:14.252Z")
     @patch("posthog.caching.calculate_results._calculate_by_filter", return_value={"not", "an empty result"})
     @patch("posthog.caching.update_cache.group.apply_async")
@@ -1207,7 +1186,7 @@ class TestCacheEventsLastSeenUsedToSkipQueries(APIBaseTest):
         run_cache_update(patch_update_cache_item)
         shared_insight.refresh_from_db()
 
-        patch_calculate_by_filter.assert_any_call(ANY, shared_insight.filters_hash, self.team, "Trends")
+        patch_calculate_by_filter.assert_any_call(ANY, self.team, "Trends")
 
     @patch("posthog.caching.update_cache.cache.set")
     @patch("posthog.caching.calculate_results._calculate_by_filter", return_value={"not": "empty result"})
@@ -1248,7 +1227,7 @@ class TestCacheEventsLastSeenUsedToSkipQueries(APIBaseTest):
         run_cache_update(patch_update_cache_item)
         shared_insight.refresh_from_db()
 
-        patch_calculate_by_filter.assert_any_call(ANY, shared_insight.filters_hash, self.team, "Retention")
+        patch_calculate_by_filter.assert_any_call(ANY, self.team, "Retention")
 
     @patch("posthog.caching.update_cache.cache.set")
     @patch("posthog.caching.calculate_results._calculate_by_filter", return_value={"not": "empty result"})
@@ -1288,7 +1267,7 @@ class TestCacheEventsLastSeenUsedToSkipQueries(APIBaseTest):
         run_cache_update(patch_update_cache_item)
         shared_insight.refresh_from_db()
 
-        patch_calculate_by_filter.assert_any_call(ANY, shared_insight.filters_hash, self.team, "Path")
+        patch_calculate_by_filter.assert_any_call(ANY, self.team, "Path")
 
     @patch("posthog.caching.update_cache.cache.set")
     @patch("posthog.caching.calculate_results._calculate_by_filter", return_value={"not": "empty result"})
@@ -1326,7 +1305,7 @@ class TestCacheEventsLastSeenUsedToSkipQueries(APIBaseTest):
         run_cache_update(patch_update_cache_item)
         shared_insight.refresh_from_db()
 
-        patch_calculate_by_filter.assert_any_call(ANY, shared_insight.filters_hash, self.team, "Trends")
+        patch_calculate_by_filter.assert_any_call(ANY, self.team, "Trends")
 
 
 class TestCacheTeamRecency(APIBaseTest):

--- a/posthog/caching/update_cache.py
+++ b/posthog/caching/update_cache.py
@@ -199,7 +199,7 @@ def update_cache_item(key: str, cache_type: CacheType, payload: dict) -> Optiona
 def _update_cache_for_queryset(
     cache_type: CacheType, filter: Filter, key: str, team: Team
 ) -> Optional[List[Dict[str, Any]]]:
-    result = calculate_result_by_cache_type(cache_type, filter, key, team)
+    result = calculate_result_by_cache_type(cache_type, filter, team)
 
     cache.set(key, {"result": result, "type": cache_type, "last_refresh": timezone.now()}, settings.CACHED_RESULTS_TTL)
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,7 +1,8 @@
 import os
 import time
 from random import randrange
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+from uuid import UUID
 
 from celery import Celery
 from celery.schedules import crontab
@@ -485,6 +486,34 @@ def update_cache_item_task(key: str, cache_type, payload: dict) -> List[Dict[str
     from posthog.caching.update_cache import update_cache_item
 
     return update_cache_item(key, cache_type, payload)
+
+
+@app.task(ignore_result=True)
+def sync_insight_cache_states_task():
+    from posthog.caching.insight_caching_state import sync_insight_cache_states
+
+    sync_insight_cache_states()
+
+
+@app.task(ignore_result=True)
+def schedule_cache_updates_task():
+    from posthog.caching.insight_cache import schedule_cache_updates
+
+    schedule_cache_updates()
+
+
+@app.task(ignore_result=True)
+def update_cache_task(caching_state_id: UUID):
+    from posthog.caching.insight_cache import update_cache
+
+    update_cache(caching_state_id)
+
+
+@app.task(ignore_result=True)
+def sync_insight_caching_state(team_id: int, insight_id: Optional[int] = None, dashboard_tile_id: Optional[int] = None):
+    from posthog.caching.insight_caching_state import sync_insight_caching_state
+
+    sync_insight_caching_state(team_id, insight_id, dashboard_tile_id)
 
 
 @app.task(ignore_result=True)

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -125,6 +125,8 @@ def unittest_snapshot(request, snapshot):
 def cache():
     from django.core.cache import cache as django_cache
 
+    django_cache.clear()
+
     yield django_cache
 
     django_cache.clear()

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -119,3 +119,12 @@ def user(base_test_mixin_fixture):
 @pytest.fixture
 def unittest_snapshot(request, snapshot):
     request.cls.snapshot = snapshot
+
+
+@pytest.fixture
+def cache():
+    from django.core.cache import cache as django_cache
+
+    yield django_cache
+
+    django_cache.clear()

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -4,11 +4,11 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q, QuerySet, UniqueConstraint
 from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.utils import timezone
 
 from posthog.models.dashboard import Dashboard
 from posthog.models.insight import Insight, generate_insight_cache_key
+from posthog.models.signals import mutable_receiver
 from posthog.models.tagged_item import build_check
 
 
@@ -56,6 +56,13 @@ class DashboardTile(models.Model):
             models.CheckConstraint(check=build_check(("insight", "text")), name="dash_tile_exactly_one_related_object"),
         ]
 
+    @property
+    def caching_state(self):
+        # uses .all and not .first so that prefetching can be used
+        for state in self.caching_states.all():
+            return state
+        return None
+
     def clean(self):
         super().clean()
 
@@ -100,7 +107,7 @@ class DashboardTile(models.Model):
         )
 
 
-@receiver(post_save, sender=Insight)
+@mutable_receiver(post_save, sender=Insight)
 def on_insight_saved(sender, instance: Insight, **kwargs):
     update_fields = kwargs.get("update_fields")
     if update_fields in [frozenset({"filters_hash"}), frozenset({"last_refresh"})]:
@@ -111,7 +118,7 @@ def on_insight_saved(sender, instance: Insight, **kwargs):
     update_filters_hashes(tile_update_candidates)
 
 
-@receiver(post_save, sender=Dashboard)
+@mutable_receiver(post_save, sender=Dashboard)
 def on_dashboard_saved(sender, instance: Dashboard, **kwargs):
     tile_update_candidates = DashboardTile.objects.select_related("insight", "dashboard").filter(dashboard=instance)
     update_filters_hashes(tile_update_candidates)

--- a/posthog/models/insight_caching_state.py
+++ b/posthog/models/insight_caching_state.py
@@ -1,5 +1,10 @@
 from django.db import models
+from django.db.models.signals import post_save
 
+from posthog.models.dashboard_tile import DashboardTile
+from posthog.models.insight import Insight
+from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.models.signals import mutable_receiver
 from posthog.models.team import Team
 from posthog.models.utils import UUIDModel
 
@@ -36,3 +41,28 @@ class InsightCachingState(UUIDModel):
 
     created_at: models.DateTimeField = models.DateTimeField(auto_now_add=True)
     updated_at: models.DateTimeField = models.DateTimeField(auto_now=True)
+
+
+@mutable_receiver(post_save, sender=SharingConfiguration)
+def sync_sharing_configuration(sender, instance: SharingConfiguration, **kwargs):
+    from posthog.celery import sync_insight_caching_state
+
+    if instance.insight_id is not None:
+        sync_insight_caching_state.delay(instance.team_id, insight_id=instance.insight_id)
+    elif instance.dashboard is not None:
+        for tile in instance.dashboard.tiles.all():
+            sync_insight_caching_state.delay(instance.team_id, dashboard_tile_id=tile.pk)
+
+
+@mutable_receiver(post_save, sender=Insight)
+def sync_insight(sender, instance: Insight, **kwargs):
+    from posthog.celery import sync_insight_caching_state
+
+    sync_insight_caching_state.delay(instance.team_id, insight_id=instance.pk)
+
+
+@mutable_receiver(post_save, sender=DashboardTile)
+def sync_dashboard_tile(sender, instance: DashboardTile, **kwargs):
+    from posthog.celery import sync_insight_caching_state
+
+    sync_insight_caching_state.delay(instance.dashboard.team_id, dashboard_tile_id=instance.pk)

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -3,16 +3,19 @@ from typing import Any, List
 
 from posthog.cache_utils import cache_for
 from posthog.models.async_migration import is_async_migration_complete
-from posthog.models.cohort import CohortPeople
-from posthog.models.person import Person, PersonDistinctId
 
 
 def delete_bulky_postgres_data(team_ids: List[int]):
     "Efficiently delete large tables for teams from postgres. Using normal CASCADE delete here can time out"
 
+    from posthog.models.cohort import CohortPeople
+    from posthog.models.insight_caching_state import InsightCachingState
+    from posthog.models.person import Person, PersonDistinctId
+
     _raw_delete(PersonDistinctId.objects.filter(team_id__in=team_ids))
     _raw_delete(CohortPeople.objects.filter(cohort__team_id__in=team_ids))
     _raw_delete(Person.objects.filter(team_id__in=team_ids))
+    _raw_delete(InsightCachingState.objects.filter(team_id__in=team_ids))
 
 
 def _raw_delete(queryset: Any):

--- a/posthog/models/test/test_insight_caching_state.py
+++ b/posthog/models/test/test_insight_caching_state.py
@@ -1,0 +1,82 @@
+from typing import Optional, cast
+
+from posthog.models import Dashboard, DashboardTile, Insight, InsightCachingState, SharingConfiguration
+from posthog.models.signals import mute_selected_signals
+from posthog.test.base import BaseTest
+
+filters = {
+    "events": [{"id": "$pageview"}],
+    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+}
+
+filters2 = {
+    **filters,
+    "events": [{"id": "$pageleave"}],
+}
+
+
+class TestInsightCachingState(BaseTest):
+    def test_insight_creation_updating_deletion(self):
+        insight = Insight.objects.create(team=self.team, filters=filters)
+
+        initial_caching_state = self.get_caching_state()
+        assert initial_caching_state is not None
+        assert initial_caching_state.insight.pk == insight.pk
+        assert initial_caching_state.dashboard_tile is None
+        assert isinstance(initial_caching_state.cache_key, str)
+
+        insight.filters = filters2
+        insight.save()
+
+        updated_caching_state = self.get_caching_state()
+        assert updated_caching_state is not None
+        assert updated_caching_state.pk == initial_caching_state.pk
+        assert updated_caching_state.cache_key != initial_caching_state.cache_key
+        assert updated_caching_state.updated_at != initial_caching_state.updated_at
+
+        insight.delete()
+
+        assert self.get_caching_state() is None
+
+    def test_dashboard_tile_creation_updating_deletion(self):
+        with mute_selected_signals():
+            dashboard = Dashboard.objects.create(team=self.team)
+            insight = Insight.objects.create(team=self.team, filters=filters)
+
+        dashboard_tile = DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        initial_caching_state = self.get_caching_state()
+        assert initial_caching_state is not None
+        assert initial_caching_state.insight.pk == insight.pk
+        assert cast(DashboardTile, initial_caching_state.dashboard_tile).pk == dashboard_tile.pk
+        assert isinstance(initial_caching_state.cache_key, str)
+
+        with mute_selected_signals():
+            insight.filters = filters2
+            insight.save()
+
+        dashboard_tile.color = "red"
+        dashboard_tile.save()
+
+        updated_caching_state = self.get_caching_state()
+        assert updated_caching_state is not None
+        assert updated_caching_state.pk == initial_caching_state.pk
+        assert updated_caching_state.cache_key != initial_caching_state.cache_key
+        assert updated_caching_state.updated_at != initial_caching_state.updated_at
+
+        dashboard_tile.delete()
+
+        assert self.get_caching_state() is None
+
+    def test_sharing_configuration_insight(self):
+        with mute_selected_signals():
+            insight = Insight.objects.create(team=self.team, filters=filters)
+
+        SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True)
+
+        assert self.get_caching_state() is not None
+
+    def get_caching_state(self) -> Optional[InsightCachingState]:
+        query_set = InsightCachingState.objects.filter(team_id=self.team.pk)
+        assert len(query_set) in (0, 1)
+        return query_set.first()

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -79,6 +79,14 @@ EVENT_PROPERTY_USAGE_INTERVAL_CRON = get_from_env(
     "0 */6 * * *",
 )
 
+# Schedule to syncronize insight cache states on. Follows crontab syntax.
+SYNC_INSIGHT_CACHE_STATES_SCHEDULE = get_from_env(
+    "CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON",
+    # Defaults to 5AM UTC on Saturday
+    "0 5 * * SAT",
+)
+
+
 UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS = get_from_env(
     "UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS", 90, type_cast=int
 )


### PR DESCRIPTION
Splitting original PR into pieces. This piece:
- Automatically creates/updates InsightCachingStates as models change
- Adds business logic around caching everywhere with tests

Nothing is hooked up _yet_ besides creating InsightCachingStates - idea is to deploy this first, make sure cloud is prepared and then merge the follow-up PR.

Depends on https://github.com/PostHog/posthog/pull/13123