### PR TITLE
chore: reduce year in posthog metatags

### DIFF
--- a/posthog/year_in_posthog/2022.html
+++ b/posthog/year_in_posthog/2022.html
@@ -297,7 +297,6 @@
     </style>
     <meta name="description" content="{{ explanation }}">
     <meta name="image" content="{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% static opengraph_image %}">
-    <meta property="og:type" content="website"/>
     <meta property="og:url" content="{{ page_url }}">
     <meta property="og:title" content="My year in PostHog">
     <meta property="og:description"


### PR DESCRIPTION
## Problem

Link unfurling seems inconsistent. Assets are available. It is very not obvious what is going on

## Changes

removes the og:type tag which I only added on a whim because let's kill all the red herrings 🐟 

## How did you test this code?

🧠 
