### PR TITLE
fix: show the social login caption at bottom for invite

### DIFF
--- a/frontend/src/lib/components/SocialLoginButton/index.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/index.tsx
@@ -21,6 +21,7 @@ interface SocialLoginButtonProps extends SharedProps {
 interface SocialLoginButtonsProps extends SharedProps {
     title?: string
     caption?: string
+    captionLocation?: 'top' | 'bottom'
     className?: string
     topDivider?: boolean
     bottomDivider?: boolean
@@ -73,6 +74,7 @@ export function SocialLoginLinkTestVersion({ provider, queryString }: SocialLogi
 export function SocialLoginButtons({
     title,
     caption,
+    captionLocation = 'top',
     className,
     topDivider,
     bottomDivider,
@@ -96,7 +98,7 @@ export function SocialLoginButtons({
 
             <div className={clsx(className, 'text-center space-y-4')}>
                 {title && <h3>{title}</h3>}
-                {caption && <span className="text-muted">{caption}</span>}
+                {caption && captionLocation === 'top' && <p className="text-muted">{caption}</p>}
                 <div className="flex gap-2 justify-center flex-wrap">
                     {Object.keys(preflight.available_social_auth_providers)
                         .sort((a, b) => order.indexOf(a) - order.indexOf(b))
@@ -112,6 +114,7 @@ export function SocialLoginButtons({
                             )
                         )}
                 </div>
+                {caption && captionLocation === 'bottom' && <p className="text-muted">{caption}</p>}
             </div>
             {bottomDivider ? <LemonDivider dashed className="my-6" /> : null}
         </>

--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -290,6 +290,7 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
                 className="mb-4"
                 title="Or sign in with"
                 caption={`Remember to log in with ${invite?.target_email}`}
+                captionLocation="bottom"
                 topDivider
                 queryString={invite ? `?invite_id=${invite.id}` : ''}
             />


### PR DESCRIPTION
## Problem

The location of the caption on the invite form was a bit awkward, it makes more sense to have it below the buttons.

## Changes
I've introduced a captionLocation prop, which defaults to `top` but can be set to `bottom` if you'd like. (other forms use the `top` position more frequently)

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/18598166/207136141-563a39ca-afb5-4484-b98e-d449db5179eb.png)  | ![image](https://user-images.githubusercontent.com/18598166/207136167-8d1d264e-b572-49e7-a33c-df2c268b891f.png)  |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

With my eyeballs... it's a bit challenging to test this since we don't have the social auth buttons show up in cypress tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
