### PR TITLE
fix(playwright): pin playwright version for ci workflow

### DIFF
--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -31,13 +31,13 @@ jobs:
               run: pnpm build-storybook --quiet
 
             - name: Install Playwright Browsers
-              run: pnpm --package playwright@1.28.1 dlx playwright install --with-deps
+              run: pnpm dlx playwright@1.28.1 install --with-deps
 
             - name: Serve Storybook and run tests
               run: |
                   pnpm dlx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
                     "pnpm dlx http-server storybook-static --port 6006" \
-                    "pnpm dlx wait-on http://127.0.0.1:6006 --timeout 60 && pnpm --package playwright@1.28.1 dlx playwright test"
+                    "pnpm dlx wait-on http://127.0.0.1:6006 --timeout 60 && pnpm dlx playwright@1.28.1 test"
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -31,7 +31,7 @@ jobs:
               run: pnpm build-storybook --quiet
 
             - name: Install Playwright Browsers
-              run: pnpm dlx playwright install --with-deps
+              run: pnpm dlx playwright@1.28.1 install --with-deps
 
             - name: Serve Storybook and run tests
               run: |

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -31,13 +31,13 @@ jobs:
               run: pnpm build-storybook --quiet
 
             - name: Install Playwright Browsers
-              run: pnpm dlx playwright@1.28.1 install --with-deps
+              run: pnpm --package playwright@1.28.1 dlx playwright install --with-deps
 
             - name: Serve Storybook and run tests
               run: |
                   pnpm dlx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
                     "pnpm dlx http-server storybook-static --port 6006" \
-                    "pnpm dlx wait-on http://127.0.0.1:6006 --timeout 60 && pnpm dlx playwright test"
+                    "pnpm dlx wait-on http://127.0.0.1:6006 --timeout 60 && pnpm --package playwright@1.28.1 dlx playwright test"
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Problem

Playwright tests in CI are failing, as the version does not match the `@playwright/test` one in package.json. Likely this should be handled by playwright install, but pnpm support isn't there yet.

## Changes

As a temp/quick fix I'm locking the playwright version for CI.

## How did you test this code?

CI runs successfully in this PR.