### PR TITLE
feat: postgres - ch sync to support groups

### DIFF
--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -182,15 +182,15 @@ def run_group_sync(team_id: int, live_run: bool, sync: bool):
                 # Update ClickHouse via Kafka message
                 raw_create_group_ch(
                     team_id=team_id,
-                    group_type_index=pg_group["group_type_index"],
+                    group_type_index=pg_group["group_type_index"],  # type: ignore
                     group_key=pg_group["group_key"],
-                    properties=pg_group["group_properties"],
+                    properties=pg_group["group_properties"],  # type: ignore
                     created_at=pg_group["created_at"],
                     sync=sync,
                 )
 
 
-def should_update_group(ch_group, pg_group: Group) -> bool:
+def should_update_group(ch_group, pg_group) -> bool:
     return json.dumps(pg_group["group_properties"]) != ch_group["properties"] or pg_group["created_at"].strftime(
         "%Y-%m-%d %H:%M:%S"
     ) != ch_group["created_at"].strftime("%Y-%m-%d %H:%M:%S")

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -183,6 +183,7 @@ def run_group_sync(team_id: int, live_run: bool, sync: bool):
                     group_key=pg_group.group_key,
                     properties=pg_group.group_properties,
                     created_at=pg_group.created_at,
+                    sync=sync,
                 )
 
 

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -4,6 +4,8 @@ import structlog
 from django.core.management.base import BaseCommand
 
 from posthog.client import sync_execute
+from posthog.models.group.group import Group
+from posthog.models.group.util import raw_create_group_ch
 from posthog.models.person import PersonDistinctId
 from posthog.models.person.person import Person
 from posthog.models.person.util import _delete_ch_distinct_id, create_person, create_person_distinct_id
@@ -22,6 +24,7 @@ class Command(BaseCommand):
         parser.add_argument("--team-id", default=None, type=int, help="Specify a team to fix data for.")
         parser.add_argument("--person", action="store_true", help="Sync persons")
         parser.add_argument("--person-distinct-id", action="store_true", help="Sync person distinct IDs")
+        parser.add_argument("--group", action="store_true", help="Sync groups")
         parser.add_argument(
             "--deletes", action="store_true", help="process deletes for data in ClickHouse but not Postgres"
         )
@@ -46,6 +49,9 @@ def run(options, sync: bool = False):  # sync used for unittests
 
     if options["person_distinct_id"]:
         run_distinct_id_sync(team_id, live_run, deletes, sync)
+
+    if options["group"]:
+        run_group_sync(team_id, live_run, sync)
 
 
 def run_person_sync(team_id: int, live_run: bool, deletes: bool, sync: bool):
@@ -139,9 +145,46 @@ def run_distinct_id_sync(team_id: int, live_run: bool, deletes: bool, sync: bool
             continue
 
     if deletes:
+        logger.info("Processing distinct id deletions")
         postgres_distinct_ids = {person_distinct_id.distinct_id for person_distinct_id in person_distinct_ids}
         for distinct_id, version in ch_distinct_id_to_version.items():
             if distinct_id not in postgres_distinct_ids:
                 logger.info(f"Deleting distinct ID {distinct_id}")
                 if live_run:
                     _delete_ch_distinct_id(team_id, UUID(int=0), distinct_id, version, sync=sync)
+
+
+def run_group_sync(team_id: int, live_run: bool, sync: bool):
+    logger.info("Running group table sync")
+    # lookup what needs to be updated in ClickHouse and send kafka messages for only those
+    pg_groups = Group.objects.filter(team_id=team_id)
+    # unfortunately we don't have version column for groups table
+    rows = sync_execute(
+        """
+            SELECT group_type_index, group_key, group_properties, created_at FROM groups WHERE team_id = %(team_id)s ORDER BY _timestamp DESC LIMIT 1 BY group_type_index, group_key
+        """,
+        {
+            "team_id": team_id,
+        },
+    )
+    ch_groups = {row[0]: {row[1]: {"properties": row[2], "created_at": row[3]}} for row in rows}
+
+    for pg_group in pg_groups:
+        ch_group = ch_groups.get(pg_group.group_type_index, {}).get(pg_group.group_key, None)
+        if ch_group is None or should_update_group(ch_group, pg_group):
+            logger.info(
+                f"Updating {pg_group.group_type_index} - {pg_group.group_key} with properties {pg_group.group_properties} and created_at {pg_group.created_at}"
+            )
+            if live_run:
+                # Update ClickHouse via Kafka message
+                raw_create_group_ch(
+                    team_id=team_id,
+                    group_type_index=pg_group.group_type_index,
+                    group_key=pg_group.group_key,
+                    properties=pg_group.group_properties,
+                    created_at=pg_group.created_at,
+                )
+
+
+def should_update_group(ch_group, pg_group: Group) -> bool:
+    return pg_group.group_properties != ch_group["properties"] or pg_group.created_at != ch_group["created_at"]

--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID, uuid4
 
 import pytest
@@ -141,7 +141,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         self.assertEqual(ch_group[3].strftime("%Y-%m-%d %H:%M:%S"), ts.strftime("%Y-%m-%d %H:%M:%S"))
 
     def test_group_sync_updates_group(self):
-        group = create_group(self.team.pk, 2, "group-key", {"a": 5})
+        group = create_group(self.team.pk, 2, "group-key", {"a": 5}, timestamp=datetime.utcnow() - timedelta(hours=3))
         group.group_properties = {"a": 5, "b": 3}
         group.save()
 
@@ -281,7 +281,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             group_type_index=2,
             group_key="group-key",
             group_properties={"a": 1234},
-            created_at=datetime.utcnow(),
+            created_at=datetime.utcnow() - timedelta(hours=3),
             version=5,
         )
 
@@ -314,7 +314,6 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             """,
             {"team_id": self.team.pk},
         )
-        # TODO: groups at least a single one
 
         if not live_run:
             self.assertEqual(

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -20,6 +20,7 @@ def raw_create_group_ch(
     properties: Dict,
     created_at: datetime.datetime,
     timestamp: Optional[datetime.datetime] = None,
+    sync: bool = False,
 ):
     """Create ClickHouse-only Group record.
 
@@ -36,7 +37,7 @@ def raw_create_group_ch(
         "_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
     }
     p = ClickhouseProducer()
-    p.produce(topic=KAFKA_GROUPS, sql=INSERT_GROUP_SQL, data=data)
+    p.produce(topic=KAFKA_GROUPS, sql=INSERT_GROUP_SQL, data=data, sync=sync)
 
 
 def create_group(
@@ -45,6 +46,7 @@ def create_group(
     group_key: str,
     properties: Optional[Dict] = None,
     timestamp: Optional[Union[datetime.datetime, str]] = None,
+    sync: bool = False,
 ) -> Group:
     """Create proper Group record (ClickHouse + Postgres)."""
     if not properties:
@@ -58,7 +60,7 @@ def create_group(
     else:
         timestamp = timestamp.astimezone(pytz.utc)
 
-    raw_create_group_ch(team_id, group_type_index, group_key, properties, timestamp, timestamp=timestamp)
+    raw_create_group_ch(team_id, group_type_index, group_key, properties, timestamp, timestamp=timestamp, sync=sync)
     group = Group.objects.create(
         team_id=team_id,
         group_type_index=group_type_index,

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -14,18 +14,25 @@ from posthog.models.group.sql import INSERT_GROUP_SQL
 
 
 def raw_create_group_ch(
-    team_id: int, group_type_index: GroupTypeIndex, group_key: str, properties: Dict, timestamp: datetime.datetime
+    team_id: int,
+    group_type_index: GroupTypeIndex,
+    group_key: str,
+    properties: Dict,
+    created_at: datetime.datetime,
+    timestamp: Optional[datetime.datetime] = None,
 ):
     """Create ClickHouse-only Group record.
 
     DON'T USE DIRECTLY - `create_group` is the correct option,
     unless you specifically want to sync Postgres state from ClickHouse yourself."""
+    if timestamp is None:
+        timestamp = now().astimezone(pytz.utc)
     data = {
         "group_type_index": group_type_index,
         "group_key": group_key,
         "team_id": team_id,
         "group_properties": json.dumps(properties),
-        "created_at": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
+        "created_at": created_at.strftime("%Y-%m-%d %H:%M:%S.%f"),
         "_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
     }
     p = ClickhouseProducer()
@@ -38,7 +45,7 @@ def create_group(
     group_key: str,
     properties: Optional[Dict] = None,
     timestamp: Optional[Union[datetime.datetime, str]] = None,
-):
+) -> Group:
     """Create proper Group record (ClickHouse + Postgres)."""
     if not properties:
         properties = {}
@@ -51,8 +58,8 @@ def create_group(
     else:
         timestamp = timestamp.astimezone(pytz.utc)
 
-    raw_create_group_ch(team_id, group_type_index, group_key, properties, timestamp)
-    Group.objects.create(
+    raw_create_group_ch(team_id, group_type_index, group_key, properties, timestamp, timestamp=timestamp)
+    group = Group.objects.create(
         team_id=team_id,
         group_type_index=group_type_index,
         group_key=group_key,
@@ -60,6 +67,7 @@ def create_group(
         created_at=timestamp,
         version=0,
     )
+    return group
 
 
 def get_aggregation_target_field(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Groups can also be out of sync, longer term we should look into adding version there, but for now we are using `argMax(group_properties, _timestamp) ` in queries.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
