### PR TITLE
feat: sorting via API in event and event properties table

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -613,6 +613,8 @@ const api = {
             limit?: number
             offset?: number
             teamId?: TeamType['id']
+            order?: string
+            search?: string
             event_type?: EventDefinitionType
         }): string {
             return new ApiRequest()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -676,6 +676,7 @@ const api = {
             is_feature_flag?: boolean
             limit?: number
             offset?: number
+            order?: string
             teamId?: TeamType['id']
         }): string {
             return new ApiRequest()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,6 +35,8 @@ import {
     RolesListParams,
     FeatureFlagAssociatedRoleType,
     SessionRecordingType,
+    DetermineEventDefinitionURLProps,
+    DeterminePropertyDefinitionURLProps,
 } from '~/types'
 import { getCurrentOrganizationId, getCurrentTeamId } from './utils/logics'
 import { CheckboxValueType } from 'antd/lib/checkbox/Group'
@@ -609,14 +611,7 @@ const api = {
             limit = EVENT_DEFINITIONS_PER_PAGE,
             teamId = getCurrentTeamId(),
             ...params
-        }: {
-            limit?: number
-            offset?: number
-            teamId?: TeamType['id']
-            order?: string
-            search?: string
-            event_type?: EventDefinitionType
-        }): string {
+        }: DetermineEventDefinitionURLProps): string {
             return new ApiRequest()
                 .eventDefinitions(teamId)
                 .withQueryString(toParams({ limit, ...params }))
@@ -671,16 +666,7 @@ const api = {
             limit = EVENT_PROPERTY_DEFINITIONS_PER_PAGE,
             teamId = getCurrentTeamId(),
             ...params
-        }: {
-            event_names?: string[]
-            excluded_properties?: string[]
-            is_event_property?: boolean
-            is_feature_flag?: boolean
-            limit?: number
-            offset?: number
-            order?: string
-            teamId?: TeamType['id']
-        }): string {
+        }: DeterminePropertyDefinitionURLProps): string {
             return new ApiRequest()
                 .propertyDefinitions(teamId)
                 .withQueryString(

--- a/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
@@ -30,8 +30,8 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
     const { eventPropertyDefinitions, eventPropertyDefinitionsLoading, filters } = useValues(
         eventPropertyDefinitionsTableLogic
     )
-    const { loadEventPropertyDefinitions, setFilters } = useActions(eventPropertyDefinitionsTableLogic)
-    const { hasDashboardCollaboration, hasIngestionTaxonomy, sorting } = useValues(organizationLogic)
+    const { loadEventPropertyDefinitions, setFilters, sorting } = useActions(eventPropertyDefinitionsTableLogic)
+    const { hasDashboardCollaboration, hasIngestionTaxonomy } = useValues(organizationLogic)
 
     const columns: LemonTableColumns<PropertyDefinition> = [
         {

--- a/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
@@ -31,7 +31,7 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
         eventPropertyDefinitionsTableLogic
     )
     const { loadEventPropertyDefinitions, setFilters } = useActions(eventPropertyDefinitionsTableLogic)
-    const { hasDashboardCollaboration, hasIngestionTaxonomy } = useValues(organizationLogic)
+    const { hasDashboardCollaboration, hasIngestionTaxonomy, sorting } = useValues(organizationLogic)
 
     const columns: LemonTableColumns<PropertyDefinition> = [
         {
@@ -48,7 +48,7 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
             render: function Render(_, definition: PropertyDefinition) {
                 return <PropertyDefinitionHeader definition={definition} hideIcon asLink />
             },
-            sorter: (a, b) => a.name.localeCompare(b.name),
+            sorter: true,
         },
         ...(hasDashboardCollaboration
             ? [
@@ -74,7 +74,7 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
                               <span className="text-muted">—</span>
                           )
                       },
-                      sorter: (a, b) => (a?.query_usage_30_day ?? 0) - (b?.query_usage_30_day ?? 0),
+                      sorter: true,
                   } as LemonTableColumn<PropertyDefinition, keyof PropertyDefinition | undefined>,
               ]
             : []),
@@ -113,6 +113,12 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
                 className="event-properties-definition-table"
                 data-attr="event-properties-definition-table"
                 loading={eventPropertyDefinitionsLoading}
+                onSort={(newSorting) =>
+                    setFilters({
+                        order: newSorting ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}` : undefined,
+                    })
+                }
+                sorting={sorting}
                 rowKey="id"
                 pagination={{
                     controlled: true,

--- a/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
@@ -169,9 +169,9 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                     url: values.eventPropertyDefinitions.current,
                     searchParams: {
                         search: values.filters.property,
+                        order: values.filters.order,
                     },
                     full: true,
-                    order: values.filters.order,
                 })
             )
         },

--- a/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
@@ -11,17 +11,14 @@ import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { loaders } from 'kea-loaders'
 import { urls } from 'scenes/urls'
-import { Sorting } from 'lib/components/LemonTable'
 
 export interface Filters {
     property: string
-    order: string
 }
 
 function cleanFilters(filter: Partial<Filters>): Filters {
     return {
         property: '',
-        order: '',
         ...filter,
     }
 }
@@ -49,7 +46,6 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
         filters: [
             {
                 property: '',
-                order: '',
             } as Filters,
             {
                 setFilters: (state, { filters }) => ({
@@ -87,14 +83,14 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                     await breakpoint(200)
                     const response = await api.get(url)
                     breakpoint()
-                    debugger
-                    const currentUrl = normalizePropertyDefinitionEndpointUrl({ url }) ?? ''
+
+                    const currentUrl = `${normalizePropertyDefinitionEndpointUrl({ url })}`
                     cache.apiCache = {
                         ...(cache.apiCache ?? {}),
                         [currentUrl]: {
                             ...response,
-                            previous: normalizePropertyDefinitionEndpointUrl(response.previous),
-                            next: normalizePropertyDefinitionEndpointUrl(response.next),
+                            previous: normalizePropertyDefinitionEndpointUrl({ url: response.previous }),
+                            next: normalizePropertyDefinitionEndpointUrl({ url: response.next }),
                             current: currentUrl,
                             page:
                                 Math.floor(
@@ -102,12 +98,10 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                                 ) + 1,
                         },
                     }
-
                     return cache.apiCache[url]
                 },
                 setLocalEventPropertyDefinition: ({ definition }) => {
                     if (!values.eventPropertyDefinitions.current) {
-                        debugger
                         return values.eventPropertyDefinitions
                     }
                     // Update cache as well
@@ -143,26 +137,6 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                 ]
             },
         ],
-        sorting: [
-            (s) => [s.filters],
-            (filters: Filters | undefined): Sorting | null => {
-                if (!filters || !filters?.order) {
-                    return {
-                        columnKey: '',
-                        order: -1,
-                    }
-                }
-                return filters.order.startsWith('-')
-                    ? {
-                          columnKey: filters.order.slice(1),
-                          order: -1,
-                      }
-                    : {
-                          columnKey: filters.order,
-                          order: 1,
-                      }
-            },
-        ],
     })),
     listeners(({ actions, values, cache }) => ({
         setFilters: () => {
@@ -173,7 +147,6 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                         search: values.filters.property,
                     },
                     full: true,
-                    order: values.filters.order || '',
                 })
             )
         },

--- a/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
@@ -6,19 +6,22 @@ import {
     normalizePropertyDefinitionEndpointUrl,
     PropertyDefinitionsPaginatedResponse,
 } from 'scenes/data-management/events/eventDefinitionsTableLogic'
-import type { eventPropertyDefinitionsTableLogicType } from './eventPropertyDefinitionsTableLogicType'
 import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { loaders } from 'kea-loaders'
 import { urls } from 'scenes/urls'
+import type { eventPropertyDefinitionsTableLogicType } from './eventPropertyDefinitionsTableLogicType'
+import { Sorting } from 'lib/components/LemonTable'
 
 export interface Filters {
     property: string
+    order: string
 }
 
 function cleanFilters(filter: Partial<Filters>): Filters {
     return {
         property: '',
+        order: '',
         ...filter,
     }
 }
@@ -46,6 +49,7 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
         filters: [
             {
                 property: '',
+                order: '',
             } as Filters,
             {
                 setFilters: (state, { filters }) => ({
@@ -137,6 +141,26 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                 ]
             },
         ],
+        sorting: [
+            (s) => [s.filters],
+            (filters: Filters | undefined): Sorting | null => {
+                if (!filters || !filters?.order) {
+                    return {
+                        columnKey: '',
+                        order: -1,
+                    }
+                }
+                return filters.order.startsWith('-')
+                    ? {
+                          columnKey: filters.order.slice(1),
+                          order: -1,
+                      }
+                    : {
+                          columnKey: filters.order,
+                          order: 1,
+                      }
+            },
+        ],
     })),
     listeners(({ actions, values, cache }) => ({
         setFilters: () => {
@@ -147,6 +171,7 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                         search: values.filters.property,
                     },
                     full: true,
+                    order: values.filters.order,
                 })
             )
         },

--- a/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
@@ -87,8 +87,8 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                     await breakpoint(200)
                     const response = await api.get(url)
                     breakpoint()
-
-                    const currentUrl = `${normalizePropertyDefinitionEndpointUrl({ url })}`
+                    debugger
+                    const currentUrl = normalizePropertyDefinitionEndpointUrl({ url }) ?? ''
                     cache.apiCache = {
                         ...(cache.apiCache ?? {}),
                         [currentUrl]: {
@@ -102,10 +102,12 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
                                 ) + 1,
                         },
                     }
+
                     return cache.apiCache[url]
                 },
                 setLocalEventPropertyDefinition: ({ definition }) => {
                     if (!values.eventPropertyDefinitions.current) {
+                        debugger
                         return values.eventPropertyDefinitions
                     }
                     // Update cache as well

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -45,7 +45,7 @@ export const scene: SceneExport = {
 
 export function EventDefinitionsTable(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
-    const { eventDefinitions, eventDefinitionsLoading, filters } = useValues(eventDefinitionsTableLogic)
+    const { eventDefinitions, eventDefinitionsLoading, filters, sorting } = useValues(eventDefinitionsTableLogic)
     const { loadEventDefinitions, setFilters } = useActions(eventDefinitionsTableLogic)
     const { hasDashboardCollaboration, hasIngestionTaxonomy } = useValues(organizationLogic)
 
@@ -64,7 +64,7 @@ export function EventDefinitionsTable(): JSX.Element {
             render: function Render(_, definition: EventDefinition) {
                 return <EventDefinitionHeader definition={definition} hideIcon asLink />
             },
-            sorter: (a, b) => a.name?.localeCompare(b.name ?? '') ?? 0,
+            sorter: true,
         },
         ...(hasDashboardCollaboration
             ? [
@@ -90,7 +90,7 @@ export function EventDefinitionsTable(): JSX.Element {
                               <span className="text-muted">—</span>
                           )
                       },
-                      sorter: (a, b) => (a?.volume_30_day ?? 0) - (b?.volume_30_day ?? 0),
+                      sorter: true,
                   } as LemonTableColumn<EventDefinition, keyof EventDefinition | undefined>,
                   {
                       title: <ThirtyDayQueryCountTitle tooltipPlacement="bottom" />,
@@ -103,7 +103,7 @@ export function EventDefinitionsTable(): JSX.Element {
                               <span className="text-muted">—</span>
                           )
                       },
-                      sorter: (a, b) => (a?.query_usage_30_day ?? 0) - (b?.query_usage_30_day ?? 0),
+                      sorter: true,
                   } as LemonTableColumn<EventDefinition, keyof EventDefinition | undefined>,
               ]
             : []),
@@ -181,6 +181,12 @@ export function EventDefinitionsTable(): JSX.Element {
                 className="events-definition-table"
                 data-attr="events-definition-table"
                 loading={eventDefinitionsLoading}
+                onSort={(newSorting) =>
+                    setFilters({
+                        order: newSorting ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}` : undefined,
+                    })
+                }
+                sorting={sorting}
                 rowKey="id"
                 pagination={{
                     controlled: true,

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -2,6 +2,10 @@ import { initKeaTests } from '~/test/init'
 import {
     EVENT_DEFINITIONS_PER_PAGE,
     eventDefinitionsTableLogic,
+    normalizeEventDefinitionEndpointUrl,
+    NormalizeEventDefinitionURLProps,
+    normalizePropertyDefinitionEndpointUrl,
+    NormalizePropertyDefinitionEndpointUrlProps,
     PROPERTY_DEFINITIONS_PER_EVENT,
 } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 import { api, MOCK_TEAM_ID } from 'lib/api.mock'
@@ -134,7 +138,139 @@ describe('eventDefinitionsTableLogic', () => {
         logic.mount()
     })
 
-    describe('normalising urls as cache keys', () => {})
+    describe('normalise urls as cache keys', () => {
+        interface NormalizeEventDefinitionURLTestCase extends NormalizeEventDefinitionURLProps {
+            expected: string | null
+        }
+
+        const testCases: NormalizeEventDefinitionURLTestCase[] = [
+            {
+                url: '',
+                full: false,
+                searchParams: undefined,
+                eventTypeFilter: undefined,
+                expected: null,
+            },
+            {
+                url: '',
+                full: true,
+                searchParams: undefined,
+                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50`,
+            },
+            {
+                url: 'anything',
+                full: false,
+                searchParams: undefined,
+                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event`,
+            },
+            {
+                url: 'anything',
+                full: true,
+                searchParams: undefined,
+                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event`,
+            },
+            {
+                url: 'anything',
+                full: true,
+                searchParams: { search: '' },
+                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event&search=`,
+            },
+            {
+                url: 'anything',
+                full: true,
+                searchParams: { search: 'tomato' },
+                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event&search=tomato`,
+            },
+            {
+                url: 'anything?offset=5',
+                full: true,
+                searchParams: { search: 'tomato' },
+                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&event_type=event&search=tomato`,
+            },
+            {
+                url: 'anything?offset=5',
+                full: true,
+                searchParams: { search: 'tomato', second: 'included' },
+                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&event_type=event&search=tomato&second=included`,
+            },
+        ]
+        testCases.forEach((testCase) => {
+            it(`should normalise ${JSON.stringify(testCase)} as ${testCase.expected}`, () => {
+                expect(normalizeEventDefinitionEndpointUrl(testCase as NormalizeEventDefinitionURLProps)).toEqual(
+                    testCase.expected
+                )
+            })
+        })
+
+        interface NormalizeEventPropertyDefinitionURLTestCase extends NormalizePropertyDefinitionEndpointUrlProps {
+            expected: string | null
+        }
+
+        const propertyDefinitionsTestCases: NormalizeEventPropertyDefinitionURLTestCase[] = [
+            {
+                url: '',
+                full: false,
+                searchParams: {},
+                expected: null,
+            },
+            {
+                url: '',
+                full: true,
+                searchParams: {},
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50`,
+            },
+            {
+                url: 'anything',
+                full: false,
+                searchParams: {},
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50`,
+            },
+            {
+                url: 'anything',
+                full: true,
+                searchParams: {},
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50`,
+            },
+            {
+                url: 'anything',
+                full: true,
+                searchParams: { search: '' },
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50&search=`,
+            },
+            {
+                url: 'anything',
+                full: true,
+                searchParams: { search: 'tomato' },
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50&search=tomato`,
+            },
+            {
+                url: 'anything?offset=5',
+                full: true,
+                searchParams: { search: 'tomato' },
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50&offset=5&search=tomato`,
+            },
+            {
+                url: 'anything?offset=5',
+                full: true,
+                searchParams: { search: 'tomato', second: 'included' },
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50&offset=5&search=tomato&second=included`,
+            },
+        ]
+        propertyDefinitionsTestCases.forEach((testCase) => {
+            it(`should normalise ${JSON.stringify(testCase)} as ${testCase.expected}`, () => {
+                expect(
+                    normalizePropertyDefinitionEndpointUrl(testCase as NormalizePropertyDefinitionEndpointUrlProps)
+                ).toEqual(testCase.expected)
+            })
+        })
+    })
 
     describe('event definitions', () => {
         it('load event definitions on navigate and cache', async () => {

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -200,6 +200,14 @@ describe('eventDefinitionsTableLogic', () => {
                 eventTypeFilter: undefined,
                 expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&event_type=event&search=tomato&second=included`,
             },
+            {
+                url: 'anything?offset=5',
+                full: true,
+                searchParams: { search: 'tomato', second: 'included' },
+                eventTypeFilter: undefined,
+                order: '-something',
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&event_type=event&order=-something&search=tomato&second=included`,
+            },
         ]
         testCases.forEach((testCase) => {
             it(`should normalise ${JSON.stringify(testCase)} as ${testCase.expected}`, () => {
@@ -260,7 +268,8 @@ describe('eventDefinitionsTableLogic', () => {
                 url: 'anything?offset=5',
                 full: true,
                 searchParams: { search: 'tomato', second: 'included' },
-                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50&offset=5&search=tomato&second=included`,
+                order: '-something',
+                expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50&offset=5&search=tomato&second=included&order=-something`,
             },
         ]
         propertyDefinitionsTestCases.forEach((testCase) => {

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -134,6 +134,8 @@ describe('eventDefinitionsTableLogic', () => {
         logic.mount()
     })
 
+    describe('normalising urls as cache keys', () => {})
+
     describe('event definitions', () => {
         it('load event definitions on navigate and cache', async () => {
             const url = urls.eventDefinitions()

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -203,17 +203,15 @@ describe('eventDefinitionsTableLogic', () => {
             {
                 url: 'anything?offset=5',
                 full: true,
-                searchParams: { search: 'tomato', second: 'included' },
+                searchParams: { search: 'tomato', second: 'included', order: '-something' },
                 eventTypeFilter: undefined,
-                order: '-something',
                 expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&second=included&order=-something&event_type=event`,
             },
             {
                 url: '',
                 full: true,
-                searchParams: { search: '' },
+                searchParams: { search: '', order: '-something' },
                 eventTypeFilter: undefined,
-                order: '-something',
                 expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=&order=-something&event_type=event`,
             },
         ]
@@ -275,8 +273,7 @@ describe('eventDefinitionsTableLogic', () => {
             {
                 url: 'anything?offset=5',
                 full: true,
-                searchParams: { search: 'tomato', second: 'included' },
-                order: '-something',
+                searchParams: { search: 'tomato', second: 'included', order: '-something' },
                 expected: `api/projects/${MOCK_TEAM_ID}/property_definitions?limit=50&offset=5&search=tomato&second=included&order=-something`,
             },
         ]

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -3,9 +3,8 @@ import {
     EVENT_DEFINITIONS_PER_PAGE,
     eventDefinitionsTableLogic,
     normalizeEventDefinitionEndpointUrl,
-    NormalizeEventDefinitionURLProps,
+    NormalizeDefinitionURLProps,
     normalizePropertyDefinitionEndpointUrl,
-    NormalizePropertyDefinitionEndpointUrlProps,
     PROPERTY_DEFINITIONS_PER_EVENT,
 } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 import { api, MOCK_TEAM_ID } from 'lib/api.mock'
@@ -141,7 +140,7 @@ describe('eventDefinitionsTableLogic', () => {
     })
 
     describe('normalise urls as cache keys', () => {
-        interface NormalizeEventDefinitionURLTestCase extends NormalizeEventDefinitionURLProps {
+        interface NormalizeEventDefinitionURLTestCase extends NormalizeDefinitionURLProps {
             expected: string | null
         }
 
@@ -150,82 +149,72 @@ describe('eventDefinitionsTableLogic', () => {
                 url: '',
                 full: false,
                 searchParams: undefined,
-                eventTypeFilter: undefined,
                 expected: null,
             },
             {
                 url: '',
                 full: true,
                 searchParams: undefined,
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50`,
             },
             {
                 url: 'anything',
                 full: false,
                 searchParams: undefined,
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50`,
             },
             {
                 url: 'anything',
                 full: true,
                 searchParams: undefined,
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50`,
             },
             {
                 url: 'anything',
                 full: true,
                 searchParams: { search: '' },
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=&event_type=event`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=`,
             },
             {
                 url: 'anything',
                 full: true,
                 searchParams: { search: 'tomato' },
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=tomato&event_type=event`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=tomato`,
             },
             {
                 url: 'anything?offset=5',
                 full: true,
                 searchParams: { search: 'tomato' },
-                eventTypeFilter: undefined,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato`,
+            },
+            {
+                url: 'anything?offset=5',
+                full: true,
+                searchParams: { search: 'tomato', event_type: 'event' },
                 expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&event_type=event`,
             },
             {
                 url: 'anything?offset=5',
                 full: true,
-                searchParams: { search: 'tomato', second: 'included' },
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&second=included&event_type=event`,
-            },
-            {
-                url: 'anything?offset=5',
-                full: true,
-                searchParams: { search: 'tomato', second: 'included', order: '-something' },
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&second=included&order=-something&event_type=event`,
+                searchParams: { search: 'tomato', event_type: 'event', order: '-something' },
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&event_type=event&order=-something`,
             },
             {
                 url: '',
                 full: true,
                 searchParams: { search: '', order: '-something' },
-                eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=&order=-something&event_type=event`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=&order=-something`,
             },
         ]
         testCases.forEach((testCase) => {
             it(`should normalise ${JSON.stringify(testCase)} as ${testCase.expected}`, () => {
-                expect(normalizeEventDefinitionEndpointUrl(testCase as NormalizeEventDefinitionURLProps)).toEqual(
+                expect(normalizeEventDefinitionEndpointUrl(testCase as NormalizeDefinitionURLProps)).toEqual(
                     testCase.expected
                 )
             })
         })
 
-        interface NormalizeEventPropertyDefinitionURLTestCase extends NormalizePropertyDefinitionEndpointUrlProps {
+        interface NormalizeEventPropertyDefinitionURLTestCase extends NormalizeDefinitionURLProps {
             expected: string | null
         }
 
@@ -281,9 +270,9 @@ describe('eventDefinitionsTableLogic', () => {
         ]
         propertyDefinitionsTestCases.forEach((testCase) => {
             it(`should normalise ${JSON.stringify(testCase)} as ${testCase.expected}`, () => {
-                expect(
-                    normalizePropertyDefinitionEndpointUrl(testCase as NormalizePropertyDefinitionEndpointUrlProps)
-                ).toEqual(testCase.expected)
+                expect(normalizePropertyDefinitionEndpointUrl(testCase as NormalizeDefinitionURLProps)).toEqual(
+                    testCase.expected
+                )
             })
         })
     })

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -156,7 +156,7 @@ describe('eventDefinitionsTableLogic', () => {
                 full: true,
                 searchParams: undefined,
                 eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event`,
             },
             {
                 url: 'anything',
@@ -177,28 +177,28 @@ describe('eventDefinitionsTableLogic', () => {
                 full: true,
                 searchParams: { search: '' },
                 eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event&search=`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=&event_type=event`,
             },
             {
                 url: 'anything',
                 full: true,
                 searchParams: { search: 'tomato' },
                 eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event&search=tomato`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=tomato&event_type=event`,
             },
             {
                 url: 'anything?offset=5',
                 full: true,
                 searchParams: { search: 'tomato' },
                 eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&event_type=event&search=tomato`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&event_type=event`,
             },
             {
                 url: 'anything?offset=5',
                 full: true,
                 searchParams: { search: 'tomato', second: 'included' },
                 eventTypeFilter: undefined,
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&event_type=event&search=tomato&second=included`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&second=included&event_type=event`,
             },
             {
                 url: 'anything?offset=5',
@@ -206,7 +206,15 @@ describe('eventDefinitionsTableLogic', () => {
                 searchParams: { search: 'tomato', second: 'included' },
                 eventTypeFilter: undefined,
                 order: '-something',
-                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&event_type=event&order=-something&search=tomato&second=included`,
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=5&search=tomato&second=included&order=-something&event_type=event`,
+            },
+            {
+                url: '',
+                full: true,
+                searchParams: { search: '' },
+                eventTypeFilter: undefined,
+                order: '-something',
+                expected: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&search=&order=-something&event_type=event`,
             },
         ]
         testCases.forEach((testCase) => {

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -24,6 +24,8 @@ describe('eventDefinitionsTableLogic', () => {
         combineUrl('', {
             limit: EVENT_DEFINITIONS_PER_PAGE,
             event_type: EventDefinitionType.Event,
+            search: '',
+            order: '',
         }).search
     }`
 
@@ -301,7 +303,7 @@ describe('eventDefinitionsTableLogic', () => {
                         count: 50,
                         results: mockEventDefinitions.slice(0, 50),
                         previous: null,
-                        next: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=50&event_type=event`,
+                        next: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=50&event_type=event&search=&order=`,
                     }),
                     apiCache: partial({
                         [startingUrl]: partial({
@@ -333,7 +335,7 @@ describe('eventDefinitionsTableLogic', () => {
                 .toMatchValues({
                     eventDefinitions: partial({
                         count: 50,
-                        next: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=50&event_type=event`,
+                        next: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=50&event_type=event&search=&order=`,
                     }),
                 })
             expect(api.get).toBeCalledTimes(1)
@@ -348,7 +350,7 @@ describe('eventDefinitionsTableLogic', () => {
                 .toMatchValues({
                     eventDefinitions: partial({
                         count: 6,
-                        previous: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event`,
+                        previous: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&event_type=event&search=&order=`,
                         next: null,
                     }),
                 })
@@ -361,7 +363,7 @@ describe('eventDefinitionsTableLogic', () => {
                 .toMatchValues({
                     eventDefinitions: partial({
                         count: 50,
-                        next: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=50&event_type=event`,
+                        next: `api/projects/${MOCK_TEAM_ID}/event_definitions?limit=50&offset=50&event_type=event&search=&order=`,
                     }),
                 })
             expect(api.get).toBeCalledTimes(2)

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -142,7 +142,13 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                 results: [],
             } as EventDefinitionsPaginatedResponse,
             {
-                loadEventDefinitions: async ({ url }, breakpoint) => {
+                loadEventDefinitions: async ({ url: _url }, breakpoint) => {
+                    let url = normalizeEventDefinitionEndpointUrl({
+                        url: _url,
+                        eventTypeFilter: values.filters.event_type,
+                        searchParams: { search: values.filters.event, order: values.filters.order },
+                    })
+
                     if (url && url in (cache.apiCache ?? {})) {
                         return cache.apiCache[url]
                     }
@@ -150,6 +156,8 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     if (!url) {
                         url = api.eventDefinitions.determineListEndpoint({
                             event_type: values.filters.event_type,
+                            search: values.filters.event,
+                            order: values.filters.order,
                         })
                     }
 
@@ -165,10 +173,12 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                             previous: normalizeEventDefinitionEndpointUrl({
                                 url: response.previous,
                                 eventTypeFilter: values.filters.event_type,
+                                searchParams: { search: values.filters.event, order: values.filters.order },
                             }),
                             next: normalizeEventDefinitionEndpointUrl({
                                 url: response.next,
                                 eventTypeFilter: values.filters.event_type,
+                                searchParams: { search: values.filters.event, order: values.filters.order },
                             }),
                             current: url,
                             page:

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -91,11 +91,11 @@ export function normalizeEventDefinitionEndpointUrl({
         ...(url
             ? {
                   ...combineUrl(url).searchParams,
-                  event_type: eventTypeFilter,
-                  ...(order ? { order } : {}),
               }
             : {}),
         ...searchParams,
+        ...(order ? { order } : {}),
+        event_type: eventTypeFilter,
     }
 
     return api.eventDefinitions.determineListEndpoint(params)
@@ -150,6 +150,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     let url = normalizeEventDefinitionEndpointUrl({
                         url: _url,
                         eventTypeFilter: values.filters.event_type,
+                        order: values.filters.order,
                     })
                     if (url && url in (cache.apiCache ?? {})) {
                         return cache.apiCache[url]
@@ -207,7 +208,6 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
             {} as Record<string, PropertyDefinitionsPaginatedResponse>,
             {
                 loadPropertiesForEvent: async ({ definition, url }, breakpoint) => {
-                    debugger
                     if (url && url in (cache.apiCache ?? {})) {
                         return {
                             ...values.eventPropertiesCacheMap,

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -156,6 +156,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                             event_type: values.filters.event_type,
                         })
                     }
+
                     await breakpoint(200)
                     cache.eventsStartTime = performance.now()
                     const response = await api.get(url)
@@ -204,6 +205,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
             {} as Record<string, PropertyDefinitionsPaginatedResponse>,
             {
                 loadPropertiesForEvent: async ({ definition, url }, breakpoint) => {
+                    debugger
                     if (url && url in (cache.apiCache ?? {})) {
                         return {
                             ...values.eventPropertiesCacheMap,

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -1,6 +1,5 @@
 import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { AnyPropertyFilter, Breadcrumb, EventDefinitionType, EventDefinition, PropertyDefinition } from '~/types'
-import type { eventDefinitionsTableLogicType } from './eventDefinitionsTableLogicType'
 import api, { PaginatedResponse } from 'lib/api'
 import { keyMappingKeys } from 'lib/components/PropertyKeyInfo'
 import { actionToUrl, combineUrl, router, urlToAction } from 'kea-router'
@@ -8,6 +7,7 @@ import { convertPropertyGroupToProperties, objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { loaders } from 'kea-loaders'
 import { urls } from 'scenes/urls'
+import type { eventDefinitionsTableLogicType } from './eventDefinitionsTableLogicType'
 import { Sorting } from 'lib/components/LemonTable'
 
 export interface EventDefinitionsPaginatedResponse extends PaginatedResponse<EventDefinition> {

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -46,40 +46,39 @@ export function createDefinitionKey(event?: EventDefinition, property?: Property
     return `${event?.id ?? 'event'}-${property?.id ?? 'property'}`
 }
 
+export interface NormalizePropertyDefinitionEndpointUrlProps {
+    url: string | null | undefined
+    searchParams?: Record<string, any>
+    full?: boolean
+}
+
 export function normalizePropertyDefinitionEndpointUrl({
     url,
     searchParams = {},
     full = false,
-    order = '',
-}: {
-    url: string | null | undefined
-    searchParams?: Record<string, any>
-    full?: boolean
-    order?: string
-}): string | null {
+}: NormalizePropertyDefinitionEndpointUrlProps): string | null {
     if (!full && !url) {
         return null
     }
     return api.propertyDefinitions.determineListEndpoint({
         ...(url ? combineUrl(url).searchParams : {}),
         ...searchParams,
-        order,
     })
 }
 
-function normalizeEventDefinitionEndpointUrl({
-    url,
-    searchParams = {},
-    full = false,
-    eventTypeFilter = EventDefinitionType.Event,
-    order = '',
-}: {
+export interface NormalizeEventDefinitionURLProps {
     url?: string | null | undefined
     searchParams?: Record<string, any>
     full?: boolean
     eventTypeFilter?: EventDefinitionType
-    order: string
-}): string | null {
+}
+
+export function normalizeEventDefinitionEndpointUrl({
+    url,
+    searchParams = {},
+    full = false,
+    eventTypeFilter = EventDefinitionType.Event,
+}: NormalizeEventDefinitionURLProps): string | null {
     if (!full && !url) {
         return null
     }
@@ -88,7 +87,6 @@ function normalizeEventDefinitionEndpointUrl({
             ? {
                   ...combineUrl(url).searchParams,
                   event_type: eventTypeFilter,
-                  order,
               }
             : {}),
         ...searchParams,
@@ -145,7 +143,6 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     let url = normalizeEventDefinitionEndpointUrl({
                         url: _url,
                         eventTypeFilter: values.filters.event_type,
-                        order: values.filters.order,
                     })
                     if (url && url in (cache.apiCache ?? {})) {
                         return cache.apiCache[url]
@@ -169,12 +166,10 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                             previous: normalizeEventDefinitionEndpointUrl({
                                 url: response.previous,
                                 eventTypeFilter: values.filters.event_type,
-                                order: values.filters.order,
                             }),
                             next: normalizeEventDefinitionEndpointUrl({
                                 url: response.next,
                                 eventTypeFilter: values.filters.event_type,
-                                order: values.filters.order,
                             }),
                             current: url,
                             page:
@@ -247,8 +242,8 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                         ...(cache.apiCache ?? {}),
                         [currentUrl]: {
                             count: response.count,
-                            previous: normalizePropertyDefinitionEndpointUrl(response.previous),
-                            next: normalizePropertyDefinitionEndpointUrl(response.next),
+                            previous: normalizePropertyDefinitionEndpointUrl({ url: response.previous }),
+                            next: normalizePropertyDefinitionEndpointUrl({ url: response.next }),
                             current: currentUrl,
                             page:
                                 Math.floor(
@@ -340,7 +335,6 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     searchParams: { search: values.filters.event },
                     full: true,
                     eventTypeFilter: values.filters.event_type,
-                    order: values.filters.order,
                 })
             )
         },

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -57,7 +57,6 @@ export function normalizePropertyDefinitionEndpointUrl({
     url,
     searchParams = {},
     full = false,
-    order = '',
 }: NormalizePropertyDefinitionEndpointUrlProps): string | null {
     if (!full && !url) {
         return null
@@ -65,7 +64,6 @@ export function normalizePropertyDefinitionEndpointUrl({
     return api.propertyDefinitions.determineListEndpoint({
         ...(url ? combineUrl(url).searchParams : {}),
         ...searchParams,
-        ...(order ? { order } : {}),
     })
 }
 
@@ -82,7 +80,6 @@ export function normalizeEventDefinitionEndpointUrl({
     searchParams = {},
     full = false,
     eventTypeFilter = EventDefinitionType.Event,
-    order = '',
 }: NormalizeEventDefinitionURLProps): string | null {
     if (!full && !url) {
         return null
@@ -94,7 +91,6 @@ export function normalizeEventDefinitionEndpointUrl({
               }
             : {}),
         ...searchParams,
-        ...(order ? { order } : {}),
         event_type: eventTypeFilter,
     }
 
@@ -146,12 +142,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                 results: [],
             } as EventDefinitionsPaginatedResponse,
             {
-                loadEventDefinitions: async ({ url: _url }, breakpoint) => {
-                    let url = normalizeEventDefinitionEndpointUrl({
-                        url: _url,
-                        eventTypeFilter: values.filters.event_type,
-                        order: values.filters.order,
-                    })
+                loadEventDefinitions: async ({ url }, breakpoint) => {
                     if (url && url in (cache.apiCache ?? {})) {
                         return cache.apiCache[url]
                     }
@@ -339,10 +330,9 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
             actions.loadEventDefinitions(
                 normalizeEventDefinitionEndpointUrl({
                     url: values.eventDefinitions.current,
-                    searchParams: { search: values.filters.event },
+                    searchParams: { search: values.filters.event, order: values.filters.order },
                     full: true,
                     eventTypeFilter: values.filters.event_type,
-                    order: values.filters.order,
                 })
             )
         },

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -46,17 +46,24 @@ export function createDefinitionKey(event?: EventDefinition, property?: Property
     return `${event?.id ?? 'event'}-${property?.id ?? 'property'}`
 }
 
-export function normalizePropertyDefinitionEndpointUrl(
-    url: string | null | undefined,
-    searchParams: Record<string, any> = {},
-    full: boolean = false
-): string | null {
+export function normalizePropertyDefinitionEndpointUrl({
+    url,
+    searchParams = {},
+    full = false,
+    order = '',
+}: {
+    url: string | null | undefined
+    searchParams?: Record<string, any>
+    full?: boolean
+    order?: string
+}): string | null {
     if (!full && !url) {
         return null
     }
     return api.propertyDefinitions.determineListEndpoint({
         ...(url ? combineUrl(url).searchParams : {}),
         ...searchParams,
+        order,
     })
 }
 
@@ -233,7 +240,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                         }
                     }
 
-                    const currentUrl = `${normalizePropertyDefinitionEndpointUrl(url)}`
+                    const currentUrl = `${normalizePropertyDefinitionEndpointUrl({ url })}`
                     cache.apiCache = {
                         ...(cache.apiCache ?? {}),
                         [currentUrl]: {

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -50,12 +50,14 @@ export interface NormalizePropertyDefinitionEndpointUrlProps {
     url: string | null | undefined
     searchParams?: Record<string, any>
     full?: boolean
+    order?: string
 }
 
 export function normalizePropertyDefinitionEndpointUrl({
     url,
     searchParams = {},
     full = false,
+    order = '',
 }: NormalizePropertyDefinitionEndpointUrlProps): string | null {
     if (!full && !url) {
         return null
@@ -63,6 +65,7 @@ export function normalizePropertyDefinitionEndpointUrl({
     return api.propertyDefinitions.determineListEndpoint({
         ...(url ? combineUrl(url).searchParams : {}),
         ...searchParams,
+        ...(order ? { order } : {}),
     })
 }
 
@@ -71,6 +74,7 @@ export interface NormalizeEventDefinitionURLProps {
     searchParams?: Record<string, any>
     full?: boolean
     eventTypeFilter?: EventDefinitionType
+    order?: string
 }
 
 export function normalizeEventDefinitionEndpointUrl({
@@ -78,6 +82,7 @@ export function normalizeEventDefinitionEndpointUrl({
     searchParams = {},
     full = false,
     eventTypeFilter = EventDefinitionType.Event,
+    order = '',
 }: NormalizeEventDefinitionURLProps): string | null {
     if (!full && !url) {
         return null
@@ -87,10 +92,12 @@ export function normalizeEventDefinitionEndpointUrl({
             ? {
                   ...combineUrl(url).searchParams,
                   event_type: eventTypeFilter,
+                  ...(order ? { order } : {}),
               }
             : {}),
         ...searchParams,
     }
+
     return api.eventDefinitions.determineListEndpoint(params)
 }
 
@@ -335,6 +342,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     searchParams: { search: values.filters.event },
                     full: true,
                     eventTypeFilter: values.filters.event_type,
+                    order: values.filters.order,
                 })
             )
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -338,8 +338,10 @@ export type ToolbarVersion = 'toolbar'
 export interface ToolbarParams {
     apiURL?: string
     jsURL?: string
-    token?: string /** public posthog-js token */
-    temporaryToken?: string /** private temporary user token */
+    /** public posthog-js token */
+    token?: string
+    /** private temporary user token */
+    temporaryToken?: string
     actionId?: number
     userIntent?: ToolbarUserIntent
     source?: ToolbarSource
@@ -1311,6 +1313,7 @@ export interface TrendsFilterType extends FilterType {
     shown_as?: ShownAsValue
     display?: ChartDisplayType
 }
+
 export interface StickinessFilterType extends FilterType {
     compare?: boolean
     show_legend?: boolean // used to show/hide legend next to insights graph
@@ -1319,6 +1322,7 @@ export interface StickinessFilterType extends FilterType {
     shown_as?: ShownAsValue
     display?: ChartDisplayType
 }
+
 export interface FunnelsFilterType extends FilterType {
     funnel_viz_type?: FunnelVizType // parameter sent to funnels API for time conversion code path
     funnel_from_step?: number // used in time to convert: initial step index to compute time to convert
@@ -1343,6 +1347,7 @@ export interface FunnelsFilterType extends FilterType {
     new_entity?: Record<string, any>[]
     hidden_legend_keys?: Record<string, boolean | undefined> // used to toggle visibilities in table and legend
 }
+
 export interface PathsFilterType extends FilterType {
     path_type?: PathType
     include_event_types?: PathType[]
@@ -1362,6 +1367,7 @@ export interface PathsFilterType extends FilterType {
     min_edge_weight?: number | undefined // Paths
     max_edge_weight?: number | undefined // Paths
 }
+
 export interface RetentionFilterType extends FilterType {
     retention_type?: RetentionType
     retention_reference?: 'total' | 'previous' // retention wrt cohort size or previous period
@@ -1370,9 +1376,11 @@ export interface RetentionFilterType extends FilterType {
     target_entity?: Record<string, any>
     period?: string
 }
+
 export interface LifecycleFilterType extends FilterType {
     shown_as?: ShownAsValue
 }
+
 export type AnyFilterType =
     | TrendsFilterType
     | StickinessFilterType
@@ -1835,6 +1843,28 @@ export interface LicenseType {
     valid_until: string
     created_at: string
 }
+
+export interface DeterminePropertyDefinitionURLProps {
+    event_names?: string[]
+    excluded_properties?: string[]
+    is_event_property?: boolean
+    is_feature_flag?: boolean
+    limit?: number
+    offset?: number
+    order?: string
+    teamId?: TeamType['id']
+}
+
+export interface DetermineEventDefinitionURLProps {
+    limit?: number
+    offset?: number
+    teamId?: TeamType['id']
+    order?: string
+    search?: string
+    event_type?: EventDefinitionType
+}
+
+export type DetermineDefinitionURLProps = DetermineEventDefinitionURLProps | DeterminePropertyDefinitionURLProps
 
 export interface EventDefinition {
     id: string

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -75,13 +75,15 @@ class EventDefinitionViewSet(
         search = self.request.GET.get("search", None)
         search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)
 
+        order = self.request.GET.get("order", "")
+
         params = {"team_id": self.team_id, "is_posthog_event": "$%", **search_kwargs}
 
         if EE_AVAILABLE and self.request.user.organization.is_feature_available(AvailableFeature.INGESTION_TAXONOMY):  # type: ignore
             from ee.models.event_definition import EnterpriseEventDefinition
 
             # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
-            sql = create_event_definitions_sql(event_type, is_enterprise=True, conditions=search_query)
+            sql = create_event_definitions_sql(event_type, is_enterprise=True, conditions=search_query, order=order)
 
             ee_event_definitions = EnterpriseEventDefinition.objects.raw(sql, params=params)
             ee_event_definitions_list = ee_event_definitions.prefetch_related(
@@ -90,7 +92,7 @@ class EventDefinitionViewSet(
 
             return ee_event_definitions_list
 
-        sql = create_event_definitions_sql(event_type, is_enterprise=False, conditions=search_query)
+        sql = create_event_definitions_sql(event_type, is_enterprise=False, conditions=search_query, order=order)
         event_definitions_list = EventDefinition.objects.raw(sql, params=params)
 
         return event_definitions_list

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Type
 
 from django.db.models import Prefetch
 from rest_framework import mixins, permissions, serializers, viewsets
@@ -75,15 +75,13 @@ class EventDefinitionViewSet(
         search = self.request.GET.get("search", None)
         search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)
 
-        order: Optional[str] = self.request.GET.get("order", "")
-
         params = {"team_id": self.team_id, "is_posthog_event": "$%", **search_kwargs}
 
         if EE_AVAILABLE and self.request.user.organization.is_feature_available(AvailableFeature.INGESTION_TAXONOMY):  # type: ignore
             from ee.models.event_definition import EnterpriseEventDefinition
 
             # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
-            sql = create_event_definitions_sql(event_type, is_enterprise=True, conditions=search_query, order=order)
+            sql = create_event_definitions_sql(event_type, is_enterprise=True, conditions=search_query)
 
             ee_event_definitions = EnterpriseEventDefinition.objects.raw(sql, params=params)
             ee_event_definitions_list = ee_event_definitions.prefetch_related(

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Optional, Type
 
 from django.db.models import Prefetch
 from rest_framework import mixins, permissions, serializers, viewsets
@@ -75,13 +75,15 @@ class EventDefinitionViewSet(
         search = self.request.GET.get("search", None)
         search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)
 
+        order: Optional[str] = self.request.GET.get("order", "")
+
         params = {"team_id": self.team_id, "is_posthog_event": "$%", **search_kwargs}
 
         if EE_AVAILABLE and self.request.user.organization.is_feature_available(AvailableFeature.INGESTION_TAXONOMY):  # type: ignore
             from ee.models.event_definition import EnterpriseEventDefinition
 
             # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
-            sql = create_event_definitions_sql(event_type, is_enterprise=True, conditions=search_query)
+            sql = create_event_definitions_sql(event_type, is_enterprise=True, conditions=search_query, order=order)
 
             ee_event_definitions = EnterpriseEventDefinition.objects.raw(sql, params=params)
             ee_event_definitions_list = ee_event_definitions.prefetch_related(

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -147,7 +147,7 @@ class QueryContext:
             if order == "name":
                 order = f"{self.posthog_eventproperty_table_join_alias}.event"
 
-            order = f"{order} {'DESC' if is_desc else 'ASC'}"
+            order = f"{order} {'DESC NULLS LAST' if is_desc else 'ASC'}"
             return dataclasses.replace(self, order=order)
         else:
             return self

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -137,7 +137,7 @@ class QueryContext:
             },
         )
 
-    def with_order(self, order: str) -> "QueryContext":
+    def with_order(self, order: Optional[str]) -> "QueryContext":
         if order:
             is_desc = False
             if order.startswith("-"):

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -144,10 +144,7 @@ class QueryContext:
                 order = order[1:]
                 is_desc = True
 
-            if order == "name":
-                order = f"{self.posthog_eventproperty_table_join_alias}.event"
-
-            order = f"{order} {'DESC NULLS LAST' if is_desc else 'ASC'}"
+            order = f"{order} {'DESC NULLS LAST' if is_desc else 'ASC NULLS FIRST'}"
             return dataclasses.replace(self, order=order)
         else:
             return self

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -73,6 +73,27 @@ class TestEventDefinitionAPI(APIBaseTest):
                 (dateutil.parser.isoparse(response_item["created_at"]) - timezone.now()).total_seconds(), 0
             )
 
+    def test_ordered_list_event_definitions(self):
+        response = self.client.get("/api/projects/@current/event_definitions/?order=-name")
+        assert [r["name"] for r in response.json()["results"]] == [
+            "watched_movie",
+            "rated_app",
+            "purchase",
+            "installed_app",
+            "entered_free_trial",
+            "$pageview",
+        ]
+
+        response = self.client.get("/api/projects/@current/event_definitions/?order=name")
+        assert [r["name"] for r in response.json()["results"]] == [
+            "$pageview",
+            "entered_free_trial",
+            "installed_app",
+            "purchase",
+            "rated_app",
+            "watched_movie",
+        ]
+
     def test_pagination_of_event_definitions(self):
         EventDefinition.objects.bulk_create(
             [EventDefinition(team=self.demo_team, name=f"z_event_{i}") for i in range(1, 301)]

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -61,6 +61,31 @@ class TestPropertyDefinitionAPI(APIBaseTest):
             self.assertEqual(response_item["query_usage_30_day"], item["query_usage_30_day"], item)
             self.assertEqual(response_item["is_numerical"], item["is_numerical"])
 
+    def test_ordered_list_property_definitions(self):
+        response = self.client.get("/api/projects/@current/property_definitions/?order=-name")
+        assert [r["name"] for r in response.json()["results"]] == [
+            "purchase_value",
+            "purchase",
+            "plan",
+            "is_first_movie",
+            "first_visit",
+            "app_rating",
+            "$current_url",
+            "$browser",
+        ]
+
+        response = self.client.get("/api/projects/@current/property_definitions/?order=name")
+        assert [r["name"] for r in response.json()["results"]] == [
+            "$browser",
+            "$current_url",
+            "app_rating",
+            "first_visit",
+            "is_first_movie",
+            "plan",
+            "purchase",
+            "purchase_value",
+        ]
+
     def test_list_numerical_property_definitions(self):
         response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?is_numerical=true")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -391,7 +391,7 @@ def _ordering(is_enterprise: bool, order: str) -> str:
             order = order[1:]
             is_desc = True
 
-        return f"ORDER BY {order} {'DESC NULLS LAST' if is_desc else 'ASC'}"
+        return f"ORDER BY {order} {'DESC NULLS LAST' if is_desc else 'ASC NULLS FIRST'}"
 
 
 def get_pk_or_uuid(queryset: QuerySet, key: Union[int, str]) -> QuerySet:


### PR DESCRIPTION
## Problem

The event and event properties tables in data management only sort the loaded page in the UI.

That's no use if you have more than one page of data

## Changes

* Adds sorting controlled by query parameter to the API endpoints
* Switches the tables to controlled sorting

## How did you test this code?

* running it locally
* .......
