### PR TITLE
fix(cohorts): Handle negated cohorts everywhere

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -83,7 +83,7 @@
        (SELECT pdi.person_id AS person_id,
                countIf(timestamp > now() - INTERVAL 2 year
                        AND timestamp < now()
-                       AND event = '$pageview') > 0 AS performed_event_condition_30_level_level_0_level_0_level_0_0
+                       AND event = '$pageview') > 0 AS performed_event_condition_6_level_level_0_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -113,7 +113,7 @@
            HAVING max(is_deleted) = 0
            AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
      WHERE 1 = 1
-       AND ((((performed_event_condition_30_level_level_0_level_0_level_0_0)))) ) as person
+       AND ((((performed_event_condition_6_level_level_0_level_0_level_0_0)))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -148,7 +148,7 @@
                    (SELECT pdi.person_id AS person_id,
                            countIf(timestamp > now() - INTERVAL 2 year
                                    AND timestamp < now()
-                                   AND event = '$pageview') > 0 AS performed_event_condition_72_level_level_0_level_0_level_0_0
+                                   AND event = '$pageview') > 0 AS performed_event_condition_8_level_level_0_level_0_level_0_0
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
@@ -178,7 +178,7 @@
                        HAVING max(is_deleted) = 0
                        AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
                  WHERE 1 = 1
-                   AND ((((performed_event_condition_72_level_level_0_level_0_level_0_0)))) ) ))
+                   AND ((((performed_event_condition_8_level_level_0_level_0_level_0_0)))) ) ))
   '
 ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.1

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -34,6 +34,220 @@
     AND sign = 1
   '
 ---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator
+  '
+  
+  INSERT INTO cohortpeople
+  SELECT id,
+         2 as cohort_id,
+         2 as team_id,
+         1 AS sign,
+         0 AS version
+  FROM
+    (SELECT id
+     FROM person
+     WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2
+            AND ((has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', '')))) )
+     GROUP BY id
+     HAVING max(is_deleted) = 0
+     AND ((has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))) as person
+  UNION ALL
+  SELECT person_id,
+         cohort_id,
+         team_id,
+         -1,
+         version
+  FROM cohortpeople
+  WHERE team_id = 2
+    AND cohort_id = 2
+    AND version < 0
+    AND sign = 1
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator.1
+  '
+  
+  INSERT INTO cohortpeople
+  SELECT id,
+         2 as cohort_id,
+         2 as team_id,
+         1 AS sign,
+         0 AS version
+  FROM
+    (SELECT person.person_id AS id
+     FROM
+       (SELECT pdi.person_id AS person_id,
+               countIf(timestamp > now() - INTERVAL 2 year
+                       AND timestamp < now()
+                       AND event = '$pageview') > 0 AS performed_event_condition_30_level_level_0_level_0_level_0_0
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event IN ['$pageview']
+          AND timestamp <= now()
+          AND timestamp >= now() - INTERVAL 2 year
+        GROUP BY person_id) behavior_query
+     INNER JOIN
+       (SELECT *,
+               id AS person_id
+        FROM
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+     WHERE 1 = 1
+       AND ((((performed_event_condition_30_level_level_0_level_0_level_0_0)))) ) as person
+  UNION ALL
+  SELECT person_id,
+         cohort_id,
+         team_id,
+         -1,
+         version
+  FROM cohortpeople
+  WHERE team_id = 2
+    AND cohort_id = 2
+    AND version < 0
+    AND sign = 1
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation
+  '
+  SELECT uuid,
+         distinct_id
+  FROM events
+  WHERE team_id = 2
+    AND (distinct_id IN
+           (SELECT distinct_id
+            FROM
+              (SELECT distinct_id,
+                      argMax(person_id, version) as person_id
+               FROM person_distinct_id2
+               WHERE team_id = 2
+               GROUP BY distinct_id
+               HAVING argMax(is_deleted, version) = 0)
+            WHERE person_id IN
+                (SELECT person.person_id AS id
+                 FROM
+                   (SELECT pdi.person_id AS person_id,
+                           countIf(timestamp > now() - INTERVAL 2 year
+                                   AND timestamp < now()
+                                   AND event = '$pageview') > 0 AS performed_event_condition_10_level_level_0_level_0_level_0_0
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['$pageview']
+                      AND timestamp <= now()
+                      AND timestamp >= now() - INTERVAL 2 year
+                    GROUP BY person_id) behavior_query
+                 INNER JOIN
+                   (SELECT *,
+                           id AS person_id
+                    FROM
+                      (SELECT id
+                       FROM person
+                       WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2
+                              AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
+                       GROUP BY id
+                       HAVING max(is_deleted) = 0
+                       AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+                 WHERE 1 = 1
+                   AND ((((performed_event_condition_10_level_level_0_level_0_level_0_0)))) ) ))
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.1
+  '
+  
+  SELECT person_id
+  FROM cohortpeople
+  WHERE team_id = 2
+    AND cohort_id = 2
+  GROUP BY person_id,
+           cohort_id,
+           team_id,
+           version
+  HAVING sum(sign) > 0
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.2
+  '
+  SELECT uuid
+  FROM events
+  WHERE team_id = 2
+    AND (distinct_id IN
+           (SELECT distinct_id
+            FROM
+              (SELECT distinct_id,
+                      argMax(person_id, version) as person_id
+               FROM person_distinct_id2
+               WHERE team_id = 2
+               GROUP BY distinct_id
+               HAVING argMax(is_deleted, version) = 0)
+            WHERE person_id IN
+                (SELECT person.person_id AS id
+                 FROM
+                   (SELECT pdi.person_id AS person_id,
+                           countIf(timestamp > now() - INTERVAL 2 year
+                                   AND timestamp < now()
+                                   AND event = '$pageview') > 0 AS performed_event_condition_4_level_level_0_level_0_level_0_0
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['$pageview']
+                      AND timestamp <= now()
+                      AND timestamp >= now() - INTERVAL 2 year
+                    GROUP BY person_id) behavior_query
+                 INNER JOIN
+                   (SELECT *,
+                           id AS person_id
+                    FROM
+                      (SELECT id
+                       FROM person
+                       WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2
+                              AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
+                       GROUP BY id
+                       HAVING max(is_deleted) = 0
+                       AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+                 WHERE 1 = 1
+                   AND ((((performed_event_condition_4_level_level_0_level_0_level_0_0)))) ) ))
+  '
+---
 # name: TestCohort.test_static_cohort_precalculated
   '
   

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -148,7 +148,7 @@
                    (SELECT pdi.person_id AS person_id,
                            countIf(timestamp > now() - INTERVAL 2 year
                                    AND timestamp < now()
-                                   AND event = '$pageview') > 0 AS performed_event_condition_10_level_level_0_level_0_level_0_0
+                                   AND event = '$pageview') > 0 AS performed_event_condition_72_level_level_0_level_0_level_0_0
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
@@ -178,26 +178,130 @@
                        HAVING max(is_deleted) = 0
                        AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
                  WHERE 1 = 1
-                   AND ((((performed_event_condition_10_level_level_0_level_0_level_0_0)))) ) ))
+                   AND ((((performed_event_condition_72_level_level_0_level_0_level_0_0)))) ) ))
   '
 ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.1
   '
   
-  SELECT person_id
-  FROM cohortpeople
-  WHERE team_id = 2
-    AND cohort_id = 2
-  GROUP BY person_id,
-           cohort_id,
-           team_id,
-           version
-  HAVING sum(sign) > 0
+  SELECT *
+  from person_distinct_id2
   '
 ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.2
   '
-  SELECT uuid
+  
+  SELECT properties
+  from person
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.3
+  '
+  
+  SELECT distinct_id
+  FROM
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0)
+  WHERE person_id IN
+      (SELECT person.person_id AS id
+       FROM
+         (SELECT pdi.person_id AS person_id,
+                 countIf(timestamp > now() - INTERVAL 2 year
+                         AND timestamp < now()
+                         AND event = '$pageview') > 0 AS performed_event_condition_22_level_level_0_level_0_level_0_0
+          FROM events e
+          INNER JOIN
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2
+             WHERE team_id = 2
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+          WHERE team_id = 2
+            AND event IN ['$pageview']
+            AND timestamp <= now()
+            AND timestamp >= now() - INTERVAL 2 year
+          GROUP BY person_id) behavior_query
+       INNER JOIN
+         (SELECT *,
+                 id AS person_id
+          FROM
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND id IN
+                 (SELECT id
+                  FROM person
+                  WHERE team_id = 2
+                    AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
+             GROUP BY id
+             HAVING max(is_deleted) = 0
+             AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+       WHERE 1 = 1
+         AND (performed_event_condition_22_level_level_0_level_0_level_0_0) )
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.4
+  '
+  
+  SELECT *,
+         id AS person_id
+  FROM
+    (SELECT id
+     FROM person
+     WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2
+            AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
+     GROUP BY id
+     HAVING max(is_deleted) = 0
+     AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.5
+  '
+  
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))
+  GROUP by id
+  HAVING max(is_deleted) = 0
+  AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))))))
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.6
+  '
+  
+  SELECT pdi.person_id AS person_id,
+         countIf(timestamp > now() - INTERVAL 2 year
+                 AND timestamp < now()
+                 AND event = '$pageview') > 0 AS performed_event_condition_22_level_level_0_level_0_level_0_0
+  FROM events e
+  INNER JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+  WHERE team_id = 2
+    AND event IN ['$pageview']
+    AND timestamp <= now()
+    AND timestamp >= now() - INTERVAL 2 year
+  GROUP BY person_id
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation.7
+  '
+  SELECT uuid,
+         distinct_id
   FROM events
   WHERE team_id = 2
     AND (distinct_id IN
@@ -215,7 +319,7 @@
                    (SELECT pdi.person_id AS person_id,
                            countIf(timestamp > now() - INTERVAL 2 year
                                    AND timestamp < now()
-                                   AND event = '$pageview') > 0 AS performed_event_condition_4_level_level_0_level_0_level_0_0
+                                   AND event = '$pageview') > 0 AS performed_event_condition_70_level_level_0_level_0_level_0_0
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
@@ -245,7 +349,7 @@
                        HAVING max(is_deleted) = 0
                        AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
                  WHERE 1 = 1
-                   AND ((((performed_event_condition_4_level_level_0_level_0_level_0_0)))) ) ))
+                   AND ((((performed_event_condition_70_level_level_0_level_0_level_0_0)))) ) ))
   '
 ---
 # name: TestCohort.test_static_cohort_precalculated

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -21,7 +21,9 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,
     _create_person,
+    flush_persons_and_events,
     snapshot_clickhouse_insert_cohortpeople_queries,
+    snapshot_clickhouse_queries,
 )
 
 
@@ -678,6 +680,113 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
         res = self._get_cohortpeople(cohort1)
         self.assertEqual(len(res), 1)
+
+    @snapshot_clickhouse_insert_cohortpeople_queries
+    def test_cohortpeople_with_not_in_cohort_operator(self):
+        _create_person(distinct_ids=["1"], team_id=self.team.pk, properties={"$some_prop": "something1"})
+        _create_person(distinct_ids=["2"], team_id=self.team.pk, properties={"$some_prop": "something2"})
+
+        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"attr": "some_val"})
+        _create_event(event="$pageview", team=self.team, distinct_id="2", properties={"attr": "some_val"})
+
+        flush_persons_and_events()
+
+        cohort0: Cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"key": "$some_prop", "value": "something1", "type": "person"}]}],
+            name="cohort0",
+        )
+        cohort0.calculate_people_ch(pending_version=0)
+
+        cohort1 = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "event_type": "events",
+                            "key": "$pageview",
+                            "negation": False,
+                            "time_interval": "year",
+                            "time_value": 2,
+                            "type": "behavioral",
+                            "value": "performed_event",
+                        },
+                        {
+                            "key": "id",
+                            "negation": True,
+                            "type": "cohort",
+                            "value": cohort0.pk,
+                        },
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        cohort1.calculate_people_ch(pending_version=0)
+
+        with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
+
+            filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}]}, team=self.team)
+            query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+            final_query = "SELECT uuid, distinct_id FROM events WHERE team_id = %(team_id)s {}".format(query)
+
+            result = sync_execute(final_query, {**params, "team_id": self.team.pk})
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][1], "2")  # distinct_id '2' is the one in cohort
+
+    @snapshot_clickhouse_queries
+    def test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation(self):
+        _create_person(distinct_ids=["1"], team_id=self.team.pk, properties={"$some_prop": "something1"})
+        _create_person(distinct_ids=["2"], team_id=self.team.pk, properties={"$some_prop": "something2"})
+
+        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"attr": "some_val"})
+        _create_event(event="$pageview", team=self.team, distinct_id="2", properties={"attr": "some_val"})
+
+        cohort0: Cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"key": "$some_prop", "value": "something1", "type": "person"}]}],
+            name="cohort0",
+        )
+
+        cohort1 = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "event_type": "events",
+                            "key": "$pageview",
+                            "negation": False,
+                            "time_interval": "year",
+                            "time_value": 2,
+                            "type": "behavioral",
+                            "value": "performed_event",
+                        },
+                        {
+                            "key": "id",
+                            "negation": True,
+                            "type": "cohort",
+                            "value": cohort0.pk,
+                        },
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}]}, team=self.team)
+        query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+        final_query = "SELECT uuid, distinct_id FROM events WHERE team_id = %(team_id)s {}".format(query)
+        self.assertIn("\nFROM person_distinct_id2\n", final_query)
+
+        result = sync_execute(final_query, {**params, "team_id": self.team.pk})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][1], "2")  # distinct_id '2' is the one in cohort
 
     def test_cohortpeople_with_nonexistent_other_cohort_filter(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"})

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -746,6 +746,8 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"attr": "some_val"})
         _create_event(event="$pageview", team=self.team, distinct_id="2", properties={"attr": "some_val"})
 
+        flush_persons_and_events()
+
         cohort0: Cohort = Cohort.objects.create(
             team=self.team,
             groups=[{"properties": [{"key": "$some_prop", "value": "something1", "type": "person"}]}],

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -686,8 +686,20 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         _create_person(distinct_ids=["1"], team_id=self.team.pk, properties={"$some_prop": "something1"})
         _create_person(distinct_ids=["2"], team_id=self.team.pk, properties={"$some_prop": "something2"})
 
-        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"attr": "some_val"})
-        _create_event(event="$pageview", team=self.team, distinct_id="2", properties={"attr": "some_val"})
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            properties={"attr": "some_val"},
+            timestamp=datetime.now() - timedelta(days=10),
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="2",
+            properties={"attr": "some_val"},
+            timestamp=datetime.now() - timedelta(days=20),
+        )
 
         flush_persons_and_events()
 
@@ -743,8 +755,20 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         _create_person(distinct_ids=["1"], team_id=self.team.pk, properties={"$some_prop": "something1"})
         _create_person(distinct_ids=["2"], team_id=self.team.pk, properties={"$some_prop": "something2"})
 
-        _create_event(event="$pageview", team=self.team, distinct_id="1", properties={"attr": "some_val"})
-        _create_event(event="$pageview", team=self.team, distinct_id="2", properties={"attr": "some_val"})
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            properties={"attr": "some_val"},
+            timestamp=datetime.now() - timedelta(days=10),
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="2",
+            properties={"attr": "some_val"},
+            timestamp=datetime.now() - timedelta(days=20),
+        )
 
         flush_persons_and_events()
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -320,11 +320,25 @@ def simplified_cohort_filter_properties(cohort: Cohort, team: Team, is_negated=F
             )
 
         elif property.type == "cohort":
+            # If entire cohort is negated, just return the negated cohort.
+            if is_negated:
+                return PropertyGroup(
+                    type=PropertyOperatorType.AND,
+                    values=[Property(type="cohort", key="id", value=cohort.pk, negation=is_negated)],
+                )
             # :TRICKY: We need to ensure we don't have infinite loops in here
             # guaranteed during cohort creation
             return Filter(data={"properties": cohort.properties.to_dict()}, team=team).property_groups
 
-    return cohort.properties
+    # We have person properties only
+    # TODO: Handle negating a complete property group
+    if is_negated:
+        return PropertyGroup(
+            type=PropertyOperatorType.AND,
+            values=[Property(type="cohort", key="id", value=cohort.pk, negation=is_negated)],
+        )
+    else:
+        return cohort.properties
 
 
 def _get_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:


### PR DESCRIPTION
## Problem

Sometimes, we wouldn't handle `NOT IN cohort` operators well when creating cohorts. We'd instead treat those as 'in' operators.

As you can imagine, this lead to lots of issues with people using cohorts that depend on other cohorts.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Did not opt for a perf-optimal solution where we'd push down negation into the properties. Will leave that to future-me.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

A crap load of unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
