### PR TITLE
chore(exports): "cursor" through chunks using sort key

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -256,7 +256,7 @@ export function addHistoricalEventsExportCapabilityV2(
                         startTime: new Date(startDate).getTime(),
                         endTime: new Date(endDate).getTime(),
                         previousSortKey: {
-                            'toDate(timestamp)': 0,
+                            'toDate(timestamp)': '1970-01-01',
                             event: '',
                             'cityHash64(distinct_id)': 0,
                             'cityHash64(uuid)': 0,
@@ -415,7 +415,7 @@ export function addHistoricalEventsExportCapabilityV2(
                 // seems pretty weak. Refactor to be a bit more robust.
                 // TODO: this doesn't actually work for export sources that rely
                 // on timestamp ordering, e.g. the replicator.
-                { 'toDate(timestamp)': 0, event: '', 'cityHash64(distinct_id)': 0, 'cityHash64(uuid)': 0 }
+                { 'toDate(timestamp)': '1970-01-01', event: '', 'cityHash64(distinct_id)': 0, 'cityHash64(uuid)': 0 }
             )
         } catch (error) {
             Sentry.captureException(error)

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -256,7 +256,10 @@ export function addHistoricalEventsExportCapabilityV2(
                         startTime: new Date(startDate).getTime(),
                         endTime: new Date(endDate).getTime(),
                         previousSortKey: {
-                            timestamp: new Date(startDate).getTime(),
+                            'toDate(timestamp)': 0,
+                            event: '',
+                            'cityHash64(distinct_id)': 0,
+                            'cityHash64(uuid)': 0,
                         },
                         retriesPerformedSoFar: 0,
                         exportId: params.id,
@@ -592,13 +595,13 @@ export function addHistoricalEventsExportCapabilityV2(
         return now >= status.statusTime + TEN_MINUTES + retryDelaySeconds(status.retriesPerformedSoFar + 1) * 1000
     }
 
-    function nextCursor(payload: ExportHistoricalEventsJobPayload, events: PluginEvent[]): OffsetParams {
+    function nextCursor(payload: ExportHistoricalEventsJobPayload, events: Record<string, any>[]): OffsetParams {
         // More on the same time window
         return {
             timestampCursor: payload.timestampCursor,
             fetchTimeInterval: payload.fetchTimeInterval,
             previousSortKey: Object.fromEntries(
-                Object.keys(payload.previousSortKey).map((key) => [key, events[events.length - 1].properties?.[key]])
+                Object.keys(payload.previousSortKey).map((key) => [key, events[events.length - 1][key]])
             ),
         }
     }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -205,9 +205,9 @@ export function addHistoricalEventsExportCapability(
                 hub.db,
                 pluginConfig.team_id,
                 new Date(timestampCursor),
-                intraIntervalOffset,
                 EVENTS_TIME_INTERVAL,
-                EVENTS_PER_RUN
+                EVENTS_PER_RUN,
+                { timestamp: 0 }
             )
         } catch (error) {
             fetchEventsError = error

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -44,9 +44,9 @@ export const fetchEventsForInterval = async (
     WHERE team_id = ${teamId}
     AND timestamp >= '${chTimestampLower}'
     AND timestamp < '${chTimestampHigher}'
-    AND ${`(${Object.entries(previousSortKey)
+    AND ${Object.entries(previousSortKey)
         .map(([key, value]) => `${key} > '${value}'`)
-        .join(' AND ')})`}
+        .join(' AND ')}
     ORDER BY ${Object.keys(previousSortKey).join(', ')}
     OFFSET 0 ROWS
     FETCH NEXT ${eventsPerRun} ROWS 


### PR DESCRIPTION
This should avoid hitting some granuales, still need to handle a couple
of TODOs but should reduce the number of rows read from disk per query.

NOTE: this doesn't emit events in timestamp order, so depending on the use case
this may not be appropriate 🤔 . There is certainly one use case that this wouldn't 
be appropriate for; the Replicator will be emitting to another posthog instance, and
as such will require events to be ordered to generate e.g. person-on-events as
expected.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
