### PR TITLE
chore: separate demo from onboarding v2

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -130,6 +130,7 @@ export const FEATURE_FLAGS = {
     WEBSITE_ANALYTICS_TEMPLATE: 'website-analytics-template', // owner: @pauldambra
     VARIANT_OVERRIDES: 'variant-overrides', // owner: @neilkakkar
     ONBOARDING_V2_EXPERIMENT: 'onboarding-v2-experiment', // owner: #team-growth
+    ONBOARDING_DEMO_EXPERIMENT: 'onboarding-demo-experiment', // owner: #team-growth
     FEATURE_FLAG_ROLLOUT_UX: 'feature-flag-rollout-ux', // owner: @neilkakkar
     ROLE_BASED_ACCESS: 'role-based-access', // owner: #team-experiments, @liyiy
     DASHBOARD_TEMPLATES: 'dashboard-templates', // owner @pauldambra

--- a/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
@@ -511,11 +511,7 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         },
         inviteTeamMembersSuccess: () => {
             if (router.values.location.pathname.includes('/ingestion')) {
-                actions.setState({
-                    ...values.currentState,
-                    isTechnicalUser: false,
-                    hasInvitedMembers: true,
-                } as IngestionState)
+                actions.setState(viewToState(INGESTION_VIEWS.TEAM_INVITED, values.currentState as IngestionState))
             }
         },
     })),
@@ -597,7 +593,7 @@ function getUrl(values: ingestionLogicV2Type['values']): string | [string, Recor
             url += `/${framework.toLowerCase()}`
         }
     } else {
-        if (!platform && isTechnicalUser && hasInvitedMembers) {
+        if (!platform && hasInvitedMembers) {
             url += '/invites-sent'
         }
     }

--- a/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
@@ -1,4 +1,4 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
@@ -7,11 +7,14 @@ import { IconChevronRight } from 'lib/components/icons'
 import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DemoProjectButton } from './PanelComponents'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function InviteTeamPanel(): JSX.Element {
     const { next } = useActions(ingestionLogicV2)
     const { showInviteModal } = useActions(inviteLogic)
     const { reportInviteMembersButtonClicked } = useActions(eventUsageLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <div>
@@ -56,10 +59,12 @@ export function InviteTeamPanel(): JSX.Element {
                         </p>
                     </div>
                 </LemonButton>
-                <DemoProjectButton
-                    text="I just want to try PostHog with some demo data."
-                    subtext="Explore insights, create dashboards, try out cohorts, and more."
-                />
+                {featureFlags[FEATURE_FLAGS.ONBOARDING_DEMO_EXPERIMENT] === 'test' ? (
+                    <DemoProjectButton
+                        text="I just want to try PostHog with some demo data."
+                        subtext="Explore insights, create dashboards, try out cohorts, and more."
+                    />
+                ) : null}
             </div>
         </div>
     )

--- a/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
@@ -1,4 +1,4 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
@@ -6,23 +6,26 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 import { IconChevronRight } from 'lib/components/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DemoProjectButton } from './PanelComponents'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function TeamInvitedPanel(): JSX.Element {
     const { completeOnboarding } = useActions(ingestionLogicV2)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <div>
             <h1 className="ingestion-title">Help is on the way!</h1>
-            <p className="prompt-text">
-                You can still explore all PostHog has to offer while you wait for your team members to join.
-            </p>
+            <p className="prompt-text">You can still explore PostHog while you wait for your team members to join.</p>
             <LemonDivider thick dashed className="my-6" />
             <div className="flex flex-col mb-6">
-                <DemoProjectButton
-                    text="Quickly try PostHog with some demo data."
-                    subtext="Explore insights, create dashboards, try out cohorts, and more."
-                />
+                {featureFlags[FEATURE_FLAGS.ONBOARDING_DEMO_EXPERIMENT] === 'test' ? (
+                    <DemoProjectButton
+                        text="Quickly try PostHog with some demo data."
+                        subtext="Explore insights, create dashboards, try out cohorts, and more."
+                    />
+                ) : null}
                 <LemonButton
                     onClick={() => {
                         completeOnboarding()


### PR DESCRIPTION
## Problem

The demo data still isn't working in production but we'd like to move forward with testing new onboarding stuff.

## Changes

This moves it out of the onboarding-v2-experiment and into its own feature flag. Also fixes a small bug in how we were handling the onboarding views after invite.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
The onboarding flow needs much better test coverage. But since it has none, I didn't do it for this pull. Will do in a follow-up pull soon.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
