### PR TITLE
fix(query-performance): Make clickhouse_lag celery metric cheap

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -293,7 +293,7 @@ def pg_plugin_server_query_timing():
             pass
 
 
-CLICKHOUSE_TABLES = ["events", "person", "person_distinct_id", "person_distinct_id2", "session_recording_events"]
+CLICKHOUSE_TABLES = ["events", "person", "person_distinct_id2", "session_recording_events"]
 
 
 @app.task(ignore_result=True)

--- a/posthog/clickhouse/dead_letter_queue.py
+++ b/posthog/clickhouse/dead_letter_queue.py
@@ -1,3 +1,4 @@
+from posthog.clickhouse.indexes import index_by_kafka_timestamp
 from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, kafka_engine, ttl_period
 from posthog.clickhouse.table_engines import ReplacingMergeTree
 from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE
@@ -43,7 +44,7 @@ SETTINGS index_granularity=512
     cluster=CLICKHOUSE_CLUSTER,
     extra_fields=f"""
     {KAFKA_COLUMNS}
-    , INDEX kafka_timestamp_minmax_dlq _timestamp TYPE minmax GRANULARITY 3
+    , {index_by_kafka_timestamp(DEAD_LETTER_QUEUE_TABLE)}
     """,
     engine=DEAD_LETTER_QUEUE_TABLE_ENGINE(),
     ttl_period=ttl_period("_timestamp", 4),  # 4 weeks

--- a/posthog/clickhouse/indexes.py
+++ b/posthog/clickhouse/indexes.py
@@ -1,0 +1,8 @@
+# Speeds up selecting max(_timestamp)
+def projection_for_max_kafka_timestamp(table: str):
+    return f"PROJECTION fast_max_kafka_timestamp_{table} (SELECT max(_timestamp))"
+
+
+# Speeds up filtering by _timestamp columns
+def index_by_kafka_timestamp(table: str):
+    return f"INDEX kafka_timestamp_minmax_{table} _timestamp TYPE minmax GRANULARITY 3"

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -1,4 +1,5 @@
 from posthog.clickhouse.base_sql import COPY_ROWS_BETWEEN_TEAMS_BASE_SQL
+from posthog.clickhouse.indexes import index_by_kafka_timestamp
 from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine
 from posthog.clickhouse.table_engines import CollapsingMergeTree, ReplacingMergeTree
 from posthog.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_DISTINCT_ID, KAFKA_PERSON_UNIQUE_ID
@@ -39,7 +40,10 @@ PERSONS_TABLE_SQL = lambda: (
     table_name=PERSONS_TABLE,
     cluster=CLICKHOUSE_CLUSTER,
     engine=PERSONS_TABLE_ENGINE(),
-    extra_fields=KAFKA_COLUMNS,
+    extra_fields=f"""
+    {KAFKA_COLUMNS}
+    , {index_by_kafka_timestamp(PERSONS_TABLE)}
+    """,
     storage_policy=STORAGE_POLICY(),
 )
 
@@ -182,7 +186,11 @@ PERSON_DISTINCT_ID2_TABLE_SQL = lambda: (
     table_name=PERSON_DISTINCT_ID2_TABLE,
     cluster=CLICKHOUSE_CLUSTER,
     engine=PERSON_DISTINCT_ID2_TABLE_ENGINE(),
-    extra_fields=KAFKA_COLUMNS + "\n, _partition UInt64",
+    extra_fields=f"""
+    {KAFKA_COLUMNS}
+    , _partition UInt64
+    , {index_by_kafka_timestamp(PERSON_DISTINCT_ID2_TABLE)}
+    """,
 )
 
 KAFKA_PERSON_DISTINCT_ID2_TABLE_SQL = lambda: PERSON_DISTINCT_ID2_TABLE_BASE_SQL.format(

--- a/posthog/models/session_recording_event/sql.py
+++ b/posthog/models/session_recording_event/sql.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from posthog.clickhouse.indexes import index_by_kafka_timestamp
 from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, kafka_engine, ttl_period
 from posthog.clickhouse.table_engines import Distributed, ReplacingMergeTree, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_SESSION_RECORDING_EVENTS
@@ -86,7 +87,10 @@ SETTINGS index_granularity=512
     table_name=SESSION_RECORDING_EVENTS_DATA_TABLE(),
     cluster=settings.CLICKHOUSE_CLUSTER,
     materialized_columns=SESSION_RECORDING_EVENTS_MATERIALIZED_COLUMNS,
-    extra_fields=KAFKA_COLUMNS,
+    extra_fields=f"""
+    {KAFKA_COLUMNS}
+    , {index_by_kafka_timestamp(SESSION_RECORDING_EVENTS_DATA_TABLE())}
+    """,
     engine=SESSION_RECORDING_EVENTS_DATA_TABLE_ENGINE(),
     ttl_period=ttl_period(),
 )


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/13371 made measuring clickhouse lag on events table cheap. But this did not affect queries for other tables

## Changes

Make 0008 migration create more projections and indexes and create these on initial schema creation.