### PR TITLE
refactor: Make persons- and groups-on-events var names accurate

### DIFF
--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -105,7 +105,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             team_id=self.team.pk,
             property_group=filter.property_groups,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self.team.actor_on_events_querying_enabled
+            if self.team.person_on_events_querying_enabled
             else PersonPropertiesMode.USING_SUBQUERY,
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
@@ -146,7 +146,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             team_id=self.team.pk,
             property_group=filter.property_groups,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self.team.actor_on_events_querying_enabled
+            if self.team.person_on_events_querying_enabled
             else PersonPropertiesMode.USING_SUBQUERY,
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
@@ -160,7 +160,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             team_id=self.team.pk,
             property_group=filter.property_groups,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self.team.actor_on_events_querying_enabled
+            if self.team.person_on_events_querying_enabled
             else PersonPropertiesMode.USING_SUBQUERY,
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
@@ -201,7 +201,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             team_id=self.team.pk,
             property_group=filter.property_groups,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self.team.actor_on_events_querying_enabled
+            if self.team.person_on_events_querying_enabled
             else PersonPropertiesMode.USING_SUBQUERY,
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
@@ -215,7 +215,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             team_id=self.team.pk,
             property_group=filter.property_groups,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self.team.actor_on_events_querying_enabled
+            if self.team.person_on_events_querying_enabled
             else PersonPropertiesMode.USING_SUBQUERY,
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -736,7 +736,7 @@ def test_breakdown_query_expression_materialised(
     with override_instance_config("GROUPS_ON_EVENTS_ENABLED", True):
         from posthog.models.team import util
 
-        util.can_enable_person_on_events = True
+        util.can_enable_actor_on_events = True
 
         materialize(table, breakdown[0], table_column="properties")
         actual = get_single_or_multi_property_string_expr(

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -151,7 +151,7 @@ class FunnelCorrelation:
     def properties_to_include(self) -> List[str]:
         props_to_include = []
         if (
-            self._team.actor_on_events_querying_enabled
+            self._team.person_on_events_querying_enabled
             and self._filter.correlation_type == FunnelCorrelationType.PROPERTIES
         ):
             # When dealing with properties, make sure funnel response comes with properties
@@ -428,7 +428,7 @@ class FunnelCorrelation:
 
     def _get_aggregation_target_join_query(self) -> str:
 
-        if self._team.actor_on_events_querying_enabled:
+        if self._team.person_on_events_querying_enabled:
             aggregation_person_join = f"""
                 JOIN funnel_actors as actors
                     ON event.person_id = actors.actor_id
@@ -495,7 +495,7 @@ class FunnelCorrelation:
 
     def _get_aggregation_join_query(self):
         if self._filter.aggregation_group_type_index is None:
-            if self._team.actor_on_events_querying_enabled and groups_on_events_querying_enabled():
+            if self._team.person_on_events_querying_enabled and groups_on_events_querying_enabled():
                 return "", {}
 
             person_query, person_query_params = PersonQuery(
@@ -514,7 +514,7 @@ class FunnelCorrelation:
 
     def _get_properties_prop_clause(self):
 
-        if self._team.actor_on_events_querying_enabled and groups_on_events_querying_enabled():
+        if self._team.person_on_events_querying_enabled and groups_on_events_querying_enabled():
             group_properties_field = f"group{self._filter.aggregation_group_type_index}_properties"
             aggregation_properties_alias = (
                 "person_properties" if self._filter.aggregation_group_type_index is None else group_properties_field
@@ -548,7 +548,7 @@ class FunnelCorrelation:
                 param_name = f"property_name_{index}"
                 if self._filter.aggregation_group_type_index is not None:
                     expression, _ = get_property_string_expr(
-                        "groups" if not self._team.actor_on_events_querying_enabled else "events",
+                        "groups" if not self._team.person_on_events_querying_enabled else "events",
                         property_name,
                         f"%({param_name})s",
                         aggregation_properties_alias,
@@ -556,12 +556,12 @@ class FunnelCorrelation:
                     )
                 else:
                     expression, _ = get_property_string_expr(
-                        "person" if not self._team.actor_on_events_querying_enabled else "events",
+                        "person" if not self._team.person_on_events_querying_enabled else "events",
                         property_name,
                         f"%({param_name})s",
                         aggregation_properties_alias,
                         materialised_table_column=aggregation_properties_alias
-                        if self._team.actor_on_events_querying_enabled
+                        if self._team.person_on_events_querying_enabled
                         else "properties",
                     )
                 person_property_params[param_name] = property_name

--- a/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
@@ -81,11 +81,11 @@ class _FunnelEventsCorrelationActors(ActorBaseQuery):
         prop_query, prop_params = event_query._get_prop_groups(
             prop_filters,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self._team.actor_on_events_querying_enabled
+            if self._team.person_on_events_querying_enabled
             else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
             person_id_joined_alias=f"""{
                 event_query.DISTINCT_ID_TABLE_ALIAS
-                if not self._team.actor_on_events_querying_enabled
+                if not self._team.person_on_events_querying_enabled
                 else event_query.EVENT_TABLE_ALIAS}.person_id""",
         )
 

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -47,7 +47,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
             filter=filter,
             entity=entity,
             team=self.team,
-            using_person_on_events=self.team.actor_on_events_querying_enabled,
+            using_person_on_events=self.team.person_on_events_querying_enabled,
         ).get_query()
 
         result = sync_execute(query, params)

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -250,7 +250,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
     def test_groups_in_period_person_on_events(self):
         from posthog.models.team import util
 
-        util.can_enable_person_on_events = True
+        util.can_enable_actor_on_events = True
         self._create_groups_and_events()
 
         filter = RetentionFilter(

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -118,7 +118,7 @@ export const FEATURE_FLAGS = {
     BILLING_LOCK_EVERYTHING: 'billing-lock-everything', // owner @timgl
     CANCEL_RUNNING_QUERIES: 'cancel-running-queries', // owner @timgl
     HISTORICAL_EXPORTS_V2: 'historical-exports-v2', // owner @macobo
-    ACTOR_ON_EVENTS_QUERYING: 'person-on-events-enabled', //owner: @EDsCODE
+    PERSON_ON_EVENTS_ENABLED: 'person-on-events-enabled', //owner: @EDsCODE
     REGION_SELECT: 'region-select', //owner: @kappa90
     INGESTION_WARNINGS_ENABLED: 'ingestion-warnings-enabled', // owner: @tiina303
     HOG_BOOK: 'hog-book', // owner: @pauldambra

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -16,7 +16,7 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.instance_setting import get_instance_setting
-from posthog.models.team.util import person_on_events_ready
+from posthog.models.team.util import actor_on_events_ready
 from posthog.models.utils import UUIDClassicModel, generate_random_token_project, sane_repr
 from posthog.settings.utils import get_list
 from posthog.utils import GenericEmails
@@ -210,13 +210,13 @@ class Team(UUIDClassicModel):
         return self.get_effective_membership_level_for_parent_membership(requesting_parent_membership)
 
     @property
-    def actor_on_events_querying_enabled(self) -> bool:
-        result = self._actor_on_events_querying_enabled
+    def person_on_events_querying_enabled(self) -> bool:
+        result = self._person_on_events_querying_enabled
         tag_queries(person_on_events_enabled=result)
         return result
 
     @cached_property
-    def _actor_on_events_querying_enabled(self) -> bool:
+    def _person_on_events_querying_enabled(self) -> bool:
         if settings.PERSON_ON_EVENTS_OVERRIDE is not None:
             return settings.PERSON_ON_EVENTS_OVERRIDE
 
@@ -233,7 +233,7 @@ class Team(UUIDClassicModel):
             )
 
         # If the async migration is not complete, don't enable actor on events querying.
-        if not person_on_events_ready():
+        if not actor_on_events_ready():
             return False
 
         # on self-hosted, use the instance setting
@@ -280,7 +280,7 @@ def groups_on_events_querying_enabled():
 
     Remove all usages of this when the feature is released to everyone.
     """
-    return person_on_events_ready() and get_instance_setting("GROUPS_ON_EVENTS_ENABLED")
+    return actor_on_events_ready() and get_instance_setting("GROUPS_ON_EVENTS_ENABLED")
 
 
 def get_available_features_for_team(team_id: int):

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -23,19 +23,19 @@ def _raw_delete(queryset: Any):
     queryset._raw_delete(queryset.db)
 
 
-can_enable_person_on_events = False
+can_enable_actor_on_events = False
 
 # :TRICKY: Avoid overly eagerly checking whether the migration is complete.
 # We instead cache negative responses for a minute and a positive one forever.
-def person_on_events_ready() -> bool:
-    global can_enable_person_on_events
+def actor_on_events_ready() -> bool:
+    global can_enable_actor_on_events
 
-    if can_enable_person_on_events:
+    if can_enable_actor_on_events:
         return True
-    can_enable_person_on_events = _person_on_events_ready()
-    return can_enable_person_on_events
+    can_enable_actor_on_events = _actor_on_events_ready()
+    return can_enable_actor_on_events
 
 
 @cache_for(timedelta(minutes=1))
-def _person_on_events_ready() -> bool:
+def _actor_on_events_ready() -> bool:
     return is_async_migration_complete("0007_persons_and_groups_on_events_backfill")

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -72,7 +72,7 @@ def get_breakdown_prop_values(
     sessions_join_clause = ""
     sessions_join_params: Dict = {}
 
-    null_person_filter = f"AND e.person_id != toUUIDOrZero('')" if team.actor_on_events_querying_enabled else ""
+    null_person_filter = f"AND e.person_id != toUUIDOrZero('')" if team.person_on_events_querying_enabled else ""
 
     if person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS:
         outer_properties: Optional[PropertyGroup] = props_to_filter
@@ -120,7 +120,7 @@ def get_breakdown_prop_values(
         from posthog.queries.funnels.funnel_event_query import FunnelEventQuery
 
         entity_filter, entity_params = FunnelEventQuery(
-            filter, team, using_person_on_events=team.actor_on_events_querying_enabled
+            filter, team, using_person_on_events=team.person_on_events_querying_enabled
         )._get_entity_query()
         entity_format_params = {"entity_query": entity_filter}
     else:

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -141,7 +141,7 @@ class FOSSCohortQuery(EventQuery):
             extra_event_properties=extra_event_properties,
             extra_person_fields=extra_person_fields,
             override_aggregate_users_by_distinct_id=override_aggregate_users_by_distinct_id,
-            using_person_on_events=team.actor_on_events_querying_enabled,
+            using_person_on_events=team.person_on_events_querying_enabled,
             **kwargs,
         )
 

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -405,7 +405,7 @@ class ClickhouseFunnelBase(ABC):
             team=self._team,
             extra_fields=[*self._extra_event_fields, *extra_fields],
             extra_event_properties=self._extra_event_properties,
-            using_person_on_events=self._team.actor_on_events_querying_enabled,
+            using_person_on_events=self._team.person_on_events_querying_enabled,
         ).get_query(entities_to_use, entity_name, skip_entity_filter=skip_entity_filter)
 
         self.params.update(params)
@@ -525,7 +525,7 @@ class ClickhouseFunnelBase(ABC):
                 action=action,
                 prepend=f"{entity_name}_{step_prefix}step_{index}",
                 person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-                if self._team.actor_on_events_querying_enabled
+                if self._team.person_on_events_querying_enabled
                 else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
                 person_id_joined_alias="person_id",
             )
@@ -548,7 +548,7 @@ class ClickhouseFunnelBase(ABC):
             property_group=entity.property_groups,
             prepend=str(index),
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self._team.actor_on_events_querying_enabled
+            if self._team.person_on_events_querying_enabled
             else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
             person_id_joined_alias="person_id",
         )
@@ -694,7 +694,7 @@ class ClickhouseFunnelBase(ABC):
         self.params.update({"breakdown": self._filter.breakdown})
         if self._filter.breakdown_type == "person":
 
-            if self._team.actor_on_events_querying_enabled:
+            if self._team.person_on_events_querying_enabled:
                 basic_prop_selector = get_single_or_multi_property_string_expr(
                     self._filter.breakdown,
                     table="events",
@@ -721,7 +721,7 @@ class ClickhouseFunnelBase(ABC):
             # :TRICKY: We only support string breakdown for group properties
             assert isinstance(self._filter.breakdown, str)
 
-            if self._team.actor_on_events_querying_enabled and groups_on_events_querying_enabled():
+            if self._team.person_on_events_querying_enabled and groups_on_events_querying_enabled():
                 properties_field = f"group{self._filter.breakdown_group_type_index}_properties"
                 expression, _ = get_property_string_expr(
                     table="events",
@@ -821,7 +821,7 @@ class ClickhouseFunnelBase(ABC):
                 extra_params={"offset": 0},
                 use_all_funnel_entities=use_all_funnel_entities,
                 person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-                if self._team.actor_on_events_querying_enabled
+                if self._team.person_on_events_querying_enabled
                 else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
             )
 

--- a/posthog/queries/paths/paths.py
+++ b/posthog/queries/paths/paths.py
@@ -155,7 +155,7 @@ class Paths:
             team=self._team,
             extra_fields=self._extra_event_fields,
             extra_event_properties=self._extra_event_properties,
-            using_person_on_events=self._team.actor_on_events_querying_enabled,
+            using_person_on_events=self._team.person_on_events_querying_enabled,
         ).get_query()
         self.params.update(params)
 

--- a/posthog/queries/retention/actors_query.py
+++ b/posthog/queries/retention/actors_query.py
@@ -108,7 +108,7 @@ def build_actor_activity_query(
         filter=filter,
         team=team,
         aggregate_users_by_distinct_id=aggregate_users_by_distinct_id,
-        using_person_on_events=team.actor_on_events_querying_enabled,
+        using_person_on_events=team.person_on_events_querying_enabled,
         retention_events_query=retention_events_query,
     )
 
@@ -116,7 +116,7 @@ def build_actor_activity_query(
         filter=filter,
         team=team,
         aggregate_users_by_distinct_id=aggregate_users_by_distinct_id,
-        using_person_on_events=team.actor_on_events_querying_enabled,
+        using_person_on_events=team.person_on_events_querying_enabled,
         retention_events_query=retention_events_query,
     )
 

--- a/posthog/queries/stickiness/stickiness.py
+++ b/posthog/queries/stickiness/stickiness.py
@@ -31,7 +31,7 @@ class Stickiness:
 
     def stickiness(self, entity: Entity, filter: StickinessFilter, team: Team) -> Dict[str, Any]:
         events_query, event_params = self.event_query_class(
-            entity, filter, team, using_person_on_events=team.actor_on_events_querying_enabled
+            entity, filter, team, using_person_on_events=team.person_on_events_querying_enabled
         ).get_query()
 
         query = f"""

--- a/posthog/queries/stickiness/stickiness_actors.py
+++ b/posthog/queries/stickiness/stickiness_actors.py
@@ -27,7 +27,7 @@ class StickinessActors(ActorBaseQuery):
             entity=self.entity,
             filter=self._filter,
             team=self._team,
-            using_person_on_events=self._team.actor_on_events_querying_enabled,
+            using_person_on_events=self._team.person_on_events_querying_enabled,
         ).get_query()
 
         return (

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -267,7 +267,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", True):
                 from posthog.models.team import util
 
-                util.can_enable_person_on_events = True
+                util.can_enable_actor_on_events = True
 
                 response = Trends().run(Filter(data=data), self.team)
                 self.assertEqual(response[0]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0])

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -33,7 +33,7 @@ from posthog.utils import encode_get_request_params
 class Lifecycle:
     def _format_lifecycle_query(self, entity: Entity, filter: Filter, team: Team) -> Tuple[str, Dict, Callable]:
         event_query, event_params = LifecycleEventQuery(
-            team=team, filter=filter, using_person_on_events=team.actor_on_events_querying_enabled
+            team=team, filter=filter, using_person_on_events=team.person_on_events_querying_enabled
         ).get_query()
 
         return (
@@ -60,7 +60,7 @@ class Lifecycle:
 
     def get_people(self, filter: Filter, team: Team, target_date: datetime, lifecycle_type: str):
         event_query, event_params = LifecycleEventQuery(
-            team=team, filter=filter, using_person_on_events=team.actor_on_events_querying_enabled
+            team=team, filter=filter, using_person_on_events=team.person_on_events_querying_enabled
         ).get_query()
 
         result = insight_sync_execute(

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -54,7 +54,7 @@ class TrendsTotalVolume:
             if join_condition != ""
             or (entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE] and not team.aggregate_users_by_distinct_id)
             else False,
-            using_person_on_events=team.actor_on_events_querying_enabled,
+            using_person_on_events=team.person_on_events_querying_enabled,
         )
         event_query, event_query_params = trend_event_query.get_query()
 

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -36,7 +36,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
         if filter.breakdown and filter.display not in NON_BREAKDOWN_DISPLAY_TYPES:
             query_type = "trends_breakdown"
             sql, params, parse_function = TrendsBreakdown(
-                entity, filter, team, using_person_on_events=team.actor_on_events_querying_enabled
+                entity, filter, team, using_person_on_events=team.person_on_events_querying_enabled
             ).get_query()
         elif filter.shown_as == TRENDS_LIFECYCLE:
             query_type = "trends_lifecycle"

--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -121,10 +121,10 @@ class TrendsActors(ActorBaseQuery):
             team=self._team,
             entity=self.entity,
             should_join_distinct_ids=not self.is_aggregating_by_groups
-            and not self._team.actor_on_events_querying_enabled,
+            and not self._team.person_on_events_querying_enabled,
             extra_event_properties=["$window_id", "$session_id"] if self._filter.include_recordings else [],
             extra_fields=extra_fields,
-            using_person_on_events=self._team.actor_on_events_querying_enabled,
+            using_person_on_events=self._team.person_on_events_querying_enabled,
         ).get_query()
 
         matching_events_select_statement = (

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -127,7 +127,7 @@ class TestMixin:
         if get_instance_setting("PERSON_ON_EVENTS_ENABLED"):
             from posthog.models.team import util
 
-            util.can_enable_person_on_events = True
+            util.can_enable_actor_on_events = True
 
         if not self.CLASS_DATA_LEVEL_SETUP:
             _setup_test_data(self)

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -7,7 +7,7 @@ from posthog.plugins.test.mock import mocked_plugin_requests_get
 
 from .base import BaseTest
 
-util.can_enable_person_on_events = True
+util.can_enable_actor_on_events = True
 
 
 class TestTeam(BaseTest):
@@ -72,7 +72,7 @@ class TestTeam(BaseTest):
         with self.is_cloud(True):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", False):
                 team = Team.objects.create_with_data(organization=self.organization)
-                self.assertTrue(team.actor_on_events_querying_enabled)
+                self.assertTrue(team.person_on_events_querying_enabled)
                 mock_feature_enabled.assert_called_once_with(
                     "person-on-events-enabled",
                     str(team.uuid),
@@ -92,10 +92,10 @@ class TestTeam(BaseTest):
         with self.is_cloud(False):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", True):
                 team = Team.objects.create_with_data(organization=self.organization)
-                self.assertTrue(team.actor_on_events_querying_enabled)
+                self.assertTrue(team.person_on_events_querying_enabled)
                 mock_feature_enabled.assert_not_called()
 
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", False):
                 team = Team.objects.create_with_data(organization=self.organization)
-                self.assertFalse(team.actor_on_events_querying_enabled)
+                self.assertFalse(team.person_on_events_querying_enabled)
                 mock_feature_enabled.assert_not_called()


### PR DESCRIPTION
## Problem

Our "actors-on-events" project consists of two parts:
	1. "persons-on-events"
	2. "groups-on-events"

In a few places in code we were mixing up these three terms, which made it confusing which component is enabled where.

## Changes

Renamed `team.actor_on_events_querying_enabled` to `team.person_on_events_querying_enabled` (since that represents only the persons-on-events part) and `can_enable_person_on_events`/`person_on_events_ready` to `can_enable_actor_on_events`/`actor_on_events_ready` (since that applies to both persons and groups).