### PR TITLE
fix: migrate billing correct deletion

### DIFF
--- a/ee/tasks/migrate_billing.py
+++ b/ee/tasks/migrate_billing.py
@@ -46,7 +46,9 @@ def migrate_billing(
                 billing_service_token = build_billing_token(license, billing.organization)
 
                 payload = {"stripe_customer_id_v1": billing.stripe_customer_id}
-                if billing.stripe_subscription_id:
+                if not billing.stripe_subscription_id:
+                    should_delete = True
+                elif billing.stripe_subscription_id:
                     subscription = stripe.Subscription.retrieve(billing.stripe_subscription_id)
                     if subscription["status"] == "active":
                         payload["stripe_subscription_id_v1"] = billing.stripe_subscription_id


### PR DESCRIPTION
## Problem
- We should delete all OrganizationBilling that have been migrated and don't have a valid subscription

## Changes
- Correctly deletes organizations

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
locally
