### PR TITLE
chore: Lemonize `UpgradeModal`

### DIFF
--- a/frontend/src/scenes/UpgradeModal.tsx
+++ b/frontend/src/scenes/UpgradeModal.tsx
@@ -1,28 +1,41 @@
-import Modal from 'antd/lib/modal/Modal'
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { posthog } from 'posthog-js'
 import { sceneLogic } from './sceneLogic'
+import { urls } from './urls'
 
 export function UpgradeModal(): JSX.Element {
     const { upgradeModalFeatureNameAndCaption } = useValues(sceneLogic)
-    const { hideUpgradeModal, takeToPricing } = useActions(sceneLogic)
+    const { hideUpgradeModal } = useActions(sceneLogic)
 
     const [featureName, featureCaption] = upgradeModalFeatureNameAndCaption ?? []
 
     return (
-        <Modal
-            title="Unleash PostHog's Full Power"
-            okText="Upgrade Now"
-            cancelText="Maybe Later"
-            onOk={takeToPricing}
-            onCancel={hideUpgradeModal}
-            visible={!!featureName}
+        <LemonModal
+            title="Unleash PostHog's full power"
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={hideUpgradeModal}>
+                        Maybe later
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        to={urls.organizationBilling()}
+                        onClick={() => posthog.capture('upgrade modal pricing interaction')}
+                    >
+                        Upgrade now
+                    </LemonButton>
+                </>
+            }
+            onClose={hideUpgradeModal}
+            isOpen={!!featureName}
         >
             <p>
                 <b>{featureName && capitalizeFirstLetter(featureName)}</b> is an advanced PostHog feature.
             </p>
             {featureCaption && <p>{featureCaption}</p>}
-            <p>Upgrade now and get access to this, as well as to other powerful enhancements.</p>
-        </Modal>
+            <p className="mb-0">Upgrade and get access to this, as well as to other powerful enhancements.</p>
+        </LemonModal>
     )
 }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -13,7 +13,6 @@ import { LoadedScene, Params, Scene, SceneConfig, SceneExport, SceneParams } fro
 import { emptySceneParams, preloadedScenes, redirects, routes, sceneConfigurations } from 'scenes/scenes'
 import { organizationLogic } from './organizationLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { UPGRADE_LINK } from 'lib/constants'
 import { appContextLogic } from './appContextLogic'
 
 /** Mapping of some scenes that aren't directly accessible from the sidebar to ones that are - for the sidebar. */
@@ -73,7 +72,6 @@ export const sceneLogic = kea<sceneLogicType>({
             }
         ) => ({ featureKey, featureName, featureCaption, featureAvailableCallback, guardOn }),
         hideUpgradeModal: true,
-        takeToPricing: true,
         reloadBrowserDueToImportError: true,
     },
     reducers: {
@@ -111,7 +109,6 @@ export const sceneLogic = kea<sceneLogicType>({
             {
                 showUpgradeModal: (_, { featureName, featureCaption }) => [featureName, featureCaption],
                 hideUpgradeModal: () => null,
-                takeToPricing: () => null,
             },
         ],
         lastReloadAt: [
@@ -209,15 +206,6 @@ export const sceneLogic = kea<sceneLogicType>({
                 featureAvailableCallback?.()
             } else {
                 actions.showUpgradeModal(featureName, featureCaption)
-            }
-        },
-        takeToPricing: () => {
-            posthog.capture('upgrade modal pricing interaction')
-            const link = UPGRADE_LINK(preflightLogic.values.preflight?.cloud)
-            if (link.target) {
-                window.open(link.url, link.target)
-            } else {
-                router.actions.push(link.url)
             }
         },
         setScene: ({ scene, scrollToTop }, _, __, previousState) => {


### PR DESCRIPTION
## Changes

Ants out, lemons in: `UpgradeModal` edition.

| Before | After |
| --- | --- |
| <img width="540" alt="Screenshot 2022-12-19 at 16 12 08" src="https://user-images.githubusercontent.com/4550621/208460922-f6c4c3d3-6e8b-46f9-bf1d-6749979439a8.png"> | <img width="503" alt="Screenshot 2022-12-19 at 16 25 53" src="https://user-images.githubusercontent.com/4550621/208460925-c6a63997-9f77-415f-8e87-10ff3f59bae2.png"> |