### PR TITLE
chore(cohorts): add cleanup task

### DIFF
--- a/posthog/models/cohort/sql.py
+++ b/posthog/models/cohort/sql.py
@@ -96,3 +96,10 @@ FROM {PERSON_STATIC_COHORT_TABLE}
 WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s
 GROUP BY person_id, cohort_id, team_id
 """
+
+CLEAR_STALE_COHORTPEOPLE = f"""
+INSERT INTO cohortpeople
+SELECT person_id, %(cohort_id)s AS cohort_id, %(team_id)s AS team_id, sign * -1, %(version)s AS version
+FROM cohortpeople
+WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version < %(version)s
+"""

--- a/posthog/models/cohort/sql.py
+++ b/posthog/models/cohort/sql.py
@@ -99,7 +99,7 @@ GROUP BY person_id, cohort_id, team_id
 
 CLEAR_STALE_COHORTPEOPLE = f"""
 INSERT INTO cohortpeople
-SELECT person_id, %(cohort_id)s AS cohort_id, %(team_id)s AS team_id, sign * -1, %(version)s AS version
+SELECT person_id, %(cohort_id)s AS cohort_id, %(team_id)s AS team_id, sign * -1, version AS version
 FROM cohortpeople
-WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version < %(version)s
+WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND sign > 0 AND version < %(version)s
 """

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -15,6 +15,7 @@ from posthog.models.action.util import format_action_filter
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.cohort.sql import (
     CALCULATE_COHORT_PEOPLE_SQL,
+    CLEAR_STALE_COHORTPEOPLE,
     GET_COHORT_SIZE_SQL,
     GET_COHORTS_BY_PERSON_UUID,
     GET_DISTINCT_ID_BY_ENTITY_SQL,
@@ -279,7 +280,7 @@ def recalculate_cohortpeople(cohort: Cohort, pending_version: int) -> Optional[i
 
 def clear_stale_cohortpeople(cohort: Cohort, current_version: int) -> None:
     sync_execute(
-        clear_stale_cohortpeople,
+        CLEAR_STALE_COHORTPEOPLE,
         {"cohort_id": cohort.pk, "team_id": cohort.team_id, "version": current_version},
     )
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -277,6 +277,13 @@ def recalculate_cohortpeople(cohort: Cohort, pending_version: int) -> Optional[i
     return count
 
 
+def clear_stale_cohortpeople(cohort: Cohort, current_version: int) -> None:
+    sync_execute(
+        clear_stale_cohortpeople,
+        {"cohort_id": cohort.pk, "team_id": cohort.team_id, "version": current_version},
+    )
+
+
 def get_cohort_size(cohort_id: int, team_id: int) -> Optional[int]:
     count_result = sync_execute(GET_COHORT_SIZE_SQL, {"cohort_id": cohort_id, "team_id": team_id})
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from posthog.models import Cohort
 from posthog.models.cohort import get_and_update_pending_version
+from posthog.models.cohort.util import clear_stale_cohortpeople
 
 logger = structlog.get_logger(__name__)
 
@@ -36,7 +37,14 @@ def calculate_cohorts() -> None:
 
 def update_cohort(cohort: Cohort) -> None:
     pending_version = get_and_update_pending_version(cohort)
+    clear_stale_cohortpeople.delay(cohort.id, cohort.version)
     calculate_cohort_ch.delay(cohort.id, pending_version)
+
+
+@shared_task(ignore_result=True)
+def clear_stale_cohort(cohort_id: int, current_version) -> None:
+    cohort: Cohort = Cohort.objects.get(pk=cohort_id)
+    clear_stale_cohortpeople(cohort, current_version)
 
 
 @shared_task(ignore_result=True, max_retries=2)

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -37,12 +37,12 @@ def calculate_cohorts() -> None:
 
 def update_cohort(cohort: Cohort) -> None:
     pending_version = get_and_update_pending_version(cohort)
-    clear_stale_cohortpeople.delay(cohort.id, cohort.version)
+    clear_stale_cohort.delay(cohort.id, cohort.version)
     calculate_cohort_ch.delay(cohort.id, pending_version)
 
 
 @shared_task(ignore_result=True)
-def clear_stale_cohort(cohort_id: int, current_version) -> None:
+def clear_stale_cohort(cohort_id: int, current_version: int) -> None:
     cohort: Cohort = Cohort.objects.get(pk=cohort_id)
     clear_stale_cohortpeople(cohort, current_version)
 

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -99,7 +99,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
 
             calculate_cohorts()
 
-        def test_clear_cohortpeople(self):
+        def test_clear_cohortpeople(self) -> None:
             sync_execute(
                 """
             INSERT INTO cohortpeople


### PR DESCRIPTION
## Problem

- cohorts versions are stale and not always cleaned up 
- this task will continually clear old version rows by inserting the opposite sign of old version rows
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
