### PR TITLE
chore: switch how we cache cypress runners in CI

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -250,6 +250,7 @@ jobs:
 
             - uses: actions/cache@v2
               with:
+                  key: cypress-runner-cache
                   path: |
                       ~/.cache/Cypress
                       node_modules

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -248,16 +248,14 @@ jobs:
                   node-version: 18
                   cache: pnpm
 
+            - uses: actions/cache@v2
+              with:
+                  path: |
+                      ~/.cache/Cypress
+                      node_modules
+
             - name: Install package.json dependencies with pnpm
               run: pnpm install
-
-            - name: Cache Cypress runners
-              id: cypress-runner-cache
-              uses: actions/cache@v3
-              with:
-                  key: cypress-runner-cache
-                  path: |
-                      /home/runner/.cache/Cypress
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -315,8 +313,7 @@ jobs:
                   config-file: cypress.e2e.config.ts
                   config: retries=2
                   spec: ${{ matrix.specs }}
-                  # if there is no cached cypress runner, install one
-                  install: ${{ steps.cypress-runner-cache.outputs.cache-hit != 'true' }}
+                  install: false
 
             - name: Archive test screenshots
               uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -246,14 +246,18 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: 18
-                  #todo understand this line
                   cache: pnpm
-                  cache-dependency-path: |
-                      **/package-lock.json
-                      /home/runner/.cache/Cypress
 
             - name: Install package.json dependencies with pnpm
               run: pnpm install
+
+            - name: Cache Cypress runners
+              id: cypress-runner-cache
+              uses: actions/cache@v3
+              with:
+                  key: cypress-runner-cache
+                  path: |
+                      /home/runner/.cache/Cypress
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -311,7 +315,8 @@ jobs:
                   config-file: cypress.e2e.config.ts
                   config: retries=2
                   spec: ${{ matrix.specs }}
-                  install: false
+                  # if there is no cached cypress runner, install one
+                  install: ${{ steps.cypress-runner-cache.outputs.cache-hit != 'true' }}
 
             - name: Archive test screenshots
               uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -246,6 +246,7 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: 18
+                  #todo understand this line
                   cache: pnpm
 
             - name: Install package.json dependencies with pnpm

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -248,6 +248,9 @@ jobs:
                   node-version: 18
                   #todo understand this line
                   cache: pnpm
+                  cache-dependency-path: |
+                      **/package-lock.json
+                      /home/runner/.cache/Cypress
 
             - name: Install package.json dependencies with pnpm
               run: pnpm install


### PR DESCRIPTION
## Problem

Cypress caching was being weird e.g. https://github.com/PostHog/posthog/actions/runs/3733173207/jobs/6333797479
## Changes

Follows Cypress docs advice on how to cache Cypress

## How did you test this code?

ran the E2E tests twice and saw the cache being used the second time