### PR TITLE
fix: validation warnings in action setup

### DIFF
--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -124,10 +124,6 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
 const validateSelector = (val: string, selectorPrompts: (s: string | null) => void): void => {
     if (val.includes('#')) {
         selectorPrompts('The ID selector "#example" does not match in PostHog actions. Use `[id="example"]` instead')
-    } else if (val.includes('.')) {
-        selectorPrompts(
-            'The class selector ".example" does not match in PostHog actions. Use `[class="example"]` instead'
-        )
     } else {
         selectorPrompts(null)
     }

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -11,6 +11,8 @@ import { LemonDialog } from 'lib/components/LemonDialog'
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { LemonLabel } from 'lib/components/LemonLabel/LemonLabel'
+import { useState } from 'react'
+import { AlertMessage } from 'lib/components/AlertMessage'
 
 const learnMoreLink = 'https://posthog.com/docs/user-guides/actions?utm_medium=in-product&utm_campaign=action-page'
 
@@ -114,6 +116,23 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
     )
 }
 
+/**
+ * There are several issues with how autocapture actions are matched. See https://github.com/PostHog/posthog/issues/7333
+ *
+ * Until they are fixed this validator can be used to guide users to working solutions
+ */
+const validateSelector = (val: string, selectorPrompts: (s: string | null) => void): void => {
+    if (val.includes('#')) {
+        selectorPrompts('The ID selector "#example" does not match in PostHog actions. Use `[id="example"]` instead')
+    } else if (val.includes('.')) {
+        selectorPrompts(
+            'The class selector ".example" does not match in PostHog actions. Use `[class="example"]` instead'
+        )
+    } else {
+        selectorPrompts(null)
+    }
+}
+
 function Option(props: {
     step: ActionStepType
     sendStep: (stepToSend: ActionStepType) => void
@@ -129,6 +148,8 @@ function Option(props: {
             [props.item]: val || null, // "" is a valid filter, we don't want it
         })
 
+    const [selectorPrompt, setSelectorPrompt] = useState(null as string | null)
+
     return (
         <div className="space-y-1">
             <LemonLabel>
@@ -136,11 +157,19 @@ function Option(props: {
             </LemonLabel>
             {props.caption && <div className="action-step-caption">{props.caption}</div>}
             {props.item === 'selector' ? (
-                <LemonTextArea
-                    onChange={onOptionChange}
-                    value={props.step[props.item] || ''}
-                    placeholder={props.placeholder}
-                />
+                <>
+                    <LemonTextArea
+                        onChange={(val: string) => {
+                            validateSelector(val, setSelectorPrompt)
+                            onOptionChange(val)
+                        }}
+                        value={props.step[props.item] || ''}
+                        placeholder={props.placeholder}
+                    />
+                    <div className={selectorPrompt ? 'visible' : 'hidden'}>
+                        <AlertMessage type="warning">{selectorPrompt}</AlertMessage>
+                    </div>
+                </>
             ) : (
                 <LemonInput
                     data-attr="edit-action-url-input"


### PR DESCRIPTION
## Problem

You cannot use # as an id selector or . as a class selector in actions. Despite what our docs say.

See https://github.com/PostHog/posthog/issues/7333

## Changes

Until you can, this guides users to a working solution

** only guides on IDs, classes turn out to be tricky **

![2022-12-22 13 57 15](https://user-images.githubusercontent.com/984817/209150405-2953b141-624c-4e07-8769-4bf92514d642.gif)

## How did you test this code?

running it locally and 👀 