### PR TITLE
chore: tag clickhouse queries made from decide/capture endpoints

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -184,6 +184,7 @@ class CHQueries:
             route_id=route.route,
             client_query_id=self._get_param(request, "client_query_id"),
             session_id=self._get_param(request, "session_id"),
+            container_hostname=settings.CONTAINER_HOSTNAME,
         )
 
         if hasattr(user, "current_team_id") and user.current_team_id:
@@ -225,7 +226,12 @@ class ShortCircuitMiddleware:
         if request.path == "/decide/" or request.path == "/decide":
             try:
                 # :KLUDGE: Manually tag ClickHouse queries as CHMiddleware is skipped
-                tag_queries(kind="request", id=request.path, route_id=resolve(request.path).route)
+                tag_queries(
+                    kind="request",
+                    id=request.path,
+                    route_id=resolve(request.path).route,
+                    container_hostname=settings.CONTAINER_HOSTNAME,
+                )
                 return get_decide(request)
             finally:
                 reset_query_tags()

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -223,6 +223,11 @@ class ShortCircuitMiddleware:
 
     def __call__(self, request: HttpRequest):
         if request.path == "/decide/" or request.path == "/decide":
-            return get_decide(request)
+            try:
+                # :KLUDGE: Manually tag ClickHouse queries as CHMiddleware is skipped
+                tag_queries(kind="request", id=request.path, route_id=resolve(request.path).route)
+                return get_decide(request)
+            finally:
+                reset_query_tags()
         response: HttpResponse = self.get_response(request)
         return response

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -91,6 +91,8 @@ BILLING_V2_ENABLED = get_from_env("BILLING_V2_ENABLED", False, type_cast=str_to_
 
 AUTO_LOGIN = get_from_env("AUTO_LOGIN", False, type_cast=str_to_bool)
 
+CONTAINER_HOSTNAME = os.getenv("HOSTNAME", "unknown")
+
 
 # Extend and override these settings with EE's ones
 if "ee.apps.EnterpriseConfig" in INSTALLED_APPS:


### PR DESCRIPTION
We had an incident where clickhouse indexes/projections seemed to affect ingestion. That's weird - let's find out what queries there are being made.

Ideally we'd also tag the pod but I don't believe we have access to that info in the app. Correct if I'm wrong.