### PR TITLE
fix(flags): More flexibility when passing in numbers

### DIFF
--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -263,7 +263,7 @@ class Property:
         # we would have passed it as a number
         try:
             # tests if string is a number & returns string if it is a number
-            int(value)
+            float(value)
             return value
         except (ValueError, TypeError):
             pass


### PR DESCRIPTION
Was thinking about: https://github.com/PostHog/posthog/pull/13219#discussion_r1043490034

and realised that not just integers, but floats will face the same problem as well. 

Example: "1.0" (which can be a version) being parsed as a float by `json.loads()`, vs the string "1.0"

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
