### PR TITLE
fix: deactivate customers remotely

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -378,10 +378,6 @@ class BillingViewset(viewsets.GenericViewSet):
             organization.available_features = data["available_features"]
             org_modified = True
 
-        if data.get("deactivated"):
-            # TODO: Mark the organization as deactivated
-            pass
-
         if org_modified:
             organization.save()
 

--- a/frontend/src/lib/components/BillingAlertsV2.tsx
+++ b/frontend/src/lib/components/BillingAlertsV2.tsx
@@ -11,7 +11,7 @@ export function BillingAlertsV2(): JSX.Element | null {
     const { currentLocation } = useValues(router)
     const [alertHidden, setAlertHidden] = useState(false)
 
-    const showAlert = billingAlert && billingVersion !== 'v2'
+    const showAlert = billingAlert && billingVersion === 'v2'
 
     useEffect(() => {
         if (showAlert) {
@@ -25,11 +25,22 @@ export function BillingAlertsV2(): JSX.Element | null {
 
     const showButton = currentLocation.pathname !== urls.organizationBilling()
 
+    if (!showAlert) {
+        return null
+    }
+
+    const buttonProps = billingAlert.contactSupport
+        ? {
+              to: 'mailto:sales@posthog.com',
+              children: 'Contact support',
+          }
+        : { to: urls.organizationBilling(), children: 'Manage billing' }
+
     return (
         <div className="my-4">
             <AlertMessage
                 type={billingAlert.status}
-                action={showButton ? { to: urls.organizationBilling(), children: 'Manage billing' } : undefined}
+                action={showButton ? buttonProps : undefined}
                 onClose={billingAlert.status !== 'error' ? () => setAlertHidden(true) : undefined}
             >
                 <b>{billingAlert.title}</b>

--- a/frontend/src/scenes/billing/v2/BillingLocked.tsx
+++ b/frontend/src/scenes/billing/v2/BillingLocked.tsx
@@ -1,32 +1,13 @@
-import { useValues } from 'kea'
-import { billingLogic } from './control/billingLogic'
 import { Billing } from '../Billing'
-import { AlertMessage } from 'lib/components/AlertMessage'
 import './BillingLocked.scss'
+import { BillingAlertsV2 } from 'lib/components/BillingAlertsV2'
 
 export function BillingLockedV2(): JSX.Element | null {
-    const { billing } = useValues(billingLogic)
-
-    const productOverLimit =
-        billing &&
-        billing.products.find((x) => {
-            return x.percentage_usage > 1
-        })
-
     return (
         <div className="BillingLocked">
             <div className="BillingLocked__main">
                 <div className="BillingLocked__content">
-                    {productOverLimit && (
-                        <div className="mb-4">
-                            <AlertMessage type="error">
-                                <b>Usage limit exceeded</b>
-                                <br />
-                                You have exceeded the usage limit for {productOverLimit.name}. Please upgrade your plan
-                                or data loss may occur.
-                            </AlertMessage>
-                        </div>
-                    )}
+                    <BillingAlertsV2 />
                     <Billing />
                 </div>
             </div>

--- a/frontend/src/scenes/billing/v2/control/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/control/billingLogic.ts
@@ -24,6 +24,7 @@ export interface BillingAlertConfig {
     status: 'info' | 'warning' | 'error'
     title: string
     message: string
+    contactSupport?: boolean
 }
 
 const parseBillingResponse = (data: Partial<BillingV2Type>): BillingV2Type => {
@@ -118,6 +119,15 @@ export const billingLogic = kea<billingLogicType>([
                             remainingHours < 24 ? pluralize(remainingHours, 'hour') : pluralize(remainingDays, 'day')
                         }.`,
                         message: `Setup billing now to ensure you don't lose access to premium features.`,
+                    }
+                }
+
+                if (billing.deactivated) {
+                    return {
+                        status: 'error',
+                        title: 'Your organization has been temporarily suspended.',
+                        message: 'Please contact support to reactivate it.',
+                        contactSupport: true,
                     }
                 }
 

--- a/frontend/src/scenes/billing/v2/control/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/control/billingLogic.ts
@@ -157,11 +157,12 @@ export const billingLogic = kea<billingLogicType>([
                 // lock cloud users without a subscription out if they are above the usage limit on any product
 
                 return Boolean(
-                    billingVersion === 'v2' &&
+                    ((billingVersion === 'v2' &&
                         !billing.has_active_subscription &&
                         billing.products.find((x) => {
                             return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
-                        }) &&
+                        })) ||
+                        billing.deactivated) &&
                         featureFlags[FEATURE_FLAGS.BILLING_LOCK_EVERYTHING]
                 )
             },

--- a/frontend/src/scenes/billing/v2/control/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/control/billingLogic.ts
@@ -169,6 +169,7 @@ export const billingLogic = kea<billingLogicType>([
                 return Boolean(
                     ((billingVersion === 'v2' &&
                         !billing.has_active_subscription &&
+                        !billing.free_trial_until &&
                         billing.products.find((x) => {
                             return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
                         })) ||

--- a/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
+++ b/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
@@ -168,6 +168,7 @@ export const billingTestLogic = kea<billingTestLogicType>([
                 return Boolean(
                     ((billingVersion === 'v2' &&
                         !billing.has_active_subscription &&
+                        !billing.free_trial_until &&
                         billing.products.find((x) => {
                             return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
                         })) ||

--- a/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
+++ b/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
@@ -24,6 +24,7 @@ export interface BillingAlertConfig {
     status: 'info' | 'warning' | 'error'
     title: string
     message: string
+    contactSupport?: boolean
 }
 
 const parseBillingResponse = (data: Partial<BillingV2Type>): BillingV2Type => {
@@ -118,6 +119,15 @@ export const billingTestLogic = kea<billingTestLogicType>([
                             remainingHours < 24 ? pluralize(remainingHours, 'hour') : pluralize(remainingDays, 'day')
                         }.`,
                         message: `Setup billing now to ensure you don't lose access to premium features.`,
+                    }
+                }
+
+                if (billing.deactivated) {
+                    return {
+                        status: 'error',
+                        title: 'Your organization has been temporarily suspended.',
+                        message: 'Please contact support to reactivate it.',
+                        contactSupport: true,
                     }
                 }
 

--- a/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
+++ b/frontend/src/scenes/billing/v2/test/billingTestLogic.ts
@@ -156,11 +156,12 @@ export const billingTestLogic = kea<billingTestLogicType>([
                 }
                 // lock cloud users without a subscription out if they are above the usage limit on any product
                 return Boolean(
-                    billingVersion === 'v2' &&
+                    ((billingVersion === 'v2' &&
                         !billing.has_active_subscription &&
                         billing.products.find((x) => {
                             return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
-                        }) &&
+                        })) ||
+                        billing.deactivated) &&
                         featureFlags[FEATURE_FLAGS.BILLING_LOCK_EVERYTHING]
                 )
             },


### PR DESCRIPTION
## Problem
- We need to be able to deactivate customers who abuse our service remotely

## Changes
- Enables using the `deactivated` attribute in the billing service to lock a customer (and its organizations) out
- Fixed a bug that prevented billing alerts from showing up

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Tested locally