### PR TITLE
chore: definition names are not editable

### DIFF
--- a/frontend/src/scenes/data-management/definition/Definition.scss
+++ b/frontend/src/scenes/data-management/definition/Definition.scss
@@ -122,6 +122,10 @@
             flex-direction: row;
             justify-content: flex-end;
         }
+
+        .DefinitionEdit--form {
+            max-width: 640px;
+        }
     }
 
     // Shared across definition view and edit modes

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -3,7 +3,7 @@ import { DefinitionPageMode } from 'scenes/data-management/definition/definition
 import { useActions, useValues } from 'kea'
 import { definitionEditLogic, DefinitionEditLogicProps } from 'scenes/data-management/definition/definitionEditLogic'
 import { LemonButton } from 'lib/components/LemonButton'
-import { Col, Divider, Row } from 'antd'
+import { Col, Row } from 'antd'
 import { Field } from 'lib/forms/Field'
 import { LemonTextArea } from 'lib/components/LemonTextArea/LemonTextArea'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
@@ -12,6 +12,7 @@ import { VerifiedEventCheckbox } from 'lib/components/DefinitionPopup/Definition
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { Form } from 'kea-forms'
 import { tagsModel } from '~/models/tagsModel'
+import { LemonDivider } from 'lib/components/LemonDivider'
 
 export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
     const logic = definitionEditLogic(props)
@@ -48,15 +49,16 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                     </>
                 }
             />
-            <Divider />
-            <Row gutter={[16, 24]} style={{ maxWidth: 640 }} className="ph-ignore-input">
-                <Col span={24}>
-                    <h1>{getPropertyLabel(definition.name) || ''}</h1>
-                    <div className="definition-sent-as">
-                        Raw event name: <pre>{definition.name}</pre>
+            <LemonDivider />
+            <div>
+                <h1>{getPropertyLabel(definition.name) || ''}</h1>
+                <div className="definition-sent-as flex-wrap">
+                    <div>Raw event name:</div>
+                    <div>
+                        <pre>{definition.name}</pre>
                     </div>
-                </Col>
-            </Row>
+                </div>
+            </div>
             {hasTaxonomyFeatures && (
                 <Row gutter={[16, 24]} className="mt-4 ph-ignore-input" style={{ maxWidth: 640 }}>
                     <Col span={24}>
@@ -120,7 +122,7 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                     </Col>
                 </Row>
             )}
-            <Divider />
+            <LemonDivider />
         </Form>
     )
 }

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -3,7 +3,6 @@ import { DefinitionPageMode } from 'scenes/data-management/definition/definition
 import { useActions, useValues } from 'kea'
 import { definitionEditLogic, DefinitionEditLogicProps } from 'scenes/data-management/definition/definitionEditLogic'
 import { LemonButton } from 'lib/components/LemonButton'
-import { Col, Row } from 'antd'
 import { Field } from 'lib/forms/Field'
 import { LemonTextArea } from 'lib/components/LemonTextArea/LemonTextArea'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
@@ -50,27 +49,25 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                 }
             />
             <LemonDivider />
-            <div>
-                <h1>{getPropertyLabel(definition.name) || ''}</h1>
-                <div className="definition-sent-as flex-wrap">
-                    <div>Raw event name:</div>
-                    <div>
-                        <pre>{definition.name}</pre>
+            <div className={'DefinitionEdit--form my-4'}>
+                <div>
+                    <h1>{getPropertyLabel(definition.name) || ''}</h1>
+                    <div className="definition-sent-as flex-wrap">
+                        <div>Raw event name:</div>
+                        <div>
+                            <pre>{definition.name}</pre>
+                        </div>
                     </div>
                 </div>
-            </div>
-            {hasTaxonomyFeatures && (
-                <Row gutter={[16, 24]} className="mt-4 ph-ignore-input" style={{ maxWidth: 640 }}>
-                    <Col span={24}>
+                {hasTaxonomyFeatures && (
+                    <div className="mt-4 ph-ignore-input">
                         <Field name="description" label="Description" data-attr="definition-description">
                             <LemonTextArea value={definition.description} />
                         </Field>
-                    </Col>
-                </Row>
-            )}
-            {hasTaxonomyFeatures && isEvent && !isPostHogProp(definition.name) && 'verified' in definition && (
-                <Row gutter={[16, 24]} className="mt-4 ph-ignore-input" style={{ maxWidth: 640 }}>
-                    <Col span={24}>
+                    </div>
+                )}
+                {hasTaxonomyFeatures && isEvent && !isPostHogProp(definition.name) && 'verified' in definition && (
+                    <div className="mt-4 ph-ignore-input">
                         <Field name="verified" data-attr="definition-verified">
                             {({ value, onChange }) => (
                                 <VerifiedEventCheckbox
@@ -81,12 +78,10 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                                 />
                             )}
                         </Field>
-                    </Col>
-                </Row>
-            )}
-            {hasTaxonomyFeatures && 'tags' in definition && (
-                <Row gutter={[16, 24]} className="mt-4 ph-ignore-input" style={{ maxWidth: 640 }}>
-                    <Col span={24}>
+                    </div>
+                )}
+                {hasTaxonomyFeatures && 'tags' in definition && (
+                    <div className="mt-4 ph-ignore-input">
                         <Field name="tags" label="Tags" data-attr="definition-tags">
                             {({ value, onChange }) => (
                                 <ObjectTags
@@ -99,12 +94,10 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                                 />
                             )}
                         </Field>
-                    </Col>
-                </Row>
-            )}
-            {hasTaxonomyFeatures && !isEvent && (
-                <Row gutter={[16, 24]} className="mt-4 ph-ignore-input" style={{ maxWidth: 640 }}>
-                    <Col span={24}>
+                    </div>
+                )}
+                {hasTaxonomyFeatures && !isEvent && (
+                    <div className="mt-4 ph-ignore-input">
                         <Field name="property_type" label="Property Type" data-attr="property-type">
                             {({ value, onChange }) => (
                                 <LemonSelect
@@ -119,9 +112,9 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                                 />
                             )}
                         </Field>
-                    </Col>
-                </Row>
-            )}
+                    </div>
+                )}
+            </div>
             <LemonDivider />
         </Form>
     )

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -5,10 +5,9 @@ import { definitionEditLogic, DefinitionEditLogicProps } from 'scenes/data-manag
 import { LemonButton } from 'lib/components/LemonButton'
 import { Col, Divider, Row } from 'antd'
 import { Field } from 'lib/forms/Field'
-import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { LemonTextArea } from 'lib/components/LemonTextArea/LemonTextArea'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
-import { isPostHogProp } from 'lib/components/PropertyKeyInfo'
+import { getPropertyLabel, isPostHogProp } from 'lib/components/PropertyKeyInfo'
 import { VerifiedEventCheckbox } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { Form } from 'kea-forms'
@@ -52,9 +51,7 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
             <Divider />
             <Row gutter={[16, 24]} style={{ maxWidth: 640 }} className="ph-ignore-input">
                 <Col span={24}>
-                    <Field name="name" label="Name">
-                        <LemonInput data-attr="definition-name" value={definition.name} disabled />
-                    </Field>
+                    <h1>{getPropertyLabel(definition.name) || ''}</h1>
                     <div className="definition-sent-as">
                         Raw event name: <pre>{definition.name}</pre>
                     </div>


### PR DESCRIPTION
## Problem

The definition edit page presented event and property definition names in a disabled input. This gave the impression they might sometimes be editable. But they're not.

## Changes

* makes the definition name an `H1`
* removes ANT components from the edit page (uses slightly less vertical space now)

| before | after |
|--------|-------|
|    <img width="789" alt="Screenshot 2022-12-19 at 17 57 46" src="https://user-images.githubusercontent.com/984817/208489873-26d4c81e-32dd-422d-9f38-03f74b880dfa.png">   |   <img width="789" alt="Screenshot 2022-12-19 at 17 53 26" src="https://user-images.githubusercontent.com/984817/208489447-fb074ffd-c2de-47eb-ac17-7812d45dc3cb.png">    |
 
## How did you test this code?

👀 