### PR TITLE
feat(billing): experiment, add a silly little 'most popular' label to the Cloud plan

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -138,6 +138,7 @@ export const FEATURE_FLAGS = {
     DASHBOARD_TEMPLATES: 'dashboard-templates', // owner @pauldambra
     DATA_EXPLORATION_LIVE_EVENTS: 'data-exploration-live-events', // owner @mariusandra
     BILLING_FEATURES_EXPERIMENT: 'billing-features-experiment', // owner: #team-growth
+    BILLING_PLAN_MOST_POPULAR_EXPERIMENT: 'billing-plan-most-popular-experiment', // owner: #team-growth, @raquelmsmith
     RECORDINGS_EXPORT: 'recordings-export', // owner: #team-session-recordings
 }
 

--- a/frontend/src/scenes/billing/v2/test/PlanTable.tsx
+++ b/frontend/src/scenes/billing/v2/test/PlanTable.tsx
@@ -1,6 +1,9 @@
 import { LemonButton, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { IconArrowRight, IconCheckmark, IconClose, IconWarning } from 'lib/components/icons'
+import { LemonSnack } from 'lib/components/LemonSnack/LemonSnack'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingTestLogic } from './billingTestLogic'
 import './PlanTable.scss'
@@ -364,6 +367,7 @@ export function PlanIcon({
 export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Element {
     const { billing } = useValues(billingTestLogic)
     const { reportBillingUpgradeClicked } = useActions(eventUsageLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const upgradeButtons = billingPlans.map((plan) => (
         <td key={`${plan.name}-cta`}>
@@ -395,6 +399,10 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                             <td key={plan.name}>
                                 <h3 className="font-bold">{plan.name}</h3>
                                 <p className="ml-0 text-xs">{plan.description}</p>
+                                {featureFlags[FEATURE_FLAGS.BILLING_PLAN_MOST_POPULAR_EXPERIMENT] === 'test' &&
+                                plan.name === 'PostHog Cloud' ? (
+                                    <LemonSnack className="text-xs mt-1">Most popular</LemonSnack>
+                                ) : null}
                             </td>
                         ))}
                     </tr>


### PR DESCRIPTION
## Problem

I've been reading [Influence by Robert Cialdini](https://smile.amazon.com/Influence-New-Expanded-Psychology-Persuasion/dp/0062937650/ref=asc_df_0062937650/?tag=hyprod-20&linkCode=df0&hvadid=509245866633&hvpos=&hvnetw=g&hvrand=4267902035707613297&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=1014232&hvtargid=pla-1019935051106&psc=1&sa-no-redirect=1), in which he talks about how simply telling someone that something is the most popular, it makes them want to buy it more (highly recommend the book FWIW). Figured it was easy enough to try on this, so here we go.

## Changes

If the feature flag is on, people will simply see a little "Most Popular" tag on the Cloud plan. We'll run an experiment to see if this has any sort of measurable impact. My hypothesis is that it won't - but we shall see.

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/18598166/206088279-114fd277-32bb-474c-a482-411ce80e05f3.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
