### PR TITLE
feat: Add `LemonSkeleton` fade-out plus small `LemonButton`/`LemonInput`

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -94,6 +94,10 @@
         height: auto;
         width: auto;
         padding: 0;
+
+        &.LemonButton--full-width {
+            width: 100%;
+        }
     }
 
     .LemonButton__icon {

--- a/frontend/src/lib/components/LemonInput/LemonInput.scss
+++ b/frontend/src/lib/components/LemonInput/LemonInput.scss
@@ -46,23 +46,32 @@
         flex-shrink: 0;
     }
 
-    &.LemonInput--hascontent {
+    &--small {
+        min-height: 2rem;
+        padding: 0.125rem 0.25rem;
+
+        .LemonIcon {
+            font-size: 1.25rem;
+        }
+    }
+
+    &--hascontent {
         > .LemonIcon {
             color: var(--primary);
         }
     }
 
-    &.LemonInput--focused {
+    &--focused {
         &:not(.LemonInput--disabled) {
             border: 1px solid var(--primary);
         }
     }
 
-    &.LemonInput--type-search {
+    &--type-search {
         // NOTE Design: Search inputs are given a specific small width
         max-width: 240px;
     }
-    &.LemonInput--fullwidth {
+    &--fullwidth {
         width: 100%;
         max-width: 100%;
     }

--- a/frontend/src/lib/components/LemonInput/LemonInput.stories.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.stories.tsx
@@ -51,3 +51,6 @@ Clearable.args = { allowClear: true }
 
 export const Numeric = Template.bind({})
 Numeric.args = { type: 'number', min: 0, step: 1, value: 3 }
+
+export const Small = Template.bind({})
+Small.args = { allowClear: true, size: 'small' }

--- a/frontend/src/lib/components/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.tsx
@@ -36,6 +36,8 @@ type LemonInputPropsBase = Pick<
     /** Special case - show a transparent background rather than white */
     transparentBackground?: boolean
 
+    size?: 'small' | 'medium'
+
     'data-attr'?: string
     'aria-label'?: string
 }
@@ -73,6 +75,7 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
         type,
         value,
         transparentBackground,
+        size,
         ...textProps
     },
     ref
@@ -93,7 +96,6 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
     allowClear = allowClear ?? (type === 'search' ? true : false)
     fullWidth = fullWidth ?? (type === 'search' ? false : true)
     prefix = prefix ?? (type === 'search' ? <IconMagnifier /> : undefined)
-
     // Type=password has some special overrides
     suffix =
         suffix ??
@@ -117,7 +119,6 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
         allowClear && value ? (
             <LemonButton
                 size="small"
-                noPadding
                 icon={<IconClose />}
                 status="primary-alt"
                 tooltip="Clear input"
@@ -144,6 +145,7 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
                 fullWidth && 'LemonInput--fullwidth',
                 type && `LemonInput--type-${type}`,
                 transparentBackground && 'LemonInput--transparent-background',
+                size && `LemonInput--${size}`,
                 className
             )}
             onKeyDown={(event) => {

--- a/frontend/src/lib/components/LemonSkeleton/LemonSkeleton.stories.tsx
+++ b/frontend/src/lib/components/LemonSkeleton/LemonSkeleton.stories.tsx
@@ -74,13 +74,33 @@ export function Customisation(): JSX.Element {
 export function DarkBackground(): JSX.Element {
     return (
         <div className="space-y-2 bg-default p-2 rounded">
-            <p>Skeletons have a bunch of presets to help with simulating other LemonUI Components</p>
+            <p className="text-light">
+                Skeletons have a bunch of presets to help with simulating other LemonUI Components
+            </p>
 
             <div className="flex items-center gap-2">
                 <LemonSkeleton.Circle />
                 <LemonSkeleton />
                 <LemonSkeleton.Button />
             </div>
+        </div>
+    )
+}
+
+export function Repeat(): JSX.Element {
+    return (
+        <div className="space-y-2 p-2 rounded">
+            <p>
+                Skeletons can be easily repeated multiple times using the <b>repeat</b> property
+            </p>
+
+            <LemonSkeleton repeat={5} />
+
+            <p>
+                Add the <b>fade</b> property to progressively fade out the repeated skeletons
+            </p>
+
+            <LemonSkeleton repeat={5} fade />
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonSkeleton/LemonSkeleton.tsx
+++ b/frontend/src/lib/components/LemonSkeleton/LemonSkeleton.tsx
@@ -1,16 +1,17 @@
 import clsx from 'clsx'
 import { range } from 'lib/utils'
-import React from 'react'
 import { LemonButtonProps } from '../LemonButton'
 import './LemonSkeleton.scss'
 
 export interface LemonSkeletonProps {
     className?: string
+    /** Repeat this component this many of times */
     repeat?: number
+    /** Used in combination with repeat to progressively fade out the repeated skeletons */
+    fade?: boolean
     active?: boolean
 }
-
-export function LemonSkeleton({ className, repeat, active = true }: LemonSkeletonProps): JSX.Element {
+export function LemonSkeleton({ className, repeat, active = true, fade = false }: LemonSkeletonProps): JSX.Element {
     const content = (
         <div className={clsx('LemonSkeleton rounded h-4', !active && 'LemonSkeleton--static', className || 'w-full')} />
     )
@@ -19,7 +20,10 @@ export function LemonSkeleton({ className, repeat, active = true }: LemonSkeleto
         return (
             <>
                 {range(repeat).map((i) => (
-                    <React.Fragment key={i}>{content}</React.Fragment>
+                    // eslint-disable-next-line react/forbid-dom-props
+                    <div key={i} style={fade ? { opacity: 1 - i / repeat } : undefined}>
+                        {content}
+                    </div>
                 ))}
             </>
         )


### PR DESCRIPTION
## Problem

My large PR 🙈  for the new Inspector panel is large... Pulling some LemonUI component changes out here

## Changes

* Adds "size=small" for LemonInput
* Fixes fullWidth for LemonButtons with `noPadding`
* Adds "fade" property to LemonSkeleton for progressive fading of the repeated skeletons.

<img width="1085" alt="Screenshot 2022-12-20 at 17 26 18" src="https://user-images.githubusercontent.com/2536520/208716191-cc374e3c-05d4-45d3-9e22-30b1019361c6.png">
<img width="1100" alt="Screenshot 2022-12-20 at 17 26 05" src="https://user-images.githubusercontent.com/2536520/208716200-f198e738-2a0b-4c04-8e4a-105fa8f077ef.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
