### PR TITLE
chore(insights-caching): Avoid N+1 syncing tiles

### DIFF
--- a/posthog/caching/insight_caching_state.py
+++ b/posthog/caching/insight_caching_state.py
@@ -73,11 +73,13 @@ def sync_insight_cache_states():
 
     tiles = (
         DashboardTile.objects.all()
-        .prefetch_related("dashboard", "dashboard__team", "dashboard__sharingconfiguration_set", "insight")
+        .filter(insight__isnull=False)
+        .prefetch_related("dashboard", "dashboard__sharingconfiguration_set", "insight", "insight__team")
         .order_by("pk")
     )
+
     for page_of_tiles in _iterate_large_queryset(tiles, 1000):
-        batch = [upsert(tile.dashboard.team, tile, lazy_loader, execute=False) for tile in page_of_tiles]
+        batch = [upsert(tile.insight.team, tile, lazy_loader, execute=False) for tile in page_of_tiles]
         _execute_insert(batch)
 
 


### PR DESCRIPTION
Following up on https://github.com/PostHog/posthog/pull/13205 - running in prod saw a few issues with its performance.