### PR TITLE
chore(time-to-see-data): person-on-events tagging, overrides

### DIFF
--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -63,7 +63,13 @@ def calculate_result_by_insight(
     cache_key = generate_insight_cache_key(insight, dashboard)
     cache_type = get_cache_type(filter)
 
-    tag_queries(team_id=team.pk, insight_id=insight.pk, cache_type=cache_type, cache_key=cache_key)
+    tag_queries(
+        team_id=team.pk,
+        insight_id=insight.pk,
+        cache_type=cache_type,
+        cache_key=cache_key,
+        person_on_events_enabled=team.actor_on_events_querying_enabled,
+    )
     return cache_key, cache_type, calculate_result_by_cache_type(cache_type, filter, team)
 
 

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -68,7 +68,6 @@ def calculate_result_by_insight(
         insight_id=insight.pk,
         cache_type=cache_type,
         cache_key=cache_key,
-        person_on_events_enabled=team.actor_on_events_querying_enabled,
     )
     return cache_key, cache_type, calculate_result_by_cache_type(cache_type, filter, team)
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -175,14 +175,15 @@ class CHQueries:
         if hasattr(user, "current_team_id") and user.current_team_id:
             tag_queries(team_id=user.current_team_id)
 
-        response: HttpResponse = self.get_response(request)
+        try:
+            response: HttpResponse = self.get_response(request)
 
-        if "api/" in request.path and "capture" not in request.path:
-            statsd.incr("http_api_request_response", tags={"id": route_id, "status_code": response.status_code})
+            if "api/" in request.path and "capture" not in request.path:
+                statsd.incr("http_api_request_response", tags={"id": route_id, "status_code": response.status_code})
 
-        reset_query_tags()
-
-        return response
+            return response
+        finally:
+            reset_query_tags()
 
 
 def shortcircuitmiddleware(f):

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 import posthoganalytics
 import pytz
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MinLengthValidator
 from django.db import models
@@ -216,6 +217,9 @@ class Team(UUIDClassicModel):
 
     @cached_property
     def _actor_on_events_querying_enabled(self) -> bool:
+        if settings.PERSON_ON_EVENTS_OVERRIDE is not None:
+            return settings.PERSON_ON_EVENTS_OVERRIDE
+
         # on PostHog Cloud, use the feature flag
         if is_cloud():
             return posthoganalytics.feature_enabled(

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -74,6 +74,9 @@ NPM_TOKEN = os.getenv("NPM_TOKEN", None)
 # Whether to capture time-to-see-data metrics
 CAPTURE_TIME_TO_SEE_DATA = get_from_env("CAPTURE_TIME_TO_SEE_DATA", False, type_cast=str_to_bool)
 
+# Only written in specific scripts - do not use outside of them.
+PERSON_ON_EVENTS_OVERRIDE = get_from_env("PERSON_ON_EVENTS_OVERRIDE", optional=True, type_cast=str_to_bool)
+
 HOOK_EVENTS: Dict[str, str] = {}
 
 


### PR DESCRIPTION
## Problem

1. I want query tags for whether person-on-events was enabled for this query
2. I want to override person-on-events in some scripts.
3. We should reset tags properly in web