### PR TITLE
feat: Remove old free allocation view

### DIFF
--- a/frontend/src/scenes/billing/v2/control/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/control/Billing.tsx
@@ -317,8 +317,6 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
         700: 'medium',
     })
 
-    const showFreeAllocationLimit = !billing?.has_active_subscription && product.free_allocation !== null
-
     const billingGaugeItems: BillingGaugeProps['items'] = useMemo(
         () =>
             [
@@ -326,26 +324,12 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                     tooltip: (
                         <>
                             <b>Free tier limit</b>
-                            {showFreeAllocationLimit ? <div>(Subscribed)</div> : null}
                         </>
                     ),
-                    color: !showFreeAllocationLimit ? 'success-light' : 'success-highlight',
+                    color: 'success-light',
                     value: product.tiers?.[0]?.up_to || 0,
                     top: true,
                 },
-                showFreeAllocationLimit
-                    ? {
-                          tooltip: (
-                              <>
-                                  <b>Free tier limit</b>
-                                  <div>(Unsubscribed)</div>
-                              </>
-                          ),
-                          color: 'success-light',
-                          value: product.free_allocation,
-                          top: true,
-                      }
-                    : (undefined as any),
                 {
                     tooltip: (
                         <>

--- a/frontend/src/scenes/billing/v2/control/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/control/billingLogic.ts
@@ -153,9 +153,10 @@ export const billingLogic = kea<billingLogicType>([
                 if (!billing || !preflight?.cloud) {
                     return false
                 }
-                // lock cloud users out if they are above the usage limit on any product
+                // lock cloud users without a subscription out if they are above the usage limit on any product
                 return Boolean(
                     billingVersion === 'v2' &&
+                        !billing.has_active_subscription &&
                         billing.products.find((x) => {
                             return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
                         }) &&

--- a/frontend/src/scenes/billing/v2/test/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/test/Billing.tsx
@@ -296,8 +296,6 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
         700: 'medium',
     })
 
-    const showFreeAllocationLimit = !billing?.has_active_subscription && product.free_allocation !== null
-
     const billingGaugeItems: BillingGaugeProps['items'] = useMemo(
         () =>
             [
@@ -305,26 +303,12 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                     tooltip: (
                         <>
                             <b>Free tier limit</b>
-                            {showFreeAllocationLimit ? <div>(Subscribed)</div> : null}
                         </>
                     ),
-                    color: !showFreeAllocationLimit ? 'success-light' : 'success-highlight',
+                    color: 'success-light',
                     value: product.tiers?.[0]?.up_to || 0,
                     top: true,
                 },
-                showFreeAllocationLimit
-                    ? {
-                          tooltip: (
-                              <>
-                                  <b>Free tier limit</b>
-                                  <div>(Unsubscribed)</div>
-                              </>
-                          ),
-                          color: 'success-light',
-                          value: product.free_allocation,
-                          top: true,
-                      }
-                    : (undefined as any),
                 {
                     tooltip: (
                         <>

--- a/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
+++ b/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
@@ -153,9 +153,10 @@ export const billingTestLogic = kea<billingTestLogicType>([
                 if (!billing || !preflight?.cloud) {
                     return false
                 }
-                // lock cloud users out if they are above the usage limit on any product
+                // lock cloud users without a subscription out if they are above the usage limit on any product
                 return Boolean(
                     billingVersion === 'v2' &&
+                        !billing.has_active_subscription &&
                         billing.products.find((x) => {
                             return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
                         }) &&


### PR DESCRIPTION
## Problem

We're not using the free allocation view. This removes it so that we can instead use `free_allocation` for determining usage percentage.

Related billing change https://github.com/PostHog/billing/pull/56

## Changes

* Removes frontend free_allocation marker
* Changes Lock screen to only show for non-subscribed users (subscribed ones should still see data but drop events in the future)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
