### PR TITLE
fix(demo): move the try/catch again

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -147,7 +147,7 @@ class TeamSerializer(serializers.ModelSerializer):
                     if validated_data.get("is_demo", False):
                         MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, request.user)
             except DatabaseError as db_err:
-                capture_exception()
+                capture_exception(db_err)
                 raise db_err
             except Exception as e:  # TODO: Remove this after 2022-12-07, the except is just temporary for debugging
                 capture_exception()

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -150,7 +150,7 @@ class TeamSerializer(serializers.ModelSerializer):
                 capture_exception(db_err)
                 raise db_err
             except Exception as e:  # TODO: Remove this after 2022-12-07, the except is just temporary for debugging
-                capture_exception()
+                capture_exception(e)
                 raise e
         return team
 


### PR DESCRIPTION
## Problem

Apparently when a `transaction.atomic()` fails, it does so kind of silently. The recommendation is to not catch the exception inside the transaction because then it may commit bad data to the database. See: https://docs.djangoproject.com/en/4.1/topics/db/transactions/#:~:text=Avoid%20catching%20exceptions%20inside%20atomic!

Sooooooo here's another shot at debugging this!

## Changes

Moved the try/except block to outside the transaction, but inside another transaction, in the hopes that the error will get raised.

I'm copy/pasting code from the internet, particularly as it involves the DatabaseError. @Twixes your eyes would be appreciated here.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
