### PR TITLE
feat: Fix lock screen race condition

### DIFF
--- a/frontend/src/scenes/billing/BillingLocked.tsx
+++ b/frontend/src/scenes/billing/BillingLocked.tsx
@@ -6,6 +6,7 @@ import { compactNumber } from 'lib/utils'
 import { LemonButton } from '@posthog/lemon-ui'
 import { IconCancel } from 'lib/components/icons'
 import { BillingLockedV2 } from './v2/BillingLocked'
+import { SpinnerOverlay } from 'lib/components/Spinner/Spinner'
 
 export const scene: SceneExport = {
     component: BillingLocked,
@@ -14,9 +15,14 @@ export const scene: SceneExport = {
 export function BillingLocked(): JSX.Element | null {
     const { billing, billingVersion } = useValues(billingLogic)
 
+    if (!billingVersion) {
+        return <SpinnerOverlay />
+    }
+
     if (billingVersion === 'v2') {
         return <BillingLockedV2 />
     }
+
     return (
         <BillingSubscribedTheme>
             <div className="flex items-center gap-2">

--- a/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
+++ b/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
@@ -49,6 +49,7 @@ export const billingTestLogic = kea<billingTestLogicType>([
         setShowLicenseDirectInput: (show: boolean) => ({ show }),
         reportBillingAlertShown: (alertConfig: BillingAlertConfig) => ({ alertConfig }),
         reportBillingV2Shown: true,
+        lockIfNecessary: true,
     }),
     connect({
         values: [featureFlagLogic, ['featureFlags'], preflightLogic, ['preflight']],
@@ -193,7 +194,7 @@ export const billingTestLogic = kea<billingTestLogicType>([
         },
     })),
 
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         reportBillingV2Shown: () => {
             posthog.capture('billing v2 shown')
         },
@@ -210,6 +211,15 @@ export const billingTestLogic = kea<billingTestLogicType>([
                 // if the activation is successful, we reload the user to get the updated billing info on the organization
                 actions.loadUser()
                 router.actions.replace('/organization/billing')
+            } else {
+                actions.lockIfNecessary()
+            }
+        },
+
+        lockIfNecessary: () => {
+            if (values.isUserLocked && router.values.location.pathname !== '/organization/billing/locked') {
+                posthog.capture('billing locked screen shown')
+                router.actions.replace(urls.billingLocked())
             }
         },
     })),
@@ -218,19 +228,17 @@ export const billingTestLogic = kea<billingTestLogicType>([
         actions.loadBilling()
     }),
 
-    urlToAction(({ actions, values }) => ({
-        '*': () => {
-            if (values.isUserLocked && router.values.location.pathname !== '/organization/billing/locked') {
-                posthog.capture('billing locked screen shown')
-                router.actions.replace(urls.billingLocked())
-            }
-        },
+    urlToAction(({ actions }) => ({
+        // IMPORTANT: This needs to be above the "*" so it takes precedence
         '/organization/billing': (_params, _search, hash) => {
             if (hash.license) {
                 actions.setShowLicenseDirectInput(true)
                 actions.setActivateLicenseValues({ license: hash.license })
                 actions.submitActivateLicense()
             }
+        },
+        '*': () => {
+            actions.lockIfNecessary()
         },
     })),
 ])


### PR DESCRIPTION
## Problem

The lock screen would show the v1 view on refresh whilst v2 is loading.
Also the router would often validate before the api request was finished which meant the initial page load might not redirect to the lock screen

## Changes

* Fixes this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->


@kappa90 this was a bit messy due to the double variants here...