### PR TITLE
chore(capture): return HTTP 413 on request entity too large

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 import structlog
 from dateutil import parser
 from django.conf import settings
-from django.core.exceptions import RequestDataTooBig
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -196,19 +195,7 @@ def get_event(request):
 
     now = timezone.now()
 
-    try:
-        data, error_response = get_data(request)
-    except RequestDataTooBig:
-        return cors_response(
-            request,
-            generate_exception_response(
-                endpoint="capture",
-                detail="Request too large.",
-                type="client_error",
-                code="request_too_large",
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            ),
-        )
+    data, error_response = get_data(request)
 
     if error_response:
         return error_response

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -30,7 +30,7 @@ from posthog.api.test.mock_sentry import mock_sentry_context_for_tagging
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.utils import generate_random_token_personal
-from posthog.settings import KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
+from posthog.settings import DATA_UPLOAD_MAX_MEMORY_SIZE, KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
 from posthog.test.base import BaseTest
 
 
@@ -141,6 +141,23 @@ class TestCapture(BaseTest):
             },
             self._to_arguments(kafka_produce),
         )
+
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_capture_event_too_large(self, kafka_produce):
+        # There is a setting in Django, `DATA_UPLOAD_MAX_MEMORY_SIZE`, which
+        # limits the size of the request body. An error is  raise, e.g. when we
+        # try to read `django.http.request.HttpRequest.body` in the view. We
+        # want to make sure this doesn't it is returned as a 413 error, not as a
+        # 500, otherwise we have issues with setting up sensible monitoring that
+        # is resilient to clients that send too much data.
+        response = self.client.post(
+            "/e/",
+            data=20 * DATA_UPLOAD_MAX_MEMORY_SIZE * "x",
+            HTTP_ORIGIN="https://localhost",
+            content_type="text/plain",
+        )
+
+        self.assertEqual(response.status_code, 413)
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_capture_events_503_on_kafka_produce_errors(self, kafka_produce):

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Tuple, Union, cast
 from uuid import UUID
 
 import structlog
+from django.core.exceptions import RequestDataTooBig
 from django.db.models import QuerySet
 from rest_framework import request, status
 from rest_framework.exceptions import ValidationError
@@ -159,6 +160,21 @@ def get_data(request):
             cors_response(
                 request,
                 generate_exception_response("capture", f"Malformed request data: {error}", code="invalid_payload"),
+            ),
+        )
+
+    except RequestDataTooBig:
+        return (
+            None,
+            cors_response(
+                request,
+                generate_exception_response(
+                    endpoint="capture",
+                    detail="Request too large.",
+                    type="client_error",
+                    code="request_too_large",
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                ),
             ),
         )
 


### PR DESCRIPTION
Previously we were raising (or at least Django was) a
`RequestDataTooBig` but then returning a 500. This isn't ideal for
monitoring as this really is a client error (assuming we specify this
limit as a part of the API.) but we'll end up alerting on this as if
it's something we can fix.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
