### PR TITLE
feat: read action step events when calculating event usage

### DIFF
--- a/ee/clickhouse/queries/experiments/utils.py
+++ b/ee/clickhouse/queries/experiments/utils.py
@@ -25,8 +25,7 @@ def requires_flag_warning(filter: Filter, team: Team) -> bool:
     for entity in entities_to_use:
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = entity.get_action()
-            for action_step in action.steps.all():
-                events.add(action_step.event)
+            events.update(action.get_step_events())
         else:
             events.add(entity.id)
 

--- a/ee/clickhouse/queries/experiments/utils.py
+++ b/ee/clickhouse/queries/experiments/utils.py
@@ -1,3 +1,5 @@
+from typing import Set, Union
+
 from posthog.client import sync_execute
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters.filter import Filter
@@ -19,7 +21,7 @@ def requires_flag_warning(filter: Filter, team: Team) -> bool:
     {parsed_date_to}
     """
 
-    events = set()
+    events: Set[Union[int, str]] = set()
     entities_to_use = filter.entities
 
     for entity in entities_to_use:

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -580,8 +580,7 @@ class FunnelCorrelation:
         for entity in self._filter.entities:
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
-                for action_step in action.steps.all():
-                    events.add(action_step.event)
+                events.update(action.get_step_events())
             else:
                 events.add(entity.id)
 

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -6,8 +6,10 @@ from typing import (
     List,
     Literal,
     Optional,
+    Set,
     Tuple,
     TypedDict,
+    Union,
     cast,
 )
 
@@ -576,7 +578,7 @@ class FunnelCorrelation:
             )
 
     def _get_funnel_step_names(self):
-        events = set()
+        events: Set[Union[int, str]] = set()
         for entity in self._filter.entities:
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()

--- a/posthog/models/action/action.py
+++ b/posthog/models/action/action.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 
 from django.db import models
 from django.db.models import Q
@@ -44,6 +45,9 @@ class Action(models.Model):
             "has_properties": self.steps.exclude(properties=[]).exists(),
             "deleted": self.deleted,
         }
+
+    def get_step_events(self) -> List[str]:
+        return [action_step.event for action_step in self.steps.all()]
 
 
 @receiver(post_save, sender=Action)

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -516,9 +516,9 @@ class ClickhouseFunnelBase(ABC):
         filters = self._build_filters(entity, index)
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = entity.get_action()
-            for action_step in action.steps.all():
+            for action_step_event in action.get_step_events():
                 if entity_name not in self.params[entity_name]:
-                    self.params[entity_name].append(action_step.event)
+                    self.params[entity_name].append(action_step_event)
 
             action_query, action_params = format_action_filter(
                 team_id=self._team.pk,

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -148,8 +148,7 @@ class FunnelEventQuery(EventQuery):
         for entity in entities_to_use:
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
-                for action_step in action.steps.all():
-                    events.add(action_step.event)
+                events.update(action.get_step_events())
             else:
                 events.add(entity.id)
 

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Set, Tuple, Union
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters.filter import Filter
@@ -142,7 +142,7 @@ class FunnelEventQuery(EventQuery):
             self._should_join_persons = False
 
     def _get_entity_query(self, entities=None, entity_name="events") -> Tuple[str, Dict[str, Any]]:
-        events = set()
+        events: Set[Union[int, str]] = set()
         entities_to_use = entities or self._filter.entities
 
         for entity in entities_to_use:

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -273,9 +273,7 @@ class SessionRecordingList(EventQuery):
         for index, entity in enumerate(self._filter.entities):
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
-                for action_step in action.steps.all():
-                    if action_step.event not in event_names_to_filter:
-                        event_names_to_filter.append(action_step.event)
+                event_names_to_filter.extend([ae for ae in action.get_step_events() if ae not in event_names_to_filter])
             else:
                 if entity.id not in event_names_to_filter:
                     event_names_to_filter.append(entity.id)

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -281,6 +281,10 @@ def _get_insight_query_usage(team_id: int, since: datetime) -> Tuple[List[str], 
         for item_filter_event in item_filters.events:
             event_usage.append(str(item_filter_event.id))
 
+        for item_filter_action in item_filters.actions:
+            action = item_filter_action.get_action()
+            event_usage.extend(action.get_step_events())
+
         counted_properties.update(FOSSColumnOptimizer(item_filters, team_id).used_properties_with_type("event"))
 
     return event_usage, counted_properties


### PR DESCRIPTION
## Problem

We realised that calculating event property usage wasn't taking into account the events in insight actions

## Changes

this makes us more consistent in how we read events from action steps
and uses that in the event property usage calculation

## How did you test this code?

letting this PR run the tests