### PR TITLE
fix(query-performance): Limit /api/event usage

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -73,6 +73,15 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
         return request.build_absolute_uri(f"{request.path}?{urllib.parse.urlencode(params)}")
 
     @extend_schema(
+        description="""
+        API for getting most recent events for a team. Returns up to 100 rows at a time.
+
+        Not suited for data exports, use data export apps for that purpose instead.
+
+        On cloud, filtering is limited to a maximum of 3 days.
+        """.strip().replace(
+            "        ", "'"
+        ),
         parameters=[
             OpenApiParameter(
                 "event",
@@ -100,7 +109,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
                 "after", OpenApiTypes.DATETIME, description="Only return events with a timestamp after this time."
             ),
             PropertiesSerializer(required=False),
-        ]
+        ],
     )
     def list(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         try:

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -18,6 +18,7 @@ from sentry_sdk import capture_exception
 from posthog.api.documentation import PropertiesSerializer, extend_schema
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.client import query_with_columns, sync_execute
+from posthog.cloud_utils import is_cloud
 from posthog.models import Element, Filter, Person
 from posthog.models.event.query_event_list import EventsQueryResponse, query_events_list
 from posthog.models.event.sql import GET_CUSTOM_EVENTS, SELECT_ONE_EVENT_SQL
@@ -137,6 +138,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
                 action_id=request.GET.get("action_id"),
                 select=select,
                 where=where,
+                validate_date_range=getattr(request, "using_personal_api_key", False) and is_cloud(),
             )
 
             result_count = (

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -118,7 +118,7 @@
          concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-11 12:14:05.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
   ORDER BY event ASC
   LIMIT 101
   '
@@ -143,7 +143,7 @@
          event
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-11 12:14:05.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
   ORDER BY timestamp DESC
   LIMIT 101
   '
@@ -169,7 +169,7 @@
          event
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-11 12:14:05.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
   GROUP BY event
   ORDER BY count(*) DESC
   LIMIT 101
@@ -197,7 +197,7 @@
          event
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-11 12:14:05.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
     AND or(equals(event, 'sign up'), like(replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''), '%val2'))
   GROUP BY event
   ORDER BY count(*) DESC, event ASC

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -118,7 +118,7 @@
          concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND timestamp < '2020-01-11 12:14:05.000000'
   ORDER BY event ASC
   LIMIT 101
   '
@@ -143,7 +143,7 @@
          event
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND timestamp < '2020-01-11 12:14:05.000000'
   ORDER BY timestamp DESC
   LIMIT 101
   '
@@ -169,7 +169,7 @@
          event
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND timestamp < '2020-01-11 12:14:05.000000'
   GROUP BY event
   ORDER BY count(*) DESC
   LIMIT 101
@@ -197,7 +197,7 @@
          event
   FROM events
   WHERE team_id = 2
-    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND timestamp < '2020-01-11 12:14:05.000000'
     AND or(equals(event, 'sign up'), like(replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''), '%val2'))
   GROUP BY event
   ORDER BY count(*) DESC, event ASC

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -94,7 +94,12 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         assert personal_api_key_object.user is not None
 
         # :KLUDGE: CHMiddleware does not receive the correct user when authenticating by api key.
-        tag_queries(user_id=personal_api_key_object.user.pk, team_id=personal_api_key_object.user.current_team_id)
+        tag_queries(
+            user_id=personal_api_key_object.user.pk,
+            team_id=personal_api_key_object.user.current_team_id,
+            access_method="personal_api_key",
+        )
+        request.using_personal_api_key = True  # type: ignore
         return personal_api_key_object.user, None
 
     @classmethod

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -44,7 +44,7 @@ def determine_event_conditions(
     before = isoparse(before_date) if isinstance(before_date, str) else default_before
 
     if validate_date_range and (after is None or before - after >= timedelta(days=3)):
-        raise ValidationError("Cannot query time range larger than 3 days using personal API key.")
+        raise ValidationError("Cannot query time range larger than 3 days using personal API key. If you are looking to export large amounts of data we recommend using the historical exports e.g. Amazon S3 export")
 
     if after is not None:
         result += "AND timestamp > %(after)s "


### PR DESCRIPTION
## Problem

Small teams using /api/event can cause us a _lot_ of clickhouse load. The api is not suited for large-scale exports, only for the live events table

## Changes

If using personal API key on cloud, raise a 400 error if filtering on over 3 days. This should stem the bleeding.

Also added instrumentation for clickhouse queries for separating requests from personal api keys from ones without. 

## How did you test this code?

Only using unit tests.
