### PR TITLE
chore: remove secondary onboarding experiment

### DIFF
--- a/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
+++ b/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
@@ -312,12 +312,8 @@ export const activationLogic = kea<activationLogicType>([
     })),
     events(({ actions }) => ({
         afterMount: () => {
-            // we artificially wait for a second so that the UI has time to render before we check for these async values
-            // this prevents the UI from flickering when the values are loaded
-            setTimeout(() => {
-                actions.loadCustomEvents()
-                actions.loadInsights()
-            }, 1000)
+            actions.loadCustomEvents()
+            actions.loadInsights()
         },
     })),
     urlToAction(({ actions, values }) => ({

--- a/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
+++ b/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
@@ -13,8 +13,6 @@ import type { activationLogicType } from './activationLogicType'
 import { urls } from 'scenes/urls'
 import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export enum ActivationTasks {
     IngestFirstEvent = 'ingest_first_event',
@@ -56,8 +54,6 @@ export const activationLogic = kea<activationLogicType>([
             ['insights'],
             dashboardsModel,
             ['rawDashboards'],
-            featureFlagLogic,
-            ['featureFlags'],
         ],
         actions: [
             inviteLogic,
@@ -133,14 +129,9 @@ export const activationLogic = kea<activationLogicType>([
         ],
     })),
     selectors({
-        shouldShowSecondaryOnboarding: [
-            (s) => [s.featureFlags],
-            (featureFlags) => featureFlags[FEATURE_FLAGS.SECONDARY_ONBOARDING_EXPERIMENT] === 'test',
-        ],
         isReady: [
-            (s) => [s.areCustomEventsLoaded, s.areInsightsLoaded, s.shouldShowSecondaryOnboarding],
-            (areCustomEventsLoaded, areInsightsLoaded, shouldShowSecondaryOnboarding) =>
-                shouldShowSecondaryOnboarding && areCustomEventsLoaded && areInsightsLoaded,
+            (s) => [s.areCustomEventsLoaded, s.areInsightsLoaded],
+            (areCustomEventsLoaded, areInsightsLoaded) => areCustomEventsLoaded && areInsightsLoaded,
         ],
         currentTeamSkippedTasks: [
             (s) => [s.skippedTasks, s.currentTeam],
@@ -319,21 +310,19 @@ export const activationLogic = kea<activationLogicType>([
             )
         },
     })),
-    events(({ actions, values }) => ({
+    events(({ actions }) => ({
         afterMount: () => {
-            if (values.shouldShowSecondaryOnboarding) {
-                // we artificially wait for a second so that the UI has time to render before we check for these async values
-                // this prevents the UI from flickering when the values are loaded
-                setTimeout(() => {
-                    actions.loadCustomEvents()
-                    actions.loadInsights()
-                }, 1000)
-            }
+            // we artificially wait for a second so that the UI has time to render before we check for these async values
+            // this prevents the UI from flickering when the values are loaded
+            setTimeout(() => {
+                actions.loadCustomEvents()
+                actions.loadInsights()
+            }, 1000)
         },
     })),
     urlToAction(({ actions, values }) => ({
         '*': (_, params) => {
-            if (values.shouldShowSecondaryOnboarding && params?.onboarding_completed && !values.hasCompletedAllTasks) {
+            if (params?.onboarding_completed && !values.hasCompletedAllTasks) {
                 actions.toggleActivationSideBar()
             } else {
                 actions.hideActivationSideBar()

--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -22,7 +22,6 @@ import { DefaultAction, inAppPromptLogic } from 'lib/logic/inAppPrompt/inAppProm
 import { hedgehogbuddyLogic } from '../HedgehogBuddy/hedgehogbuddyLogic'
 import { HedgehogBuddyWithLogic } from '../HedgehogBuddy/HedgehogBuddy'
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
-import { activationLogic } from '../ActivationSidebar/activationLogic'
 
 const HELP_UTM_TAGS = '?utm_medium=in-product&utm_campaign=help-button-top'
 
@@ -88,7 +87,6 @@ export function HelpButton({
     const { hedgehogModeEnabled } = useValues(hedgehogbuddyLogic)
     const { setHedgehogModeEnabled } = useActions(hedgehogbuddyLogic)
     const { toggleActivationSideBar } = useActions(navigationLogic)
-    const { shouldShowSecondaryOnboarding } = useValues(activationLogic)
 
     return (
         <>
@@ -149,19 +147,17 @@ export function HelpButton({
                                 Read the docs
                             </LemonButton>
                         )}
-                        {shouldShowSecondaryOnboarding && (
-                            <LemonButton
-                                icon={<IconTrendingUp />}
-                                status="stealth"
-                                fullWidth
-                                onClick={() => {
-                                    toggleActivationSideBar()
-                                    hideHelp()
-                                }}
-                            >
-                                Quick Start
-                            </LemonButton>
-                        )}
+                        <LemonButton
+                            icon={<IconTrendingUp />}
+                            status="stealth"
+                            fullWidth
+                            onClick={() => {
+                                toggleActivationSideBar()
+                                hideHelp()
+                            }}
+                        >
+                            Quick Start
+                        </LemonButton>
                         {validProductTourSequences.length > 0 && (
                             <LemonButton
                                 icon={<IconMessages />}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -134,7 +134,6 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_ROLLOUT_UX: 'feature-flag-rollout-ux', // owner: @neilkakkar
     SIGNUP_PRODUCT_BENEFITS_EXPERIMENT: 'signup-product-benefits-experiment', // owner: #team-growth
     ROLE_BASED_ACCESS: 'role-based-access', // owner: #team-experiments, @liyiy
-    SECONDARY_ONBOARDING_EXPERIMENT: 'secondary-onboarding-experiment', // owner: #team-growth
     DASHBOARD_TEMPLATES: 'dashboard-templates', // owner @pauldambra
     DATA_EXPLORATION_LIVE_EVENTS: 'data-exploration-live-events', // owner @mariusandra
     BILLING_FEATURES_EXPERIMENT: 'billing-features-experiment', // owner: #team-growth


### PR DESCRIPTION
## Problem
As shown [here](https://app.posthog.com/insights/BCz83SNC) and [here](https://app.posthog.com/insights/xRkm1jLt), people in orgs who have seen the new secondary onboarding sidebar convert about 19% more to opt-ing in to session recordings, and 17% to perform a Discovery (analyse an insight, dashboard, recording, or cohort).

We therefore have decided to release this without a feature flag.

## Changes
- Remove the experiment feature flag

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- tested locally
