### PR TITLE
fix: make role_at_organization optional

### DIFF
--- a/frontend/src/lib/components/SignupRoleSelect.tsx
+++ b/frontend/src/lib/components/SignupRoleSelect.tsx
@@ -3,7 +3,7 @@ import { LemonSelect } from './LemonSelect'
 
 export default function SignupRoleSelect({ className }: { className?: string }): JSX.Element {
     return (
-        <Field name="role_at_organization" label="What is your role?" className={className}>
+        <Field name="role_at_organization" label="What is your role?" className={className} showOptional>
             <LemonSelect
                 fullWidth
                 data-attr="signup-role-at-organization"

--- a/frontend/src/scenes/authentication/inviteSignupLogic.ts
+++ b/frontend/src/scenes/authentication/inviteSignupLogic.ts
@@ -78,14 +78,13 @@ export const inviteSignupLogic = kea<inviteSignupLogicType>([
     forms(({ actions, values }) => ({
         signup: {
             defaults: { email_opt_in: true, role_at_organization: '' } as AcceptInvitePayloadInterface,
-            errors: ({ password, first_name, role_at_organization }) => ({
+            errors: ({ password, first_name }) => ({
                 password: !password
                     ? 'Please enter your password to continue'
                     : password.length < 8
                     ? 'Password must be at least 8 characters'
                     : undefined,
                 first_name: !first_name ? 'Please enter your name' : undefined,
-                role_at_organization: !role_at_organization ? 'Please enter your role' : undefined,
             }),
             submit: async (payload, breakpoint) => {
                 await breakpoint()

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -74,10 +74,9 @@ export const signupLogic = kea<signupLogicType>([
                 organization_name: '',
                 role_at_organization: '',
             } as SignupForm,
-            errors: ({ first_name, organization_name, role_at_organization }) => ({
+            errors: ({ first_name, organization_name }) => ({
                 first_name: !first_name ? 'Please enter your name' : undefined,
                 organization_name: !organization_name ? 'Please enter your organization name' : undefined,
-                role_at_organization: !role_at_organization ? 'Please select your role' : undefined,
             }),
             submit: async (payload, breakpoint) => {
                 await breakpoint()
@@ -109,7 +108,6 @@ export const signupLogic = kea<signupLogicType>([
                     actions.setSignupPanel2Values({
                         first_name: 'X',
                         organization_name: 'Y',
-                        role_at_organization: 'other',
                     })
                     actions.submitSignupPanel2()
                 } else {

--- a/frontend/src/scenes/organization/ConfirmOrganization/confirmOrganizationLogic.test.ts
+++ b/frontend/src/scenes/organization/ConfirmOrganization/confirmOrganizationLogic.test.ts
@@ -35,14 +35,13 @@ describe('confirmOrganizationLogic', () => {
     })
 
     describe('form', () => {
-        it('requires org name, first name, and role to be set', async () => {
+        it('requires org name and first name to be set', async () => {
             await expectLogic(logic, () => {
                 logic.actions.submitConfirmOrganization()
             }).toMatchValues({
                 confirmOrganizationValidationErrors: {
                     first_name: 'Please enter your name',
                     organization_name: 'Please enter your organization name',
-                    role_at_organization: 'Please enter your role',
                 },
             })
         })

--- a/frontend/src/scenes/organization/ConfirmOrganization/confirmOrganizationLogic.ts
+++ b/frontend/src/scenes/organization/ConfirmOrganization/confirmOrganizationLogic.ts
@@ -41,10 +41,9 @@ export const confirmOrganizationLogic = kea<confirmOrganizationLogicType>([
     forms(() => ({
         confirmOrganization: {
             defaults: {} as ConfirmOrganizationFormValues,
-            errors: ({ organization_name, first_name, role_at_organization }) => ({
+            errors: ({ organization_name, first_name }) => ({
                 first_name: !first_name ? 'Please enter your name' : undefined,
                 organization_name: !organization_name ? 'Please enter your organization name' : undefined,
-                role_at_organization: !role_at_organization ? 'Please enter your role' : undefined,
             }),
 
             submit: async (formValues) => {


### PR DESCRIPTION
## Problem

The role field isn't strictly necessary.

## Changes

This makes the `role_at_organization` field on all signup forms optional.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated a test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
