### PR TITLE
feat: capture aborts to metrics

### DIFF
--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -7,7 +7,7 @@ export interface TimeToSeeDataPayload {
     time_to_see_data_ms: number
     dashboard_query_id?: string
     query_id?: string
-    status?: 'failure' | 'success'
+    status?: 'failure' | 'success' | 'cancelled'
     api_response_bytes?: number
     api_url?: string
     insight?: string

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1247,6 +1247,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             if (values.featureFlags[FEATURE_FLAGS.CANCEL_RUNNING_QUERIES]) {
                 await api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: dashboardQueryId })
 
+                // TRICKY: we cancel just once using the dashboard query id.
+                // we can record the queryId that happened to capture the AbortError exception
+                // and request the cancellation, but it is probably not particularly relevant
                 await captureTimeToSeeData(values.currentTeamId, {
                     type: 'insight_load',
                     context: 'dashboard',

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -188,7 +188,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         duplicateTile: (tile: DashboardTile) => ({ tile }),
         loadingDashboardItemsStarted: (action: string, dashboardQueryId: string) => ({ action, dashboardQueryId }),
         setInitialLoadResponseBytes: (responseBytes: number) => ({ responseBytes }),
-        abortQuery: (payload: { queryId: string; exception?: Record<string, any> }) => payload,
+        abortQuery: (payload: { dashboardQueryId: string; queryId: string; queryStartTime: number }) => payload,
     }),
 
     loaders(({ actions, props, values }) => ({
@@ -1050,7 +1050,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     } else if (e.name === 'AbortError' || e.message?.name === 'AbortError') {
                         if (!cancelled) {
                             // cancel all insight requests for this query in one go
-                            actions.abortQuery({ queryId: dashboardQueryId })
+                            actions.abortQuery({ dashboardQueryId: dashboardQueryId, queryId: queryId, queryStartTime })
                         }
                         cancelled = true
                     } else {
@@ -1242,10 +1242,21 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.setShouldReportOnAPILoad(true)
             }
         },
-        abortQuery: ({ queryId }) => {
+        abortQuery: async ({ dashboardQueryId, queryId, queryStartTime }) => {
             const { currentTeamId } = values
             if (values.featureFlags[FEATURE_FLAGS.CANCEL_RUNNING_QUERIES]) {
-                api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: queryId })
+                await api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: dashboardQueryId })
+
+                await captureTimeToSeeData(values.currentTeamId, {
+                    type: 'insight_load',
+                    context: 'dashboard',
+                    dashboard_query_id: dashboardQueryId,
+                    query_id: queryId,
+                    status: 'cancelled',
+                    time_to_see_data_ms: Math.floor(performance.now() - queryStartTime),
+                    insights_fetched: 0,
+                    insights_fetched_cached: 0,
+                })
             }
         },
     })),

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -862,11 +862,24 @@ export const insightLogic = kea<insightLogicType>([
             )
             actions.setIsLoading(true)
         },
-        abortQuery: ({ queryId }) => {
+        abortQuery: async ({ queryId }) => {
             const { currentTeamId } = values
 
             if (values.featureFlags[FEATURE_FLAGS.CANCEL_RUNNING_QUERIES]) {
-                api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: queryId })
+                await api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: queryId })
+
+                const duration = performance.now() - values.queryStartTimes[queryId]
+                await captureTimeToSeeData(values.currentTeamId, {
+                    type: 'insight_load',
+                    context: 'insight',
+                    query_id: queryId,
+                    status: 'cancelled',
+                    time_to_see_data_ms: Math.floor(duration),
+                    insights_fetched: 0,
+                    insights_fetched_cached: 0,
+                    api_response_bytes: 0,
+                    insight: values.activeView,
+                })
             }
         },
         endQuery: ({ queryId, view, lastRefresh, scene, exception, response }) => {


### PR DESCRIPTION
stacked on top of #13178 

## Problem

We abort queries but aren't capturing that to our time-to-metrics so can't account for it in performance visualisation

## Changes

captures cancellation requests

## How did you test this code?

I didn't yet 🤣 - pushing this so I can reference it in parent PR
