### PR TITLE
chore: add patchable decorator

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -40,7 +40,7 @@ from posthog.settings import (
     CLICKHOUSE_VERIFY,
     TEST,
 )
-from posthog.utils import generate_short_id
+from posthog.utils import generate_short_id, patchable
 
 InsertParams = Union[list, tuple, types.GeneratorType]
 NonInsertParams = Dict[str, Any]
@@ -138,6 +138,7 @@ def validated_client_query_id() -> Optional[str]:
     return f"{client_query_team_id}_{client_query_id}_{random_id}"
 
 
+@patchable
 def sync_execute(
     query,
     args=None,
@@ -421,6 +422,7 @@ def substitute_params(query, params):
     return cast(SyncClient, ch_client).substitute_params(query, params)
 
 
+@patchable
 def _prepare_query(client: SyncClient, query: str, args: QueryArgs):
     """
     Given a string query with placeholders we do one of two things:

--- a/posthog/migrations/0187_stale_events.py
+++ b/posthog/migrations/0187_stale_events.py
@@ -8,7 +8,7 @@ def set_created_at(apps, schema_editor):
     try:
         from posthog.client import sync_execute
     except ImportError:
-        sync_execute = None  # type: ignore
+        sync_execute = None
 
     EventDefinition = apps.get_model("posthog", "EventDefinition")
     for instance in EventDefinition.objects.filter(created_at=None):


### PR DESCRIPTION
## Problem

I'm benchmarking a bunch of teams with alternative schemas with a script. Need to patch certain functions for it to work though.

<details><summary>See script in question</summary>

```python
from contextlib import contextmanager
from time import perf_counter

import structlog
from django.conf import settings
from django.core.management.base import BaseCommand

from posthog.models import DashboardTile
from posthog.clickhouse.query_tagging import tag_queries, reset_query_tags
from posthog.models.utils import UUIDT
from posthog.utils import generate_short_id
from posthog.caching.calculate_results import calculate_result_by_insight


logger = structlog.get_logger(__name__)


class Command(BaseCommand):
    help = "Benchmark clickhouse queries for certain teams"

    def add_arguments(self, parser):
        parser.add_argument("--id", default=None, type=str, help="ID for this run of queries, stored as a query tag")
        parser.add_argument("--team-id", nargs='+', required=True, type=int, help="Specify teams to benchmark")
        parser.add_argument(
            "--live-run", action="store_true", help="Run queries, default logs queries that would be run"
        )
        parser.add_argument(
            "--override-person-on-events",
            default=None,
            type=bool,
            help="Override whether person-on-events is enabled for queries",
        )
        parser.add_argument(
            "--events-table-name",
            type=str,
            help="override what table will be queried instead of events"
        )
        parser.add_argument(
            "--date-from-override",
            type=str,
            help="override date from for these queries (ex: -90d)"
        )

    def handle(self, *args, **options):
        run(options)


def run(options):
    if 'id' not in options:
        options["id"] = generate_short_id()
    if 'override_person_on_events' in options:
        settings.PERSON_ON_EVENTS_OVERRIDE = options['override_person_on_events']
    if not options["live_run"]:
        disable_sync_execute()
    if 'events_table_name' in options:
        patch_query_building(options['events_table_name'])
    if 'date_from_override' in options:
        patch_date_from(options['date_from_override'])

    tiles = DashboardTile.objects.filter(
        dashboard__team_id__in=options["team_id"], insight__isnull=False
    ).select_related("insight", "dashboard", "dashboard__team").order_by('pk')
    tile_count = tiles.count()
    logger.info("Benchmarking team", **options, tile_count=tile_count)
    overall_start = perf_counter()

    for i, tile in enumerate(tiles):
        start_time = perf_counter()
        client_query_id = f"{options['id']}::{str(UUIDT())}"
        team = tile.dashboard.team
        tag_queries(
            kind="benchmark_team",
            id=options["id"],
            team_id=team.pk,
            person_on_events_enabled=team.person_on_events_querying_enabled,
            client_query_id=client_query_id,
        )
        try:
            calculate_result_by_insight(team, tile.insight, tile.dashboard)  # type: ignore
            success = True
        except Exception as err:
            success = False
        finally:
            reset_query_tags()
        duration = perf_counter() - start_time
        logger.info(
            "Finished query",
            duration=duration,
            success=success,
            client_query_id=client_query_id,
            id=options['id'],
            team_id=team.pk,
            index=i,
            tile_id=tile.pk,
            tile_count=tile_count,
        )
    logger.info("Finished benchmarking team", duration=perf_counter() - overall_start, **options)


def disable_sync_execute():
    from posthog.client import ch_pool

    @contextmanager
    def get_client():
        with original_get_client() as client:
            original_execute = client.execute
            client.execute = lambda *args, **kwargs: []

            try:
                yield client
            finally:
                client.execute = original_execute

    original_get_client = ch_pool.get_client
    ch_pool.get_client = get_client


def patch_query_building(events_table_name):
    from posthog.client import _prepare_query

    def patched_prepare_query(prepare_query, client, query, args):
        query = query.replace('events', events_table_name)
        return prepare_query(client, query, args)

    _prepare_query._patch(patched_prepare_query)

def patch_date_from(date_from: str):
    from posthog.models.filters import Filter, PathFilter, RetentionFilter

    for FilterClass in (Filter, PathFilter, RetentionFilter):
        setattr(FilterClass, '_date_from', property(lambda self: date_from))
```

</details>