### PR TITLE
refactor(insights): Clean up activity descriptions

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.insight.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.insight.test.tsx
@@ -76,7 +76,7 @@ describe('the activity log logic', () => {
             const actual = logic.values.humanizedActivity
 
             const renderedDescription = render(<>{actual[0].description}</>).container
-            expect(renderedDescription).toHaveTextContent('peter changed details on test insight')
+            expect(renderedDescription).toHaveTextContent('peter changed query definition on test insight')
         })
 
         it('can handle change of filters on a retention graph', async () => {
@@ -106,7 +106,7 @@ describe('the activity log logic', () => {
             const actual = logic.values.humanizedActivity
 
             const renderedDescription = render(<>{actual[0].description}</>).container
-            expect(renderedDescription).toHaveTextContent('peter changed details on test insight')
+            expect(renderedDescription).toHaveTextContent('peter changed query definition on test insight')
         })
 
         it('can handle soft delete', async () => {

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -61,9 +61,6 @@ import {
 import { CardMeta, Resizeable } from 'lib/components/Cards/Card'
 import { DashboardPrivilegeLevel } from 'lib/constants'
 
-// TODO: Add support for Retention to InsightDetails
-export const INSIGHT_TYPES_WHERE_DETAILS_UNSUPPORTED: InsightType[] = [InsightType.RETENTION]
-
 type DisplayedType = ChartDisplayType | 'RetentionContainer' | 'FunnelContainer' | 'PathsContainer'
 
 const displayMap: Record<

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -66,7 +66,7 @@ const insightActionsMapping: Record<
         const filtersAfter = change?.after as Partial<FilterType>
 
         return {
-            description: 'changed query definition',
+            description: ['changed query definition'],
             extendedDescription: (
                 <div className="summary-card">
                     <QuerySummary filters={filtersAfter} />

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -13,7 +13,6 @@ import { BreakdownSummary, FiltersSummary, QuerySummary } from 'lib/components/C
 import '../../lib/components/Cards/InsightCard/InsightCard.scss'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { pluralize } from 'lib/utils'
-import { INSIGHT_TYPES_WHERE_DETAILS_UNSUPPORTED } from 'lib/components/Cards/InsightCard/InsightCard'
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 
 const nameOrLinkToInsight = (short_id?: InsightShortId | null, name?: string | null): string | JSX.Element => {
@@ -64,30 +63,18 @@ const insightActionsMapping: Record<
         }
     },
     filters: function onChangedFilter(change) {
-        // const filtersBefore = change?.before as FeatureFlagFilters
         const filtersAfter = change?.after as Partial<FilterType>
-        let extendedDescription: JSX.Element | undefined = undefined
-        const changes: Description[] = []
 
-        if (filtersAfter.insight && INSIGHT_TYPES_WHERE_DETAILS_UNSUPPORTED.includes(filtersAfter.insight)) {
-            changes.push(<>changed details</>)
-        } else {
-            changes.push(<>changed details</>)
-            extendedDescription = (
+        return {
+            description: 'changed query definition',
+            extendedDescription: (
                 <div className="summary-card">
                     <QuerySummary filters={filtersAfter} />
                     <FiltersSummary filters={filtersAfter} />
                     {filtersAfter.breakdown_type && <BreakdownSummary filters={filtersAfter} />}
                 </div>
-            )
+            ),
         }
-
-        if (changes.length > 0) {
-            return { description: changes, extendedDescription }
-        }
-
-        console.error({ change }, 'could not describe this change')
-        return null
     },
     deleted: function onSoftDelete(change, logItem, asNotification) {
         const isDeleted = detectBoolean(change?.after)


### PR DESCRIPTION
## Problem

Noticed an out-of-date TODO in `frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx`.

## Changes

Removed TODO and cleaned up `onChangedFilter` in `frontend/src/scenes/saved-insights/activityDescriptions.tsx` accordingly.
BTW I don't see where `extendedDescription` is shown, can you point me in the right direction?