### PR TITLE
docs(playwright): replace yarn with pnpm in readme

### DIFF
--- a/playwright/e2e-vrt/README.md
+++ b/playwright/e2e-vrt/README.md
@@ -14,7 +14,7 @@ We're using Playwright to run visual regression tests against Storybook. To crea
 
     - Get inspiration from one of the existing tests. Lemon Button and Insights scene are good examples.
 
-    - Use Playwright's [codegen feature](https://playwright.dev/docs/codegen-intro) to record user interactions interactively e.g. `pnpm playwright codegen http://localhost:6006/iframe.html?args=&id=scenes-app-insights--trends-line&viewMode=story`.
+    - Use Playwright's [codegen feature](https://playwright.dev/docs/codegen-intro) to record user interactions interactively e.g. `pnpm playwright codegen "http://localhost:6006/iframe.html?args=&id=scenes-app-insights--trends-line&viewMode=story"`.
 
     - Use Playwright's [debug mode](https://playwright.dev/docs/debug) to inspect an existing test in a headed browser e.g. `pnpm playwright test --debug e2e-vrt/scenes-app/mytest.spec.ts:17:5`. Sprinkle in `await page.pause()` in your test to stop at specific lines.
 

--- a/playwright/e2e-vrt/README.md
+++ b/playwright/e2e-vrt/README.md
@@ -14,9 +14,9 @@ We're using Playwright to run visual regression tests against Storybook. To crea
 
     - Get inspiration from one of the existing tests. Lemon Button and Insights scene are good examples.
 
-    - Use Playwright's [codegen feature](https://playwright.dev/docs/codegen-intro) to record user interactions interactively e.g. `yarn playwright codegen http://localhost:6006/iframe.html?args=&id=scenes-app-insights--trends-line&viewMode=story`.
+    - Use Playwright's [codegen feature](https://playwright.dev/docs/codegen-intro) to record user interactions interactively e.g. `pnpm playwright codegen http://localhost:6006/iframe.html?args=&id=scenes-app-insights--trends-line&viewMode=story`.
 
-    - Use Playwright's [debug mode](https://playwright.dev/docs/debug) to inspect an existing test in a headed browser e.g. `yarn playwright test --debug e2e-vrt/scenes-app/mytest.spec.ts:17:5`. Sprinkle in `await page.pause()` in your test to stop at specific lines.
+    - Use Playwright's [debug mode](https://playwright.dev/docs/debug) to inspect an existing test in a headed browser e.g. `pnpm playwright test --debug e2e-vrt/scenes-app/mytest.spec.ts:17:5`. Sprinkle in `await page.pause()` in your test to stop at specific lines.
 
 2. Add screenshot expectations:
 

--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -46,9 +46,9 @@ See `bin/ci_functional_tests.sh` for how these tests are run in CI. For local
 testing:
 
 1. run docker `docker compose -f docker-compose.dev.yml up` (in posthog folder)
-1. setup the test DBs `yarn setup:test`
-1. start the plugin-server with `CLICKHOUSE_DATABASE='default' DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog yarn start:dev`
-1. run the tests with `CLICKHOUSE_DATABASE='default' DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog yarn functional_tests --watch`
+1. setup the test DBs `pnpm setup:test`
+1. start the plugin-server with `CLICKHOUSE_DATABASE='default' DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog pnpm start:dev`
+1. run the tests with `CLICKHOUSE_DATABASE='default' DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog pnpm functional_tests --watch`
 
 ## CLI flags
 


### PR DESCRIPTION
## Problem

The readme for Playwright wasn't updated with the transition to pnpm.

## Changes

This PR updates the readme.

## How did you test this code?

Tried the commands locally.