### PR TITLE
fix: Don't load deleted dashboard tiles

### DIFF
--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -133,10 +133,7 @@ def update_filters_hashes(tile_update_candidates):
 
 def get_tiles_ordered_by_position(dashboard: Dashboard, size: str = "xs") -> List[DashboardTile]:
     tiles = list(
-        dashboard.tiles.select_related("insight", "text")
-        .exclude(insight__deleted=True)
-        .order_by("insight__order")
-        .all()
+        dashboard.tiles.select_related("insight", "text").exclude(deleted=True).order_by("insight__order").all()
     )
     tiles.sort(key=lambda x: x.layouts.get(size, {}).get("y", 100))
     return tiles

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -133,7 +133,11 @@ def update_filters_hashes(tile_update_candidates):
 
 def get_tiles_ordered_by_position(dashboard: Dashboard, size: str = "xs") -> List[DashboardTile]:
     tiles = list(
-        dashboard.tiles.select_related("insight", "text").exclude(deleted=True).order_by("insight__order").all()
+        dashboard.tiles.select_related("insight", "text")
+        .exclude(deleted=True)
+        .exclude(insight__deleted=True)
+        .order_by("insight__order")
+        .all()
     )
     tiles.sort(key=lambda x: x.layouts.get(size, {}).get("y", 100))
     return tiles

--- a/posthog/models/test/test_dashboard_tile_model.py
+++ b/posthog/models/test/test_dashboard_tile_model.py
@@ -38,6 +38,16 @@ class TestDashboardTileModel(APIBaseTest):
 
         assert len(capture_query_context.captured_queries) == 1
 
+    def test_loads_dashboard_tiles_excludes_deleted(self) -> None:
+        tiles = get_tiles_ordered_by_position(dashboard=self.dashboard)
+        assert len(tiles) == 10
+
+        tiles[0].deleted = True
+        tiles[0].save()
+
+        tiles = get_tiles_ordered_by_position(dashboard=self.dashboard)
+        assert len(tiles) == 9
+
     def test_cannot_add_a_tile_with_insight_and_text_on_validation(self) -> None:
         insight = Insight.objects.create(team=self.team, short_id="123456", name="My Test subscription")
         text = Text.objects.create(team=self.team, body="I am a text")

--- a/posthog/models/test/test_dashboard_tile_model.py
+++ b/posthog/models/test/test_dashboard_tile_model.py
@@ -45,8 +45,12 @@ class TestDashboardTileModel(APIBaseTest):
         tiles[0].deleted = True
         tiles[0].save()
 
+        insight = Insight.objects.get(team=self.team, short_id="123456-1")
+        insight.deleted = True
+        insight.save()
+
         tiles = get_tiles_ordered_by_position(dashboard=self.dashboard)
-        assert len(tiles) == 9
+        assert len(tiles) == 8
 
     def test_cannot_add_a_tile_with_insight_and_text_on_validation(self) -> None:
         insight = Insight.objects.create(team=self.team, short_id="123456", name="My Test subscription")


### PR DESCRIPTION
## Problem

For exports, we filtered for the insight being deleted but not the tile which is the more important thing

## Changes

* Changes this around and adds a test

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests - @pauldambra made me do it...