### PR TITLE
feat: sync distinct_ids with billing service for reporting purposes

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -184,21 +184,20 @@ class BillingViewset(viewsets.GenericViewSet):
             self._update_org_details(org, response)
 
         # check if the distinct_ids are in sync, if not patch the billing service
-        if response.get("distinct_ids"):
-            received_distinct_ids = response["distinct_ids"]
-            local_distinct_ids = []
-            if is_cloud() and org:
-                local_distinct_ids = list(org.members.values_list("distinct_id", flat=True))
-            else:
-                local_distinct_ids = list(User.objects.values_list("distinct_id", flat=True))
+        received_distinct_ids = response.get("distinct_ids") or []
+        local_distinct_ids = []
+        if is_cloud() and org:
+            local_distinct_ids = list(org.members.values_list("distinct_id", flat=True))
+        else:
+            local_distinct_ids = list(User.objects.values_list("distinct_id", flat=True))
 
-            if set(received_distinct_ids) != set(local_distinct_ids):
-                billing_service_token = build_billing_token(license, org)
-                requests.patch(
-                    f"{BILLING_SERVICE_URL}/api/billing/",
-                    headers={"Authorization": f"Bearer {billing_service_token}"},
-                    json={"distinct_ids": local_distinct_ids},
-                )
+        if set(received_distinct_ids) != set(local_distinct_ids):
+            billing_service_token = build_billing_token(license, org)
+            requests.patch(
+                f"{BILLING_SERVICE_URL}/api/billing/",
+                headers={"Authorization": f"Bearer {billing_service_token}"},
+                json={"distinct_ids": local_distinct_ids},
+            )
 
         return Response(response)
 

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -60,7 +60,6 @@ def create_billing_customer(**kwargs) -> Dict[str, Any]:
             }
         ],
         "billing_period": {"current_period_start": "2022-10-07T11:12:48", "current_period_end": "2022-11-07T11:12:48"},
-        "distinct_ids": [],
     }
     data.update(kwargs)
     return data
@@ -213,6 +212,7 @@ class TestBillingAPI(APILicensedTest):
             "id": self.license.key.split("::")[0],
             "organization_id": str(self.organization.id),
             "organization_name": "Test",
+            "distinct_ids": [self.user.distinct_id],
         }
 
     @patch("ee.api.billing.requests.get")
@@ -252,7 +252,6 @@ class TestBillingAPI(APILicensedTest):
                 "current_period_start": "2022-10-07T11:12:48",
                 "current_period_end": "2022-11-07T11:12:48",
             },
-            "distinct_ids": [],
         }
 
     @patch("ee.api.billing.requests.get")

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -518,20 +518,3 @@ class TestBillingAPI(APILicensedTest):
                 "usage": 0,
             },
         }
-
-    @patch("ee.api.billing.requests.patch")
-    @patch("ee.api.billing.requests.get")
-    def test_billing_distinct_ids_in_sync(self, mock_request, mock_patch, *args):
-        mock_request.return_value.status_code = 200
-        mock_request.return_value.json.return_value = create_billing_response(
-            customer=create_billing_customer(has_active_subscription=True)
-        )
-        self.organization.customer_id = None
-        self.organization.usage = None
-        self.organization.members.add(self.user)
-        self.organization.save()
-
-        res = self.client.get("/api/billing-v2")
-        assert res.status_code == 200
-        assert mock_patch.call_count == 1
-        assert mock_patch.call_args[1]["json"]["distinct_ids"] == [self.user.distinct_id]


### PR DESCRIPTION
## Problem
NOTE: This PR needs to be merged before: https://github.com/PostHog/billing/pull/55

We want to sync the the org or instance users' `distinct_id`s to the billing service, so that we can correctly report events

## Changes
- Check if the `distinct_ids` reported by the server are correct, otherwise patch them

## How did you test this code?
- Added a test
