### PR TITLE
ci(e2e): Upgrade Cypress action to v5 for Node 18 support

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -299,7 +299,7 @@ jobs:
                   $DOCKER_RUN ./bin/docker-server &> /tmp/logs/server.txt &
 
             - name: Cypress run
-              uses: cypress-io/github-action@v4
+              uses: cypress-io/github-action@v5
               with:
                   config-file: cypress.e2e.config.ts
                   config: retries=2


### PR DESCRIPTION
## Changes

We're on Node 18 post-#12650, so this updated the Cypress action to use Node 18 too (see https://github.com/cypress-io/github-action/releases/tag/v5.0.0). My suspicion is this _might_ fix the failures on #13251, but we'll see. (CC @mariusandra)