### PR TITLE
fix: Rename groups tab to Groups

### DIFF
--- a/frontend/src/scenes/groups/GroupsTabs.tsx
+++ b/frontend/src/scenes/groups/GroupsTabs.tsx
@@ -22,7 +22,7 @@ export function GroupsTabs(): JSX.Element {
             <Tabs.TabPane tab="Persons" key="-1" />
 
             {showGroupsIntroductionPage ? (
-                <Tabs.TabPane tab="Introducing Group Analytics" key="0" />
+                <Tabs.TabPane tab="Groups" key="0" />
             ) : (
                 groupTypes.map((groupType) => (
                     <Tabs.TabPane


### PR DESCRIPTION
## Problem

Previously the groups tab name was "Introducing Group Analytics" which didn't make any sense. Now it's "Groups", like the "Persons" tab next to it 

## Changes

The before picture
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/22766134/207375017-e4ebcff7-8438-4877-adf8-c1033e293b9a.png">


## How did you test this code?

I didn't, but it's just a string change
