### PR TITLE
fix: delay on dashboard filters change

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -4,13 +4,6 @@
     .dashboard-items-action-icon {
         margin-right: 6px;
     }
-
-    .dashboard-items-action-refresh-text {
-        &.completed {
-            position: absolute;
-            left: 30px;
-        }
-    }
 }
 
 .dashboard-header {

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -98,13 +98,20 @@ export function DashboardReloadAction(): JSX.Element {
                 <span className="dashboard-items-action-icon">
                     {itemsLoading ? <LoadingOutlined /> : <ReloadOutlined />}
                 </span>
-                <span className={clsx('dashboard-items-action-refresh-text', itemsLoading && 'invisible')}>
-                    <LastRefreshText />
-                </span>
-                <span
-                    className={clsx('dashboard-items-action-refresh-text', 'completed', !itemsLoading && 'invisible')}
-                >
-                    Refreshed {refreshMetrics.completed} out of {refreshMetrics.total}
+                <span className={clsx('dashboard-items-action-refresh-text')}>
+                    {itemsLoading ? (
+                        <>
+                            {refreshMetrics.total ? (
+                                <>
+                                    Refreshed {refreshMetrics.completed} out of {refreshMetrics.total}
+                                </>
+                            ) : (
+                                <>Refreshing...</>
+                            )}
+                        </>
+                    ) : (
+                        <LastRefreshText />
+                    )}
                 </span>
             </Dropdown.Button>
         </>

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -893,6 +893,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
     })),
     listeners(({ actions, values, cache, props, sharedListeners }) => ({
+        updateFiltersSuccess: () => {
+            actions.refreshAllDashboardItems({ action: 'refresh_insights_on_filters_updated' })
+        },
         setRefreshError: sharedListeners.reportRefreshTiming,
         setRefreshStatuses: sharedListeners.reportRefreshTiming,
         setRefreshStatus: sharedListeners.reportRefreshTiming,


### PR DESCRIPTION
## Problem

Releasing dashboard query cancellation meant I was watching the dashboard more closely than usual. And thought I'd introduced a delay between changing a filter and updating the data for the user.
Actually we weren't showing the user that we were saving the filter. 

![2022-12-08 10 34 53](https://user-images.githubusercontent.com/984817/206425041-d914a5cf-7c04-489d-a71c-9261ae1a8145.gif)

## Changes

* moves updating the filter into the loader
* refreshes only the insights not the whole dashboard after loading it
* shows that spinner status in the place the user is used to looking

![show-status-not-pause](https://user-images.githubusercontent.com/984817/206424619-22e2782a-c36c-4e1e-8038-9e82515ae444.gif)

## How did you test this code?

running it locally with network throttled