### PR TITLE
fix(persons-modal): Fix unrounded part of box overflowing

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -266,7 +266,7 @@ export function ActorRow({ actor, onOpenRecording }: ActorRowProps): JSX.Element
             </div>
 
             {expanded ? (
-                <div className="bg-side border-t">
+                <div className="bg-side border-t rounded-b">
                     <Tabs defaultActiveKey={tab} onChange={setTab} tabBarStyle={{ paddingLeft: 20, marginBottom: 0 }}>
                         <Tabs.TabPane tab="Properties" key="properties">
                             {Object.keys(actor.properties).length ? (

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -642,32 +642,36 @@
 }
 
 .rounded-sm {
-    border-radius: 0.125rem; /* 2px */
+    border-radius: calc(var(--radius) / 2); /* 2px */
 }
 .rounded {
-    border-radius: 0.25rem; /* 4px */
+    border-radius: var(--radius); /* 4px */
 }
 .rounded-t {
-    border-top-left-radius: 0.25rem; /* 4px */
-    border-top-right-radius: 0.25rem; /* 4px */
+    border-top-left-radius: var(--radius); /* 4px */
+    border-top-right-radius: var(--radius); /* 4px */
+}
+.rounded-b {
+    border-bottom-left-radius: var(--radius); /* 4px */
+    border-bottom-right-radius: var(--radius); /* 4px */
 }
 .rounded-md {
-    border-radius: 0.375rem; /* 6px */
+    border-radius: calc(var(--radius) * 1.5); /* 6px */
 }
 .rounded-lg {
-    border-radius: 0.5rem; /* 8px */
+    border-radius: calc(var(--radius) * 2); /* 8px */
 }
 .rounded-xl {
-    border-radius: 0.75rem; /* 12px */
+    border-radius: calc(var(--radius) * 3); /* 12px */
 }
 .rounded-2xl {
-    border-radius: 1rem; /* 16px */
+    border-radius: calc(var(--radius) * 4); /* 16px */
 }
 .rounded-3xl {
-    border-radius: 1.5rem; /* 24px */
+    border-radius: calc(var(--radius) * 6); /* 24px */
 }
 .rounded-full {
-    border-radius: 9999px;
+    border-radius: 1000rem;
 }
 
 .overflow-auto {


### PR DESCRIPTION
## Problem

Noticed this is off when working on persons-on-events support in the persons modal:

<img width="108" alt="Screenshot 2022-12-07 at 15 59 19" src="https://user-images.githubusercontent.com/4550621/206227959-96084beb-0af1-4bf7-9163-6a5ca8e04fee.png">

plus noticed our `.rounded*` classes don't use the `--radius` CSS variable.

## Changes

Fixes above.