### PR TITLE
feat: add a basic means for marking that a team/project has seen an event

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -188,19 +188,19 @@ def _ensure_web_feature_flags_in_properties(
                 event["properties"][f"$feature/{k}"] = v
 
 
-def _update_event_seen_cache(team_id: int, ttl=60 * 60 * 24):
+def _update_event_seen_cache(team_id: int, ttl=60 * 60 * 24) -> None:
     # Defaults to expiring this key in Redis after 24 hours
     r = get_client()
     r.setex(f"posthog_event_seen_for_team:{team_id}", ttl, time.time())
 
 
-def _has_team_seen_events(team_id: int):
+def _has_team_seen_events(team_id: int) -> bool:
     r = get_client()
     exists = bool(r.exists(f"posthog_event_seen_for_team:{team_id}"))
     return exists
 
 
-def mark_events_seen_for_team(team_id: int):
+def mark_events_seen_for_team(team_id: int) -> None:
     # If this is the first time we've seen an event for this team in 24 hours
     # we update the db to make sure that we have marked the team as ingesting events
     try:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -196,7 +196,7 @@ def _update_event_seen_cache(team_id: int, ttl=60 * 60 * 24):
 
 def _has_team_seen_events(team_id: int):
     r = get_client()
-    exists = bool(r.get(f"posthog_event_seen_for_team:{team_id}"))
+    exists = bool(r.exists(f"posthog_event_seen_for_team:{team_id}"))
     return exists
 
 
@@ -261,7 +261,8 @@ def get_event(request):
         if db_error:
             send_events_to_dead_letter_queue = True
 
-    mark_events_seen_for_team(ingestion_context.team_id)
+    if ingestion_context:
+        mark_events_seen_for_team(ingestion_context.team_id)
 
     if isinstance(data, dict):
         if data.get("batch"):  # posthog-python and posthog-ruby

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -129,8 +129,19 @@ class TestCapture(BaseTest):
                 ],
             },
         }
+
+        # NOTE: at the time of writing, there are two queries for the endpoint,
+        # one to authenticate the request, and the other to cache if a specific
+        # team has received events before. We hence run this test twice to
+        # verify that the cached value prevents the second query on the second request.
         with self.assertNumQueries(2):
+            self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost")
+
+        # NOTE: here the second query seen in the above test is no longer made,
+        # due to the value being cached.
+        with self.assertNumQueries(1):
             response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost")
+
         self.assertEqual(response.get("access-control-allow-origin"), "https://localhost")
         self.assertDictContainsSubset(
             {


### PR DESCRIPTION
## Problem

We want to tighten up the feedback loop for moving a user beyond the onboarding flow. This updates the `ingested_event` on a team the first time an event is seen for that team/project _at the edge_. This removes an entire category of issues with slowdowns of our pipeline. When we get an event for a team/project we immediately let the user know.

You can check out the code for the onboarding flow here:
https://github.com/PostHog/posthog/blob/e13db278a53a020f0c1308ba93886f6d1df107ff/frontend/src/scenes/ingestion/v1/panels/VerificationPanel.tsx#L28

## Changes

This will update a Team object to update `ingested_event` at most once a day.
The best case scenario is a redis call for each event and a postgres call once a day for each team.
The worst case scenario is two redis calls and a pg call per event.

## TODO:
We need to move this telemetry to Python:
https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/team-manager.ts#L245

Probably remove this logic entirely from the Plugin Server

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
