### PR TITLE
fix: File playback caching issue

### DIFF
--- a/frontend/src/scenes/session-recordings/file-playback/SessionRecodingFilePlayback.tsx
+++ b/frontend/src/scenes/session-recordings/file-playback/SessionRecodingFilePlayback.tsx
@@ -11,7 +11,7 @@ import { PayGatePage } from 'lib/components/PayGatePage/PayGatePage'
 
 export function SessionRecordingFilePlayback(): JSX.Element {
     const { loadFromFile, resetSessionRecording } = useActions(sessionRecodingFilePlaybackLogic)
-    const { sessionRecording, sessionRecordingLoading } = useValues(sessionRecodingFilePlaybackLogic)
+    const { sessionRecording, sessionRecordingLoading, playerKey } = useValues(sessionRecodingFilePlaybackLogic)
     const { hasAvailableFeature } = useValues(userLogic)
     const filePlaybackEnabled = hasAvailableFeature(AvailableFeature.RECORDINGS_FILE_EXPORT)
 
@@ -49,7 +49,7 @@ export function SessionRecordingFilePlayback(): JSX.Element {
                     <SessionRecordingPlayer
                         sessionRecordingId=""
                         sessionRecordingData={sessionRecording}
-                        playerKey="file-playback"
+                        playerKey={playerKey}
                     />
                 </div>
             ) : (

--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecodingFilePlaybackLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecodingFilePlaybackLogic.test.ts
@@ -1,0 +1,31 @@
+import { initKeaTests } from '~/test/init'
+import { expectLogic } from 'kea-test-utils'
+import { sessionRecodingFilePlaybackLogic } from './sessionRecodingFilePlaybackLogic'
+
+describe('sessionRecodingFilePlaybackLogic', () => {
+    let logic: ReturnType<typeof sessionRecodingFilePlaybackLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    describe('file-playback logic', () => {
+        beforeEach(() => {
+            logic = sessionRecodingFilePlaybackLogic()
+            logic.mount()
+        })
+
+        it('should generate a new playerKey on load', () => {
+            expectLogic(logic).toMatchValues({
+                playerKey: 'file-playback',
+            })
+
+            logic.actions.loadFromFileSuccess({} as any)
+            const playerKey = logic.values.playerKey
+            expect(playerKey).toMatch(/^file-playback-.{36}$/)
+
+            logic.actions.loadFromFileSuccess({} as any)
+            expect(playerKey).not.toEqual(logic.values.playerKey)
+        })
+    })
+})

--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecodingFilePlaybackLogic.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecodingFilePlaybackLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, path, selectors } from 'kea'
+import { connect, kea, path, reducers, selectors } from 'kea'
 import { Breadcrumb, SessionPlayerData } from '~/types'
 import { urls } from 'scenes/urls'
 import { loaders } from 'kea-loaders'
@@ -8,6 +8,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import type { sessionRecodingFilePlaybackLogicType } from './sessionRecodingFilePlaybackLogicType'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { uuid } from 'lib/utils'
 
 export type ExportedSessionRecordingFile = {
     version: '2022-12-02'
@@ -58,6 +59,16 @@ export const sessionRecodingFilePlaybackLogic = kea<sessionRecodingFilePlaybackL
             resetSessionRecording: () => null,
         },
     })),
+
+    reducers({
+        playerKey: [
+            'file-playback',
+            {
+                loadFromFileSuccess: () => `file-playback-${uuid()}`,
+                resetSessionRecording: () => 'file-playback',
+            },
+        ],
+    }),
 
     beforeUnload(({ values, actions }) => ({
         enabled: () => !!values.sessionRecording,


### PR DESCRIPTION
## Problem

Noticed during the demo that the player is cached due to the logic key which means when you upload a new recording you don't see it.

## Changes

* Create a new key each time a file is loaded

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests for once!