### PR TITLE
chore(query-performance): Track key usage

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -94,7 +94,12 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         assert personal_api_key_object.user is not None
 
         # :KLUDGE: CHMiddleware does not receive the correct user when authenticating by api key.
-        tag_queries(user_id=personal_api_key_object.user.pk, team_id=personal_api_key_object.user.current_team_id)
+        tag_queries(
+            user_id=personal_api_key_object.user.pk,
+            team_id=personal_api_key_object.user.current_team_id,
+            access_method="personal_api_key",
+        )
+        request.using_personal_api_key = True  # type: ignore
         return personal_api_key_object.user, None
 
     @classmethod


### PR DESCRIPTION
Split out from https://github.com/PostHog/posthog/pull/13430 to measure usage of people accessing the API via public keys