### PR TITLE
fix: explicit tile undelete when patching insights

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -226,7 +226,10 @@ class InsightSerializer(InsightBasicSerializer):
         dashboards = validated_data.pop("dashboards", None)
 
         insight = Insight.objects.create(
-            team=team, created_by=created_by, last_modified_by=request.user, **validated_data
+            team=team,
+            created_by=created_by,
+            last_modified_by=request.user,
+            **validated_data,
         )
 
         if dashboards is not None:
@@ -289,7 +292,7 @@ class InsightSerializer(InsightBasicSerializer):
         return updated_insight
 
     def _update_insight_dashboards(self, dashboards: List[Dashboard], instance: Insight) -> None:
-        old_dashboard_ids = [tile.dashboard_id for tile in instance.dashboard_tiles.exclude(deleted=True).all()]
+        old_dashboard_ids = [tile.dashboard_id for tile in instance.dashboard_tiles.all()]
         new_dashboard_ids = [d.id for d in dashboards if not d.deleted]
 
         if sorted(old_dashboard_ids) == sorted(new_dashboard_ids):
@@ -310,7 +313,11 @@ class InsightSerializer(InsightBasicSerializer):
         for dashboard in candidate_dashboards:
             if dashboard.team != instance.team:
                 raise serializers.ValidationError("Dashboard not found")
-            DashboardTile.objects.create(insight=instance, dashboard=dashboard)
+            tile, _ = DashboardTile.objects.get_or_create(insight=instance, dashboard=dashboard)
+            if tile.deleted:
+                tile.deleted = False
+                tile.save()
+
         if ids_to_remove:
             DashboardTile.objects.filter(dashboard_id__in=ids_to_remove, insight=instance).update(deleted=True)
         # also update dashboards set so activity log can detect the change
@@ -376,11 +383,23 @@ class InsightSerializer(InsightBasicSerializer):
         return dashboard_tile
 
 
-class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
+class InsightViewSet(
+    TaggedItemViewSetMixin,
+    StructuredViewSetMixin,
+    ForbidDestroyModel,
+    viewsets.ModelViewSet,
+):
     queryset = Insight.objects.all()
     serializer_class = InsightSerializer
-    permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
-    throttle_classes = [PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle]
+    permission_classes = [
+        IsAuthenticated,
+        ProjectMembershipNecessaryPermissions,
+        TeamMemberAccessPermission,
+    ]
+    throttle_classes = [
+        PassThroughClickHouseBurstRateThrottle,
+        PassThroughClickHouseSustainedRateThrottle,
+    ]
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (csvrenderers.CSVRenderer,)
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["short_id", "created_by"]
@@ -614,7 +633,9 @@ Using the correct cache and enriching the response with dashboard specific confi
 
         if filter.insight == INSIGHT_STICKINESS or filter.shown_as == TRENDS_STICKINESS:
             stickiness_filter = StickinessFilter(
-                request=request, team=team, get_earliest_timestamp=get_earliest_timestamp
+                request=request,
+                team=team,
+                get_earliest_timestamp=get_earliest_timestamp,
             )
             result = self.stickiness_query_class().run(stickiness_filter, team)
         else:
@@ -663,12 +684,21 @@ Using the correct cache and enriching the response with dashboard specific confi
         filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS}, team=self.team)
 
         if filter.funnel_viz_type == FunnelVizType.TRENDS:
-            return {"result": ClickhouseFunnelTrends(team=team, filter=filter).run(), "timezone": team.timezone}
+            return {
+                "result": ClickhouseFunnelTrends(team=team, filter=filter).run(),
+                "timezone": team.timezone,
+            }
         elif filter.funnel_viz_type == FunnelVizType.TIME_TO_CONVERT:
-            return {"result": ClickhouseFunnelTimeToConvert(team=team, filter=filter).run(), "timezone": team.timezone}
+            return {
+                "result": ClickhouseFunnelTimeToConvert(team=team, filter=filter).run(),
+                "timezone": team.timezone,
+            }
         else:
             funnel_order_class = get_funnel_order_class(filter)
-            return {"result": funnel_order_class(team=team, filter=filter).run(), "timezone": team.timezone}
+            return {
+                "result": funnel_order_class(team=team, filter=filter).run(),
+                "timezone": team.timezone,
+            }
 
     # ******************************************
     # /projects/:id/insights/retention
@@ -730,7 +760,10 @@ Using the correct cache and enriching the response with dashboard specific confi
     @action(methods=["POST"], detail=True)
     def viewed(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         InsightViewed.objects.update_or_create(
-            team=self.team, user=request.user, insight=self.get_object(), defaults={"last_viewed_at": now()}
+            team=self.team,
+            user=request.user,
+            insight=self.get_object(),
+            defaults={"last_viewed_at": now()},
         )
         return Response(status=status.HTTP_201_CREATED)
 
@@ -751,7 +784,13 @@ Using the correct cache and enriching the response with dashboard specific confi
         if not Insight.objects.filter(id=item_id, team_id=self.team_id).exists():
             return Response("", status=status.HTTP_404_NOT_FOUND)
 
-        activity_page = load_activity(scope="Insight", team_id=self.team_id, item_id=item_id, limit=limit, page=page)
+        activity_page = load_activity(
+            scope="Insight",
+            team_id=self.team_id,
+            item_id=item_id,
+            limit=limit,
+            page=page,
+        )
         return activity_page_response(activity_page, limit, page, request)
 
     @action(methods=["POST"], detail=False)

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -292,7 +292,7 @@ class InsightSerializer(InsightBasicSerializer):
         return updated_insight
 
     def _update_insight_dashboards(self, dashboards: List[Dashboard], instance: Insight) -> None:
-        old_dashboard_ids = [tile.dashboard_id for tile in instance.dashboard_tiles.all()]
+        old_dashboard_ids = [tile.dashboard_id for tile in instance.dashboard_tiles.exclude(deleted=True).all()]
         new_dashboard_ids = [d.id for d in dashboards if not d.deleted]
 
         if sorted(old_dashboard_ids) == sorted(new_dashboard_ids):

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -40,6 +40,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -83,6 +84,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -178,6 +180,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -268,6 +271,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -406,6 +410,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -542,6 +547,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -681,6 +687,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -788,6 +795,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -925,6 +933,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1017,6 +1026,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1086,6 +1096,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1222,6 +1233,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1291,6 +1303,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1334,6 +1347,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1452,6 +1466,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1483,7 +1498,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-a8c6-0001-284a-8fee08338829'::uuid, 144, 2626, 3459, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:51.654838+00:00'::timestamptz, '2022-12-13T01:12:51.654838+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-5404-0001-dad7-b7788141b5cc'::uuid, 1, 66, 74, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:40.324974+00:00'::timestamptz, '2022-12-23T12:12:40.324974+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -1617,6 +1632,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1712,6 +1728,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1802,6 +1819,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -1942,6 +1960,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2040,6 +2059,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2145,6 +2165,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2222,6 +2243,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2253,7 +2275,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-a8a4-0001-89cf-751900394bc5'::uuid, 144, 2626, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:51.620814+00:00'::timestamptz, '2022-12-13T01:12:51.620814+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-53f2-0001-9d4b-d3df7d5fc2e6'::uuid, 1, 66, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:40.306865+00:00'::timestamptz, '2022-12-23T12:12:40.306865+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -2317,6 +2339,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2360,6 +2383,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2403,6 +2427,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2508,6 +2533,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2585,6 +2611,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2616,7 +2643,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-aba3-0001-d0fb-f4b90374b8fa'::uuid, 144, 2629, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.387851+00:00'::timestamptz, '2022-12-13T01:12:52.387851+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-5769-0001-af1c-156057dbc81b'::uuid, 1, 69, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.193377+00:00'::timestamptz, '2022-12-23T12:12:41.193377+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -2680,6 +2707,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2723,6 +2751,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2858,6 +2887,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -2889,7 +2919,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-abba-0001-7f2c-f9a58887e53e'::uuid, 144, 2629, 3463, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.410769+00:00'::timestamptz, '2022-12-13T01:12:52.410769+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-577a-0001-df5f-ad4e9d2789bb'::uuid, 1, 69, 78, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.210194+00:00'::timestamptz, '2022-12-23T12:12:41.210194+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -2994,6 +3024,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3102,6 +3133,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3192,6 +3224,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3287,6 +3320,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3392,6 +3426,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3473,6 +3508,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3603,6 +3639,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3634,7 +3671,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-abe6-0001-89ff-020cfb97a9cd'::uuid, 144, 2630, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.454201+00:00'::timestamptz, '2022-12-13T01:12:52.454201+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-579d-0001-06a3-9af7863ce3e7'::uuid, 1, 70, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.245662+00:00'::timestamptz, '2022-12-23T12:12:41.245662+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -3698,6 +3735,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3741,6 +3779,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3859,6 +3898,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -3911,7 +3951,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-abf9-0001-e53c-2503d653ba13'::uuid, 144, 2630, 3464, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.473766+00:00'::timestamptz, '2022-12-13T01:12:52.473766+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-57ad-0001-dd4d-764752dc7d11'::uuid, 1, 70, 79, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.261276+00:00'::timestamptz, '2022-12-23T12:12:41.261276+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -4016,6 +4056,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4111,6 +4152,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4227,6 +4269,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4336,6 +4379,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4472,6 +4516,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4611,6 +4656,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4742,6 +4788,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4785,6 +4832,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4828,6 +4876,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4871,6 +4920,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -4914,6 +4964,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5019,6 +5070,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5062,6 +5114,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5105,6 +5158,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5182,6 +5236,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5242,7 +5297,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ac43-0001-5dcd-1a3b36cb5ee8'::uuid, 144, 2627, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.547943+00:00'::timestamptz, '2022-12-13T01:12:52.547943+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-57e7-0001-e5c8-0028a30c6998'::uuid, 1, 67, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.319230+00:00'::timestamptz, '2022-12-23T12:12:41.319230+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -5342,6 +5397,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5385,6 +5441,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5462,6 +5519,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5493,7 +5551,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ac58-0001-2a64-f584c79ae4f3'::uuid, 144, 2628, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.568812+00:00'::timestamptz, '2022-12-13T01:12:52.568812+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-57f8-0001-cf80-a8983034e3d4'::uuid, 1, 68, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.336689+00:00'::timestamptz, '2022-12-23T12:12:41.336689+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -5593,6 +5651,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5636,6 +5695,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5679,6 +5739,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5756,6 +5817,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5787,7 +5849,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ac76-0001-a2db-8d8d3c032b14'::uuid, 144, 2629, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.598121+00:00'::timestamptz, '2022-12-13T01:12:52.598121+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-580a-0001-3258-763bbc0cd635'::uuid, 1, 69, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.354334+00:00'::timestamptz, '2022-12-23T12:12:41.354334+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -5887,6 +5949,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -5930,6 +5993,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6007,6 +6071,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6038,7 +6103,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ac8b-0001-bf12-98c4aa56827f'::uuid, 144, 2630, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.619363+00:00'::timestamptz, '2022-12-13T01:12:52.619363+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-581c-0001-c95c-954b3e492deb'::uuid, 1, 70, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.372130+00:00'::timestamptz, '2022-12-23T12:12:41.372130+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -6114,6 +6179,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6313,6 +6379,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6467,6 +6534,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6578,6 +6646,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6695,6 +6764,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6764,6 +6834,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6882,6 +6953,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -6987,6 +7059,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7064,6 +7137,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7157,7 +7231,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-aafc-0001-884d-b213dad8d629'::uuid, 144, 2627, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.220942+00:00'::timestamptz, '2022-12-13T01:12:52.220942+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-56de-0001-3563-2aca54a3ab06'::uuid, 1, 67, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.054127+00:00'::timestamptz, '2022-12-23T12:12:41.054127+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -7221,6 +7295,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7264,6 +7339,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7382,6 +7458,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7413,7 +7490,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ab19-0001-2018-cc5404c41a27'::uuid, 144, 2627, 3460, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.249162+00:00'::timestamptz, '2022-12-13T01:12:52.249162+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-56f0-0001-126b-28f847d823b4'::uuid, 1, 67, 75, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.072185+00:00'::timestamptz, '2022-12-23T12:12:41.072185+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -7451,6 +7528,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7501,6 +7579,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7619,6 +7698,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7650,7 +7730,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ab2b-0000-06b0-b2ddeda4d045'::uuid, 144, 2627, 3461, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.267026+00:00'::timestamptz, '2022-12-13T01:12:52.267026+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-5707-0001-64cc-7b7c56a097b1'::uuid, 1, 67, 76, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.095483+00:00'::timestamptz, '2022-12-23T12:12:41.095483+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -7755,6 +7835,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7840,6 +7921,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7935,6 +8017,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -7999,6 +8082,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8097,6 +8181,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8192,6 +8277,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8297,6 +8383,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8374,6 +8461,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8405,7 +8493,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ab5e-0001-263c-a4364f3bda96'::uuid, 144, 2628, NULL, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.318974+00:00'::timestamptz, '2022-12-13T01:12:52.318974+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-5733-0001-fd7b-34cf9cfb2003'::uuid, 1, 68, NULL, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.139316+00:00'::timestamptz, '2022-12-23T12:12:41.139316+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -8482,6 +8570,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8525,6 +8614,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8643,6 +8733,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8674,7 +8765,7 @@
   '
   
   INSERT INTO posthog_insightcachingstate AS state (id, team_id, insight_id, dashboard_tile_id, cache_key, target_cache_age_seconds, created_at, updated_at, refresh_attempt)
-  VALUES ('0185090a-ab72-0001-1ac6-061e6dc724f0'::uuid, 144, 2628, 3462, 'cache_c9b7f1812694e57913a894da0e95b7fc', NULL, '2022-12-13T01:12:52.338383+00:00'::timestamptz, '2022-12-13T01:12:52.338383+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
+  VALUES ('01853ee6-5744-0001-3716-5c0aa426b805'::uuid, 1, 68, 77, 'cache_8ebf94c84ccaac0ea4f796d475478017', NULL, '2022-12-23T12:12:41.156776+00:00'::timestamptz, '2022-12-23T12:12:41.156776+00:00'::timestamptz, 0) ON CONFLICT (insight_id, coalesce(dashboard_tile_id, -1)) DO
   UPDATE
   SET last_refresh =
     (SELECT CASE
@@ -8786,6 +8877,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8881,6 +8973,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -8971,6 +9064,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -9173,6 +9267,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -9298,6 +9393,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -9407,6 +9503,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -9543,6 +9640,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -9732,6 +9830,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -9775,6 +9874,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -9886,6 +9986,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -10029,6 +10130,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -10101,6 +10203,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -10291,6 +10394,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -10402,6 +10506,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -10519,6 +10624,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -10588,6 +10694,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",
@@ -10705,6 +10812,7 @@
          "posthog_team"."ingested_event",
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -549,6 +549,9 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         self.dashboard_api.add_insight_to_dashboard([dashboard_id], insight_id)
 
+        insight_json = self.dashboard_api.get_insight(insight_id)
+        assert insight_json["dashboards"] == [dashboard_id]
+
     def test_can_update_insight_with_inconsistent_dashboards(self) -> None:
         """
         Regression test because there are some DashboardTiles in production that should not exist.

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -39,9 +39,16 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
 
     def test_get_insight_items(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
 
-        Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team, created_by=self.user)
+        Insight.objects.create(
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            created_by=self.user,
+        )
 
         # create without user
         Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team)
@@ -88,7 +95,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         # Updating fields that don't change the substance of the insight should affect updated_at
         # BUT NOT last_modified_at or last_modified_by
         with freeze_time("2021-09-20T12:00:00Z"):
-            response_2 = self.client.patch(f"/api/projects/{self.team.id}/insights/{insight_id}", {"favorited": True})
+            response_2 = self.client.patch(
+                f"/api/projects/{self.team.id}/insights/{insight_id}",
+                {"favorited": True},
+            )
             self.assertEqual(response_2.status_code, status.HTTP_200_OK)
             self.assertDictContainsSubset(
                 {
@@ -105,7 +115,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         # AND last_modified_at plus last_modified_by
         with freeze_time("2021-10-21T12:00:00Z"):
             response_3 = self.client.patch(
-                f"/api/projects/{self.team.id}/insights/{insight_id}", {"filters": {"events": []}}
+                f"/api/projects/{self.team.id}/insights/{insight_id}",
+                {"filters": {"events": []}},
             )
             self.assertEqual(response_3.status_code, status.HTTP_200_OK)
             self.assertDictContainsSubset(
@@ -136,7 +147,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.client.force_login(alt_user)
         with freeze_time("2022-01-01T12:00:00Z"):
             response_5 = self.client.patch(
-                f"/api/projects/{self.team.id}/insights/{insight_id}", {"description": "Lorem ipsum."}
+                f"/api/projects/{self.team.id}/insights/{insight_id}",
+                {"description": "Lorem ipsum."},
             )
             self.assertEqual(response_5.status_code, status.HTTP_200_OK)
             self.assertDictContainsSubset(
@@ -151,33 +163,56 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             )
 
     def test_get_saved_insight_items(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
 
         Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), saved=True, team=self.team, created_by=self.user
+            filters=Filter(data=filter_dict).to_dict(),
+            saved=True,
+            team=self.team,
+            created_by=self.user,
         )
 
         # create without saved
-        Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team, created_by=self.user)
+        Insight.objects.create(
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            created_by=self.user,
+        )
 
         # create without user
         Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team)
 
-        response = self.client.get(f"/api/projects/{self.team.id}/insights/", data={"saved": "true", "user": "true"})
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/",
+            data={"saved": "true", "user": "true"},
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(len(response.json()["results"]), 1)
         self.assertEqual(len(response.json()["results"][0]["short_id"]), 8)
 
     def test_get_favorited_insight_items(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
 
         Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), favorited=True, team=self.team, created_by=self.user
+            filters=Filter(data=filter_dict).to_dict(),
+            favorited=True,
+            team=self.team,
+            created_by=self.user,
         )
 
         # create without favorited
-        Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team, created_by=self.user)
+        Insight.objects.create(
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            created_by=self.user,
+        )
 
         # create without user
         Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team)
@@ -189,7 +224,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual((response.json()["results"][0]["favorited"]), True)
 
     def test_get_insight_in_dashboard_context(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
 
         dashboard_id, _ = self.dashboard_api.create_dashboard(
             {"name": "the dashboard", "filters": {"date_from": "-180d"}}
@@ -210,11 +248,19 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
     def test_get_insight_by_short_id(self) -> None:
         filter_dict = {"events": [{"id": "$pageview"}]}
 
-        Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678")
+        Insight.objects.create(
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
+        )
 
         # Red herring: Should be ignored because it's not on the current team (even though the user has access)
         new_team = Team.objects.create(organization=self.organization)
-        Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=new_team, short_id="12345678")
+        Insight.objects.create(
+            filters=Filter(data=filter_dict).to_dict(),
+            team=new_team,
+            short_id="12345678",
+        )
 
         response = self.client.get(f"/api/projects/{self.team.id}/insights/?short_id=12345678")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -230,7 +276,11 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         """
         filter_dict = {"events": [{"id": "$pageview"}]}
 
-        Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678")
+        Insight.objects.create(
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
+        )
         Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team, saved=True)
 
         response = self.client.get(f"/api/projects/{self.team.id}/insights/?basic=true")
@@ -329,14 +379,21 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
     def test_searching_insights_includes_tags_and_description(self) -> None:
         insight_one_id, _ = self.dashboard_api.create_insight(
-            {"name": "needle in a haystack", "filters": {"events": [{"id": "$pageview"}]}}
+            {
+                "name": "needle in a haystack",
+                "filters": {"events": [{"id": "$pageview"}]},
+            }
         )
         insight_two_id, _ = self.dashboard_api.create_insight(
             {"name": "not matching", "filters": {"events": [{"id": "$pageview"}]}}
         )
 
         insight_three_id, _ = self.dashboard_api.create_insight(
-            {"name": "not matching name", "filters": {"events": [{"id": "$pageview"}]}, "tags": ["needle"]}
+            {
+                "name": "not matching name",
+                "filters": {"events": [{"id": "$pageview"}]},
+                "tags": ["needle"],
+            }
         )
 
         insight_four_id, _ = self.dashboard_api.create_insight(
@@ -351,7 +408,11 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         matching = self.client.get(f"/api/projects/{self.team.id}/insights/?search=needle")
         self.assertEqual(matching.status_code, status.HTTP_200_OK)
         matched_insights = [insight["id"] for insight in matching.json()["results"]]
-        assert sorted(matched_insights) == [insight_one_id, insight_three_id, insight_four_id]
+        assert sorted(matched_insights) == [
+            insight_one_id,
+            insight_three_id,
+            insight_four_id,
+        ]
 
     @freeze_time("2012-01-14T03:21:34.000Z")
     def test_create_insight_items(self) -> None:
@@ -455,9 +516,38 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         new_dashboard_id, _ = self.dashboard_api.create_dashboard({})
         # accidentally include a deleted dashboard
         _, update_response = self.dashboard_api.update_insight(
-            insight_id, {"dashboards": [dashboard_id, deleted_dashboard_id, new_dashboard_id]}
+            insight_id,
+            {"dashboards": [dashboard_id, deleted_dashboard_id, new_dashboard_id]},
         )
         assert sorted(update_response["dashboards"]) == [dashboard_id, new_dashboard_id]
+
+    def test_insight_items_on_a_dashboard_ignore_deleted_dashboard_tiles(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({})
+
+        insight_id, insight_json = self.dashboard_api.create_insight(
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                    "date_from": "-90d",
+                },
+                "dashboards": [dashboard_id],
+            }
+        )
+
+        tile: DashboardTile = DashboardTile.objects.get(insight_id=insight_id, dashboard_id=dashboard_id)
+        tile.deleted = True
+        tile.save()
+
+        insight_json = self.dashboard_api.get_insight(insight_id)
+        assert insight_json["dashboards"] == []
+
+        insight_by_short_id = self.client.get(
+            f'/api/projects/{self.team.pk}/insights?short_id={insight_json["short_id"]}'
+        )
+        assert insight_by_short_id.json()["results"][0]["dashboards"] == []
+
+        self.dashboard_api.add_insight_to_dashboard([dashboard_id], insight_id)
 
     def test_can_update_insight_with_inconsistent_dashboards(self) -> None:
         """
@@ -568,9 +658,13 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(sorted(response_data["tags"]), sorted(["add", "these", "tags"]))
             self.assertEqual(response_data["created_by"]["distinct_id"], self.user.distinct_id)
             self.assertEqual(
-                response_data["effective_restriction_level"], Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+                response_data["effective_restriction_level"],
+                Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT,
             )
-            self.assertEqual(response_data["effective_privilege_level"], Dashboard.PrivilegeLevel.CAN_EDIT)
+            self.assertEqual(
+                response_data["effective_privilege_level"],
+                Dashboard.PrivilegeLevel.CAN_EDIT,
+            )
 
             response = self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}")
 
@@ -629,7 +723,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertIsNotNone(original_filters_hash)
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/insights/{insight_id}", {"filters_hash": "should not update the value"}
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"filters_hash": "should not update the value"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["filters_hash"], original_filters_hash)
@@ -732,7 +827,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         )
 
         for custom_name, expected_name in zip(
-            ["Custom filter", 100, "", "  ", None], ["Custom filter", "100", None, None, None]
+            ["Custom filter", 100, "", "  ", None],
+            ["Custom filter", "100", None, None, None],
         ):
             response = self.client.patch(
                 f"/api/projects/{self.team.id}/insights/{insight.id}",
@@ -796,13 +892,26 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(objects[0].filters["layout"], "horizontal")
         self.assertEqual(len(objects[0].short_id), 8)
 
-    @patch("posthog.api.insight.synchronously_update_cache", wraps=synchronously_update_cache)
+    @patch(
+        "posthog.api.insight.synchronously_update_cache",
+        wraps=synchronously_update_cache,
+    )
     def test_insight_refreshing(self, spy_update_insight_cache) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"filters": {"date_from": "-14d"}})
 
         with freeze_time("2012-01-14T03:21:34.000Z"):
-            _create_event(team=self.team, event="$pageview", distinct_id="1", properties={"prop": "val"})
-            _create_event(team=self.team, event="$pageview", distinct_id="2", properties={"prop": "another_val"})
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id="1",
+                properties={"prop": "val"},
+            )
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id="2",
+                properties={"prop": "another_val"},
+            )
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -816,7 +925,13 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                 data={
                     "filters": {
                         "events": [{"id": "$pageview"}],
-                        "properties": [{"key": "another", "value": "never_return_this", "operator": "is_not"}],
+                        "properties": [
+                            {
+                                "key": "another",
+                                "value": "never_return_this",
+                                "operator": "is_not",
+                            }
+                        ],
                     },
                     "dashboards": [dashboard_id],
                 },
@@ -845,7 +960,23 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(spy_update_insight_cache.call_count, 3)
             self.assertEqual(
                 response["result"][0]["data"],
-                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.0, 0.0],
+                [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    2.0,
+                    1.0,
+                    0.0,
+                ],
             )
             self.assertEqual(response["last_refresh"], "2012-01-16T05:01:34Z")
             self.assertEqual(response["last_modified_at"], "2012-01-15T04:01:34Z")  # did not change
@@ -859,7 +990,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         #  Test property filter
 
         dashboard = Dashboard.objects.get(pk=dashboard_id)
-        dashboard.filters = {"properties": [{"key": "prop", "value": "val"}], "date_from": "-14d"}
+        dashboard.filters = {
+            "properties": [{"key": "prop", "value": "val"}],
+            "date_from": "-14d",
+        }
         dashboard.save()
         with freeze_time("2012-01-16T05:01:34.000Z"):
             response = self.client.get(
@@ -868,7 +1002,23 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(spy_update_insight_cache.call_count, 4)
             self.assertEqual(
                 response["result"][0]["data"],
-                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+                [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                    0.0,
+                ],
             )
 
     # BASIC TESTING OF ENDPOINTS. /queries as in depth testing for each insight
@@ -900,7 +1050,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         response_nonexistent_property_data.pop("last_refresh")
         response_nonexistent_cohort_data.pop("last_refresh")
         self.assertEntityResponseEqual(
-            response_nonexistent_property_data["result"], response_nonexistent_cohort_data["result"]
+            response_nonexistent_property_data["result"],
+            response_nonexistent_cohort_data["result"],
         )  # Both cases just empty
 
     def test_cohort_without_match_group_works(self) -> None:
@@ -919,7 +1070,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         response_nonexistent_property_data.pop("last_refresh")
         response_cohort_without_match_groups_data.pop("last_refresh")
         self.assertEntityResponseEqual(
-            response_nonexistent_property_data["result"], response_cohort_without_match_groups_data["result"]
+            response_nonexistent_property_data["result"],
+            response_cohort_without_match_groups_data["result"],
         )  # Both cases just empty
 
     def test_precalculated_cohort_works(self) -> None:
@@ -928,7 +1080,18 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         whatever_cohort: Cohort = Cohort.objects.create(
             id=113,
             team=self.team,
-            groups=[{"properties": [{"type": "person", "key": "foo", "value": "bar", "operator": "exact"}]}],
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "type": "person",
+                            "key": "foo",
+                            "value": "bar",
+                            "operator": "exact",
+                        }
+                    ]
+                }
+            ],
             last_calculation=timezone.now(),
         )
 
@@ -949,14 +1112,18 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         response_precalculated_cohort_data.pop("last_refresh")
 
         self.assertEntityResponseEqual(
-            response_user_property_data["result"], response_precalculated_cohort_data["result"]
+            response_user_property_data["result"],
+            response_precalculated_cohort_data["result"],
         )
 
     def test_insight_trends_compare(self) -> None:
         with freeze_time("2012-01-14T03:21:34.000Z"):
             for i in range(25):
                 _create_event(
-                    team=self.team, event="$pageview", distinct_id="1", properties={"$some_property": f"value{i}"}
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id="1",
+                    properties={"$some_property": f"value{i}"},
                 )
 
         with freeze_time("2012-01-15T04:01:34.000Z"):
@@ -974,7 +1141,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         with freeze_time("2012-01-14T03:21:34.000Z"):
             for i in range(25):
                 _create_event(
-                    team=self.team, event="$pageview", distinct_id="1", properties={"$some_property": f"value{i}"}
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id="1",
+                    properties={"$some_property": f"value{i}"},
                 )
 
         with freeze_time("2012-01-15T04:01:34.000Z"):
@@ -993,13 +1163,21 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         people = journeys_for(
             {
                 "1": [
-                    {"event": "$pageview", "properties": {"$session_id": "one"}, "timestamp": "2012-01-14 00:16:00"},
+                    {
+                        "event": "$pageview",
+                        "properties": {"$session_id": "one"},
+                        "timestamp": "2012-01-14 00:16:00",
+                    },
                     {
                         "event": "$pageview",
                         "properties": {"$session_id": "one"},
                         "timestamp": "2012-01-14 00:16:10",
                     },  # 10s session
-                    {"event": "$pageview", "properties": {"$session_id": "two"}, "timestamp": "2012-01-15 00:16:00"},
+                    {
+                        "event": "$pageview",
+                        "properties": {"$session_id": "two"},
+                        "timestamp": "2012-01-15 00:16:00",
+                    },
                     {
                         "event": "$pageview",
                         "properties": {"$session_id": "two"},
@@ -1007,13 +1185,21 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                     },  # 50s session, day 2
                 ],
                 "2": [
-                    {"event": "$pageview", "properties": {"$session_id": "three"}, "timestamp": "2012-01-14 00:16:00"},
+                    {
+                        "event": "$pageview",
+                        "properties": {"$session_id": "three"},
+                        "timestamp": "2012-01-14 00:16:00",
+                    },
                     {
                         "event": "$pageview",
                         "properties": {"$session_id": "three"},
                         "timestamp": "2012-01-14 00:16:30",
                     },  # 30s session
-                    {"event": "$pageview", "properties": {"$session_id": "four"}, "timestamp": "2012-01-15 00:16:00"},
+                    {
+                        "event": "$pageview",
+                        "properties": {"$session_id": "four"},
+                        "timestamp": "2012-01-15 00:16:00",
+                    },
                     {
                         "event": "$pageview",
                         "properties": {"$session_id": "four"},
@@ -1021,7 +1207,11 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                     },  # 20s session, day 2
                 ],
                 "3": [
-                    {"event": "$pageview", "properties": {"$session_id": "five"}, "timestamp": "2012-01-15 00:16:00"},
+                    {
+                        "event": "$pageview",
+                        "properties": {"$session_id": "five"},
+                        "timestamp": "2012-01-15 00:16:00",
+                    },
                     {
                         "event": "$pageview",
                         "properties": {"$session_id": "five"},
@@ -1046,8 +1236,14 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             result = response.json()["result"]
 
-            self.assertEqual([resp["breakdown_value"] for resp in result], ["[10.0,30.0]", "[30.0,50.01]"])
-            self.assertEqual(result[0]["labels"], ["13-Jan-2012", "14-Jan-2012", "15-Jan-2012", "16-Jan-2012"])
+            self.assertEqual(
+                [resp["breakdown_value"] for resp in result],
+                ["[10.0,30.0]", "[30.0,50.01]"],
+            )
+            self.assertEqual(
+                result[0]["labels"],
+                ["13-Jan-2012", "14-Jan-2012", "15-Jan-2012", "16-Jan-2012"],
+            )
             self.assertEqual(result[0]["data"], [0, 2, 2, 0])
             self.assertEqual(result[1]["data"], [0, 2, 4, 0])
 
@@ -1078,7 +1274,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
     def test_insight_paths_basic(self) -> None:
         _create_person(team=self.team, distinct_ids=["person_1"])
         _create_event(
-            properties={"$current_url": "/", "test": "val"}, distinct_id="person_1", event="$pageview", team=self.team
+            properties={"$current_url": "/", "test": "val"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
         )
         _create_event(
             properties={"$current_url": "/about", "test": "val"},
@@ -1089,7 +1288,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         _create_person(team=self.team, distinct_ids=["dontcount"])
         _create_event(
-            properties={"$current_url": "/", "test": "val"}, distinct_id="dontcount", event="$pageview", team=self.team
+            properties={"$current_url": "/", "test": "val"},
+            distinct_id="dontcount",
+            event="$pageview",
+            team=self.team,
         )
         _create_event(
             properties={"$current_url": "/about", "test": "val"},
@@ -1103,7 +1305,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             data={"properties": json.dumps([{"key": "test", "value": "val"}])},
         ).json()
         post_response = self.client.post(
-            f"/api/projects/{self.team.id}/insights/path", {"properties": [{"key": "test", "value": "val"}]}
+            f"/api/projects/{self.team.id}/insights/path",
+            {"properties": [{"key": "test", "value": "val"}]},
         ).json()
         self.assertEqual(len(get_response["result"]), 1)
         self.assertEqual(len(post_response["result"]), 1)
@@ -1147,13 +1350,23 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(response["timezone"], "UTC")
 
     def test_insight_retention_basic(self) -> None:
-        _create_person(team=self.team, distinct_ids=["person1"], properties={"email": "person1@test.com"})
+        _create_person(
+            team=self.team,
+            distinct_ids=["person1"],
+            properties={"email": "person1@test.com"},
+        )
         _create_event(
-            team=self.team, event="$pageview", distinct_id="person1", timestamp=timezone.now() - timedelta(days=11)
+            team=self.team,
+            event="$pageview",
+            distinct_id="person1",
+            timestamp=timezone.now() - timedelta(days=11),
         )
 
         _create_event(
-            team=self.team, event="$pageview", distinct_id="person1", timestamp=timezone.now() - timedelta(days=10)
+            team=self.team,
+            event="$pageview",
+            distinct_id="person1",
+            timestamp=timezone.now() - timedelta(days=10),
         )
         response = self.client.get(f"/api/projects/{self.team.id}/insights/retention/").json()
 
@@ -1168,14 +1381,24 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertNotEqual(user2.team.id, self.team.id)
         self.client.force_login(self.user)
 
-        _create_person(team=self.team, distinct_ids=["person1"], properties={"email": "person1@test.com"})
-
-        _create_event(
-            team=self.team, event="$pageview", distinct_id="person1", timestamp=timezone.now() - timedelta(days=6)
+        _create_person(
+            team=self.team,
+            distinct_ids=["person1"],
+            properties={"email": "person1@test.com"},
         )
 
         _create_event(
-            team=self.team, event="$pageview", distinct_id="person1", timestamp=timezone.now() - timedelta(days=5)
+            team=self.team,
+            event="$pageview",
+            distinct_id="person1",
+            timestamp=timezone.now() - timedelta(days=6),
+        )
+
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="person1",
+            timestamp=timezone.now() - timedelta(days=5),
         )
 
         events_filter = json.dumps([{"id": "$pageview"}])
@@ -1187,7 +1410,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         self.client.force_login(user2)
         response_team2 = self.client.get(
-            f"/api/projects/{self.team.id}/insights/trend/?events={events_filter}", data={"token": user2.team.api_token}
+            f"/api/projects/{self.team.id}/insights/trend/?events={events_filter}",
+            data={"token": user2.team.api_token},
         )
 
         self.assertEqual(response_team1.status_code, 200)
@@ -1239,16 +1463,23 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         response = self.client.get(
             f"/api/projects/{self.team.id}/insights/trend/?events={json.dumps([{'id': '$pageview'}])}"
         )
-        self.assertDictEqual(self.permission_denied_response("You don't have access to the project."), response.json())
+        self.assertDictEqual(
+            self.permission_denied_response("You don't have access to the project."),
+            response.json(),
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_insight_trends_allowed_if_project_private_and_org_member_and_project_member(self) -> None:
+    def test_insight_trends_allowed_if_project_private_and_org_member_and_project_member(
+        self,
+    ) -> None:
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
         self.team.access_control = True
         self.team.save()
         ExplicitTeamMembership.objects.create(
-            team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.MEMBER
+            team=self.team,
+            parent_membership=self.organization_membership,
+            level=ExplicitTeamMembership.Level.MEMBER,
         )
         response = self.client.get(
             f"/api/projects/{self.team.id}/insights/trend/?events={json.dumps([{'id': '$pageview'}])}"
@@ -1265,34 +1496,59 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             f"/api/projects/{self.team.id}/insights/trend/?events={json.dumps([{'id': '$pageview'}])}&properties=%5B%5D&display=ActionsLineGraph"
         )
 
-        self.assertEqual(patch_capture_exception.call_count, 0, patch_capture_exception.call_args_list)
+        self.assertEqual(
+            patch_capture_exception.call_count,
+            0,
+            patch_capture_exception.call_args_list,
+        )
 
         # Properties with an array
-        events = [{"id": "$pageview", "properties": [{"key": "something", "value": ["something"]}]}]
+        events = [
+            {
+                "id": "$pageview",
+                "properties": [{"key": "something", "value": ["something"]}],
+            }
+        ]
         self.client.get(
             f"/api/projects/{self.team.id}/insights/trend/?events={json.dumps(events)}&properties=%5B%5D&display=ActionsLineGraph"
         )
-        self.assertEqual(patch_capture_exception.call_count, 0, patch_capture_exception.call_args_list)
+        self.assertEqual(
+            patch_capture_exception.call_count,
+            0,
+            patch_capture_exception.call_args_list,
+        )
 
         # Breakdown with ints in funnels
         cohort_one_id = self._create_one_person_cohort([{"key": "prop", "value": 5, "type": "person"}])
         cohort_two_id = self._create_one_person_cohort([{"key": "prop", "value": 6, "type": "person"}])
 
         events = [
-            {"id": "$pageview", "properties": [{"key": "something", "value": ["something"]}]},
+            {
+                "id": "$pageview",
+                "properties": [{"key": "something", "value": ["something"]}],
+            },
             {"id": "$pageview"},
         ]
         response = self.client.post(
             f"/api/projects/{self.team.id}/insights/funnel/",
-            {"events": events, "breakdown": [cohort_one_id, cohort_two_id], "breakdown_type": "cohort"},
+            {
+                "events": events,
+                "breakdown": [cohort_one_id, cohort_two_id],
+                "breakdown_type": "cohort",
+            },
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(patch_capture_exception.call_count, 0, patch_capture_exception.call_args_list)
+        self.assertEqual(
+            patch_capture_exception.call_count,
+            0,
+            patch_capture_exception.call_args_list,
+        )
 
     def _create_one_person_cohort(self, properties: List[Dict[str, Any]]) -> int:
         Person.objects.create(team=self.team, properties=properties)
         cohort_one_id = self.client.post(
-            f"/api/projects/{self.team.id}/cohorts", data={"name": "whatever", "groups": [{"properties": properties}]}
+            f"/api/projects/{self.team.id}/cohorts",
+            data={"name": "whatever", "groups": [{"properties": properties}]},
         ).json()["id"]
         return cohort_one_id
 
@@ -1301,7 +1557,9 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         filter_dict = {"events": [{"id": "$pageview"}]}
 
         insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
         )
 
         response = self.client.post(f"/api/projects/{self.team.id}/insights/{insight.id}/viewed")
@@ -1312,12 +1570,17 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(created_insight_viewed.insight, insight)
         self.assertEqual(created_insight_viewed.team, self.team)
         self.assertEqual(created_insight_viewed.user, self.user)
-        self.assertEqual(created_insight_viewed.last_viewed_at, datetime(2022, 3, 22, 0, 0, tzinfo=pytz.UTC))
+        self.assertEqual(
+            created_insight_viewed.last_viewed_at,
+            datetime(2022, 3, 22, 0, 0, tzinfo=pytz.UTC),
+        )
 
     def test_update_insight_viewed(self) -> None:
         filter_dict = {"events": [{"id": "$pageview"}]}
         insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
         )
         with freeze_time("2022-03-22T00:00:00.000Z"):
             response = self.client.post(f"/api/projects/{self.team.id}/insights/{insight.id}/viewed")
@@ -1329,13 +1592,18 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(InsightViewed.objects.count(), 1)
 
             updated_insight_viewed = InsightViewed.objects.all()[0]
-            self.assertEqual(updated_insight_viewed.last_viewed_at, datetime(2022, 3, 23, 0, 0, tzinfo=pytz.UTC))
+            self.assertEqual(
+                updated_insight_viewed.last_viewed_at,
+                datetime(2022, 3, 23, 0, 0, tzinfo=pytz.UTC),
+            )
 
     def test_cant_create_insight_viewed_for_another_team(self) -> None:
         other_team = Team.objects.create(organization=self.organization, name="other team")
         filter_dict = {"events": [{"id": "$pageview"}]}
         insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
         )
 
         response = self.client.post(f"/api/projects/{other_team.id}/insights/{insight.id}/viewed")
@@ -1347,7 +1615,9 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         other_team = Team.objects.create(organization=self.organization, name="other team")
         filter_dict = {"events": [{"id": "$pageview"}]}
         insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=other_team, short_id="12345678"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=other_team,
+            short_id="12345678",
         )
 
         response = self.client.post(f"/api/projects/{self.team.id}/insights/{insight.id}/viewed")
@@ -1359,7 +1629,9 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         filter_dict = {"events": [{"id": "$pageview"}]}
 
         insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
         )
 
         self.client.post(f"/api/projects/{self.team.id}/insights/{insight.id}/viewed")
@@ -1377,7 +1649,11 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
     def test_get_recently_viewed_insights_when_no_insights_viewed(self) -> None:
         filter_dict = {"events": [{"id": "$pageview"}]}
 
-        Insight.objects.create(filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678")
+        Insight.objects.create(
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
+        )
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/insights/?my_last_viewed=true&order=-my_last_viewed_at"
@@ -1391,10 +1667,14 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         filter_dict = {"events": [{"id": "$pageview"}]}
 
         insight_1 = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
         )
         insight_2 = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="98765432"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="98765432",
         )
 
         self.client.post(f"/api/projects/{self.team.id}/insights/{insight_1.id}/viewed")
@@ -1428,10 +1708,17 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         filter_dict = {"events": [{"id": "$pageview"}]}
 
         insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="12345678"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="12345678",
         )
         another_user = User.objects.create_and_join(self.organization, "team2@posthog.com", None)
-        InsightViewed.objects.create(team=self.team, user=another_user, insight=insight, last_viewed_at=timezone.now())
+        InsightViewed.objects.create(
+            team=self.team,
+            user=another_user,
+            insight=insight,
+            last_viewed_at=timezone.now(),
+        )
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/insights/?my_last_viewed=true&order=-my_last_viewed_at"
@@ -1443,7 +1730,10 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(len(response_data["results"]), 0)
 
     def test_get_recent_insights_with_feature_flag(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}], "breakdown": "$feature/insight-with-flag-used"}
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "breakdown": "$feature/insight-with-flag-used",
+        }
         filter_dict2 = {
             "events": [{"id": "$pageview"}],
             "properties": [{"key": "$active_feature_flag", "value": "insight-with-flag-used"}],
@@ -1451,12 +1741,20 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         filter_dict3 = {"events": [{"id": "$pageview"}], "breakdown": "email"}
 
         insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(), team=self.team, short_id="11223344"
+            filters=Filter(data=filter_dict).to_dict(),
+            team=self.team,
+            short_id="11223344",
         )
         insight2 = Insight.objects.create(
-            filters=Filter(data=filter_dict2).to_dict(), team=self.team, short_id="44332211"
+            filters=Filter(data=filter_dict2).to_dict(),
+            team=self.team,
+            short_id="44332211",
         )
-        Insight.objects.create(filters=Filter(data=filter_dict3).to_dict(), team=self.team, short_id="00992281")
+        Insight.objects.create(
+            filters=Filter(data=filter_dict3).to_dict(),
+            team=self.team,
+            short_id="00992281",
+        )
 
         response = self.client.get(f"/api/projects/{self.team.id}/insights/?feature_flag=insight-with-flag-used")
         response_data = response.json()
@@ -1467,7 +1765,9 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         # insight 3 is not included in response
         self.assertCountEqual(ids_in_response, [insight.id, insight2.id])
 
-    def test_cannot_create_insight_with_dashboards_relation_from_another_team(self) -> None:
+    def test_cannot_create_insight_with_dashboards_relation_from_another_team(
+        self,
+    ) -> None:
         dashboard_own_team: Dashboard = Dashboard.objects.create(team=self.team)
         another_team = Team.objects.create(organization=self.organization)
         dashboard_other_team: Dashboard = Dashboard.objects.create(team=another_team)
@@ -1509,9 +1809,13 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
     def test_an_insight_on_no_dashboard_has_no_restrictions(self) -> None:
         _, response_data = self.dashboard_api.create_insight(data={"name": "not on a dashboard"})
         self.assertEqual(
-            response_data["effective_restriction_level"], Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+            response_data["effective_restriction_level"],
+            Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT,
         )
-        self.assertEqual(response_data["effective_privilege_level"], Dashboard.PrivilegeLevel.CAN_EDIT)
+        self.assertEqual(
+            response_data["effective_privilege_level"],
+            Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
 
     def test_an_insight_on_unrestricted_dashboard_has_no_restrictions(self) -> None:
         dashboard: Dashboard = Dashboard.objects.create(team=self.team)
@@ -1519,28 +1823,43 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             data={"name": "on an unrestricted dashboard", "dashboards": [dashboard.pk]}
         )
         self.assertEqual(
-            response_data["effective_restriction_level"], Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+            response_data["effective_restriction_level"],
+            Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT,
         )
-        self.assertEqual(response_data["effective_privilege_level"], Dashboard.PrivilegeLevel.CAN_EDIT)
+        self.assertEqual(
+            response_data["effective_privilege_level"],
+            Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
 
-    def test_an_insight_on_restricted_dashboard_has_restrictions_cannot_edit_without_explicit_privilege(self) -> None:
+    def test_an_insight_on_restricted_dashboard_has_restrictions_cannot_edit_without_explicit_privilege(
+        self,
+    ) -> None:
         dashboard: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
         _, response_data = self.dashboard_api.create_insight(
             data={"name": "on a restricted dashboard", "dashboards": [dashboard.pk]}
         )
         self.assertEqual(
-            response_data["effective_restriction_level"], Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            response_data["effective_restriction_level"],
+            Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
-        self.assertEqual(response_data["effective_privilege_level"], Dashboard.PrivilegeLevel.CAN_VIEW)
+        self.assertEqual(
+            response_data["effective_privilege_level"],
+            Dashboard.PrivilegeLevel.CAN_VIEW,
+        )
 
-    def test_an_insight_on_both_restricted_and_unrestricted_dashboard_has_no_restrictions(self) -> None:
+    def test_an_insight_on_both_restricted_and_unrestricted_dashboard_has_no_restrictions(
+        self,
+    ) -> None:
         dashboard_restricted: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
         dashboard_unrestricted: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT,
         )
         _, response_data = self.dashboard_api.create_insight(
             data={
@@ -1549,59 +1868,93 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             }
         )
         self.assertEqual(
-            response_data["effective_restriction_level"], Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            response_data["effective_restriction_level"],
+            Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
-        self.assertEqual(response_data["effective_privilege_level"], Dashboard.PrivilegeLevel.CAN_EDIT)
+        self.assertEqual(
+            response_data["effective_privilege_level"],
+            Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
 
     def test_an_insight_on_restricted_dashboard_does_not_restrict_admin(self) -> None:
         dashboard_restricted: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
 
         admin = User.objects.create_and_join(
-            organization=self.organization, email="y@x.com", password=None, level=OrganizationMembership.Level.ADMIN
+            organization=self.organization,
+            email="y@x.com",
+            password=None,
+            level=OrganizationMembership.Level.ADMIN,
         )
         self.client.force_login(admin)
         _, response_data = self.dashboard_api.create_insight(
-            data={"name": "on a restricted and unrestricted dashboard", "dashboards": [dashboard_restricted.pk]}
+            data={
+                "name": "on a restricted and unrestricted dashboard",
+                "dashboards": [dashboard_restricted.pk],
+            }
         )
         self.assertEqual(
-            response_data["effective_restriction_level"], Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            response_data["effective_restriction_level"],
+            Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
-        self.assertEqual(response_data["effective_privilege_level"], Dashboard.PrivilegeLevel.CAN_EDIT)
+        self.assertEqual(
+            response_data["effective_privilege_level"],
+            Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
 
-    def test_an_insight_on_both_restricted_dashboard_does_not_restrict_with_explicit_privilege(self) -> None:
+    def test_an_insight_on_both_restricted_dashboard_does_not_restrict_with_explicit_privilege(
+        self,
+    ) -> None:
         dashboard_restricted: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
 
         DashboardPrivilege.objects.create(
-            dashboard=dashboard_restricted, user=self.user, level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            dashboard=dashboard_restricted,
+            user=self.user,
+            level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
 
         _, response_data = self.dashboard_api.create_insight(
-            data={"name": "on a restricted and unrestricted dashboard", "dashboards": [dashboard_restricted.pk]}
+            data={
+                "name": "on a restricted and unrestricted dashboard",
+                "dashboards": [dashboard_restricted.pk],
+            }
         )
         self.assertEqual(
-            response_data["effective_restriction_level"], Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            response_data["effective_restriction_level"],
+            Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
-        self.assertEqual(response_data["effective_privilege_level"], Dashboard.PrivilegeLevel.CAN_EDIT)
+        self.assertEqual(
+            response_data["effective_privilege_level"],
+            Dashboard.PrivilegeLevel.CAN_EDIT,
+        )
 
     def test_cannot_update_an_insight_if_on_restricted_dashboard(self) -> None:
         dashboard_restricted: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
 
         insight_id, response_data = self.dashboard_api.create_insight(
-            data={"name": "on a restricted and unrestricted dashboard", "dashboards": [dashboard_restricted.pk]}
+            data={
+                "name": "on a restricted and unrestricted dashboard",
+                "dashboards": [dashboard_restricted.pk],
+            }
         )
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/insights/{insight_id}", {"name": "changing when restricted"}
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"name": "changing when restricted"},
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_non_admin_user_cannot_add_an_insight_to_a_restricted_dashboard(self) -> None:
+    def test_non_admin_user_cannot_add_an_insight_to_a_restricted_dashboard(
+        self,
+    ) -> None:
         # create insight and dashboard separately with default user
         dashboard_restricted_id, _ = self.dashboard_api.create_dashboard(
             {"restriction_level": Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT}
@@ -1611,32 +1964,41 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         # user with no permissions on the dashboard cannot add insight to it
         user_without_permissions = User.objects.create_and_join(
-            organization=self.organization, email="no_access_user@posthog.com", password=None
+            organization=self.organization,
+            email="no_access_user@posthog.com",
+            password=None,
         )
         self.client.force_login(user_without_permissions)
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/insights/{insight_id}", {"dashboards": [dashboard_restricted_id]}
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"dashboards": [dashboard_restricted_id]},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
         self.client.force_login(self.user)
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/insights/{insight_id}", {"dashboards": [dashboard_restricted_id]}
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"dashboards": [dashboard_restricted_id]},
         )
         assert response.status_code == status.HTTP_200_OK
 
-    def test_non_admin_user_with_privilege_can_add_an_insight_to_a_restricted_dashboard(self) -> None:
+    def test_non_admin_user_with_privilege_can_add_an_insight_to_a_restricted_dashboard(
+        self,
+    ) -> None:
         # create insight and dashboard separately with default user
         dashboard_restricted: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
 
         insight_id, response_data = self.dashboard_api.create_insight(data={"name": "starts un-restricted dashboard"})
 
         user_with_permissions = User.objects.create_and_join(
-            organization=self.organization, email="with_access_user@posthog.com", password=None
+            organization=self.organization,
+            email="with_access_user@posthog.com",
+            password=None,
         )
 
         DashboardPrivilege.objects.create(
@@ -1648,14 +2010,16 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.client.force_login(user_with_permissions)
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/insights/{insight_id}", {"dashboards": [dashboard_restricted.id]}
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"dashboards": [dashboard_restricted.id]},
         )
         assert response.status_code == status.HTTP_200_OK
 
     def test_admin_user_can_add_an_insight_to_a_restricted_dashboard(self) -> None:
         # create insight and dashboard separately with default user
         dashboard_restricted: Dashboard = Dashboard.objects.create(
-            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+            team=self.team,
+            restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT,
         )
 
         insight_id, response_data = self.dashboard_api.create_insight(data={"name": "starts un-restricted dashboard"})
@@ -1670,14 +2034,22 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.client.force_login(admin)
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/insights/{insight_id}", {"dashboards": [dashboard_restricted.id]}
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"dashboards": [dashboard_restricted.id]},
         )
         assert response.status_code == status.HTTP_200_OK
 
-    def test_saving_an_insight_with_new_filters_updates_the_dashboard_tile(self) -> None:
+    def test_saving_an_insight_with_new_filters_updates_the_dashboard_tile(
+        self,
+    ) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({})
         insight_id, _ = self.dashboard_api.create_insight(
-            {"filters": {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}}
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                }
+            }
         )
         self.dashboard_api.add_insight_to_dashboard([dashboard_id], insight_id)
 
@@ -1685,7 +2057,12 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         response = self.client.patch(
             f"/api/projects/{self.team.id}/insights/{insight_id}",
-            {"filters": {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Chrome"}]}},
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Chrome"}],
+                }
+            },
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1695,17 +2072,25 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertIsNotNone(after_save)
         self.assertNotEqual(before_save, after_save)
 
-    def test_saving_an_insight_with_unchanged_filters_does_not_update_the_dashboard_tile(self) -> None:
+    def test_saving_an_insight_with_unchanged_filters_does_not_update_the_dashboard_tile(
+        self,
+    ) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({})
         insight_id, _ = self.dashboard_api.create_insight(
-            {"filters": {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}}
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                }
+            }
         )
         self.dashboard_api.add_insight_to_dashboard([dashboard_id], insight_id)
 
         before_save = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id).filters_hash
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/insights/{insight_id}", {"name": "a non-filter change"}
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"name": "a non-filter change"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1715,17 +2100,25 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertIsNotNone(after_save)
         self.assertEqual(before_save, after_save)
 
-    def test_saving_a_dashboard_with_new_filters_updates_the_dashboard_tile(self) -> None:
+    def test_saving_a_dashboard_with_new_filters_updates_the_dashboard_tile(
+        self,
+    ) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({})
         insight_id, _ = self.dashboard_api.create_insight(
-            {"filters": {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}}
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                }
+            }
         )
         self.dashboard_api.add_insight_to_dashboard([dashboard_id], insight_id)
 
         before_save = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id).filters_hash
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}", {"filters": {"date_from": "-14d"}}
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}",
+            {"filters": {"date_from": "-14d"}},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1735,17 +2128,25 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertIsNotNone(after_save)
         self.assertNotEqual(before_save, after_save)
 
-    def test_saving_a_dashboard_with_unchanged_filters_does_not_update_the_dashboard_tile(self) -> None:
+    def test_saving_a_dashboard_with_unchanged_filters_does_not_update_the_dashboard_tile(
+        self,
+    ) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "the dashboard's name"})
         insight_id, _ = self.dashboard_api.create_insight(
-            {"filters": {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}}
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                }
+            }
         )
         self.dashboard_api.add_insight_to_dashboard([dashboard_id], insight_id)
 
         before_save = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id).filters_hash
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}", {"name": "the dashboard's name"}
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}",
+            {"name": "the dashboard's name"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1755,7 +2156,9 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertIsNotNone(after_save)
         self.assertEqual(before_save, after_save)
 
-    def test_saving_an_insight_without_changing_dashboards_does_not_update_the_dashboard_tiles(self) -> None:
+    def test_saving_an_insight_without_changing_dashboards_does_not_update_the_dashboard_tiles(
+        self,
+    ) -> None:
         """
         Regression test. Sending an unchanged dashboard list to the API should not update the dashboard tiles.
         Previously it was resetting the tiles which was removing their layouts and making dashboard tiles move about :/
@@ -1764,7 +2167,12 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         dashboard_two_id, _ = self.dashboard_api.create_dashboard({"name": "the other dashboard's name"})
 
         insight_id, _ = self.dashboard_api.create_insight(
-            {"filters": {"events": [{"id": "$pageview"}], "properties": [{"key": "$browser", "value": "Mac OS X"}]}}
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                }
+            }
         )
 
         self.dashboard_api.add_insight_to_dashboard([dashboard_id, dashboard_two_id], insight_id)
@@ -1795,7 +2203,8 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         api_response = self.client.delete(f"/api/projects/{self.team.id}/insights/{insight_id}")
         self.assertEqual(api_response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertEqual(
-            self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}").status_code, status.HTTP_200_OK
+            self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}").status_code,
+            status.HTTP_200_OK,
         )
 
     def test_soft_delete_causes_404(self) -> None:
@@ -1821,13 +2230,17 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(update_response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(
-            self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}").status_code, status.HTTP_200_OK
+            self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}").status_code,
+            status.HTTP_200_OK,
         )
 
     def test_cancel_running_query(self) -> None:
         # There is no good way of writing a test that tests this without it being very slow
         #  Just verify it doesn't throw an error
-        response = self.client.post(f"/api/projects/{self.team.id}/insights/cancel", {"client_query_id": f"testid"})
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/cancel",
+            {"client_query_id": f"testid"},
+        )
         self.assertEqual(response.status_code, 201, response.content)
 
     @patch("posthog.decorators.get_safe_cache")


### PR DESCRIPTION
## Problem

In [this ticket ](https://posthoghelp.zendesk.com/agent/tickets/1290)a user's insight is in a very strange state where it reports being on dashboards despite the tile being deleted and won't let the user add or remove from dashboards

I can't replicate that locally but can intuit one possible error based on the code

## Changes

Fixes the possible error which should be fixed even if it isn't the bug here

## How did you test this code?

added a developer test and forced an insight into a broken state to test it locally
