### PR TITLE
chore: increase sentry sampling rate for capture endpoints

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -29,11 +29,8 @@ def traces_sampler(sampling_context: dict) -> float:
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
 
         # Ingestion endpoints (high volume)
-        if path.startswith("/batch"):
-            return 0.00000001  # 0.000001%
-        # Ingestion endpoints (high volume)
-        elif path.startswith(("/capture", "/decide", "/track", "/s", "/e")):
-            return 0.0000001  # 0.00001%
+        if path.startswith(("/batch", "/capture", "/decide", "/track", "/s", "/e")):
+            return 0.000001  # 0.0001%
         # Probes/monitoring endpoints
         elif path.startswith(("/_health", "/_readyz", "/_livez")):
             return 0.00001  # 0.001%


### PR DESCRIPTION
## Problem

Performance traces on Sentry don't give enough samples for the capture endpoints, more points would be great in building confidence about where our optimization avenues are. Exemple for [`/s/` below](https://sentry.io/organizations/posthog/performance/summary/?project=1899813&query=transaction.duration%3A%3C15m&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=24h&transaction=%2Fs%2F%5B%23%5D.%2A&unselectedSeries=p100%28%29) we only captured two traces today so far.

![image](https://user-images.githubusercontent.com/6241083/208122309-93dd2b7a-ebc8-478f-8013-28200d3d8b8b.png)

## Changes

Raise the sampling rate for capture endpoints 10-fold. From a promql computation, this should yield ~200 traces/day from prod-us, instead of 20.

![image](https://user-images.githubusercontent.com/6241083/208121695-c292feed-efc1-45df-8fd1-5e73ab81553c.png)

## How did you test this code?

🙏 