### PR TITLE
chore: event definition follow up

### DIFF
--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -105,8 +105,8 @@ class EventDefinitionViewSet(
             event_type,
             is_enterprise=is_enterprise,
             conditions=search_query,
-            order=order,
-            direction=order_direction,
+            order_expr=order,
+            order_direction=order_direction,
         )
         return event_definition_object_manager.raw(sql, params=params)
 

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -2,7 +2,7 @@ import json
 import re
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, List, Literal, Optional, Tuple, Union, cast
 from uuid import UUID
 
 import structlog
@@ -359,8 +359,8 @@ def create_event_definitions_sql(
     event_type: EventDefinitionType,
     is_enterprise: bool = False,
     conditions: str = "",
-    order_UNSAFE: str = "",
-    order_direction: str = "DESC",
+    order: str = "",
+    direction: Literal["ASC", "DESC"] = "DESC",
 ) -> str:
     # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
     if is_enterprise:
@@ -391,10 +391,8 @@ def create_event_definitions_sql(
 
     # Only return event definitions
     raw_event_definition_fields = ",".join(event_definition_fields)
-    provided_ordering = (
-        f"{order_UNSAFE} {order_direction} {'NULLS FIRST' if order_direction == 'ASC' else 'NULLS LAST'}"
-    )
-    ordering = f"ORDER BY {provided_ordering}, name ASC"
+    additional_ordering = f"{order} {direction} {'NULLS FIRST' if direction == 'ASC' else 'NULLS LAST'}, "
+    ordering = f"ORDER BY {additional_ordering} name ASC"
 
     if event_type == EventDefinitionType.EVENT_CUSTOM:
         shared_conditions += " AND posthog_eventdefinition.name NOT LIKE %(is_posthog_event)s"


### PR DESCRIPTION
## Problem

mini-refactor follow up to #13362 

## Changes

Flattens the sql generation structure in event_definition api slightly so its (IMHO) easier to follow

Would be nice to go for a builder as in the property_definition code but I have to time-box my day

## How did you test this code?

using the existing developer tests
