### PR TITLE
feat: better insight searching

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -419,7 +419,7 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestr
 
         queryset = queryset.select_related("created_by", "last_modified_by", "team")
         if self.action == "list":
-            queryset = queryset.filter(deleted=False)
+            queryset = queryset.filter(deleted=False).prefetch_related("tagged_items__tag")
             queryset = self._filter_request(self.request, queryset)
 
         order = self.request.GET.get("order", None)
@@ -473,7 +473,10 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestr
                 queryset = queryset.filter(filters__insight=request.GET[INSIGHT])
             elif key == "search":
                 queryset = queryset.filter(
-                    Q(name__icontains=request.GET["search"]) | Q(derived_name__icontains=request.GET["search"])
+                    Q(name__icontains=request.GET["search"])
+                    | Q(derived_name__icontains=request.GET["search"])
+                    | Q(tagged_items__tag__name__icontains=request.GET["search"])
+                    | Q(description__icontains=request.GET["search"])
                 )
             elif key == "dashboards":
                 dashboards_filter = request.GET["dashboards"]


### PR DESCRIPTION
## Problem

People want to be dazzled when searching for insights from the insights list page, but currently it fizzles because tags and descriptions aren't searched.

## Changes

Well, prepare to be dazzled because now tags and descriptions _are_ searched

![2022-12-15 12 08 01](https://user-images.githubusercontent.com/984817/207856383-5e5d5d61-2f3e-4ec8-850f-27d7c4d2eaf8.gif)

relates to #12816 since we added better dashboard searching already

## How did you test this code?

developer tests ⌨️ and testing locally 👀 