### PR TITLE
fix: Disable text selection whilst dragging the hedgehog

### DIFF
--- a/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
@@ -223,6 +223,16 @@ export function HedgehogBuddy({ onClose }: { onClose: () => void }): JSX.Element
         }
     }, [animation, isDragging])
 
+    useEffect(() => {
+        if (isDragging) {
+            document.body.classList.add('select-none')
+        } else {
+            document.body.classList.remove('select-none')
+        }
+
+        return () => document.body.classList.remove('select-none')
+    }, [isDragging])
+
     const onClick = (): void => {
         !isDragging && setPopupVisible(!popupVisible)
     }


### PR DESCRIPTION
## Problem

Dragging the hedgehog selects text on the page which is not desireable


## Changes

* Disable selection whilst this is happening

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
