### PR TITLE
chore(time-to-see-data): tag ch queries with session_id, cache_key

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -21,10 +21,11 @@ def get_query_tag_value(key: str) -> Optional[Any]:
 
 
 def tag_queries(**kwargs):
+    tags = {key: value for key, value in kwargs.items() if value is not None}
     try:
-        thread_local_storage.query_tags.update(kwargs)
+        thread_local_storage.query_tags.update(tags)
     except AttributeError:
-        thread_local_storage.query_tags = kwargs
+        thread_local_storage.query_tags = tags
 
 
 def reset_query_tags():

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.viewsets import GenericViewSet
 from statshog.defaults.django import statsd
 
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import User
 from posthog.models.filters.utils import get_filter
 from posthog.utils import should_refresh
@@ -41,6 +42,8 @@ def cached_function(f: Callable[[U, Request], T]) -> Callable[[U, Request], T]:
 
         filter = get_filter(request=request, team=team)
         cache_key = generate_cache_key(f"{filter.toJSON()}_{team.pk}")
+
+        tag_queries(cache_key=cache_key)
 
         # return cached result when possible
         if not should_refresh(request):

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -170,6 +170,8 @@ class CHQueries:
             kind="request",
             id=request.path,
             route_id=route.route,
+            client_query_id=self._get_param(request, "client_query_id"),
+            session_id=self._get_param(request, "session_id"),
         )
 
         if hasattr(user, "current_team_id") and user.current_team_id:
@@ -184,6 +186,13 @@ class CHQueries:
             return response
         finally:
             reset_query_tags()
+
+    def _get_param(self, request: HttpRequest, name: str):
+        if name in request.GET:
+            return request.GET[name]
+        if name in request.POST:
+            return request.POST[name]
+        return None
 
 
 def shortcircuitmiddleware(f):


### PR DESCRIPTION
## Problem

Iterating on time-to-see-data and query metrics. Having these keys helps with exposing the pain project as well.