### PR TITLE
fix(query-performance): Set optimize_on_insert=0 on cohort recalculation

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -261,6 +261,7 @@ def recalculate_cohortpeople(cohort: Cohort, pending_version: int) -> Optional[i
     sync_execute(
         recalcluate_cohortpeople_sql,
         {**cohort_params, "cohort_id": cohort.pk, "team_id": cohort.team_id, "new_version": pending_version},
+        settings={"optimize_on_insert": 0},
     )
 
     count = get_cohort_size(cohort.pk, cohort.team_id)


### PR DESCRIPTION
optimize_on_insert documentation: https://clickhouse.com/docs/en/operations/settings/settings/#optimize-on-insert

Having this setting on (default) increases memory usage during inserts, thereby slowing things down. Small performance win, there's probably other tuning we could do here as well.