### PR TITLE
fix: Upgrade docker-compose when we upgrade the hobby stack

### DIFF
--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -55,6 +55,12 @@ cd posthog
 git pull
 cd ../
 
+# Upgrade Docker Compose to version 2.13.0
+echo "Setting up Docker Compose"
+sudo rm /usr/local/bin/docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.13.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose || true
+sudo chmod +x /usr/local/bin/docker-compose
+
 rm -f docker-compose.yml
 cp posthog/docker-compose.base.yml docker-compose.base.yml
 cp posthog/docker-compose.hobby.yml docker-compose.yml.tmpl


### PR DESCRIPTION
## Problem

Some hobby users are still using docker compose version < 2. We need to bring them up to speed with an upgrade.

## Changes

remove and upgrade docker compose on hobby deploys

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
