### PR TITLE
chore(tests): add snapshot_postgres_queries_context context manager

### DIFF
--- a/posthog/api/test/__snapshots__/test_organization_members.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_members.ambr
@@ -47,15 +47,6 @@
 ---
 # name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.10
   '
-  SELECT (1) AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
-  '
----
-# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.11
-  '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_user" ON ("posthog_organizationmembership"."user_id" = "posthog_user"."id")
@@ -64,7 +55,7 @@
          AND "posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid) /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
   '
 ---
-# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.12
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.11
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -180,51 +171,6 @@
 ---
 # name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.6
   '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-  ORDER BY "posthog_team"."access_control" ASC,
-           "posthog_team"."id" ASC
-  LIMIT 1
-  '
----
-# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.7
-  '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -247,6 +193,27 @@
   FROM "posthog_user"
   WHERE "posthog_user"."id" = 2
   LIMIT 21 /**/
+  '
+---
+# name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.7
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
   '
 ---
 # name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.8
@@ -272,22 +239,10 @@
 ---
 # name: TestOrganizationMembersAPI.test_list_organization_members_is_not_nplus1.9
   '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
+  SELECT (1) AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1 /*controller='organization_members-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/members/%3F%24'*/
   '
 ---

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -1,48 +1,5 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags
   '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '
----
-# name: TestFeatureFlagMatcher.test_multiple_flags.1
-  '
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",
          "posthog_grouptypemapping"."group_type",
@@ -53,7 +10,7 @@
   WHERE "posthog_grouptypemapping"."team_id" = 2
   '
 ---
-# name: TestFeatureFlagMatcher.test_multiple_flags.2
+# name: TestFeatureFlagMatcher.test_multiple_flags.1
   '
   SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
@@ -67,7 +24,7 @@
          AND "posthog_person"."team_id" = 2)
   '
 ---
-# name: TestFeatureFlagMatcher.test_multiple_flags.3
+# name: TestFeatureFlagMatcher.test_multiple_flags.2
   '
   SELECT (true) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0"
@@ -77,7 +34,7 @@
          AND "posthog_group"."group_type_index" = 2)
   '
 ---
-# name: TestFeatureFlagMatcher.test_multiple_flags.4
+# name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
   SELECT ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"') AS "flag_X_condition_0",
          ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"') AS "flag_X_condition_0"
@@ -87,7 +44,7 @@
          AND "posthog_group"."group_type_index" = 2)
   '
 ---
-# name: TestFeatureFlagMatcher.test_multiple_flags.5
+# name: TestFeatureFlagMatcher.test_multiple_flags.4
   '
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",
@@ -99,7 +56,7 @@
   WHERE "posthog_grouptypemapping"."team_id" = 2
   '
 ---
-# name: TestFeatureFlagMatcher.test_multiple_flags.6
+# name: TestFeatureFlagMatcher.test_multiple_flags.5
   '
   SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
@@ -113,7 +70,7 @@
          AND "posthog_person"."team_id" = 2)
   '
 ---
-# name: TestFeatureFlagMatcher.test_multiple_flags.7
+# name: TestFeatureFlagMatcher.test_multiple_flags.6
   '
   SELECT ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"') AS "flag_X_condition_0",
          ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"') AS "flag_X_condition_0"


### PR DESCRIPTION
While working on https://github.com/PostHog/posthog/pull/13191 I added a
field to the Team model and noticed that snapshots were updated. This is
due to the snapshotting capturing all of the test code rather than just
the system under test.

I've updated the ones that were affected by that PR, there are probably
others that could do with the same treatment but I'll leave it at that
for now.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
