### PR TITLE
fix: wrong import billing migration

### DIFF
--- a/posthog/management/commands/migrate_billing.py
+++ b/posthog/management/commands/migrate_billing.py
@@ -15,8 +15,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            from multi_tenancy.tasks.migrate_billing import migrate_billing
+            from multi_tenancy.migrate_billing import migrate_billing
         except ImportError:
+            print("Couldn't import multi_tenancy.migrate_billing")  # noqa T201
             return
 
         dry_run = options["dry_run"]


### PR DESCRIPTION
## Problem
We're importing the task from the `posthog_cloud` repo with the wrong path

## Changes
Fix the path

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
.
