### PR TITLE
chore: share this and font size fangling

### DIFF
--- a/posthog/year_in_posthog/2022.html
+++ b/posthog/year_in_posthog/2022.html
@@ -175,10 +175,6 @@
             align-items: center;
         }
 
-        .footer .logo {
-            width: 3rem;
-        }
-
         .highlight {
             color: {{ highlight_color }};
         }
@@ -194,6 +190,12 @@
         }
 
         .text-2xl {
+            font-weight: 600;
+            font-size: 2rem;
+            line-height: 1;
+        }
+
+        .text-3xl {
             font-weight: 600;
             font-size: 3rem;
             line-height: 1;
@@ -225,6 +227,10 @@
             padding-bottom: 1rem;
         }
 
+        .pt-4 {
+            padding-top: 1rem;
+        }
+
         .pl-8 {
             padding-left: 2rem;
         }
@@ -246,6 +252,7 @@
             display: flex;
             flex-direction: column;
             flex-basis: 100%;
+            font-size: 1.5rem;
         }
 
         .sharing {
@@ -254,9 +261,11 @@
             width: 100%;
             justify-content: space-around;
             padding-top: 4rem;
+            align-items: center;
+            white-space: nowrap;
         }
 
-        .sharing > div {
+        .sharing * {
             display: flex;
             flex-basis: 100%;
         }
@@ -277,6 +286,13 @@
 
             .footer .sharing {
                 display: flex;
+            }
+
+            .footer .sharing > div:first-child {
+                font-weight: 400;
+                font-size: 1rem;
+                line-height: 1;
+                padding-right: 0.75rem;
             }
 
             .sharing {
@@ -327,15 +343,15 @@
             <img class="badge" src="{% static image_png %}" width="326" height="326" alt="image for this badge {{ badge }}. An illustration of a hedgehog who is a {{ human_badge }}">
         </picture>
 
-        <h1 class="highlight text-2xl">{{ human_badge }}</h1>
+        <h1 class="highlight text-3xl">{{ human_badge }}</h1>
     </div>
     <div class="right column">
         <div class="muted">You earned this badge because...</div>
-        <div class="highlight text-xl my-8">{{ explanation }}</div>
-        <div class="stats">
+        <div class="highlight text-2xl my-8">{{ explanation }}</div>
+        <div class="stats pt-4">
             {% for stat in stats %}
                 <div class="stat px-1">
-                    <div class="highlight text-2xl">{{ stat.count }}</div>
+                    <div class="highlight text-3xl">{{ stat.count }}</div>
                     <div>{{ stat.description }}</div>
                 </div>
             {% endfor %}

--- a/posthog/year_in_posthog/sharing-buttons.html
+++ b/posthog/year_in_posthog/sharing-buttons.html
@@ -1,3 +1,4 @@
+<div>Share to</div>
 <div>
     <a target="_blank"
        aria-label="share year in posthog 2022 to facebook"


### PR DESCRIPTION
## Problem

make it clearer social icons are for sharing
text size fangling

## Changes

<img width="1029" alt="Screenshot 2022-12-15 at 10 54 16" src="https://user-images.githubusercontent.com/984817/207841530-9ef8ea13-6cae-4f73-bb2b-7972809ad546.png">


<img width="616" alt="Screenshot 2022-12-15 at 10 54 30" src="https://user-images.githubusercontent.com/984817/207841543-b9177ffb-9264-4e4c-9738-c73c20589ec4.png">

## How did you test this code?

👀 
