### PR TITLE
fix(query-performance): 0008 migration runs into an error

### DIFF
--- a/posthog/async_migrations/migrations/0008_speed_up_kafka_timestamp_filters.py
+++ b/posthog/async_migrations/migrations/0008_speed_up_kafka_timestamp_filters.py
@@ -54,12 +54,12 @@ class Migration(AsyncMigrationDefinition):
         ),
         AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
-            sql=f"ALTER TABLE events_dead_letter_queue ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' ADD INDEX kafka_timestamp_minmax _timestamp TYPE minmax GRANULARITY 3",
-            rollback=f"ALTER TABLE events_dead_letter_queue ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' DROP INDEX kafka_timestamp_minmax",
+            sql=f"ALTER TABLE events_dead_letter_queue ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' ADD INDEX kafka_timestamp_minmax_dlq _timestamp TYPE minmax GRANULARITY 3",
+            rollback=f"ALTER TABLE events_dead_letter_queue ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' DROP INDEX kafka_timestamp_minmax_dlq",
         ),
         AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
-            sql=f"ALTER TABLE events_dead_letter_queue ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' MATERIALIZE INDEX kafka_timestamp_minmax",
+            sql=f"ALTER TABLE events_dead_letter_queue ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' MATERIALIZE INDEX kafka_timestamp_minmax_dlq",
             rollback=None,
         ),
     ]

--- a/posthog/clickhouse/dead_letter_queue.py
+++ b/posthog/clickhouse/dead_letter_queue.py
@@ -43,7 +43,7 @@ SETTINGS index_granularity=512
     cluster=CLICKHOUSE_CLUSTER,
     extra_fields=f"""
     {KAFKA_COLUMNS}
-    , INDEX kafka_timestamp_minmax _timestamp TYPE minmax GRANULARITY 3
+    , INDEX kafka_timestamp_minmax_dlq _timestamp TYPE minmax GRANULARITY 3
     """,
     engine=DEAD_LETTER_QUEUE_TABLE_ENGINE(),
     ttl_period=ttl_period("_timestamp", 4),  # 4 weeks


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/13371 ran into an error in production:

> Exception was thrown while running operation 4 : Failed to execute ClickHouse op: sql=ALTER TABLE events_dead_letter_queue ON CLUSTER 'posthog' ADD INDEX kafka_timestamp_minmax _timestamp TYPE minmax GRANULARITY 3, query_id=018529ef-6975-0000-e10f-cad2040b2047, exception=Code: 44. DB::Exception: There was an error on [ch9.posthog.net:9000]: Code: 44. DB::Exception: Cannot add index kafka_timestamp_minmax: index with this name already exists. (ILLEGAL_COLUMN) (version 22.3.6.5 (official build)). Stack trace: 0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xb37173a in /usr/bin/clickhouse 1. DB::Exception::Exception<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, unsigned short&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&>(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, unsigned short&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) @ 0x15d25442 in /usr/bin/clickhouse 2. DB::DDLQueryStatusSource::generate() @ 0x15d20721 in /usr/bin/clickhouse 3. DB::ISource::tryGenerate() @ 0x168fc395 in /usr/bin/clickhouse 4. DB::ISource::work() @ 0x168fbf5a in /usr/bin/clickhouse 5. DB::SourceWithProgress::work() @ 0x16b53862 in /usr/bin/clickhouse 6. DB::ExecutionThreadContext::executeTask() @ 0x1691c6e3 in /usr/bin/clickhouse 7. DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) @ 0x1691013e in /usr/bin/clickhouse 8. DB::PipelineExecutor::executeImpl(unsigned long) @ 0x1690f48b in /usr/bin/clickhouse 9. DB::PipelineExecutor::execute(unsigned long) @ 0x1690ed58 in /usr/bin/clickhouse 10. ? @ 0x1692052d in /usr/bin/clickhouse 11. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0xb418b97 in /usr/bin/clickhouse 12. ? @ 0xb41c71d in /usr/bin/clickhouse 13. ? @ 0x7f4089d54609 in ? 14. __clone @ 0x7f4089c79163 in ? |  

We now rename the index