### PR TITLE
fix: Image for non-picture supporting browsers

### DIFF
--- a/posthog/year_in_posthog/2022.html
+++ b/posthog/year_in_posthog/2022.html
@@ -324,7 +324,7 @@
         <picture class="badge my-8">
             <source type="image/webp" srcset="{% static image_webp %}" width="326" height="326" >
             <source type="image/png" srcset="{% static image_png %}" width="326" height="326" >
-            <img src="{% static image_png %}" alt="image for this badge {{ badge }}. An illustration of a hedgehog who is a {{ human_badge }}">
+            <img class="badge" src="{% static image_png %}" alt="image for this badge {{ badge }}. An illustration of a hedgehog who is a {{ human_badge }}">
         </picture>
 
         <h1 class="highlight text-2xl">{{ human_badge }}</h1>

--- a/posthog/year_in_posthog/2022.html
+++ b/posthog/year_in_posthog/2022.html
@@ -324,7 +324,7 @@
         <picture class="badge my-8">
             <source type="image/webp" srcset="{% static image_webp %}" width="326" height="326" >
             <source type="image/png" srcset="{% static image_png %}" width="326" height="326" >
-            <img class="badge" src="{% static image_png %}" alt="image for this badge {{ badge }}. An illustration of a hedgehog who is a {{ human_badge }}">
+            <img class="badge" src="{% static image_png %}" width="326" height="326" alt="image for this badge {{ badge }}. An illustration of a hedgehog who is a {{ human_badge }}">
         </picture>
 
         <h1 class="highlight text-2xl">{{ human_badge }}</h1>


### PR DESCRIPTION
## Problem

Firefox falls back to the <img> which was missing the classname

## Changes

* Fixes it 