### PR TITLE
feat: Updated the allowed endpoints to include session recordings

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -16,6 +16,18 @@ from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Team
 
 from .auth import PersonalAPIKeyAuthentication
 
+ALWAYS_ALLOWED_ENDPOINTS = [
+    "decide",
+    "engage",
+    "track",
+    "capture",
+    "batch",
+    "e",
+    "s",
+    "static",
+    "_health",
+]
+
 
 class AllowIPMiddleware:
     trusted_proxies: List[str] = []
@@ -54,7 +66,7 @@ class AllowIPMiddleware:
 
     def __call__(self, request: HttpRequest):
         response: HttpResponse = self.get_response(request)
-        if request.path.split("/")[1] in ["decide", "engage", "track", "capture", "batch", "e", "static", "_health"]:
+        if request.path.split("/")[1] in ALWAYS_ALLOWED_ENDPOINTS:
             return response
         ip = self.extract_client_ip(request)
         if ip and any(ip_address(ip) in ip_network(block, strict=False) for block in self.ip_blocks):

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -150,6 +150,7 @@ urlpatterns = [
     path("site_app/<int:id>/<str:token>/<str:hash>/", site_app.get_site_app),
     re_path(r"^demo.*", login_required(demo_route)),
     # ingestion
+    # NOTE: When adding paths here that should be public make sure to update ALWAYS_ALLOWED_ENDPOINTS in middleware.py
     opt_slash_path("decide", decide.get_decide),
     opt_slash_path("e", capture.get_event),
     opt_slash_path("engage", capture.get_event),


### PR DESCRIPTION
## Problem

Thanks to @gyfis who [originally attempted this here](https://github.com/PostHog/posthog/pull/13216) but got stuck by CI issues 

## Changes

Adds `/s/` to the  allowed list and makes a note in urls.py about updating this list

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
