### PR TITLE
feat: Added persistence for only matching filter

### DIFF
--- a/frontend/src/scenes/session-recordings/player/list/eventsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/list/eventsListLogic.ts
@@ -144,12 +144,14 @@ export const eventsListLogic = kea<eventsListLogicType>([
                     : eventsBeforeFiltering
 
                 const matchingEventIds = new Set(matchingEvents.map((e) => e.uuid))
+                const shouldShowOnlyMatching = matchingEvents.length > 0 && showOnlyMatching
+
                 return events
                     .filter(
                         (e) =>
                             (windowIdFilter === RecordingWindowFilter.All ||
                                 e.playerPosition?.windowId === windowIdFilter) &&
-                            (!showOnlyMatching || matchingEventIds.has(String(e.id)))
+                            (!shouldShowOnlyMatching || matchingEventIds.has(String(e.id)))
                     )
                     .map((e) => ({
                         ...e,

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -31,6 +31,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         ],
         showOnlyMatching: [
             false,
+            { persist: true },
             {
                 setShowOnlyMatching: (_, { showOnlyMatching }) => showOnlyMatching,
             },


### PR DESCRIPTION
## Problem

The "show only matching" filter is not persisted.

## Changes

* Persist it like the other player settings
* Change the logic to only filter if there are actual matching events

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
