### PR TITLE
fix: sending unchanged dashboards list when patching insights wiped layout info :/

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -303,6 +303,10 @@ class InsightSerializer(InsightBasicSerializer):
     def _update_insight_dashboards(self, dashboards: List[Dashboard], instance: Insight) -> None:
         old_dashboard_ids = [tile.dashboard_id for tile in instance.dashboard_tiles.exclude(deleted=True).all()]
         new_dashboard_ids = [d.id for d in dashboards if not d.deleted]
+
+        if sorted(old_dashboard_ids) == sorted(new_dashboard_ids):
+            return
+
         ids_to_add = [id for id in new_dashboard_ids if id not in old_dashboard_ids]
         ids_to_remove = [id for id in old_dashboard_ids if id not in new_dashboard_ids]
         # does this user have permission on dashboards to add... if they are restricted

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1712,6 +1712,41 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertIsNotNone(after_save)
         self.assertEqual(before_save, after_save)
 
+    def test_saving_an_insight_without_changing_dashboards_does_not_update_the_dashboard_tiles(self):
+        """
+        Regression test. Sending an unchanged dashboard list to the API should not update the dashboard tiles.
+        Previously it was resetting the tiles which was removing their layouts and making dashboard tiles move about :/
+        """
+        dashboard_id, _ = self._create_dashboard({"name": "the dashboard's name"})
+        dashboard_two_id, _ = self._create_dashboard({"name": "the other dashboard's name"})
+
+        insight_id, _ = self._create_insight(
+            {"filters": {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}}
+        )
+
+        self._add_insight_to_dashboard([dashboard_id, dashboard_two_id], insight_id)
+
+        self._set_tile_layout(dashboard_id, expected_tiles_to_update=1)
+        self._set_tile_layout(dashboard_two_id, expected_tiles_to_update=1)
+
+        tiles = DashboardTile.objects.filter(insight_id=insight_id)
+        layouts = [tile.layouts for tile in tiles]
+        assert len(layouts) == 2
+        for layout in layouts:
+            assert layout != {}
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"name": "the new name", "dashboards": [dashboard_id, dashboard_two_id]},
+        )  # the UI sends entire insight objects, where these tests send individual fields
+        # here we send unchanged dashboards list to trigger the bug
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        tiles_after_save = DashboardTile.objects.filter(insight_id=insight_id)
+        layouts_after_save = [tile.layouts for tile in tiles_after_save]
+        assert layouts_after_save == layouts
+
     def test_hard_delete_is_forbidden(self) -> None:
         insight_id, _ = self._create_insight({"name": "to be deleted"})
         api_response = self.client.delete(f"/api/projects/{self.team.id}/insights/{insight_id}")
@@ -1866,3 +1901,45 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         self.maxDiff = None
         self.assertEqual(activity, expected)
+
+    def _set_tile_layout(self, dashboard_id: int, expected_tiles_to_update: int) -> None:
+        dashboard_json = self._get_dashboard(dashboard_id)
+        tiles = dashboard_json["tiles"]
+        assert len(tiles) == expected_tiles_to_update
+
+        x = 0
+        y = 0
+        for tile in tiles:
+            x += 1
+            y += 1
+
+            tile_id = tile["id"]
+            # layouts used to live on insights, but moved onto the relation from a dashboard to its insights
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/dashboards/{dashboard_id}",
+                {
+                    "tiles": [
+                        {
+                            "id": tile_id,
+                            "layouts": {
+                                "sm": {
+                                    "w": "7",
+                                    "h": "5",
+                                    "x": str(x),
+                                    "y": str(y),
+                                    "moved": "False",
+                                    "static": "False",
+                                },
+                                "xs": {"x": "0", "y": "0", "w": "6", "h": "5"},
+                            },
+                        }
+                    ]
+                },
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def _get_dashboard(self, dashboard_id: int, query_params: str = "") -> Dict:
+        response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/{query_params}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()


### PR DESCRIPTION
## Problem

Users were reporting that dashboard layouts were buggy and we couldn't consistently reproduce the problem

See #13078 

After some investigation and users sharing what was happening. Narrowed down to editing an insight causing the problem rather than editing the dashboards

That reproduction meant I could figure out that if you patch an insight with an unchanged list of dashboards then the code would wipe the tiles' layouts

This is usually fine as that code is intended to add or remove not to edit

## Changes

Skips that code if the list of dashboards is unchanged when patching an insight

## How did you test this code?

added a regression test
and confirmed locally
