### PR TITLE
fix: create valid (for us) id selectors

### DIFF
--- a/frontend/src/lib/actionUtils.test.ts
+++ b/frontend/src/lib/actionUtils.test.ts
@@ -1,0 +1,22 @@
+import { elementToSelector } from 'lib/actionUtils'
+import { ElementType } from '~/types'
+
+describe('elementToSelector', () => {
+    it('generates a data attr not an #ID', () => {
+        const element = {
+            attr_id: 'tomato',
+        } as ElementType
+
+        const actual = elementToSelector(element, [])
+        expect(actual).toEqual('[id="tomato"]')
+    })
+
+    it('generates a data attr not an dot class selector', () => {
+        const element = {
+            attr_class: ['potato', 'soup'],
+        } as ElementType
+
+        const actual = elementToSelector(element, [])
+        expect(actual).toEqual('[class="potato"][class="soup"]')
+    })
+})

--- a/frontend/src/lib/actionUtils.test.ts
+++ b/frontend/src/lib/actionUtils.test.ts
@@ -11,12 +11,12 @@ describe('elementToSelector', () => {
         expect(actual).toEqual('[id="tomato"]')
     })
 
-    it('generates a data attr not an dot class selector', () => {
+    it('generates an incorrect class selector', () => {
         const element = {
             attr_class: ['potato', 'soup'],
         } as ElementType
 
         const actual = elementToSelector(element, [])
-        expect(actual).toEqual('[class="potato"][class="soup"]')
+        expect(actual).toEqual('.potato.soup')
     })
 })

--- a/frontend/src/lib/actionUtils.ts
+++ b/frontend/src/lib/actionUtils.ts
@@ -31,7 +31,7 @@ export function elementToSelector(element: ElementType, dataAttributes: string[]
         return selector
     }
     if (element.attr_id) {
-        selector += `#${cssEscape(element.attr_id)}`
+        selector += `[id="${cssEscape(element.attr_id)}"]`
         return selector
     }
     if (element.tag_name) {
@@ -40,7 +40,7 @@ export function elementToSelector(element: ElementType, dataAttributes: string[]
     if (element.attr_class) {
         selector += element.attr_class
             .filter((a) => a)
-            .map((a) => `.${cssEscape(a)}`)
+            .map((a) => `[class="${cssEscape(a)}"]`)
             .join('')
     }
     if (element.href && element.tag_name === 'a') {

--- a/frontend/src/lib/actionUtils.ts
+++ b/frontend/src/lib/actionUtils.ts
@@ -40,7 +40,7 @@ export function elementToSelector(element: ElementType, dataAttributes: string[]
     if (element.attr_class) {
         selector += element.attr_class
             .filter((a) => a)
-            .map((a) => `[class="${cssEscape(a)}"]`)
+            .map((a) => `.${cssEscape(a)}`)
             .join('')
     }
     if (element.href && element.tag_name === 'a') {


### PR DESCRIPTION
## Problem

When creating an action from an event in the live events table. We will pick selectors like "#my-id" or ".one-class.and-another". But we can't actually match those selectors when processing the action 🤦 

Fixing that is hard, but in the meantime we can not create selectors that won't work

## Changes

* generates `[id="blah"]` instead of `#blah`
* ~~generates `[class="first"][class="second"]` instead of `.first.second`~~

## How did you test this code?

added a developer test and created an action locally that matched on ID