### PR TITLE
fix: Don't use tmpl ext for docker-compose base yml

### DIFF
--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -56,7 +56,7 @@ git pull
 cd ../
 
 rm -f docker-compose.yml
-cp posthog/docker-compose.base.yml docker-compose.base.tmpl
+cp posthog/docker-compose.base.yml docker-compose.base.yml
 cp posthog/docker-compose.hobby.yml docker-compose.yml.tmpl
 envsubst < docker-compose.yml.tmpl > docker-compose.yml
 rm docker-compose.yml.tmpl


### PR DESCRIPTION
## Problem

This fixes an issue with the hobby upgrade.

## Changes

Hobby upgrade needs just a simple copy not a template copy

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
