### PR TITLE
fix: ignore ids for billing migration

### DIFF
--- a/posthog/management/commands/migrate_billing.py
+++ b/posthog/management/commands/migrate_billing.py
@@ -12,6 +12,7 @@ class Command(BaseCommand):
         parser.add_argument("--recordings_free_price_id", type=str, help="Price ID for free recordings")
         parser.add_argument("--limit", type=int, help="Limit the number of orgs to process")
         parser.add_argument("--organization-id", type=str, help="Only migrate this organization ID")
+        parser.add_argument("--ignore-ids", type=str, help="Comma-separated list of org IDs to ignore")
 
     def handle(self, *args, **options):
         try:
@@ -25,6 +26,11 @@ class Command(BaseCommand):
         recordings_free_price_id = options["recordings_free_price_id"]
         limit = options["limit"]
         organization_id = options["organization_id"]
+        ignore_ids = options["ignore_ids"]
+        if ignore_ids:
+            ignore_ids = ignore_ids.split(",")
+        else:
+            ignore_ids = []
 
         migrated_orgs = migrate_billing(
             events_price_map,
@@ -32,6 +38,7 @@ class Command(BaseCommand):
             dry_run=dry_run,
             limit=limit,
             organization_id=organization_id,
+            ignore_ids=ignore_ids,
         )
 
         if dry_run:


### PR DESCRIPTION
## Problem
- We want to skip some organizations from being migrated

## Changes
- Add a command argument to the billing migration to ignore some ids

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
.