### PR TITLE
feat: guidance for using projects in the new project modal

### DIFF
--- a/frontend/src/scenes/project/CreateProjectModal.tsx
+++ b/frontend/src/scenes/project/CreateProjectModal.tsx
@@ -40,10 +40,23 @@ export function CreateProjectModal({
             title={currentOrganization ? `Create a project in ${currentOrganization.name}` : 'Create a project'}
             description={
                 <p>
-                    Safely silo data by using multiple projects.{' '}
+                    Most companies will want 3 projects:
+                    <br />
+                    1. Local Development
+                    <br />
+                    2. Staging
+                    <br />
+                    3. Production
+                    <br />
+                    <br />
+                    <strong>Tip:</strong> we recommend using the same project for both your website and app to track
+                    across them. You can always apply a filter to focus on just one.{' '}
                     <Link to="https://posthog.com/manual/organizations-and-projects#projects" target="_blank">
-                        Learn more in Docs.
+                        Learn more here.
                     </Link>
+                    <br />
+                    <br />
+                    <strong>Bonus tip:</strong> you can rename your "Default Project" to "Production".
                 </p>
             }
             footer={
@@ -64,7 +77,7 @@ export function CreateProjectModal({
         >
             <PureField label="Project name">
                 <LemonInput
-                    placeholder="The Next Big Thing"
+                    placeholder="Production / Staging / Local Development"
                     maxLength={64}
                     autoFocus
                     value={name}


### PR DESCRIPTION
## Problem

Often users are separating each product into a different environment, leading to a suboptimal experience where they can't track conversion across their marketing website and app + they don't have a unified view of the customer. I've updated the docs here https://github.com/PostHog/posthog.com/pull/4905

## Changes

This gives them the opinionated best practices as they make projects.

<img width="574" alt="Screenshot Homepage • PostHog (Google Chrome) 2022-12-15 at 23 15@2x" src="https://user-images.githubusercontent.com/22766134/207987024-20227ddd-25c5-4acd-ae2b-2353c7be98d7.png">

## How did you test this code?

Ran it locally