### PR TITLE
feat: cancel dashboard queries when filters change

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -758,6 +758,7 @@ describe('dashboardLogic', () => {
                 })
         })
     })
+
     describe('lastRefreshed', () => {
         it('should be the earliest refreshed dashboard', async () => {
             logic = dashboardLogic({ id: 5 })
@@ -788,6 +789,27 @@ describe('dashboardLogic', () => {
                 .toDispatchActions(['loadDashboardItemsSuccess'])
                 .toNotHaveDispatchedActions(['refreshAllDashboardItems'])
                 .toFinishListeners()
+        })
+    })
+
+    describe('text tiles', () => {
+        beforeEach(async () => {
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        it('can remove text tiles', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.removeTile(TEXT_TILE)
+            })
+                .toFinishAllListeners()
+                .toDispatchActions([
+                    dashboardsModel.actionTypes.tileRemovedFromDashboard,
+                    logic.actionTypes.removeTileSuccess,
+                ])
+
+            expect(logic.values.textTiles).toEqual([])
         })
     })
 
@@ -839,27 +861,6 @@ describe('dashboardLogic', () => {
                 dashboards: t.insight!.dashboards,
             }))
         ).toEqual([])
-    })
-
-    describe('text tiles', () => {
-        beforeEach(async () => {
-            logic = dashboardLogic({ id: 5 })
-            logic.mount()
-            await expectLogic(logic).toFinishAllListeners()
-        })
-
-        it('can remove text tiles', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.removeTile(TEXT_TILE)
-            })
-                .toFinishAllListeners()
-                .toDispatchActions([
-                    dashboardsModel.actionTypes.tileRemovedFromDashboard,
-                    logic.actionTypes.removeTileSuccess,
-                ])
-
-            expect(logic.values.textTiles).toEqual([])
-        })
     })
 })
 /* eslint-enable  @typescript-eslint/no-non-null-assertion */


### PR DESCRIPTION
## Problem

See #13041 

We cancel queries in insight logic when filters change. 

## Changes

Let's cancel them on dashboards too

Implements the cancellation without refactoring (make it work -> make it right -> make it fast)

![dash-cancellation](https://user-images.githubusercontent.com/984817/206167177-0bf8daa1-6ada-45be-9eff-154037ca1d25.gif)

## How did you test this code?

* add a sleep to all clickhouse insight queries
* visit a dashboard
* click refresh
* change filter
* see the front end calls the cancel API
