### PR TITLE
fix(permissioning): License-gate multiple project creation

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -40,7 +40,7 @@ class PremiumMultiprojectPermissions(permissions.BasePermission):
                 # if we're not requesting to make a demo project
                 # and if the org already has more than 1 non-demo project (need to be able to make the initial project)
                 # and the org isn't allowed to make multiple projects
-                "is_demo" not in request.data
+                ("is_demo" not in request.data or not request.data["is_demo"])
                 and user.organization.teams.exclude(is_demo=True).count() >= 1
                 and not user.organization.is_feature_available(AvailableFeature.ORGANIZATIONS_PROJECTS)
             )


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/12877 introduced a regression where we didn't license-gate multiple projects. This fixes it.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
