### PR TITLE
fix(billing): show the correct version

### DIFF
--- a/frontend/src/scenes/ingestion/v1/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/v1/panels/BillingPanel.tsx
@@ -70,9 +70,9 @@ export function BillingPanel(): JSX.Element {
                     <div className="text-left flex flex-col space-y-4">
                         <h1 className="ingestion-title">Add payment method</h1>
                         {testExperiment ? (
-                            <BillingV2 redirectPath={urls.ingestion() + '/billing'} />
-                        ) : (
                             <BillingV2Test redirectPath={urls.ingestion() + '/billing'} showCurrentUsage={false} />
+                        ) : (
+                            <BillingV2 redirectPath={urls.ingestion() + '/billing'} />
                         )}
 
                         <LemonDivider dashed />

--- a/frontend/src/scenes/ingestion/v2/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/BillingPanel.tsx
@@ -70,9 +70,9 @@ export function BillingPanel(): JSX.Element {
                     <div className="text-left flex flex-col space-y-4">
                         <h1 className="ingestion-title">Add payment method</h1>
                         {testExperiment ? (
-                            <BillingV2 redirectPath={urls.ingestion() + '/billing'} />
-                        ) : (
                             <BillingV2Test redirectPath={urls.ingestion() + '/billing'} showCurrentUsage={false} />
+                        ) : (
+                            <BillingV2 redirectPath={urls.ingestion() + '/billing'} />
                         )}
 
                         <LemonDivider dashed />


### PR DESCRIPTION
## Problem

On `/ingestion/billing` we were accidentally showing the test version for the control and vice versa. 

## Changes

Now showing the correct version shows.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
