### PR TITLE
chore: count requested insight cancellations

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -791,6 +791,7 @@ Using the correct cache and enriching the response with dashboard specific confi
             f"KILL QUERY ON CLUSTER '{CLICKHOUSE_CLUSTER}' WHERE query_id LIKE %(client_query_id)s",
             {"client_query_id": f"{self.team.pk}_{request.data['client_query_id']}%"},
         )
+        statsd.incr("clickhouse.query.cancellation_requested", tags={"team_id": self.team.pk})
         return Response(status=status.HTTP_201_CREATED)
 
     @action(methods=["POST"], detail=False)


### PR DESCRIPTION
## Problem

we don't know how many query cancellations are being requested

## Changes

So increment a counter when we request cancellations.

This doesn't tell us how many queries were actually cancelled but it does give us an indication of volume. And we should then see this change as we add dashboard cancellation

## How did you test this code?

I didn't 🙈 
