### PR TITLE
fix(plugins): Export FetchError to plugins

### DIFF
--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -1,6 +1,6 @@
 // This module wraps node-fetch with a sentry tracing-aware extension
 
-import fetch, { FetchError,Request, Response } from 'node-fetch'
+import fetch, { FetchError, Request, Response } from 'node-fetch'
 
 import { runInSpan } from '../sentry'
 

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -1,6 +1,6 @@
 // This module wraps node-fetch with a sentry tracing-aware extension
 
-import fetch, { Request, Response } from 'node-fetch'
+import fetch, { FetchError,Request, Response } from 'node-fetch'
 
 import { runInSpan } from '../sentry'
 
@@ -16,5 +16,6 @@ function fetchWrapper(...args: Parameters<typeof fetch>): Promise<Response> {
 }
 
 fetchWrapper.isRedirect = fetch.isRedirect
+fetchWrapper.FetchError = FetchError
 
 export default fetchWrapper


### PR DESCRIPTION
## Problem

The BigQuery app users FetchError to figure out what to do with certain types of errors. However, we don't actually export FetchError

## Changes
export FetchError to 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

add `import { FetchError} from 'node-fetch'` to top of a plugin, and `console.log(FetchError)` to validate it's not undefined anymore
