### PR TITLE
feat: test query cancellation

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.queryCancellation.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.queryCancellation.test.ts
@@ -1,0 +1,178 @@
+import { expectLogic, partial } from 'kea-test-utils'
+import { initKeaTests } from '~/test/init'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { dashboardsModel } from '~/models/dashboardsModel'
+import { insightsModel } from '~/models/insightsModel'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { DashboardType, InsightModel, InsightShortId } from '~/types'
+import { useMocks } from '~/mocks/jest'
+import { now } from 'lib/dayjs'
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+import api from 'lib/api'
+import { boxToString, dashboardResult, insightOnDashboard, tileFromInsight } from 'scenes/dashboard/dashboardLogic.test'
+
+const seenQueryIDs: string[] = []
+
+describe('dashboardLogic query cancellation', () => {
+    let logic: ReturnType<typeof dashboardLogic.build>
+
+    let dashboards: Record<number, DashboardType> = {}
+
+    let dashboardTwelveInsightLoadedCount = 0
+
+    beforeEach(() => {
+        jest.spyOn(api, 'update')
+
+        const insights: Record<number, InsightModel> = {
+            2040: {
+                ...insightOnDashboard(2040, [12]),
+                id: 2040,
+                short_id: '2040' as InsightShortId,
+                last_refresh: now().toISOString(),
+            },
+        }
+        dashboards = {
+            12: {
+                ...dashboardResult(12, [tileFromInsight(insights['2040'])]),
+            },
+        }
+        useMocks({
+            get: {
+                '/api/projects/:team/dashboards/12/': { ...dashboards['12'] },
+                '/api/projects/:team/dashboards/': {
+                    count: 1,
+                    next: null,
+                    previous: null,
+                    results: [{ ...dashboards['12'] }],
+                },
+                '/api/projects/:team/insights/:id/': (req) => {
+                    const clientQueryId = req.url.searchParams.get('client_query_id')
+                    if (clientQueryId !== null) {
+                        seenQueryIDs.push(clientQueryId)
+                    }
+
+                    const dashboard = req.url.searchParams.get('from_dashboard')
+                    if (!dashboard) {
+                        throw new Error('the logic must always add this param')
+                    }
+                    const matched = insights[boxToString(req.params['id'])]
+                    if (!matched) {
+                        return [404, null]
+                    }
+                    if (dashboard === '12') {
+                        dashboardTwelveInsightLoadedCount++
+                        // delay for 2 seconds before response without pausing
+                        // but only the first time that dashboard 12 refreshes its results
+                        if (dashboardTwelveInsightLoadedCount === 1) {
+                            return new Promise((resolve) =>
+                                setTimeout(() => {
+                                    resolve([200, matched])
+                                }, 2000)
+                            )
+                        }
+                    }
+                    return [200, matched]
+                },
+            },
+            post: {
+                '/api/projects/:team/insights/cancel/': [201],
+            },
+            patch: {
+                '/api/projects/:team/dashboards/:id/': async (req) => {
+                    const dashboardId = typeof req.params['id'] === 'string' ? req.params['id'] : req.params['id'][0]
+                    const payload = await req.json()
+                    return [200, { ...dashboards[dashboardId], ...payload }]
+                },
+                '/api/projects/:team/insights/:id/': async (req) => {
+                    try {
+                        const updates = await req.json()
+                        if (typeof updates !== 'object') {
+                            return [500, `this update should receive an object body not ${JSON.stringify(updates)}`]
+                        }
+                        const insightId = boxToString(req.params.id)
+
+                        const starting: InsightModel = insights[insightId]
+                        insights[insightId] = {
+                            ...starting,
+                            ...updates,
+                        }
+
+                        starting.dashboards?.forEach((dashboardId) => {
+                            // remove this insight from any dashboard it is already on
+                            dashboards[dashboardId].tiles = dashboards[dashboardId].tiles.filter(
+                                (t) => !!t.insight && t.insight.id !== starting.id
+                            )
+                        })
+
+                        insights[insightId].dashboards?.forEach((dashboardId: number) => {
+                            // then add it to any it new references
+                            dashboards[dashboardId].tiles.push(tileFromInsight(insights[insightId]))
+                        })
+
+                        return [200, insights[insightId]]
+                    } catch (e) {
+                        return [500, e]
+                    }
+                },
+            },
+        })
+        initKeaTests()
+        dashboardsModel.mount()
+        insightsModel.mount()
+    })
+
+    describe('cancelling queries', () => {
+        beforeEach(async () => {
+            logic = dashboardLogic({ id: 12 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        it('cancels a running query', async () => {
+            jest.spyOn(api, 'create')
+
+            setTimeout(() => {
+                // this change of filters will dispatch cancellation on the first query
+                // will run while the -180d query is still running
+                logic.actions.setDates('-90d', null)
+            }, 200)
+            // dispatches an artificially slow data request
+            // takes 3000 milliseconds to return
+            logic.actions.setDates('-180d', null)
+
+            await expectLogic(logic)
+                .toDispatchActions([
+                    'setDates',
+                    'updateFilters',
+                    'abortAnyRunningQuery',
+                    'refreshAllDashboardItems',
+                    'abortAnyRunningQuery',
+                    'setDates',
+                    'updateFilters',
+                    'abortAnyRunningQuery',
+                    'abortQuery',
+                    'refreshAllDashboardItems',
+                    eventUsageLogic.actionTypes.reportDashboardRefreshed,
+                ])
+                .toMatchValues({
+                    filters: partial({ date_from: '-90d' }),
+                })
+
+            const mockCreateCalls = (api.create as jest.Mock).mock.calls
+            // there will be at least two used client query ids
+            // the most recent has not been cancelled
+            // the one before that has been
+            // the query IDs are made of `${dashboard query ID}::{insight query ID}`
+            // only the dashboard query ID is sent to the API
+            const cancelledQueryID = seenQueryIDs[seenQueryIDs.length - 2].split('::')[0]
+            expect(mockCreateCalls).toEqual([
+                [
+                    `api/projects/${MOCK_TEAM_ID}/insights/cancel`,
+                    {
+                        client_query_id: cancelledQueryID,
+                    },
+                ],
+            ])
+        })
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -20,7 +20,6 @@ import { insightsModel } from '~/models/insightsModel'
 import {
     AUTO_REFRESH_DASHBOARD_THRESHOLD_HOURS,
     DashboardPrivilegeLevel,
-    FEATURE_FLAGS,
     OrganizationMembershipLevel,
 } from 'lib/constants'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -974,7 +973,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     })
                     totalResponseBytes += getResponseBytes(refreshedInsightResponse)
                 } catch (e: any) {
-                    console.error(e)
                     if (isBreakpoint(e)) {
                         cancelled = true
                     } else if (e.name === 'AbortError' || e.message?.name === 'AbortError') {
@@ -1163,23 +1161,22 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
         abortQuery: async ({ dashboardQueryId, queryId, queryStartTime }) => {
             const { currentTeamId } = values
-            if (values.featureFlags[FEATURE_FLAGS.CANCEL_RUNNING_QUERIES]) {
-                await api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: dashboardQueryId })
 
-                // TRICKY: we cancel just once using the dashboard query id.
-                // we can record the queryId that happened to capture the AbortError exception
-                // and request the cancellation, but it is probably not particularly relevant
-                await captureTimeToSeeData(values.currentTeamId, {
-                    type: 'insight_load',
-                    context: 'dashboard',
-                    dashboard_query_id: dashboardQueryId,
-                    query_id: queryId,
-                    status: 'cancelled',
-                    time_to_see_data_ms: Math.floor(performance.now() - queryStartTime),
-                    insights_fetched: 0,
-                    insights_fetched_cached: 0,
-                })
-            }
+            await api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: dashboardQueryId })
+
+            // TRICKY: we cancel just once using the dashboard query id.
+            // we can record the queryId that happened to capture the AbortError exception
+            // and request the cancellation, but it is probably not particularly relevant
+            await captureTimeToSeeData(values.currentTeamId, {
+                type: 'insight_load',
+                context: 'dashboard',
+                dashboard_query_id: dashboardQueryId,
+                query_id: queryId,
+                status: 'cancelled',
+                time_to_see_data_ms: Math.floor(performance.now() - queryStartTime),
+                insights_fetched: 0,
+                insights_fetched_cached: 0,
+            })
         },
     })),
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -988,8 +988,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                 refreshesFinished += 1
                 if (refreshesFinished === insights.length) {
-                    breakpoint()
-
                     const payload: TimeToSeeDataPayload = {
                         type: 'dashboard_load',
                         context: 'dashboard',

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -28,10 +28,11 @@ import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { useAvailableFeatures } from '~/mocks/features'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
-import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+import { MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { DashboardPrivilegeLevel, DashboardRestrictionLevel } from 'lib/constants'
+import api from 'lib/api'
 
 const API_FILTERS: Partial<FilterType> = {
     insight: InsightType.TRENDS as InsightType,
@@ -103,6 +104,8 @@ function insightModelWith(properties: Record<string, any>): InsightModel {
     } as InsightModel
 }
 
+const seenQueryIDs: string[] = []
+
 describe('insightLogic', () => {
     let logic: ReturnType<typeof insightLogic.build>
 
@@ -112,6 +115,11 @@ describe('insightLogic', () => {
             get: {
                 '/api/projects/:team/tags': [],
                 '/api/projects/:team/insights/trend/': async (req) => {
+                    const clientQueryId = req.url.searchParams.get('client_query_id')
+                    if (clientQueryId !== null) {
+                        seenQueryIDs.push(clientQueryId)
+                    }
+
                     if (JSON.parse(req.url.searchParams.get('events') || '[]')?.[0]?.throw) {
                         return [500, { status: 0, detail: 'error from the API' }]
                     }
@@ -200,6 +208,7 @@ describe('insightLogic', () => {
                     200,
                     { id: 12, short_id: Insight12, ...((req.body as any) || {}) },
                 ],
+                '/api/projects/997/insights/cancel/': [201],
             },
             patch: {
                 '/api/projects/:team/insights/:id': async (req) => {
@@ -1230,6 +1239,8 @@ describe('insightLogic', () => {
         })
 
         it('cancels a running query', async () => {
+            jest.spyOn(api, 'create')
+
             setTimeout(() => {
                 // this change of filters will dispatch cancellation on the first query
                 // will run while the -180d query is still running
@@ -1251,6 +1262,19 @@ describe('insightLogic', () => {
                 .toMatchValues({
                     filters: partial({ date_from: '-90d' }),
                 })
+
+            const mockCreateCalls = (api.create as jest.Mock).mock.calls
+            // there will be at least two used client query ids
+            // the most recent has not been cancelled
+            // the one before that has been
+            expect(mockCreateCalls).toEqual([
+                [
+                    `api/projects/${MOCK_TEAM_ID}/insights/cancel`,
+                    {
+                        client_query_id: seenQueryIDs[seenQueryIDs.length - 2],
+                    },
+                ],
+            ])
         })
     })
 })

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -47,7 +47,7 @@ import { urls } from 'scenes/urls'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { actionsModel } from '~/models/actionsModel'
 import * as Sentry from '@sentry/react'
-import { DashboardPrivilegeLevel, FEATURE_FLAGS } from 'lib/constants'
+import { DashboardPrivilegeLevel } from 'lib/constants'
 import { groupsModel } from '~/models/groupsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
@@ -867,22 +867,20 @@ export const insightLogic = kea<insightLogicType>([
         abortQuery: async ({ queryId }) => {
             const { currentTeamId } = values
 
-            if (values.featureFlags[FEATURE_FLAGS.CANCEL_RUNNING_QUERIES]) {
-                await api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: queryId })
+            await api.create(`api/projects/${currentTeamId}/insights/cancel`, { client_query_id: queryId })
 
-                const duration = performance.now() - values.queryStartTimes[queryId]
-                await captureTimeToSeeData(values.currentTeamId, {
-                    type: 'insight_load',
-                    context: 'insight',
-                    query_id: queryId,
-                    status: 'cancelled',
-                    time_to_see_data_ms: Math.floor(duration),
-                    insights_fetched: 0,
-                    insights_fetched_cached: 0,
-                    api_response_bytes: 0,
-                    insight: values.activeView,
-                })
-            }
+            const duration = performance.now() - values.queryStartTimes[queryId]
+            await captureTimeToSeeData(values.currentTeamId, {
+                type: 'insight_load',
+                context: 'insight',
+                query_id: queryId,
+                status: 'cancelled',
+                time_to_see_data_ms: Math.floor(duration),
+                insights_fetched: 0,
+                insights_fetched_cached: 0,
+                api_response_bytes: 0,
+                insight: values.activeView,
+            })
         },
         endQuery: ({ queryId, view, lastRefresh, scene, exception, response }) => {
             if (values.timeout) {


### PR DESCRIPTION
## Problem

stacked on top of https://github.com/PostHog/posthog/pull/13414

It's tricky to work with cancellations because several things work together over time. So, it's not fun.

## Changes

Adds tests on dashboard and insight cancellation

## How did you test this code?

it is tests