### PR TITLE
chore: move dev postgres settings out of base dockerfile

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -13,7 +13,6 @@ services:
             POSTGRES_USER: posthog
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
-        command: postgres -c 'max_connections=1000'
 
     redis:
         image: redis:6.2.7-alpine

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,11 @@ services:
             service: db
         ports:
             - '5432:5432'
+        # something in the django app when running in dev mode
+        # (maybe only in Pycharm) keeps many idle transactions open
+        # and eventually kills postgres, these settings aim to stop that happening.
+        # They are only for DEV and should not be used in production.
+        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000
 
     redis:
         extends:


### PR DESCRIPTION
## Problem

When we refactored to a dev dockerfile the base includes a postgres setting that was added for a possibly PyCharm specific problem.

## Changes

* moves the setting back into the dev dockerfile
* as a fly-by kills idle connections after 5 minutes as well as letting a dev box open many of them 
* 
## How did you test this code?

running docker compose and seeing I could still run the migrate script