### PR TITLE
chore: make snapshots more specific for posthog/api/test/test_action.py

### DIFF
--- a/posthog/api/test/__snapshots__/test_action.ambr
+++ b/posthog/api/test/__snapshots__/test_action.ambr
@@ -26,45 +26,14 @@
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.1
   '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
+  SELECT "ee_license"."id",
+         "ee_license"."created_at",
+         "ee_license"."plan",
+         "ee_license"."valid_until",
+         "ee_license"."key",
+         "ee_license"."max_users"
+  FROM "ee_license"
+  WHERE "ee_license"."valid_until" >= '2022-12-08T13:25:51.402980+00:00'::timestamptz /**/
   '
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.10
@@ -137,51 +106,6 @@
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.12
   '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-  ORDER BY "posthog_team"."access_control" ASC,
-           "posthog_team"."id" ASC
-  LIMIT 1
-  '
----
-# name: TestActionApi.test_listing_actions_is_not_nplus1.13
-  '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -206,7 +130,7 @@
   LIMIT 21 /**/
   '
 ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.14
+# name: TestActionApi.test_listing_actions_is_not_nplus1.13
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -249,7 +173,7 @@
   LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.15
+# name: TestActionApi.test_listing_actions_is_not_nplus1.14
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -278,7 +202,7 @@
   LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.16
+# name: TestActionApi.test_listing_actions_is_not_nplus1.15
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -299,7 +223,7 @@
   LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.17
+# name: TestActionApi.test_listing_actions_is_not_nplus1.16
   '
   SELECT "posthog_action"."id",
          "posthog_action"."name",
@@ -345,7 +269,7 @@
            "posthog_action"."name" ASC /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.18
+# name: TestActionApi.test_listing_actions_is_not_nplus1.17
   '
   SELECT "posthog_actionstep"."id",
          "posthog_actionstep"."action_id",
@@ -368,102 +292,6 @@
   '
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.2
-  '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
-  '
----
-# name: TestActionApi.test_listing_actions_is_not_nplus1.3
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
-  '
----
-# name: TestActionApi.test_listing_actions_is_not_nplus1.4
-  '
-  SELECT "posthog_action"."id",
-         "posthog_action"."name",
-         "posthog_action"."team_id",
-         "posthog_action"."description",
-         "posthog_action"."created_at",
-         "posthog_action"."created_by_id",
-         "posthog_action"."deleted",
-         "posthog_action"."post_to_slack",
-         "posthog_action"."slack_message_format",
-         "posthog_action"."is_calculating",
-         "posthog_action"."updated_at",
-         "posthog_action"."last_calculated_at",
-         COUNT("posthog_action_events"."event_id") AS "count",
-         "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_action"
-  LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
-  LEFT OUTER JOIN "posthog_user" ON ("posthog_action"."created_by_id" = "posthog_user"."id")
-  WHERE ("posthog_action"."team_id" = 2
-         AND NOT "posthog_action"."deleted"
-         AND "posthog_action"."team_id" = 2)
-  GROUP BY "posthog_action"."id",
-           "posthog_user"."id"
-  ORDER BY "posthog_action"."last_calculated_at" DESC,
-           "posthog_action"."name" ASC /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
-  '
----
-# name: TestActionApi.test_listing_actions_is_not_nplus1.5
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -502,10 +330,104 @@
          "posthog_team"."event_properties_with_usage",
          "posthog_team"."event_properties_numerical"
   FROM "posthog_team"
-  WHERE "posthog_team"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-  ORDER BY "posthog_team"."access_control" ASC,
-           "posthog_team"."id" ASC
-  LIMIT 1
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
+  '
+---
+# name: TestActionApi.test_listing_actions_is_not_nplus1.3
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
+  '
+---
+# name: TestActionApi.test_listing_actions_is_not_nplus1.4
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
+  '
+---
+# name: TestActionApi.test_listing_actions_is_not_nplus1.5
+  '
+  SELECT "posthog_action"."id",
+         "posthog_action"."name",
+         "posthog_action"."team_id",
+         "posthog_action"."description",
+         "posthog_action"."created_at",
+         "posthog_action"."created_by_id",
+         "posthog_action"."deleted",
+         "posthog_action"."post_to_slack",
+         "posthog_action"."slack_message_format",
+         "posthog_action"."is_calculating",
+         "posthog_action"."updated_at",
+         "posthog_action"."last_calculated_at",
+         COUNT("posthog_action_events"."event_id") AS "count",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_action"
+  LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_action"."created_by_id" = "posthog_user"."id")
+  WHERE ("posthog_action"."team_id" = 2
+         AND NOT "posthog_action"."deleted"
+         AND "posthog_action"."team_id" = 2)
+  GROUP BY "posthog_action"."id",
+           "posthog_user"."id"
+  ORDER BY "posthog_action"."last_calculated_at" DESC,
+           "posthog_action"."name" ASC /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.6

--- a/posthog/api/test/__snapshots__/test_action.ambr
+++ b/posthog/api/test/__snapshots__/test_action.ambr
@@ -33,7 +33,7 @@
          "ee_license"."key",
          "ee_license"."max_users"
   FROM "ee_license"
-  WHERE "ee_license"."valid_until" >= '2022-12-08T13:25:51.402980+00:00'::timestamptz /**/
+  WHERE "ee_license"."valid_until" >= '2021-12-12T00:00:00+00:00'::timestamptz /**/
   '
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.10

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 from rest_framework import status
 
+from posthog.cloud_utils import TEST_clear_cloud_cache
 from posthog.models import Action, ActionStep, Organization, Tag, User
 from posthog.test.base import (
     APIBaseTest,
@@ -258,6 +259,8 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
     @freeze_time("2021-12-12")
     def test_listing_actions_is_not_nplus1(self) -> None:
+        TEST_clear_cloud_cache()  # HACK: if we do not clear the cache, we get different results in CI
+
         with self.assertNumQueries(7), snapshot_postgres_queries_context(self):
             self.client.get(f"/api/projects/{self.team.id}/actions/")
 

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -9,7 +9,7 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     QueryMatchingTest,
     _create_event,
-    snapshot_postgres_queries,
+    snapshot_postgres_queries_context,
 )
 
 
@@ -256,23 +256,22 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.get(f"/api/projects/{self.team.id}/actions/{action.id}/count").json()
         self.assertEqual(response, {"count": 1})
 
-    @snapshot_postgres_queries
     def test_listing_actions_is_not_nplus1(self) -> None:
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7), snapshot_postgres_queries_context(self):
             self.client.get(f"/api/projects/{self.team.id}/actions/")
 
         Action.objects.create(
             team=self.team, name="first", created_by=User.objects.create_and_join(self.organization, "a", "")
         )
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(7), snapshot_postgres_queries_context(self):
             self.client.get(f"/api/projects/{self.team.id}/actions/")
 
         Action.objects.create(
             team=self.team, name="second", created_by=User.objects.create_and_join(self.organization, "b", "")
         )
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(7), snapshot_postgres_queries_context(self):
             self.client.get(f"/api/projects/{self.team.id}/actions/")
 
     def test_get_tags_on_non_ee_returns_empty_list(self):

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -256,6 +256,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.get(f"/api/projects/{self.team.id}/actions/{action.id}/count").json()
         self.assertEqual(response, {"count": 1})
 
+    @freeze_time("2021-12-12")
     def test_listing_actions_is_not_nplus1(self) -> None:
         with self.assertNumQueries(7), snapshot_postgres_queries_context(self):
             self.client.get(f"/api/projects/{self.team.id}/actions/")

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from infi.clickhouse_orm import Database
 
 from posthog.client import sync_execute
-from posthog.cloud_utils import TEST_clear_cloud_cache
 from posthog.test.base import TestMixin, run_clickhouse_statement_in_parallel
 
 
@@ -131,13 +130,3 @@ def cache():
     yield django_cache
 
     django_cache.clear()
-
-
-@pytest.fixture(autouse=True)
-def reset_is_cloud_cached():
-    """
-    Make sure that before every test, we reset the is_cloud_cached value
-    otherwise we can end up with tests that pass locally but fail in CI.
-    """
-    TEST_clear_cloud_cache()
-    yield

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from infi.clickhouse_orm import Database
 
 from posthog.client import sync_execute
+from posthog.cloud_utils import TEST_clear_cloud_cache
 from posthog.test.base import TestMixin, run_clickhouse_statement_in_parallel
 
 
@@ -130,3 +131,13 @@ def cache():
     yield django_cache
 
     django_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_is_cloud_cached():
+    """
+    Make sure that before every test, we reset the is_cloud_cached value
+    otherwise we can end up with tests that pass locally but fail in CI.
+    """
+    TEST_clear_cloud_cache()
+    yield


### PR DESCRIPTION
Avoids picking up any queries that aren't part of the system under test.

I'm not sure why is_cloud isn't being cleared for these tests 🤷 

For context, I'm doing this to avoid getting unrelated snapshot updates e.g. on https://github.com/PostHog/posthog/pull/13191/files#diff-dfdfc375123a5a9cd5bcd531a922170ef6d53705ac01c8ba255833d97c9d929f

It also doesn't completely fix the underlying issue, as the `has_permissions` handling 
for views results in the entirety of team, organisation and memberships being SELECTed
from the DB.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
