### PR TITLE
feat: set dashboard tab in the url so it persists on refresh

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -33,7 +33,11 @@ export const dashboardsLogic = kea<dashboardsLogicType>({
     actionToUrl: ({ values }) => ({
         setCurrentTab: () => {
             const tab = values.currentTab === DashboardsTab.All ? undefined : values.currentTab
-            router.values.searchParams['tab'] !== tab && router.actions.push(router.values.location.pathname, { tab })
+            if (router.values.searchParams['tab'] === tab) {
+                return
+            }
+
+            router.actions.push(router.values.location.pathname, { ...router.values.searchParams, tab })
         },
     }),
     urlToAction: ({ actions }) => ({

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -3,6 +3,7 @@ import Fuse from 'fuse.js'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import type { dashboardsLogicType } from './dashboardsLogicType'
 import { userLogic } from 'scenes/userLogic'
+import { router } from 'kea-router'
 
 export enum DashboardsTab {
     All = 'all',
@@ -29,6 +30,18 @@ export const dashboardsLogic = kea<dashboardsLogicType>({
             },
         ],
     },
+    actionToUrl: ({ values }) => ({
+        setCurrentTab: () => {
+            const tab = values.currentTab === DashboardsTab.All ? undefined : values.currentTab
+            router.values.searchParams['tab'] !== tab && router.actions.push(router.values.location.pathname, { tab })
+        },
+    }),
+    urlToAction: ({ actions }) => ({
+        '/dashboard': (_, searchParams) => {
+            const tab = searchParams['tab'] || DashboardsTab.All
+            actions.setCurrentTab(tab)
+        },
+    }),
     selectors: {
         dashboards: [
             (selectors) => [


### PR DESCRIPTION
## Problem

The dashboards page doesn't remember what tab you are on, so it can be frustrating if you fresh and lose your place

## Changes

Not any more!

## How did you test this code?

👁️ locally