### PR TITLE
perf(demo): Reduce frequency of `demo_reset_master_team` to twice a week

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -92,8 +92,9 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         sender.add_periodic_task(crontab(hour=4, minute=0), verify_persons_data_in_sync.s())
 
     if is_cloud() or settings.DEMO:
-        # Reset master project data every day at 5 AM UTC
-        sender.add_periodic_task(crontab(hour=5, minute=0), demo_reset_master_team.s())
+        # Reset master project data every Monday at Thursday at 5 AM UTC. Mon and Thu because doing this every day
+        # would be too hard on ClickHouse, and those days ensure most users will have data at most 3 days old.
+        sender.add_periodic_task(crontab(day_of_week="mon,thu", hour=5, minute=0), demo_reset_master_team.s())
 
     sender.add_periodic_task(crontab(day_of_week="fri", hour=0, minute=0), clean_stale_partials.s())
 


### PR DESCRIPTION
## Problem

We need to regularly run `demo_reset_master_team` to regenerate demo data. However, regeneration involves deleting the existing data, and that's hard on ClickHouse, as very many parts are rewritten in the process.

## Changes

We can reduce the load by running `demo_reset_master_team` only 2x per week, instead of 7x.
