### PR TITLE
fix: year in posthog anon and login

### DIFF
--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -199,8 +199,11 @@ export const userLogic = kea<userLogicType>([
 
     urlToAction(({ values }) => ({
         '/year_in_posthog/2022': () => {
+            if (window.POSTHOG_APP_CONTEXT?.year_in_hog_url) {
+                window.location.href = `${window.location.origin}${window.POSTHOG_APP_CONTEXT.year_in_hog_url}`
+            }
             if (values.user?.uuid) {
-                window.location.href = `/year_in_posthog/2022/${values.user?.uuid}`
+                window.location.href = `${window.location.origin}/year_in_posthog/2022/${values.user?.uuid}`
             }
         },
     })),

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -198,6 +198,10 @@ export const userLogic = kea<userLogicType>([
     }),
 
     urlToAction(({ values }) => ({
-        '/year_in_posthog/2022': () => (window.location.href = `/year_in_posthog/2022/${values.user?.uuid}`),
+        '/year_in_posthog/2022': () => {
+            if (values.user?.uuid) {
+                window.location.href = `/year_in_posthog/2022/${values.user?.uuid}`
+            }
+        },
     })),
 ])

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -167,6 +167,7 @@ urlpatterns = [
     path("", include("social_django.urls", namespace="social")),
     path("uploaded_media/<str:image_uuid>", uploaded_media.download),
     path("year_in_posthog/2022/<str:user_uuid>", year_in_posthog.render_2022),
+    path("year_in_posthog/2022/<str:user_uuid>/", year_in_posthog.render_2022),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## Problem

routing to the year in hog page was dodgy. 
sometimes we were redirecting to /yip/2022/undefined and couldn't recover
waiting for the user uuid is slower than using the URL off the app context

## Changes

* routing is less didgy with both slash and trailing slash explicit
* never redirect to /yip/2022/posthog
* redirect directly if the URL is in the app context

### slowed down to 1/4 speed

![routing](https://user-images.githubusercontent.com/984817/207740398-e353530c-af10-4dcf-96f8-7cbf9796ce7a.gif)

## How did you test this code?

running it locally and 👁️ 