### PR TITLE
fix: demo data explicitly catch exceptions in matrix

### DIFF
--- a/posthog/tasks/demo_create_data.py
+++ b/posthog/tasks/demo_create_data.py
@@ -1,4 +1,5 @@
 from celery import shared_task
+from sentry_sdk import capture_exception
 
 from posthog.demo.matrix.manager import MatrixManager
 from posthog.demo.products.hedgebox.matrix import HedgeboxMatrix
@@ -11,4 +12,8 @@ def create_data_for_demo_team(team_id: int, user_id: int) -> None:
     team = Team.objects.get(pk=team_id)
     user = User.objects.get(pk=user_id)
     if team and user:
-        MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, user)
+        try:
+            MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, user)
+        except Exception as e:  # TODO: Remove this after 2022-12-22, the except is just temporary for debugging
+            capture_exception(e)
+            raise e


### PR DESCRIPTION
## Problem

The matrix manager is copying demo events, but no persons, insights, or dashboards. In the past these would fail silently, I thought it was because it was in an atomic transaction, but now I am not sure. Figured I could try to explicitly raise an exception to see if any errors are captured that way.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Just adds a try/except to see if it catches any other errors.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
