### PR TITLE
chore(ingestion): set ingested_event before delaying anon. events

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -5,7 +5,7 @@
     "types": "dist/index.d.ts",
     "main": "dist/index.js",
     "scripts": {
-        "test": "jest --runInBand --forceExit tests/",
+        "test": "jest --runInBand --forceExit",
         "functional_tests": "jest --config ./jest.config.functional.js",
         "start": "yarn start:dist",
         "start:dist": "BASE_DIR=.. node dist/index.js",

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -18,14 +18,6 @@ export async function emitToBufferStep(
 ): Promise<StepResult> {
     status.debug('🔁', 'Running emitToBufferStep', { event: event.event, distinct_id: event.distinct_id })
 
-    // Set `posthog_team.ingested_event` early such that e.g. the onboarding
-    // flow is allowed to proceed as soon as there has been an event starts
-    // processed as opposed to having to wait for the event to be buffered.
-    const team = await runner.hub.teamManager.fetchTeam(event.team_id)
-    if (team) {
-        await runner.hub.teamManager.setTeamIngestedEvent(team, event.properties || {})
-    }
-
     const personContainer = new LazyPersonContainer(event.team_id, event.distinct_id, runner.hub)
 
     if (event.event === '$snapshot') {
@@ -40,6 +32,14 @@ export async function emitToBufferStep(
             eventId: event.uuid,
             processEventAt,
         })
+
+        // Set `posthog_team.ingested_event` early such that e.g. the onboarding
+        // flow is allowed to proceed as soon as there has been an event starts
+        // processed as opposed to having to wait for the event to be buffered.
+        const team = await runner.hub.teamManager.fetchTeam(event.team_id)
+        if (team) {
+            await runner.hub.teamManager.setTeamIngestedEvent(team, event.properties || {})
+        }
 
         // TODO: handle delaying offset commit for this message, according to
         // producer acknowledgement. It's a little tricky as it stands as we do

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -226,7 +226,7 @@ ON CONSTRAINT posthog_eventdefinition_team_id_name_80fa0b87_uniq DO UPDATE SET l
         )
     }
 
-    private async setTeamIngestedEvent(team: Team, properties: Properties) {
+    public async setTeamIngestedEvent(team: Team, properties: Properties) {
         if (team && !team.ingested_event) {
             await this.db.postgresQuery(
                 `UPDATE posthog_team SET ingested_event = $1 WHERE id = $2`,

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -60,6 +60,10 @@ beforeEach(() => {
             kafkaProducer: {
                 queueMessage: jest.fn(),
             },
+            teamManager: {
+                setTeamIngestedEvent: jest.fn(),
+                fetchTeam: jest.fn().mockResolvedValue({ id: 2, ingested_event: false }),
+            },
         },
     }
 })
@@ -86,6 +90,14 @@ describe('emitToBufferStep()', () => {
         })
         expect(runner.hub.db.fetchPerson).toHaveBeenCalledWith(2, 'my_id')
         expect(response).toEqual(null)
+
+        // We should have also set `posthog_team.ingested_event` to true, even
+        // though the event hasn't been completely processed but is being
+        // delayed instead.
+        expect(runner.hub.teamManager.setTeamIngestedEvent).toHaveBeenCalledWith(
+            { id: 2, ingested_event: false },
+            { foo: 'bar' }
+        )
     })
 
     it('calls `pluginsProcessEventStep` next if not buffering', async () => {


### PR DESCRIPTION
Now that we delay anonymous events, we end up having a delay in the
onboarding flow where we need to wait for he flag to be set before
informing the user that an event has successfully been captured.

This is a lesser cousin of
https://github.com/PostHog/posthog/pull/13191 which offers the added
feature of informing the user of the capture date of the latest event,
but has some more work to do re. performance. I would like to get this
in first to unblock the person-on-events re-enabling for new customers.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
