### PR TITLE
fix: functional tests running instructions

### DIFF
--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -45,8 +45,10 @@ runtime stack.
 See `bin/ci_functional_tests.sh` for how these tests are run in CI. For local
 testing:
 
-1. start the plugin-server with `yarn start:dev`
-1. run the tests with `yarn functional_tests --watch`
+1. run docker `docker compose -f docker-compose.dev.yml up` (in posthog folder)
+1. setup the test DBs `yarn setup:test`
+1. start the plugin-server with `CLICKHOUSE_DATABASE='default' DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog yarn start:dev`
+1. run the tests with `CLICKHOUSE_DATABASE='default' DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog yarn functional_tests --watch`
 
 ## CLI flags
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Unfortunately we can't run functional tests against the test CH test DB easily 
(problem is that we should write to `_test` kafka topic for it to end up in the CH test db, to do that node env needs to be test, but if node env was set to test we didn't end up running ingestion 🤷‍♀️  )


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Update instructions to be explicit about using postgres test db, but clickhouse default db, which is a combination that works.
Made it also be more comprehensive and include the docker + test db setup steps.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
