### PR TITLE
fix: migrate billing ignore ids check

### DIFF
--- a/ee/tasks/migrate_billing.py
+++ b/ee/tasks/migrate_billing.py
@@ -36,7 +36,7 @@ def migrate_billing(
                 stripe_customer_id__exact=""
             )[:limit]
         for billing in query:
-            if billing.organization.id in ignore_ids:
+            if str(billing.organization.id) in ignore_ids:
                 print("Ignoring: ", billing.organization.name)  # noqa T201
                 continue
             try:


### PR DESCRIPTION
## Problem
`billing.organization.id` is a UUID so when checking if an array of ids contains it, it returns `false`

## Changes
- Fix check to stringify the organization id

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- Tested locally
