### PR TITLE
chore: Allow using clickhouse 22.8

### DIFF
--- a/posthog/settings/service_requirements.py
+++ b/posthog/settings/service_requirements.py
@@ -17,5 +17,5 @@ if SKIP_SERVICE_VERSION_REQUIREMENTS and not (TEST or DEBUG):
 SERVICE_VERSION_REQUIREMENTS = [
     ServiceVersionRequirement(service="postgresql", supported_version=">=11.0.0,<=14.1.0"),
     ServiceVersionRequirement(service="redis", supported_version=">=5.0.0,<=6.3.0"),
-    ServiceVersionRequirement(service="clickhouse", supported_version=">=21.6.0,<22.4.0"),
+    ServiceVersionRequirement(service="clickhouse", supported_version=">=21.6.0,<22.9.0"),
 ]


### PR DESCRIPTION
## Problem
Migrations will not run because dev is running a too-new version of clickhouse. Didn't know we had this until it broke 😂 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
