### PR TITLE
chore(ingestion): if person is not identified, buffer event

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -4,14 +4,7 @@ import { Producer } from 'kafkajs'
 import parsePrometheusTextFormat from 'parse-prometheus-text-format'
 import { Pool } from 'pg'
 
-import {
-    ActionStep,
-    PluginLogEntry,
-    RawAction,
-    RawClickHouseEvent,
-    RawPerson,
-    RawSessionRecordingEvent,
-} from '../src/types'
+import { ActionStep, PluginLogEntry, RawAction, RawClickHouseEvent, RawSessionRecordingEvent } from '../src/types'
 import { Plugin, PluginConfig } from '../src/types'
 import { parseRawClickHouseEvent } from '../src/utils/event'
 import { UUIDT } from '../src/utils/utils'
@@ -109,8 +102,8 @@ export const fetchEvents = async (clickHouseClient: ClickHouse, teamId: number, 
 export const fetchPersons = async (clickHouseClient: ClickHouse, teamId: number) => {
     const queryResult = (await clickHouseClient.querying(
         `SELECT * FROM person WHERE team_id = ${teamId} ORDER BY created_at ASC`
-    )) as unknown as ClickHouse.ObjectQueryResult<RawPerson>
-    return queryResult.data
+    )) as unknown as ClickHouse.ObjectQueryResult<any>
+    return queryResult.data.map((person) => ({ ...person, properties: JSON.parse(person.properties) }))
 }
 
 export const fetchSessionRecordingsEvents = async (clickHouseClient: ClickHouse, teamId: number) => {

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { KAFKA_BUFFER } from '../../../config/kafka-topics'
-import { Hub, IngestionPersonData, TeamId } from '../../../types'
+import { Hub, Person, TeamId } from '../../../types'
 import { status } from '../../../utils/status'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { EventPipelineRunner, StepResult } from './runner'
@@ -12,7 +12,7 @@ export async function emitToBufferStep(
     shouldBuffer: (
         hub: Hub,
         event: PluginEvent,
-        person: IngestionPersonData | undefined,
+        person: Person | undefined,
         teamId: TeamId
     ) => boolean = shouldSendEventToBuffer
 ): Promise<StepResult> {
@@ -91,7 +91,7 @@ export async function emitToBufferStep(
 export function shouldSendEventToBuffer(
     hub: Hub,
     event: PluginEvent,
-    person: IngestionPersonData | undefined,
+    person: Person | undefined,
     teamId: TeamId
 ): boolean {
     // Libraries by default create a unique id for this `type-name_value` for $groupidentify,
@@ -121,7 +121,14 @@ export function shouldSendEventToBuffer(
         isMergingAliasEvent: isMergingAliasEvent.toString(),
         isMergingIdentifyEvent: isMergingIdentifyEvent.toString(),
     }
-    if (conversionBufferDisabled || person || isGroupIdentifyEvent || isMergingIdentifyEvent || isMergingAliasEvent) {
+
+    if (
+        conversionBufferDisabled ||
+        person?.is_identified ||
+        isGroupIdentifyEvent ||
+        isMergingIdentifyEvent ||
+        isMergingAliasEvent
+    ) {
         status.debug('🔁', 'Not sending event to buffer', {
             event,
             person,

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -267,6 +267,6 @@ describe('shouldSendEventToBuffer()', () => {
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 2)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 3)).toEqual(false)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, { is_identified: true } as Person, 1)).toEqual(false)
-        expect(shouldSendEventToBuffer(runner.hub, anonEvent, { is_identified: false } as Person, 1)).toEqual(false)
+        expect(shouldSendEventToBuffer(runner.hub, anonEvent, { is_identified: false } as Person, 1)).toEqual(true)
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -266,6 +266,7 @@ describe('shouldSendEventToBuffer()', () => {
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 1)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 2)).toEqual(true)
         expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 3)).toEqual(false)
-        expect(shouldSendEventToBuffer(runner.hub, anonEvent, {} as Person, 1)).toEqual(false)
+        expect(shouldSendEventToBuffer(runner.hub, anonEvent, { is_identified: true } as Person, 1)).toEqual(false)
+        expect(shouldSendEventToBuffer(runner.hub, anonEvent, { is_identified: false } as Person, 1)).toEqual(false)
     })
 })


### PR DESCRIPTION
## Problem

This handles the case where a user:

 1. visits a site on one device
 2. visits a site on another device and logs in
 3. visits a site on the first device and logs in. We want to associate the
    events with the person created by step 2.

Previously the anonymous events from step 3 would not have been delayed, and therefore would be associated with the anonymous person created as a result of step 1

NOTE: I'm not 100% sure that `is_identifed` is what I want. Can we rely on it? There appears to be a comparison further down in the buffer step that mentioned checking that `distinct_id === device_id`, is this a better check?

NOTE: I'm not 100% sure this catches all cases for anonymous user events so would love some input if people can think of other cases. I'd love to catch them all as otherwise we'll be in a position where we need to retroactively apply the changes to the data, which will be a little involved.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Delay events that are associated with an unidentified person.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
