### PR TITLE
fix(persons): Use identify instead of delete_person_property event

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -333,7 +333,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             now=datetime.now(),
             sent_at=None,
             event={
-                "event": "$delete_person_property",
+                "event": "$identify",
                 "properties": {"$unset": [request.data["$unset"]]},
                 "distinct_id": person.distinct_ids[0],
                 "timestamp": datetime.now().isoformat(),

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -402,7 +402,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             now=mock.ANY,
             sent_at=None,
             event={
-                "event": "$delete_person_property",
+                "event": "$identify",
                 "distinct_id": "some_distinct_id",
                 "properties": {"$unset": ["foo"]},
                 "timestamp": mock.ANY,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
`$delete_person_property` unnecessarily clutters up the event dropdown. We may as well use $identify

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
use $identify

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
