### PR TITLE
fix(roles): move feature flags permission edit to the bottom of page

### DIFF
--- a/frontend/src/scenes/ResourcePermissionModal.tsx
+++ b/frontend/src/scenes/ResourcePermissionModal.tsx
@@ -244,7 +244,7 @@ function OrganizationResourcePermissionRoles({ roles }: { roles: RoleType[] }): 
             <h5 className="mt-4">Roles with edit access</h5>
             <Row>
                 {roles.map((role) => (
-                    <span key={role.id} className="simple-tag tag-light-blue text-primary-alt">
+                    <span key={role.id} className="simple-tag tag-light-blue text-primary-alt mr-2">
                         <b>{role.name}</b>{' '}
                     </span>
                 ))}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -251,24 +251,6 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                 </Field>
                             </Col>
                             <Col span={12}>
-                                {featureFlags[FEATURE_FLAGS.ROLE_BASED_ACCESS] && (
-                                    <Card title="Permissions" className="mb-4">
-                                        <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
-                                            <ResourcePermission
-                                                resourceType={Resource.FEATURE_FLAGS}
-                                                isNewResource={id === 'new'}
-                                                onChange={(roleIds) => setRolesToAdd(roleIds)}
-                                                rolesToAdd={rolesToAdd}
-                                                addableRoles={addableRoles}
-                                                addableRolesLoading={unfilteredAddableRolesLoading}
-                                                onAdd={() => addAssociatedRoles()}
-                                                roles={derivedRoles}
-                                                deleteAssociatedRole={(id) => deleteAssociatedRole({ roleId: id })}
-                                                canEdit={featureFlag.can_edit}
-                                            />
-                                        </PayGateMini>
-                                    </Card>
-                                )}
                                 <FeatureFlagInstructions featureFlagKey={featureFlag.key || 'my-flag'} />
                             </Col>
                         </Row>
@@ -278,6 +260,25 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                         <FeatureFlagReleaseConditions />
                         <Divider />
                         {featureFlags[FEATURE_FLAGS.AUTO_ROLLBACK_FEATURE_FLAGS] && <FeatureFlagAutoRollback />}
+                        {featureFlags[FEATURE_FLAGS.ROLE_BASED_ACCESS] && (
+                            <Card title="Permissions" className="mb-4">
+                                <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
+                                    <ResourcePermission
+                                        resourceType={Resource.FEATURE_FLAGS}
+                                        isNewResource={id === 'new'}
+                                        onChange={(roleIds) => setRolesToAdd(roleIds)}
+                                        rolesToAdd={rolesToAdd}
+                                        addableRoles={addableRoles}
+                                        addableRolesLoading={unfilteredAddableRolesLoading}
+                                        onAdd={() => addAssociatedRoles()}
+                                        roles={derivedRoles}
+                                        deleteAssociatedRole={(id) => deleteAssociatedRole({ roleId: id })}
+                                        canEdit={featureFlag.can_edit}
+                                    />
+                                </PayGateMini>
+                            </Card>
+                        )}
+
                         <LemonDivider className="mt-8" />
                         <div className="flex items-center gap-2 justify-end">
                             <LemonButton


### PR DESCRIPTION
## Problem

Received feedback that editing a flag's custom permissions makes more sense at the bottom of the page.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
<img width="1116" alt="Screen Shot 2022-12-15 at 1 24 03 PM" src="https://user-images.githubusercontent.com/25164963/207938334-788d03ac-e3d6-46ee-91c5-e5f6c485e831.png">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
