### PR TITLE
fix(query-performance): Instrument events api, track personal API key usage.

### DIFF
--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -528,7 +528,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response_invalid_token = self.client.get(f"/api/projects/{self.team.id}/events?token=invalid")
         self.assertEqual(response_invalid_token.status_code, 401)
 
-    @patch("posthog.models.event.query_event_list.query_with_columns")
+    @patch("posthog.models.event.query_event_list.insight_query_with_columns")
     def test_optimize_query(self, patch_query_with_columns):
         #  For ClickHouse we normally only query the last day,
         # but if a user doesn't have many events we still want to return events that are older

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -11,6 +11,7 @@ from rest_framework import authentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.jwt import PosthogJwtAudience, decode_jwt
 from posthog.models.personal_api_key import hash_key_value
 from posthog.models.user import User
@@ -91,6 +92,9 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             key_last_used_at = now
             personal_api_key_object.save()
         assert personal_api_key_object.user is not None
+
+        # :KLUDGE: CHMiddleware does not receive the correct user when authenticating by api key.
+        tag_queries(user_id=personal_api_key_object.user.pk, team_id=personal_api_key_object.user.current_team_id)
         return personal_api_key_object.user, None
 
     @classmethod

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -1,19 +1,32 @@
 from typing import Optional
 
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.client import sync_execute
+from posthog.client import query_with_columns, sync_execute
 from posthog.types import FilterType
 
 
 # Wrapper around sync_execute, adding query tags for insights performance
-def insight_sync_execute(
+def insight_sync_execute(query, args=None, *, query_type: str, filter: Optional["FilterType"] = None, **kwargs):
+    _tag_query(query, query_type, filter)
+
+    return sync_execute(query, args=args, **kwargs)
+
+
+# Wrapper around `query_with_columns`
+def insight_query_with_columns(
     query,
     args=None,
     *,
     query_type: str,
     filter: Optional["FilterType"] = None,
-    settings=None,
+    **kwargs,
 ):
+    _tag_query(query, query_type, filter)
+
+    return query_with_columns(query, args=args, **kwargs)
+
+
+def _tag_query(query, query_type, filter: Optional["FilterType"]):
     tag_queries(
         query_type=query_type,
         has_joins="JOIN" in query,
@@ -22,5 +35,3 @@ def insight_sync_execute(
 
     if filter is not None:
         tag_queries(filter=filter.to_dict(), **filter.query_tags())
-
-    return sync_execute(query, args=args, settings=settings)


### PR DESCRIPTION
- /api/event was untracked
- we did not tag team_id/user_id properly when using api keys