### PR TITLE
fix: Allow session recordings through the IP BLOCK

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -54,7 +54,7 @@ class AllowIPMiddleware:
 
     def __call__(self, request: HttpRequest):
         response: HttpResponse = self.get_response(request)
-        if request.path.split("/")[1] in ["decide", "engage", "track", "capture", "batch", "e", "static", "_health"]:
+        if request.path.split("/")[1] in ["decide", "engage", "track", "capture", "batch", "e", "s", "static", "_health"]:
             return response
         ip = self.extract_client_ip(request)
         if ip and any(ip_address(ip) in ip_network(block, strict=False) for block in self.ip_blocks):


### PR DESCRIPTION
## Problem

We want to allow the session recording endpoint through the IP block. Fixes [#7481](https://github.com/PostHog/posthog/issues/7481).

## Changes

This change allows the session recording through the IP block that is configured with set with `ALLOWED_IP_BLOCKS`.
More context in the issue: [#7481](https://github.com/PostHog/posthog/issues/7481). As described there, the `s` endpoint is the only one missing when comparing with the [public-endpoints](https://posthog.com/docs/self-host/configure/running-behind-proxy#public-endpoints) described in the PostHog docs.
