### PR TITLE
fix(ci): use bundled version of playwright (closes microsoft/playwright#19562)

### DIFF
--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -31,13 +31,13 @@ jobs:
               run: pnpm build-storybook --quiet
 
             - name: Install Playwright Browsers
-              run: pnpm dlx playwright@1.28.1 install --with-deps
+              run: pnpm exec playwright install --with-deps
 
             - name: Serve Storybook and run tests
               run: |
                   pnpm dlx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
                     "pnpm dlx http-server storybook-static --port 6006" \
-                    "pnpm dlx wait-on http://127.0.0.1:6006 --timeout 60 && pnpm dlx playwright@1.28.1 test"
+                    "pnpm dlx wait-on http://127.0.0.1:6006 --timeout 60 && pnpm exec playwright test"
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Problem

Right now we're locking the installed version of playwright in our ci workflow to circumvent issues when the `pnpm dlx` installed version does not match the bundled one. This happens as `pnpm dlx` does not re-use a package already in `node_modules`, unlike `npx` does.

## Changes

- Since we're installing dependencies beforehand, we now simply use `pnpm exec` to run the bundled playwright and don't have to lock the version any more.

## How did you test this code?

Workflow run in this PR.