### PR TITLE
fix: Errors due to email not being a string

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -2,7 +2,7 @@ import './PlayerMeta.scss'
 import { dayjs } from 'lib/dayjs'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
 import { useActions, useValues } from 'kea'
-import { PersonHeader } from 'scenes/persons/PersonHeader'
+import { asDisplay, PersonHeader } from 'scenes/persons/PersonHeader'
 import { playerMetaLogic } from 'scenes/session-recordings/player/playerMetaLogic'
 import { TZLabel } from 'lib/components/TZLabel'
 import { percentage } from 'lib/utils'
@@ -70,11 +70,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                     {!sessionPerson ? (
                         <LemonSkeleton.Circle className="w-12 h-12" />
                     ) : (
-                        <ProfilePicture
-                            name={sessionPerson?.name}
-                            email={sessionPerson?.properties?.$email}
-                            size={!isFullScreen ? 'xxl' : 'md'}
-                        />
+                        <ProfilePicture name={asDisplay(sessionPerson)} size={!isFullScreen ? 'xxl' : 'md'} />
                     )}
                 </div>
                 <div className="overflow-hidden ph-no-capture">


### PR DESCRIPTION
## Problem

We weren't using the `asDisplay` helper which led to a bug for a user where they couldn't load a recording as they weirdly chose to track `email` as an object 🤷 

Fixes: https://sentry.io/organizations/posthog/issues/3795924995/

## Changes

* Fixes it 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
