### PR TITLE
fix: Some recording events not being displayed

### DIFF
--- a/frontend/src/scenes/session-recordings/player/list/eventsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/list/eventsListLogic.test.ts
@@ -155,56 +155,63 @@ describe('eventsListLogic', () => {
             await expectLogic(logic, () => {
                 sessionRecordingDataLogic({ sessionRecordingId: '1' }).actions.loadRecordingSnapshots()
                 sessionRecordingDataLogic({ sessionRecordingId: '1' }).actions.loadRecordingMeta()
-            })
-                .toDispatchActionsInAnyOrder([
-                    sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadRecordingSnapshotsSuccess,
-                    sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadRecordingMetaSuccess,
-                    sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadEventsSuccess,
-                ])
-                .toMatchValues({
-                    eventListData: [
-                        expect.objectContaining({
-                            playerPosition: {
-                                time: 0,
-                                windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
-                            },
-                            timestamp: '2021-12-09T19:36:59.223000Z',
-                            type: 'events',
-                        }),
-                        expect.objectContaining({
-                            playerPosition: {
-                                time: 39000,
-                                windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
-                            },
-                            timestamp: '2021-12-09T19:37:39.223000Z',
-                            type: 'events',
-                        }),
-                        expect.objectContaining({
-                            playerPosition: {
-                                time: 40000,
-                                windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
-                            },
-                            timestamp: '2021-12-09T19:37:40.223000Z',
-                            type: 'events',
-                        }),
-                        expect.objectContaining({
-                            playerPosition: {
-                                time: 99000,
-                                windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
-                            },
-                            timestamp: '2021-12-09T19:38:39.223000Z',
-                            type: 'events',
-                        }),
-                        expect.objectContaining({
-                            playerPosition: {
-                                time: 159000,
-                                windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
-                            },
-                            timestamp: '2021-12-09T19:39:39.223000Z',
-                            type: 'events',
-                        }),
-                    ],
-                })
+            }).toDispatchActionsInAnyOrder([
+                sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadRecordingSnapshotsSuccess,
+                sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadRecordingMetaSuccess,
+                sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadEventsSuccess,
+            ])
+
+            expect(logic.values.eventListData).toMatchObject([
+                expect.objectContaining({
+                    playerPosition: {
+                        time: 0,
+                        windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                    },
+                    name: '$event_before_recording_starts',
+                    timestamp: '2021-12-09T19:35:59.223000Z',
+                }),
+                expect.objectContaining({
+                    playerPosition: {
+                        time: 0,
+                        windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                    },
+                    timestamp: '2021-12-09T19:36:59.223000Z',
+                    name: '$pageview',
+                }),
+                expect.objectContaining({
+                    playerPosition: {
+                        time: 40000,
+                        windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                    },
+                    timestamp: '2021-12-09T19:37:39.223000Z',
+                    name: 'blah',
+                }),
+                // NO autocapture event as wrong windowId
+                expect.objectContaining({
+                    playerPosition: {
+                        time: 41000,
+                        windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                    },
+                    timestamp: '2021-12-09T19:37:40.223000Z',
+                    name: 'backend event',
+                }),
+                expect.objectContaining({
+                    playerPosition: {
+                        time: 100000,
+                        windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
+                    },
+                    timestamp: '2021-12-09T19:38:39.223000Z',
+                    name: 'nightly',
+                }),
+                expect.objectContaining({
+                    playerPosition: {
+                        windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
+                        time: 160000,
+                    },
+                    timestamp: '2021-12-09T19:39:39.223000Z',
+                    name: 'gooddog',
+                }),
+            ])
         })
         it('should filter events by fuzzy query', async () => {
             await expectLogic(logic, () => {
@@ -235,7 +242,7 @@ describe('eventsListLogic', () => {
                     eventListData: [
                         expect.objectContaining({
                             playerPosition: {
-                                time: 99000,
+                                time: 100000,
                                 windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                             },
                             timestamp: '2021-12-09T19:38:39.223000Z',
@@ -243,7 +250,7 @@ describe('eventsListLogic', () => {
                         }),
                         expect.objectContaining({
                             playerPosition: {
-                                time: 159000,
+                                time: 160000,
                                 windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                             },
                             timestamp: '2021-12-09T19:39:39.223000Z',

--- a/frontend/src/scenes/session-recordings/player/list/listLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/list/listLogic.ts
@@ -103,7 +103,11 @@ export const listLogic = kea<listLogicType>([
         },
         handleRowClick: ({ playerPosition }) => {
             if (playerPosition) {
-                actions.seek(playerPosition)
+                // NOTE: Seek to 1 second before the event to make sure the event is visible
+                actions.seek({
+                    ...playerPosition,
+                    time: Math.max(0, playerPosition.time - 1000),
+                })
             }
         },
     })),

--- a/frontend/src/scenes/session-recordings/player/playerUtils.test.ts
+++ b/frontend/src/scenes/session-recordings/player/playerUtils.test.ts
@@ -131,21 +131,32 @@ describe('getPlayerPositionFromEpochTime', () => {
         ).toEqual({ windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f', time: 227777 })
     })
 
-    it('returns null if it does not find the player time', () => {
+    it('returns null if it does not find the player window', () => {
         expect(
             getPlayerPositionFromEpochTime(
-                1739102187000,
+                1639078847000,
+                '17da0b382b1165-00c767cd61e6e3-1c306851-13c680-17da0b382b210b-not',
+                metadata.startAndEndTimesByWindowId ?? {}
+            )
+        ).toEqual(null)
+    })
+
+    it('clamps to the nearest snapshot if the window exists', () => {
+        expect(
+            getPlayerPositionFromEpochTime(
+                0,
                 '17da0b382b1165-00c767cd61e6e3-1c306851-13c680-17da0b382b210b',
                 metadata.startAndEndTimesByWindowId ?? {}
             )
-        ).toEqual(null)
+        ).toEqual({ time: 0, windowId: '17da0b382b1165-00c767cd61e6e3-1c306851-13c680-17da0b382b210b' })
+
         expect(
             getPlayerPositionFromEpochTime(
-                1739102187000,
-                'b382b1165-00c767cd61e6e3-1c306851-13c680-17da0b382b210b',
+                999999999999999999,
+                '17da0b382b1165-00c767cd61e6e3-1c306851-13c680-17da0b382b210b',
                 metadata.startAndEndTimesByWindowId ?? {}
             )
-        ).toEqual(null)
+        ).toEqual({ time: 2684579, windowId: '17da0b382b1165-00c767cd61e6e3-1c306851-13c680-17da0b382b210b' })
     })
 })
 

--- a/frontend/src/scenes/session-recordings/player/playerUtils.ts
+++ b/frontend/src/scenes/session-recordings/player/playerUtils.ts
@@ -135,8 +135,13 @@ export function getPlayerPositionFromEpochTime(
         const windowStartTime = startAndEndTimesByWindowId[windowId].startTimeEpochMs
         const windowEndTime = startAndEndTimesByWindowId[windowId].endTimeEpochMs
 
-        if (windowStartTime > epochTime || windowEndTime < epochTime) {
-            return null
+        // We clamp the events to always be within the window range
+        // This way events that are offset by a few seconds don't get lost
+        if (windowStartTime > epochTime) {
+            epochTime = windowStartTime
+        }
+        if (windowEndTime < epochTime) {
+            epochTime = windowEndTime
         }
 
         return {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -136,6 +136,7 @@ describe('sessionRecordingDataLogic', () => {
 
     describe('loading session events', () => {
         const expectedEvents = [
+            expect.objectContaining(recordingEventsJson[0]),
             expect.objectContaining(recordingEventsJson[1]),
             expect.objectContaining(recordingEventsJson[2]),
             expect.objectContaining(recordingEventsJson[4]),
@@ -154,6 +155,33 @@ describe('sessionRecordingDataLogic', () => {
                         before: '2021-12-09T20:23:24Z',
                         person_id: 1,
                         orderBy: ['timestamp'],
+                        properties: {
+                            type: 'OR',
+                            values: [
+                                {
+                                    type: 'AND',
+                                    values: [
+                                        {
+                                            key: '$session_id',
+                                            operator: 'is_not_set',
+                                            type: 'event',
+                                            value: 'is_not_set',
+                                        },
+                                    ],
+                                },
+                                {
+                                    type: 'AND',
+                                    values: [
+                                        {
+                                            key: '$session_id',
+                                            operator: 'exact',
+                                            type: 'event',
+                                            value: ['2'],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
                     },
                 })
         })
@@ -189,24 +217,26 @@ describe('sessionRecordingDataLogic', () => {
                     },
                 })
                 .toDispatchActions([logic.actionCreators.loadEvents(firstNext), 'loadEventsSuccess'])
-                .toMatchValues({
-                    sessionEventsData: {
-                        next: undefined,
-                        events: [
-                            expect.objectContaining(recordingEventsJson[1]),
-                            expect.objectContaining(recordingEventsJson[1]),
-                            expect.objectContaining(recordingEventsJson[2]),
-                            expect.objectContaining(recordingEventsJson[2]),
-                            expect.objectContaining(recordingEventsJson[4]),
-                            expect.objectContaining(recordingEventsJson[4]),
-                            expect.objectContaining(recordingEventsJson[5]),
-                            expect.objectContaining(recordingEventsJson[5]),
-                            expect.objectContaining(recordingEventsJson[6]),
-                            expect.objectContaining(recordingEventsJson[6]),
-                        ],
-                    },
-                })
                 .toNotHaveDispatchedActions(['loadEvents'])
+
+            expect(logic.values.sessionEventsData).toMatchObject({
+                next: undefined,
+                events: [
+                    expect.objectContaining(recordingEventsJson[0]),
+                    expect.objectContaining(recordingEventsJson[1]),
+                    expect.objectContaining(recordingEventsJson[0]),
+                    expect.objectContaining(recordingEventsJson[1]),
+                    expect.objectContaining(recordingEventsJson[2]),
+                    expect.objectContaining(recordingEventsJson[2]),
+                    expect.objectContaining(recordingEventsJson[4]),
+                    expect.objectContaining(recordingEventsJson[4]),
+                    expect.objectContaining(recordingEventsJson[5]),
+                    expect.objectContaining(recordingEventsJson[5]),
+                    expect.objectContaining(recordingEventsJson[6]),
+                    expect.objectContaining(recordingEventsJson[6]),
+                ],
+            })
+
             expect(api.get).toBeCalledTimes(3)
         })
         it('server error mid-fetch', async () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -820,7 +820,7 @@ export interface RecordingTimeMixinType {
     playerTime: number | null
     playerPosition: PlayerPosition | null
     colonTimestamp?: string
-    isOutOfBand?: boolean // Did the event or console log not originate from the same client library as the recording
+    capturedInWindow?: boolean // Did the event or console log not originate from the same client library as the recording
 }
 
 export interface RecordingEventType extends EventType, RecordingTimeMixinType {


### PR DESCRIPTION
## Problem

A while ago we implemented some logic to make sure that clicking an event would move the seekbar 1 second before it happened. This actually introduced an issue we have seen elsewhere that some events were not shown when they should have been.

## Changes

* Replaces the old logic so the 1 second offset is applied on click, not when filtering events
* Changes the API call to events to pre-filter for the same `$session_id` or events without a `$session_id` (server side events)
* Ensured all events are attached to the window list, even if out of range by clamping to the start or end of the recording


**NOTE** - locally we have a helpful flag that resets the `$session_id` on page load. This has the side-effect of showing a pageview at the end of the recording as momentarily after the `$session_id` is changed. Not a big deal but good to be aware of if we see something strange.


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Mostly with my 👀 ...