### PR TITLE
fix: search local taxonomic items by posthog name

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -328,4 +328,17 @@ describe('infiniteListLogic', () => {
                 })
         })
     })
+
+    it('searches autocapture elements using posthog property', async () => {
+        const logicWithProps = infiniteListLogic({
+            taxonomicFilterLogicKey: 'test-element-list',
+            listGroupType: TaxonomicFilterGroupType.Elements,
+            taxonomicGroupTypes: [TaxonomicFilterGroupType.Elements],
+        })
+        logicWithProps.mount()
+
+        await expectLogic(logicWithProps, () => logicWithProps.actions.setSearchQuery('css')).toMatchValues({
+            localItems: { count: 1, results: [{ name: 'selector' }], searchQuery: 'css' },
+        })
+    })
 })


### PR DESCRIPTION
## Problem

Several "local" taxonomic items have display names that contain text that are not in their actual name

e.g.

"CSS Selector" -> "selector"
"Continent code" -> "$geoip_continent_code"

## Changes

For these local items (person properties, and elements. although includes events since they _could_ be mapped *if* they were local) searches both the actual property name and its display value

| before | after |
|--|--|
|![before](https://user-images.githubusercontent.com/984817/209132143-881ad66a-df89-4369-bf98-9a7d97dd75eb.gif)| ![after](https://user-images.githubusercontent.com/984817/209132177-d1662bdc-339b-4c0b-bb49-374309bf9e8b.gif)|

## How did you test this code?

added a developer test and checked it locally
