### PR TITLE
fix: center the Year in PostHog 2022 badge description

### DIFF
--- a/posthog/year_in_posthog/2022.html
+++ b/posthog/year_in_posthog/2022.html
@@ -100,7 +100,8 @@
         }
 
         h1 {
-            margin: 0
+            margin: 0;
+            text-align: center;
         }
 
         .flex {


### PR DESCRIPTION
## Problem

When the text wrapped it was apparent that the text wasn't centered

See https://posthog.slack.com/archives/C04DN0KMS8N/p1671028983395249

## Changes

centers it

## How did you test this code?

:eyes: locally
