### PR TITLE
chore: Switch provider for kafka for dev. Bitnami no longer supports arm64 on dockerhub

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -10,6 +10,7 @@ on:
     pull_request:
         paths:
             - docker-compose.hobby.yml
+            - docker-compose.base.yml
             - bin/deploy-hobby
             - .github/workflows/ci-hobby.yml
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -34,17 +34,13 @@ services:
         restart: on-failure
 
     kafka:
-        image: bitnami/kafka:2.8.1-debian-10-r99
+        image: ubuntu/kafka:3.1-22.04_edge
         restart: on-failure
         depends_on:
             - zookeeper
         environment:
-            KAFKA_BROKER_ID: 1001
-            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
-            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
-            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
-            ALLOW_PLAINTEXT_LISTENER: 'true'
+            ZOOKEEPER_HOST: zookeeper
+            ZOOKEEPER_PORT: 2181
 
     object_storage:
         image: minio/minio:RELEASE.2022-06-25T15-50-16Z

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -34,13 +34,17 @@ services:
         restart: on-failure
 
     kafka:
-        image: ubuntu/kafka:3.1-22.04_edge
+        image: wurstmeister/kafka:2.13-2.8.1
         restart: on-failure
         depends_on:
             - zookeeper
         environment:
-            ZOOKEEPER_HOST: zookeeper
-            ZOOKEEPER_PORT: 2181
+            KAFKA_BROKER_ID: 1001
+            KAFKA_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_LISTENERS: PLAINTEXT://:9092
+            KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_ALLOW_PLAINTEXT_LISTENER: 'true'
 
     object_storage:
         image: minio/minio:RELEASE.2022-06-25T15-50-16Z


### PR DESCRIPTION
## Problem

We were using the docker container labled:
https://hub.docker.com/layers/bitnami/kafka/2.8.1-debian-10-r99/images/sha256-5a85aeb27ffad227df55f7253a5b3634472d9d028ca20da0d6b9e7bb049d41e9?context=explore

As you might notice there is only `linux/amd64` listed as supported platforms. They seemed to have dumped support for anything `linux/arm64/v8` 😢 
<img width="648" alt="image" src="https://user-images.githubusercontent.com/391319/209040644-72163ef6-c5fe-490e-bc71-ee67be83eef5.png">


This PR switches dev and hobby over to [wurstmeister/kafka](https://hub.docker.com/r/wurstmeister/kafka)
<img width="767" alt="image" src="https://user-images.githubusercontent.com/391319/209042849-942fea4e-b0ad-4b3b-8797-38650293165e.png">
This is what we were using a few years ago and used to _not_ support ARM64 🤷 


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
