### PR TITLE
feat(lemon-checkbox): use slightly smaller gap

### DIFF
--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -17,7 +17,7 @@
         display: flex;
         align-items: center;
         cursor: pointer;
-        gap: 0.75rem;
+        gap: 0.5rem;
         min-height: 1.5rem;
 
         svg {
@@ -99,7 +99,6 @@
         &.LemonCheckbox--small {
             label {
                 padding: 0 0.5rem;
-                gap: 0.5rem;
                 min-height: 2rem;
             }
         }


### PR DESCRIPTION
## Problem

For some use cases like the insights legend (and the upcoming lemonified lifecycle insight toggles), I find the checkbox gap a tad too large. Other use cases are not impacted negatively by a smaller gap. Let me know with a quick 👍 / 👎  what you think, or wether this is totally bikeshedding.

## Changes

- Changes the gap from 12 to 8px. See examples below.

| before                                                                                                                                           | after                                                                                                                                           |
|--------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="305" alt="legend_before" src="https://user-images.githubusercontent.com/1851359/209123792-83504184-70a4-4949-be91-1b25c7c331fd.png"> | <img width="327" alt="legend_after" src="https://user-images.githubusercontent.com/1851359/209123796-cfae7ac5-c454-4fcb-b419-ba03fd6bde97.png"> |
| <img width="716" alt="modal_before" src="https://user-images.githubusercontent.com/1851359/209123804-6d1781d8-b351-4a39-8d48-efed885d44e5.png">  | <img width="723" alt="modal_after" src="https://user-images.githubusercontent.com/1851359/209123801-1a936f05-5f27-4e70-be4b-bbbcd1aa6a5f.png">  |
