### PR TITLE
chore: slim posthog-js init calls

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -22,9 +22,7 @@ export function loadPostHogJS(): void {
             window.JS_POSTHOG_API_KEY,
             configWithSentry({
                 api_host: window.JS_POSTHOG_HOST,
-                _capture_metrics: true,
                 rageclick: true,
-                debug: window.JS_POSTHOG_SELF_CAPTURE,
                 persistence: 'localStorage+cookie',
                 _capture_performance: true,
                 bootstrap: !!window.POSTHOG_USER_IDENTITY_WITH_FLAGS ? window.POSTHOG_USER_IDENTITY_WITH_FLAGS : {},


### PR DESCRIPTION
The two removed settings do the following:
- debug: console.logs triggered events
- _capture_metrics: Captures metrics on performance of posthog-js

I believe were not making use of either right now, so lets remove.

Related: https://github.com/PostHog/posthog.com/issues/4894