### PR TITLE
chore: increase sentry sampling rate for capture endpoints (revert revert)

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -29,11 +29,8 @@ def traces_sampler(sampling_context: dict) -> float:
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
 
         # Ingestion endpoints (high volume)
-        if path.startswith("/batch"):
-            return 0.00000001  # 0.000001%
-        # Ingestion endpoints (high volume)
-        elif path.startswith(("/capture", "/decide", "/track", "/s", "/e")):
-            return 0.0000001  # 0.00001%
+        if path.startswith(("/batch", "/capture", "/decide", "/track", "/s", "/e")):
+            return 0.000001  # 0.0001%
         # Probes/monitoring endpoints
         elif path.startswith(("/_health", "/_readyz", "/_livez")):
             return 0.00001  # 0.001%


### PR DESCRIPTION
Reverts PostHog/posthog#13399

Was unrelated to today's incident. Re-enabling these for increased observability.