### PR TITLE
fix(historical-exports): do not send sent_at in exports

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -18,8 +18,13 @@ export const capture = async (
     event: string,
     properties: object = {},
     token: string | null = null,
-    sentAt: Date = new Date()
+    sentAt: Date = new Date(),
+    eventTime: Date = new Date(),
+    now: Date = new Date()
 ) => {
+    // WARNING: this capture method is meant to simulate the ingestion of events
+    // from the capture endpoint, but there is no guarantee that is is 100%
+    // accurate.
     await producer.send({
         topic: 'events_plugin_ingestion',
         messages: [
@@ -31,7 +36,7 @@ export const capture = async (
                     ip: '',
                     site_url: '',
                     team_id: teamId,
-                    now: new Date(),
+                    now: now,
                     sent_at: sentAt,
                     uuid: uuid,
                     data: JSON.stringify({
@@ -39,7 +44,7 @@ export const capture = async (
                         properties: { ...properties, uuid },
                         distinct_id: distinctId,
                         team_id: teamId,
-                        timestamp: new Date(),
+                        timestamp: eventTime,
                     }),
                 }),
             },

--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -17,7 +17,8 @@ export const capture = async (
     uuid: string,
     event: string,
     properties: object = {},
-    token: string | null = null
+    token: string | null = null,
+    sentAt: Date = new Date()
 ) => {
     await producer.send({
         topic: 'events_plugin_ingestion',
@@ -31,7 +32,7 @@ export const capture = async (
                     site_url: '',
                     team_id: teamId,
                     now: new Date(),
-                    sent_at: new Date(),
+                    sent_at: sentAt,
                     uuid: uuid,
                     data: JSON.stringify({
                         event,

--- a/plugin-server/functional_tests/exports-v2.test.ts
+++ b/plugin-server/functional_tests/exports-v2.test.ts
@@ -94,10 +94,10 @@ test.concurrent(`exports: historical exports v2`, async () => {
     // First let's capture an event and wait for it to be ingested so
     // so we can check that the historical event is the same as the one
     // passed to processEvent on initial ingestion.
-    const eventTime = new Date('2022-01-01T00:00:00.000Z')
-    const sentAt = new Date('2022-01-02T00:00:00.000Z')
-    const now = new Date('2022-01-03T00:00:00.000Z')
-    const skewAdjustedTimestamp = new Date(now.getTime() - (sentAt.getTime() - eventTime.getTime()))
+    const eventTime = new Date('2022-01-01T05:08:00.000Z')
+    const sentAt = new Date('2022-01-01T05:10:00.000Z')
+    const now = new Date('2022-01-01T05:00:00.000Z')
+    const skewAdjustedTimestamp = new Date('2022-01-01T04:58:00.000Z')
     const properties = {
         name: 'hehe',
         uuid: new UUIDT().toString(),

--- a/plugin-server/functional_tests/exports-v2.test.ts
+++ b/plugin-server/functional_tests/exports-v2.test.ts
@@ -110,8 +110,6 @@ test.concurrent(`exports: historical exports v2`, async () => {
         expect(exportEvents).toEqual([
             expect.objectContaining({
                 event: '$autocapture',
-                // TODO: send `sent_at` with real time exports as well
-                // sent_at: sentAt.toISOString(),
                 timestamp: eventTime.toISOString(),
                 uuid: uuid,
                 distinct_id: distinctId,

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -30,6 +30,17 @@ function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | nu
     if (data['timestamp']) {
         const timestamp = parseDate(data['timestamp'])
         if (sentAt && timestamp.isValid) {
+            // To handle clock skew on the timestamp sent by a client, we
+            // attempt to calculate the skew based on the difference between the
+            // client generated timestamp and the sent_at timestamp, which if
+            // not sent is set as the time the capture endpoint server
+            // timestamp.
+            //
+            // The capture endpoint also sets a `now` field which is also the
+            // time of capture.
+            //
+            // NOTE: the sent_at time can be overridden by the client, so this
+            // is not a guarantee that the skew is correct.
             // sent_at - timestamp == now - x
             // x = now + (timestamp - sent_at)
             try {

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -32,15 +32,16 @@ function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | nu
         if (sentAt && timestamp.isValid) {
             // To handle clock skew on the timestamp sent by a client, we
             // attempt to calculate the skew based on the difference between the
-            // client generated timestamp and the sent_at timestamp, which if
-            // not sent is set as the time the capture endpoint server
-            // timestamp.
+            // client generated timestamp and the sent_at timestamp, which is
+            // set on the client at point of posting to the capture endpoint.
             //
-            // The capture endpoint also sets a `now` field which is also the
-            // time of capture.
+            // The capture endpoint also sets a `now` field which is the server
+            // time, so we calculate the skew as:
             //
-            // NOTE: the sent_at time can be overridden by the client, so this
-            // is not a guarantee that the skew is correct.
+            //      skew = sent_at - now
+            //
+            // And adjust the timestamp accordingly.
+
             // sent_at - timestamp == now - x
             // x = now + (timestamp - sent_at)
             try {

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -30,13 +30,12 @@ function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | nu
     if (data['timestamp']) {
         const timestamp = parseDate(data['timestamp'])
         if (sentAt && timestamp.isValid) {
-            // To handle clock skew on the timestamp sent by a client, we
-            // attempt to calculate the skew based on the difference between the
-            // client generated timestamp and the sent_at timestamp, which is
-            // set on the client at point of posting to the capture endpoint.
+            // To handle clock skew between the client and server, we attempt
+            // to compute the skew based on the difference between the
+            // client-generated `sent_at` and the server-generated `now`
+            // filled by the capture endpoint.
             //
-            // The capture endpoint also sets a `now` field which is the server
-            // time, so we calculate the skew as:
+            // We calculate the skew as:
             //
             //      skew = sent_at - now
             //

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -69,7 +69,6 @@ const convertClickhouseEventToPluginEvent = (event: RawClickHouseEvent): Histori
         event: clickhouseEvent.event || '',
         ip: clickhouseEvent.properties['$ip'] || '',
         site_url: '',
-        sent_at: clickhouseEvent.timestamp.toISO(),
     }
     return addHistoricalExportEventProperties(parsedEvent)
 }

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -69,7 +69,7 @@ const convertClickhouseEventToPluginEvent = (event: RawClickHouseEvent): Histori
         event: clickhouseEvent.event || '',
         ip: clickhouseEvent.properties['$ip'] || '',
         site_url: '',
-        sent_at: clickhouseEvent.created_at.toISO(),
+        sent_at: clickhouseEvent.timestamp.toISO(),
     }
     return addHistoricalExportEventProperties(parsedEvent)
 }

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1245,3 +1245,39 @@ class TestCapture(BaseTest):
                 # refactor best suited for another PR, hence accessing the call_args
                 # directly here
                 self.assertEqual(kafka_produce.call_args[1]["data"]["token"], "token123")
+
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_capture_event_with_value_overrides_according_to_replicator(self, kafka_produce):
+        # Check that for the values required to import historical data, we override appropriately.
+        response = self.client.post(
+            "/track/",
+            {
+                "data": json.dumps(
+                    [
+                        {
+                            "event": "event1",
+                            "uuid": "017d37c1-f285-0000-0e8b-e02d131925dc",
+                            "sent_at": "2020-01-01T00:00:00Z",
+                            "distinct_id": "id1",
+                            "properties": {"token": self.team.api_token},
+                        }
+                    ]
+                ),
+                "api_key": self.team.api_token,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        kafka_produce_call = kafka_produce.call_args_list[0].kwargs
+        event_data = json.loads(kafka_produce_call["data"]["data"])
+
+        self.assertDictContainsSubset(
+            {
+                "uuid": "017d37c1-f285-0000-0e8b-e02d131925dc",
+                "sent_at": "2020-01-01T00:00:00Z",
+                "event": "event1",
+                "distinct_id": "id1",
+            },
+            event_data,
+        )

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1247,7 +1247,7 @@ class TestCapture(BaseTest):
                 self.assertEqual(kafka_produce.call_args[1]["data"]["token"], "token123")
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
-    def test_capture_event_with_value_overrides_according_to_replicator(self, kafka_produce):
+    def test_capture_event_can_override_attributes_important_in_replicator_exports(self, kafka_produce):
         # Check that for the values required to import historical data, we override appropriately.
         response = self.client.post(
             "/track/",
@@ -1259,6 +1259,7 @@ class TestCapture(BaseTest):
                             "uuid": "017d37c1-f285-0000-0e8b-e02d131925dc",
                             "sent_at": "2020-01-01T00:00:00Z",
                             "distinct_id": "id1",
+                            "timestamp": "2020-01-01T00:00:00Z",
                             "properties": {"token": self.team.api_token},
                         }
                     ]
@@ -1276,6 +1277,7 @@ class TestCapture(BaseTest):
             {
                 "uuid": "017d37c1-f285-0000-0e8b-e02d131925dc",
                 "sent_at": "2020-01-01T00:00:00Z",
+                "timestamp": "2020-01-01T00:00:00Z",
                 "event": "event1",
                 "distinct_id": "id1",
             },


### PR DESCRIPTION
I have added tests to check the alignment of the "live" events and the historical exports.

Previously we were also sending a `sent_at` set to `created_at` when exporting historical 
events. These aren't semantically equivalent so I think it's safer to exclude it from the conversion.

I'm looking into this in response to [a user wanting to migrate data from US -> EU](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1672731608369629) and concerns around
getting duplicate events on multiple runs of the export. We're still not guaranteed to not 
get duplicates in ClickHouse fwiw, would require an optimize final to force merge, but I
want to make sure we're at least getting timestamps correctly imported.

I may be missing something however, so would _love_ a sanity check on if `sent_at` being sent 
is actually an issue.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
