### PR TITLE
fix: sync groups script had a bug where we'd update all groups after the first one

### DIFF
--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -170,10 +170,10 @@ def run_group_sync(team_id: int, live_run: bool, sync: bool):
             "team_id": team_id,
         },
     )
-    ch_groups = {row[0]: {row[1]: {"properties": row[2], "created_at": row[3]}} for row in rows}
+    ch_groups = {(row[0], row[1]): {"properties": row[2], "created_at": row[3]} for row in rows}
 
     for pg_group in pg_groups:
-        ch_group = ch_groups.get(pg_group["group_type_index"], {}).get(pg_group["group_key"], None)
+        ch_group = ch_groups.get((pg_group["group_type_index"], pg_group["group_key"]), None)
         if ch_group is None or should_update_group(ch_group, pg_group):
             logger.info(
                 f"Updating {pg_group['group_type_index']} - {pg_group['group_key']} with properties {pg_group['group_properties']} and created_at {pg_group['created_at']}"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

There's a bug, where we only keep the last group key per group type index for ch groups, making us try to update every earlier group.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
