### PR TITLE
fix(query-performance): Make `clickhouse_lag` celery metric cheap.

### DIFF
--- a/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
+++ b/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
@@ -22,7 +22,7 @@ class Migration(AsyncMigrationDefinition):
         AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"ALTER TABLE sharded_events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' ADD PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))",
-            rollback=f"ALTER TABLE sharded_events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' ADD PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))",
+            rollback=f"ALTER TABLE sharded_events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' DROP PROJECTION fast_max_kafka_timestamp",
         ),
         AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,

--- a/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
+++ b/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
@@ -2,6 +2,7 @@ import structlog
 from django.conf import settings
 
 from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperationSQL
+from posthog.client import sync_execute
 from posthog.constants import AnalyticsDBMS
 from posthog.version_requirement import ServiceVersionRequirement
 
@@ -17,6 +18,17 @@ class Migration(AsyncMigrationDefinition):
     posthog_max_version = "1.45.99"
 
     service_version_requirements = [ServiceVersionRequirement(service="clickhouse", supported_version=">=22.3.0")]
+
+    def is_required(self):
+        __import__("IPython").embed()  # FIXME
+        return "fast_max_kafka_timestamp" not in self.get_table_definition()
+
+    def get_table_definition(self) -> str:
+        result = sync_execute(
+            "SELECT create_table_query FROM system.tables WHERE database = %(database)s AND name = %(name)s",
+            {"database": settings.CLICKHOUSE_DATABASE, "name": "sharded_events"},
+        )
+        return result[0][0] if len(result) > 0 else ""
 
     operations = [
         AsyncMigrationOperationSQL(

--- a/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
+++ b/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
@@ -20,7 +20,6 @@ class Migration(AsyncMigrationDefinition):
     service_version_requirements = [ServiceVersionRequirement(service="clickhouse", supported_version=">=22.3.0")]
 
     def is_required(self):
-        __import__("IPython").embed()  # FIXME
         return "fast_max_kafka_timestamp" not in self.get_table_definition()
 
     def get_table_definition(self) -> str:

--- a/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
+++ b/posthog/async_migrations/migrations/0008_max_timestamp_projection.py
@@ -1,0 +1,32 @@
+import structlog
+from django.conf import settings
+
+from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperationSQL
+from posthog.constants import AnalyticsDBMS
+from posthog.version_requirement import ServiceVersionRequirement
+
+logger = structlog.get_logger(__name__)
+
+
+class Migration(AsyncMigrationDefinition):
+    description = "Create a projection on max(_timestamp) to speed up `clickhouse_lag` celery task. Requires ClickHouse 22.3 or above"
+
+    depends_on = "0007_persons_and_groups_on_events_backfill"
+
+    posthog_min_version = "1.41.0"
+    posthog_max_version = "1.45.99"
+
+    service_version_requirements = [ServiceVersionRequirement(service="clickhouse", supported_version=">=22.3.0")]
+
+    operations = [
+        AsyncMigrationOperationSQL(
+            database=AnalyticsDBMS.CLICKHOUSE,
+            sql=f"ALTER TABLE sharded_events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' ADD PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))",
+            rollback=f"ALTER TABLE sharded_events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' ADD PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))",
+        ),
+        AsyncMigrationOperationSQL(
+            database=AnalyticsDBMS.CLICKHOUSE,
+            sql=f"ALTER TABLE sharded_events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' MATERIALIZE PROJECTION fast_max_kafka_timestamp",
+            rollback=None,
+        ),
+    ]

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -295,9 +295,6 @@ def pg_plugin_server_query_timing():
 
 CLICKHOUSE_TABLES = ["events", "person", "person_distinct_id", "person_distinct_id2", "session_recording_events"]
 
-if settings.CLICKHOUSE_REPLICATION:
-    CLICKHOUSE_TABLES.extend(["sharded_events", "sharded_session_recording_events"])
-
 
 @app.task(ignore_result=True)
 def clickhouse_lag():

--- a/posthog/clickhouse/dead_letter_queue.py
+++ b/posthog/clickhouse/dead_letter_queue.py
@@ -41,7 +41,10 @@ SETTINGS index_granularity=512
 ).format(
     table_name=DEAD_LETTER_QUEUE_TABLE,
     cluster=CLICKHOUSE_CLUSTER,
-    extra_fields=KAFKA_COLUMNS,
+    extra_fields=f"""
+    {KAFKA_COLUMNS}
+    , INDEX kafka_timestamp_minmax _timestamp TYPE minmax GRANULARITY 3
+    """,
     engine=DEAD_LETTER_QUEUE_TABLE_ENGINE(),
     ttl_period=ttl_period("_timestamp", 4),  # 4 weeks
 )

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -26,6 +26,7 @@
       group4_created_at DateTime64
       
       
+      
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
       SETTINGS kafka_skip_broken_messages = 100
@@ -35,7 +36,7 @@
 # name: test_create_kafka_table_with_different_kafka_host[kafka_app_metrics]
   '
   
-  CREATE TABLE kafka_app_metrics ON CLUSTER posthog
+  CREATE TABLE kafka_app_metrics ON CLUSTER 'posthog'
   (
       team_id Int64,
       timestamp DateTime64(6, 'UTC'),
@@ -105,6 +106,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64
+      
       
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
@@ -230,7 +232,7 @@
 # name: test_create_table_query[app_metrics]
   '
   
-  CREATE TABLE app_metrics ON CLUSTER posthog
+  CREATE TABLE app_metrics ON CLUSTER 'posthog'
   (
       team_id Int64,
       timestamp DateTime64(6, 'UTC'),
@@ -329,6 +331,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
+      
   ) ENGINE = Distributed('posthog', 'posthog_test', 'events', sipHash64(distinct_id))
   
   '
@@ -503,7 +506,7 @@
 # name: test_create_table_query[kafka_app_metrics]
   '
   
-  CREATE TABLE kafka_app_metrics ON CLUSTER posthog
+  CREATE TABLE kafka_app_metrics ON CLUSTER 'posthog'
   (
       team_id Int64,
       timestamp DateTime64(6, 'UTC'),
@@ -573,6 +576,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64
+      
       
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
@@ -890,9 +894,7 @@
       window_id VARCHAR,
       snapshot_data VARCHAR,
       created_at DateTime64(6, 'UTC')
-      
-      , has_full_snapshot Int8 COMMENT 'column_materializer::has_full_snapshot'
-  
+      , has_full_snapshot Int8 COMMENT 'column_materializer::has_full_snapshot', events_summary Array(String) COMMENT 'column_materializer::events_summary', click_count Int8 COMMENT 'column_materializer::click_count', keypress_count Int8 COMMENT 'column_materializer::keypress_count', timestamps_summary Array(DateTime64(6, 'UTC')) COMMENT 'column_materializer::timestamps_summary', first_event_timestamp Nullable(DateTime64(6, 'UTC')) COMMENT 'column_materializer::first_event_timestamp', last_event_timestamp Nullable(DateTime64(6, 'UTC')) COMMENT 'column_materializer::last_event_timestamp', urls Array(String) COMMENT 'column_materializer::urls'
       
   , _timestamp DateTime
   , _offset UInt64
@@ -924,7 +926,7 @@
 # name: test_create_table_query[sharded_app_metrics]
   '
   
-  CREATE TABLE sharded_app_metrics ON CLUSTER posthog
+  CREATE TABLE sharded_app_metrics ON CLUSTER 'posthog'
   (
       team_id Int64,
       timestamp DateTime64(6, 'UTC'),
@@ -988,6 +990,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
+      , PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))
   ) ENGINE = ReplacingMergeTree(_timestamp)
   PARTITION BY toYYYYMM(timestamp)
   ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
@@ -1030,9 +1033,7 @@
       window_id VARCHAR,
       snapshot_data VARCHAR,
       created_at DateTime64(6, 'UTC')
-      
-      , has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot') COMMENT 'column_materializer::has_full_snapshot'
-  
+      , has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot'), events_summary Array(String) MATERIALIZED JSONExtract(JSON_QUERY(snapshot_data, '$.events_summary[*]'), 'Array(String)'), click_count Int8 MATERIALIZED length(arrayFilter((x) -> JSONExtractInt(x, 'type') = 3 AND JSONExtractInt(x, 'data', 'source') = 2 AND JSONExtractInt(x, 'data', 'source') = 2, events_summary)), keypress_count Int8 MATERIALIZED length(arrayFilter((x) -> JSONExtractInt(x, 'type') = 3 AND JSONExtractInt(x, 'data', 'source') = 5, events_summary)), timestamps_summary Array(DateTime64(6, 'UTC')) MATERIALIZED arraySort(arrayMap((x) -> toDateTime(JSONExtractInt(x, 'timestamp') / 1000), events_summary)), first_event_timestamp Nullable(DateTime64(6, 'UTC')) MATERIALIZED if(empty(timestamps_summary), NULL, arrayReduce('min', timestamps_summary)), last_event_timestamp Nullable(DateTime64(6, 'UTC')) MATERIALIZED if(empty(timestamps_summary), NULL, arrayReduce('max', timestamps_summary)), urls Array(String) MATERIALIZED arrayFilter(x -> x != '', arrayMap((x) -> JSONExtractString(x, 'data', 'href'), events_summary))
       
   , _timestamp DateTime
   , _offset UInt64
@@ -1076,6 +1077,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
+      
   ) ENGINE = Distributed('posthog', 'posthog_test', 'events', sipHash64(distinct_id))
   
   '
@@ -1281,7 +1283,7 @@
 # name: test_create_table_query_replicated_and_storage[sharded_app_metrics]
   '
   
-  CREATE TABLE sharded_app_metrics ON CLUSTER posthog
+  CREATE TABLE sharded_app_metrics ON CLUSTER 'posthog'
   (
       team_id Int64,
       timestamp DateTime64(6, 'UTC'),
@@ -1345,6 +1347,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
+      , PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))
   ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.events', '{replica}', _timestamp)
   PARTITION BY toYYYYMM(timestamp)
   ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
@@ -1387,9 +1390,7 @@
       window_id VARCHAR,
       snapshot_data VARCHAR,
       created_at DateTime64(6, 'UTC')
-      
-      , has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot') COMMENT 'column_materializer::has_full_snapshot'
-  
+      , has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot'), events_summary Array(String) MATERIALIZED JSONExtract(JSON_QUERY(snapshot_data, '$.events_summary[*]'), 'Array(String)'), click_count Int8 MATERIALIZED length(arrayFilter((x) -> JSONExtractInt(x, 'type') = 3 AND JSONExtractInt(x, 'data', 'source') = 2 AND JSONExtractInt(x, 'data', 'source') = 2, events_summary)), keypress_count Int8 MATERIALIZED length(arrayFilter((x) -> JSONExtractInt(x, 'type') = 3 AND JSONExtractInt(x, 'data', 'source') = 5, events_summary)), timestamps_summary Array(DateTime64(6, 'UTC')) MATERIALIZED arraySort(arrayMap((x) -> toDateTime(JSONExtractInt(x, 'timestamp') / 1000), events_summary)), first_event_timestamp Nullable(DateTime64(6, 'UTC')) MATERIALIZED if(empty(timestamps_summary), NULL, arrayReduce('min', timestamps_summary)), last_event_timestamp Nullable(DateTime64(6, 'UTC')) MATERIALIZED if(empty(timestamps_summary), NULL, arrayReduce('max', timestamps_summary)), urls Array(String) MATERIALIZED arrayFilter(x -> x != '', arrayMap((x) -> JSONExtractString(x, 'data', 'href'), events_summary))
       
   , _timestamp DateTime
   , _offset UInt64

--- a/posthog/management/commands/test/test_run_async_migrations.py
+++ b/posthog/management/commands/test/test_run_async_migrations.py
@@ -58,7 +58,7 @@ def test_complete_noop_migrations(caplog):
     # First validate the 0001 is present
     call_command("run_async_migrations", "--plan")
     output = "\n".join([rec.message for rec in caplog.records])
-    assert "0001" in output
+    assert "0001_events_sample_by" in output
 
     call_command("run_async_migrations", "--complete-noop-migrations")
 
@@ -66,7 +66,7 @@ def test_complete_noop_migrations(caplog):
     caplog.clear()
     call_command("run_async_migrations", "--plan")
     output = "\n".join([rec.message for rec in caplog.records])
-    assert "0001" not in output
+    assert "0001_events_sample_by" not in output
 
 
 @pytest.fixture(autouse=True)

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     group4_created_at DateTime64
     {materialized_columns}
     {extra_fields}
+    {projections}
 ) ENGINE = {engine}
 """
 
@@ -78,6 +79,7 @@ ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64
     engine=EVENTS_DATA_TABLE_ENGINE(),
     extra_fields=KAFKA_COLUMNS,
     materialized_columns=EVENTS_TABLE_MATERIALIZED_COLUMNS,
+    projections=", PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))",
     sample_by="SAMPLE BY cityHash64(distinct_id)",
     storage_policy=STORAGE_POLICY(),
 )
@@ -97,6 +99,7 @@ KAFKA_EVENTS_TABLE_JSON_SQL = lambda: (
     engine=kafka_engine(topic=KAFKA_EVENTS_JSON),
     extra_fields="",
     materialized_columns="",
+    projections="",
 )
 
 EVENTS_TABLE_JSON_MV_SQL = lambda: """
@@ -142,6 +145,7 @@ WRITABLE_EVENTS_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     engine=Distributed(data_table=EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
     extra_fields=KAFKA_COLUMNS,
     materialized_columns="",
+    projections="",
 )
 
 # This table is responsible for reading from events on a cluster setting
@@ -151,6 +155,7 @@ DISTRIBUTED_EVENTS_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     engine=Distributed(data_table=EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
     extra_fields=KAFKA_COLUMNS,
     materialized_columns=EVENTS_TABLE_PROXY_MATERIALIZED_COLUMNS,
+    projections="",
 )
 
 INSERT_EVENT_SQL = (

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     group4_created_at DateTime64
     {materialized_columns}
     {extra_fields}
-    {projections}
+    {indexes}
 ) ENGINE = {engine}
 """
 
@@ -79,7 +79,10 @@ ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64
     engine=EVENTS_DATA_TABLE_ENGINE(),
     extra_fields=KAFKA_COLUMNS,
     materialized_columns=EVENTS_TABLE_MATERIALIZED_COLUMNS,
-    projections=", PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))",
+    indexes="""
+    , PROJECTION fast_max_kafka_timestamp (SELECT max(_timestamp))
+    , INDEX kafka_timestamp_minmax _timestamp TYPE minmax GRANULARITY 3
+    """,
     sample_by="SAMPLE BY cityHash64(distinct_id)",
     storage_policy=STORAGE_POLICY(),
 )
@@ -99,7 +102,7 @@ KAFKA_EVENTS_TABLE_JSON_SQL = lambda: (
     engine=kafka_engine(topic=KAFKA_EVENTS_JSON),
     extra_fields="",
     materialized_columns="",
-    projections="",
+    indexes="",
 )
 
 EVENTS_TABLE_JSON_MV_SQL = lambda: """
@@ -145,7 +148,7 @@ WRITABLE_EVENTS_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     engine=Distributed(data_table=EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
     extra_fields=KAFKA_COLUMNS,
     materialized_columns="",
-    projections="",
+    indexes="",
 )
 
 # This table is responsible for reading from events on a cluster setting
@@ -155,7 +158,7 @@ DISTRIBUTED_EVENTS_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     engine=Distributed(data_table=EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
     extra_fields=KAFKA_COLUMNS,
     materialized_columns=EVENTS_TABLE_PROXY_MATERIALIZED_COLUMNS,
-    projections="",
+    indexes="",
 )
 
 INSERT_EVENT_SQL = (


### PR DESCRIPTION
## Problem

Similar to https://github.com/PostHog/posthog/pull/13368, clickhouse_lag task consumes excessive resources: ~25% of what we spend on updating all dashboards per day.

## Changes

- Don't track sharded_events/sharded_session_recording_events
- Add a 0008 async migration to use a PROJECTION to make this query fast. It depends on 22.3 so can't be a normal migration.
- Fix an issue with async migrations causing this async migration to fail

## Note for release

New async migration 0008 which speeds up some internal instrumentation. Requires clickhouse 22.3.