### PR TITLE
fix(cohorts): Handle negations for behavioural filters

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -352,6 +352,92 @@
                    AND ((((performed_event_condition_70_level_level_0_level_0_level_0_0)))) ) ))
   '
 ---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_for_behavioural_cohorts
+  '
+  
+  INSERT INTO cohortpeople
+  SELECT id,
+         2 as cohort_id,
+         2 as team_id,
+         1 AS sign,
+         0 AS version
+  FROM
+    (SELECT behavior_query.person_id AS id
+     FROM
+       (SELECT pdi.person_id AS person_id,
+               minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_28_level_level_0_level_0_0
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event IN ['signup']
+        GROUP BY person_id) behavior_query
+     WHERE 1 = 1
+       AND (((first_time_condition_28_level_level_0_level_0_0))) ) as person
+  UNION ALL
+  SELECT person_id,
+         cohort_id,
+         team_id,
+         -1,
+         version
+  FROM cohortpeople
+  WHERE team_id = 2
+    AND cohort_id = 2
+    AND version < 0
+    AND sign = 1
+  '
+---
+# name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_for_behavioural_cohorts.1
+  '
+  
+  INSERT INTO cohortpeople
+  SELECT id,
+         2 as cohort_id,
+         2 as team_id,
+         1 AS sign,
+         0 AS version
+  FROM
+    (SELECT behavior_query.person_id AS id
+     FROM
+       (SELECT pdi.person_id AS person_id,
+               countIf(timestamp > now() - INTERVAL 2 year
+                       AND timestamp < now()
+                       AND event = '$pageview') > 0 AS performed_event_condition_29_level_level_0_level_0_level_0_0,
+               minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_29_level_level_0_level_1_level_0_level_0_level_0_0
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event IN ['$pageview', 'signup']
+        GROUP BY person_id) behavior_query
+     WHERE 1 = 1
+       AND ((((performed_event_condition_29_level_level_0_level_0_level_0_0))
+             AND ((((NOT first_time_condition_29_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person
+  UNION ALL
+  SELECT person_id,
+         cohort_id,
+         team_id,
+         -1,
+         version
+  FROM cohortpeople
+  WHERE team_id = 2
+    AND cohort_id = 2
+    AND version < 0
+    AND sign = 1
+  '
+---
 # name: TestCohort.test_static_cohort_precalculated
   '
   

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -366,7 +366,7 @@
      FROM
        (SELECT pdi.person_id AS person_id,
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
-        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_28_level_level_0_level_0_0
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_9_level_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -379,7 +379,7 @@
           AND event IN ['signup']
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND (((first_time_condition_28_level_level_0_level_0_0))) ) as person
+       AND (((first_time_condition_9_level_level_0_level_0_0))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -408,9 +408,9 @@
        (SELECT pdi.person_id AS person_id,
                countIf(timestamp > now() - INTERVAL 2 year
                        AND timestamp < now()
-                       AND event = '$pageview') > 0 AS performed_event_condition_29_level_level_0_level_0_level_0_0,
+                       AND event = '$pageview') > 0 AS performed_event_condition_10_level_level_0_level_0_level_0_0,
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
-        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_29_level_level_0_level_1_level_0_level_0_level_0_0
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_10_level_level_0_level_1_level_0_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -423,8 +423,8 @@
           AND event IN ['$pageview', 'signup']
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND ((((performed_event_condition_29_level_level_0_level_0_level_0_0))
-             AND ((((NOT first_time_condition_29_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person
+       AND ((((performed_event_condition_10_level_level_0_level_0_level_0_0))
+             AND ((((NOT first_time_condition_10_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -814,6 +814,95 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][1], "2")  # distinct_id '2' is the one in cohort
 
+    @snapshot_clickhouse_insert_cohortpeople_queries
+    def test_cohortpeople_with_not_in_cohort_operator_for_behavioural_cohorts(self):
+        _create_person(distinct_ids=["1"], team_id=self.team.pk, properties={"$some_prop": "something"})
+        _create_person(distinct_ids=["2"], team_id=self.team.pk, properties={"$some_prop": "something"})
+
+        _create_event(
+            event="signup",
+            team=self.team,
+            distinct_id="1",
+            properties={"attr": "some_val"},
+            timestamp=datetime.now() - timedelta(days=10),
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="1",
+            properties={"attr": "some_val"},
+            timestamp=datetime.now() - timedelta(days=10),
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="2",
+            properties={"attr": "some_val"},
+            timestamp=datetime.now() - timedelta(days=20),
+        )
+        flush_persons_and_events()
+
+        cohort0: Cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "event_type": "events",
+                            "key": "signup",
+                            "negation": False,
+                            "time_interval": "day",
+                            "time_value": 15,
+                            "type": "behavioral",
+                            "value": "performed_event_first_time",
+                        },
+                    ]
+                }
+            ],
+            name="cohort0",
+        )
+        cohort0.calculate_people_ch(pending_version=0)
+
+        cohort1 = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "event_type": "events",
+                            "key": "$pageview",
+                            "negation": False,
+                            "time_interval": "year",
+                            "time_value": 2,
+                            "type": "behavioral",
+                            "value": "performed_event",
+                        },
+                        {
+                            "key": "id",
+                            "negation": True,
+                            "type": "cohort",
+                            "value": cohort0.pk,
+                        },
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        cohort1.calculate_people_ch(pending_version=0)
+
+        with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
+
+            filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}]}, team=self.team)
+            query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+            final_query = "SELECT uuid, distinct_id FROM events WHERE team_id = %(team_id)s {}".format(query)
+
+            result = sync_execute(final_query, {**params, "team_id": self.team.pk})
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][1], "2")  # distinct_id '2' is the one in cohort
+
     def test_cohortpeople_with_nonexistent_other_cohort_filter(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"})
         Person.objects.create(team_id=self.team.pk, distinct_ids=["2"], properties={"foo": "non"})

--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -136,7 +136,10 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
 
         self._fields.append(full_condition)
 
-        return (column_name, {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_params})
+        return (
+            f"{'NOT' if prop.negation else ''} {column_name}",
+            {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_params},
+        )
 
     def get_restarted_performing_event(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
         event = (prop.event_type, prop.key)
@@ -168,7 +171,10 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
 
         self._fields.append(full_condition)
 
-        return (column_name, {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_params})
+        return (
+            f"{'NOT' if prop.negation else ''} {column_name}",
+            {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_params},
+        )
 
     def get_performed_event_first_time(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
         event = (prop.event_type, prop.key)
@@ -186,7 +192,7 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
 
         self._fields.append(field)
 
-        return column_name, {f"{date_param}": date_value, **entity_params}
+        return (f"{'NOT' if prop.negation else ''} {column_name}", {f"{date_param}": date_value, **entity_params})
 
     def get_performed_event_regularly(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
         event = (prop.event_type, prop.key)
@@ -236,7 +242,7 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
 
         self._fields.append(field)
 
-        return column_name, {**entity_params, **params}
+        return (f"{'NOT' if prop.negation else ''} {column_name}", {**entity_params, **params})
 
     @cached_property
     def sequence_filters_to_query(self) -> List[Property]:


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/13468 , where I realised we don't handle negations at all for behavioral filters in cohorts.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
