### PR TITLE
fix(data-exploration): cohort persons query endpoint

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -65,12 +65,15 @@ export function getEventsEndpoint(query: EventsNode | EventsQuery): string {
 }
 
 export function getPersonsEndpoint(query: PersonsNode): string {
-    return api.persons.determineListUrl({
+    const params = {
         properties: [...(query.fixedProperties || []), ...(query.properties || [])],
         ...(query.search ? { search: query.search } : {}),
-        ...(query.cohort ? { cohort: query.cohort } : {}),
         ...(query.distinctId ? { distinct_id: query.distinctId } : {}),
-    })
+    }
+    if (query.cohort) {
+        return api.cohorts.determineListUrl(query.cohort, params)
+    }
+    return api.persons.determineListUrl(params)
 }
 
 interface LegacyInsightQueryParams {


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/13389

## Changes

- Makes the cohort persons query use the right API endpoint, which scopes the list down by cohort.

## How did you test this code?

Locally, I could replicate the bug and verify that after the fix I could see the correct list of persons.

Thanks for finding and filing!