### PR TITLE
ci(backend): Pin Python version for async migrations tests

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -372,7 +372,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: ${{ inputs.python-version }}
+                  python-version: 3.8.14
 
             - name: Install SAML (python3-saml) dependencies
               shell: bash


### PR DESCRIPTION
## Problem

Seeing this in PR checks: "TypeError: required field "lineno" missing from alias" (https://github.com/PostHog/posthog/actions/runs/3621114322/jobs/6104150476).

## Changes

Apparently this is because we aren't pinning the Python version properly in the async migrations check (found this report: https://github.com/pytest-dev/pytest/discussions/9195). So now we'll be 100% 3.8.14.