### PR TITLE
chore: add optional pyroscope profiling client

### DIFF
--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -29,6 +29,7 @@ from posthog.settings.ee import *
 from posthog.settings.ingestion import *
 from posthog.settings.feature_flags import *
 from posthog.settings.geoip import *
+from posthog.settings.pyroscope import *
 from posthog.settings.schedules import *
 from posthog.settings.sentry import *
 from posthog.settings.shell_plus import *

--- a/posthog/settings/pyroscope.py
+++ b/posthog/settings/pyroscope.py
@@ -1,0 +1,25 @@
+import os
+
+import pyroscope
+
+from posthog.settings import get_from_env
+from posthog.settings.base_variables import TEST
+
+
+def pyroscope_init() -> None:
+    if not TEST and os.getenv("PYROSCOPE_TOKEN"):
+        sample_rate = get_from_env("PYROSCOPE_SAMPLE_RATE", type_cast=int, default=100)
+
+        pyroscope.configure(
+            application_name=os.getenv("PYROSCOPE_APP_NAME", "posthog"),
+            server_address=os.getenv("PYROSCOPE_ADDRESS", "https://ingest.pyroscope.cloud"),
+            auth_token=os.environ["PYROSCOPE_TOKEN"],
+            sample_rate=sample_rate,
+            detect_subprocesses=True,  # detect subprocesses started by the main process
+            oncpu=True,  # report cpu time only
+            native=True,  # profile native extensions
+            gil_only=False,  # only include traces for threads that are holding on to the GIL
+        )
+
+
+pyroscope_init()

--- a/requirements.in
+++ b/requirements.in
@@ -51,6 +51,7 @@ Pillow==9.2.0
 posthoganalytics==2.1.2
 psycopg2-binary==2.8.6
 pyjwt==2.4.0
+pyroscope-io==0.8.0
 python-dateutil==2.8.1
 python3-saml==1.12.0
 pytz==2021.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,9 @@ certifi==2019.11.28
     #   sentry-sdk
     #   urllib3
 cffi==1.14.5
-    # via cryptography
+    # via
+    #   cryptography
+    #   milksnakex
 charset-normalizer==2.1.0
     # via
     #   aiohttp
@@ -207,6 +209,8 @@ marshmallow-enum==1.5.1
     # via dataclasses-json
 maxminddb==2.2.0
     # via geoip2
+milksnakex==0.1.6
+    # via pyroscope-io
 mimesis==5.2.1
     # via -r requirements.in
 monotonic==1.5
@@ -257,6 +261,8 @@ pyopenssl==22.0.0
     # via urllib3
 pyparsing==3.0.7
     # via packaging
+pyroscope-io==0.8.0
+    # via -r requirements.in
 pyrsistent==0.18.1
     # via jsonschema
 pysocks==1.7.1


### PR DESCRIPTION
## Problem

[pyroscope.io](https://pyroscope.io/)'s continous python profiling seems to be pretty good, especially in a multi-threaded environment like ours. I am using it locally to identify optimizations to the capture endpoint, and it would be great to take a few profiles in a k8s environment.

Like Sentry, the integration is disabled in test mode and if PYROSCOPE_TOKEN is not set. We'll set it via chart values when relevant. It is set to hopefully collect the most relevant info for our gunicorn setup: `gil_only=False` is set to collect all the CPU usage, including the kafka producer threads, not just the one thread holding the GIL.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested locally by setting the right envvar and getting profiles in pyroscope.cloud
