### PR TITLE
fix: people always have at least the astroonaut badge

### DIFF
--- a/posthog/year_in_posthog/year_in_posthog.py
+++ b/posthog/year_in_posthog/year_in_posthog.py
@@ -90,7 +90,7 @@ def render_2022(request, user_uuid: str) -> HttpResponse:
     try:
         data = calculate_year_in_posthog_2022(user_uuid)
 
-        badge = sort_list_based_on_preference(data["badges"])
+        badge = sort_list_based_on_preference(data["badges"] or ["astronaut"])
 
         stats = stats_for_badge(data, badge)
 


### PR DESCRIPTION
## Problem

Max the hedgehog tried to get his badge without logging in

https://sentry.io/organizations/posthog/issues/3808314145/?project=1899813&referrer=slack

## Changes

ensure folk in weird states always have at least the minimum badge

## How did you test this code?

🧠 