### PR TITLE
fix: Fallback to django json if drf fails

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -1,13 +1,15 @@
-import base64
 import json
 from typing import Any, Optional
 
+import structlog
 from dateutil import parser
-from rest_framework import exceptions, request, response, serializers, viewsets
+from django.http import JsonResponse
+from rest_framework import exceptions, request, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
+from sentry_sdk import capture_exception
 
 from posthog.api.person import PersonSerializer
 from posthog.api.routing import StructuredViewSetMixin
@@ -24,6 +26,8 @@ from posthog.rate_limit import PassThroughClickHouseBurstRateThrottle, PassThrou
 from posthog.utils import format_query_params_absolute_url
 
 DEFAULT_RECORDING_CHUNK_LIMIT = 20  # Should be tuned to find the best value
+
+logger = structlog.get_logger(__name__)
 
 
 class SessionRecordingMetadataSerializer(serializers.Serializer):
@@ -82,7 +86,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
         return Response(list_recordings(filter, request, self.team))
 
     # Returns meta data about the recording
-    def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+    def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         session_recording_id = kwargs["pk"]
         recording_start_time_string = request.GET.get("recording_start_time")
         recording_start_time = parser.parse(recording_start_time_string) if recording_start_time_string else None
@@ -127,7 +131,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
                 team=self.team, user=request.user, session_id=session_recording_id
             )
 
-        return response.Response(
+        return Response(
             {
                 "result": {
                     "session_recording": session_recording_serializer.data,
@@ -162,29 +166,24 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
             else None
         )
 
-        # NOTE: This is debug code to try and see what is going on for very specific failures due to unicode errors
-        try:
-            JSONRenderer().render(data=session_recording_snapshot_data["snapshot_data_by_window_id"])
-        except Exception as e:
-            return response.Response(
-                {
-                    "error": "Unicode error when decoding snapshot data",
-                    "detail": str(e),
-                    "base64_content": base64.b64encode(
-                        json.dumps(session_recording_snapshot_data["snapshot_data_by_window_id"]).encode("utf-8")
-                    ),
-                },
-                status=400,
-            )
-
-        return response.Response(
-            {
-                "result": {
-                    "next": next_url,
-                    "snapshot_data_by_window_id": session_recording_snapshot_data["snapshot_data_by_window_id"],
-                }
+        res = {
+            "result": {
+                "next": next_url,
+                "snapshot_data_by_window_id": session_recording_snapshot_data["snapshot_data_by_window_id"],
             }
-        )
+        }
+
+        # NOTE: We have seen some issues with encoding of emojis, specifically when there is a lone "surrogate pair". See #13272 for more details
+        # The Django JsonResponse handles this case, but the DRF Response does not. So we fall back to the Django JsonResponse if we encounter an error
+        try:
+            JSONRenderer().render(data=res)
+        except Exception:
+            capture_exception(
+                Exception("DRF Json encoding failed, falling back to Django JsonResponse"), {"response_data": res}
+            )
+            return JsonResponse(res)
+
+        return Response(res)
 
     # Returns properties given a list of session recording ids
     @action(methods=["GET"], detail=False)

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -32,9 +32,20 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin):
         source=0,
         has_full_snapshot=True,
         type=2,
+        snapshot_data=None,
     ):
         if team_id is None:
             team_id = self.team.pk
+
+        snapshot = {
+            "timestamp": timestamp.timestamp() * 1000,
+            "has_full_snapshot": has_full_snapshot,
+            "type": type,
+            "data": {"source": source},
+        }
+
+        if snapshot_data:
+            snapshot_data.update(snapshot)
 
         create_session_recording_events(
             team_id=team_id,
@@ -42,14 +53,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin):
             timestamp=timestamp,
             session_id=session_id,
             window_id=window_id,
-            snapshots=[
-                {
-                    "timestamp": timestamp.timestamp() * 1000,
-                    "has_full_snapshot": has_full_snapshot,
-                    "type": type,
-                    "data": {"source": source},
-                }
-            ],
+            snapshots=[snapshot_data],
         )
 
     def create_chunked_snapshots(
@@ -420,3 +424,23 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin):
             response_data = response.json()
 
             self.assertEqual(len(response_data["results"]), 0)
+
+    def test_regression_encoded_emojis_dont_crash(self):
+
+        Person.objects.create(
+            team=self.team, distinct_ids=["user"], properties={"$some_prop": "something", "email": "bob@bob.com"}
+        )
+        self.create_snapshot(
+            "user", "1", now() - relativedelta(days=1), snapshot_data={"texts": ["\\ud83d\udc83\\ud83c\\udffb"]}
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1/snapshots")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+
+        assert "base64_content" in response_data
+        assert response_data["error"] == "Unicode error when decoding snapshot data"
+        assert (
+            response_data["detail"]
+            == "'utf-8' codec can't encode character '\\udc83' in position 23: surrogates not allowed"
+        )

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -430,20 +430,32 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin):
         Person.objects.create(
             team=self.team, distinct_ids=["user"], properties={"$some_prop": "something", "email": "bob@bob.com"}
         )
-        self.create_snapshot(
-            "user",
-            "1",
-            now() - relativedelta(days=1),
-            snapshot_data={"texts": ["\\ud83d\udc83\\ud83c\\udffb"]},  # This is an invalid encoded emoji
-        )
+        with freeze_time("2022-01-01T12:00:00.000Z"):
+
+            self.create_snapshot(
+                "user",
+                "1",
+                now() - relativedelta(days=1),
+                snapshot_data={"texts": ["\\ud83d\udc83\\ud83c\\udffb"]},  # This is an invalid encoded emoji
+            )
 
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1/snapshots")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
 
-        assert "base64_content" in response_data
-        assert response_data["error"] == "Unicode error when decoding snapshot data"
-        assert (
-            response_data["detail"]
-            == "'utf-8' codec can't encode character '\\udc83' in position 23: surrogates not allowed"
-        )
+        assert response_data == {
+            "result": {
+                "next": None,
+                "snapshot_data_by_window_id": {
+                    "": [
+                        {
+                            "texts": ["\\ud83d\udc83\\ud83c\\udffb"],
+                            "timestamp": 1640952000000.0,
+                            "has_full_snapshot": True,
+                            "type": 2,
+                            "data": {"source": 0},
+                        }
+                    ]
+                },
+            }
+        }

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -45,7 +45,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin):
         }
 
         if snapshot_data:
-            snapshot_data.update(snapshot)
+            snapshot.update(snapshot_data)
 
         create_session_recording_events(
             team_id=team_id,
@@ -53,7 +53,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin):
             timestamp=timestamp,
             session_id=session_id,
             window_id=window_id,
-            snapshots=[snapshot_data],
+            snapshots=[snapshot],
         )
 
     def create_chunked_snapshots(

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -431,7 +431,10 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin):
             team=self.team, distinct_ids=["user"], properties={"$some_prop": "something", "email": "bob@bob.com"}
         )
         self.create_snapshot(
-            "user", "1", now() - relativedelta(days=1), snapshot_data={"texts": ["\\ud83d\udc83\\ud83c\\udffb"]}
+            "user",
+            "1",
+            now() - relativedelta(days=1),
+            snapshot_data={"texts": ["\\ud83d\udc83\\ud83c\\udffb"]},  # This is an invalid encoded emoji
         )
 
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1/snapshots")


### PR DESCRIPTION
## Problem

Follow up work to the previous debugging commit. If we have issues encoding the response, fallback to the Django JsonResponse. This may cause issues with emojis, but rather render them poorly (they might even be incorrect on the client that it was recorded from) than fail all together

See https://github.com/PostHog/posthog/issues/13272

## Changes
* Fallback
* Capture exception so we can look further into it


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests