### PR TITLE
fix(storybook): use node 16 for storybook-deploy workflow

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -22,10 +22,10 @@ jobs:
               with:
                   version: 7.x.x
 
-            - name: Set up Node 18
+            - name: Set up Node 16
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 16
                   cache: pnpm
                   cache-dependency-path: posthog/pnpm-lock.yaml
 


### PR DESCRIPTION
## Problem

The GitHub workflow `storybook-deploy` was broken with the switch to pnpm. This wasn't noticed in the [respective PR](https://github.com/PostHog/posthog/pull/13190), as the workflow only runs on `master`.

## Changes

Use node 16 for the workflow, which should fix the issue.

## How did you test this code?

I did a similar change to other storybook related workflows and am assuming this will solve the issue here as well.