### PR TITLE
fix(flags): Don't coerce strings to numbers

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import structlog
@@ -142,7 +142,10 @@ def get_decide(request: HttpRequest):
                 )
 
             property_overrides = get_geoip_properties(get_ip_address(request))
-            all_property_overrides = {**property_overrides, **(data.get("person_properties") or {})}
+            all_property_overrides: Dict[str, Union[str, int]] = {
+                **property_overrides,
+                **(data.get("person_properties") or {}),
+            }
 
             feature_flags, _ = get_active_feature_flags(
                 team.pk,

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -275,7 +275,6 @@ class Cohort(models.Model):
     def insert_users_by_list(self, items: List[str]) -> None:
         """
         Items can be distinct_id or email
-        Important! Does not insert into clickhouse
         """
         batchsize = 1000
         from posthog.models.cohort.util import insert_static_cohort

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -310,8 +310,8 @@ class FeatureFlagMatcher:
         groups: Dict[GroupTypeName, str] = {},
         cache: Optional[FlagsMatcherCache] = None,
         hash_key_overrides: Dict[str, str] = {},
-        property_value_overrides: Dict[str, str] = {},
-        group_property_value_overrides: Dict[str, Dict[str, str]] = {},
+        property_value_overrides: Dict[str, Union[str, int]] = {},
+        group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
     ):
         self.feature_flags = feature_flags
         self.distinct_id = distinct_id
@@ -431,6 +431,7 @@ class FeatureFlagMatcher:
 
     @cached_property
     def query_conditions(self) -> Dict[str, bool]:
+
         team_id = self.feature_flags[0].team_id
         person_query: QuerySet = Person.objects.filter(
             team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id
@@ -578,8 +579,8 @@ def _get_active_feature_flags(
     distinct_id: str,
     person_id: Optional[int] = None,
     groups: Dict[GroupTypeName, str] = {},
-    property_value_overrides: Dict[str, str] = {},
-    group_property_value_overrides: Dict[str, Dict[str, str]] = {},
+    property_value_overrides: Dict[str, Union[str, int]] = {},
+    group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
 ) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict]]:
     cache = FlagsMatcherCache(team_id)
 
@@ -608,8 +609,8 @@ def get_active_feature_flags(
     distinct_id: str,
     groups: Dict[GroupTypeName, str] = {},
     hash_key_override: Optional[str] = None,
-    property_value_overrides: Dict[str, str] = {},
-    group_property_value_overrides: Dict[str, Dict[str, str]] = {},
+    property_value_overrides: Dict[str, Union[str, int]] = {},
+    group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
 ) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict]]:
 
     all_feature_flags = FeatureFlag.objects.filter(team_id=team_id, active=True, deleted=False).only(

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -257,6 +257,17 @@ class Property:
             return False
         if isinstance(value, int):
             return value
+
+        # `json.loads()` converts strings to numbers if possible
+        # and we don't want this behavior, as if we wanted a number
+        # we would have passed it as a number
+        try:
+            # tests if string is a number & returns string if it is a number
+            int(value)
+            return value
+        except (ValueError, TypeError):
+            pass
+
         try:
             return json.loads(value)
         except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
## Problem

A customer complained that flags weren't working as expected (see: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1670431735297899 )

On investigation, I found that we're converting strings to numbers when we call `json.loads()` on a property value.


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
