### PR TITLE
chore(historical-export): make s3 chunk larger

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -163,6 +163,17 @@ export function addHistoricalEventsExportCapabilityV2(
 
     const currentPublicJobs = pluginConfig.plugin?.public_jobs || {}
 
+    // Returns the number of events to fetch per chunk, defaulting to 10000
+    // if the plugin is PostHog S3 Export plugin, otherwise we detault to
+    // 500. This is to avoid writting lots of small files to S3.
+    //
+    // It also has the other benefit of using fewer requests to ClickHouse. In
+    // it's current implementation the querying logic for pulling pages of
+    // events from ClickHouse will read a much larger amount of data from disk
+    // than is required, due to us trying to order the dataset by `timestamp`
+    // and this not being included in the `sharded_events` table.
+    const eventsPerRun = pluginConfig.plugin?.name === 'S3 Export' ? 10000 : EVENTS_PER_RUN
+
     // If public job hasn't been registered or has changed, update it!
     if (
         Object.keys(currentPublicJobs[INTERFACE_JOB_NAME]?.payload || {}).length !=
@@ -407,7 +418,7 @@ export function addHistoricalEventsExportCapabilityV2(
                 new Date(payload.timestampCursor),
                 payload.offset,
                 payload.fetchTimeInterval,
-                EVENTS_PER_RUN
+                eventsPerRun
             )
         } catch (error) {
             Sentry.captureException(error)
@@ -589,25 +600,25 @@ export function addHistoricalEventsExportCapabilityV2(
 
     function nextCursor(payload: ExportHistoricalEventsJobPayload, eventCount: number): OffsetParams {
         // More on the same time window
-        if (eventCount === EVENTS_PER_RUN) {
+        if (eventCount === eventsPerRun) {
             return {
                 timestampCursor: payload.timestampCursor,
                 fetchTimeInterval: payload.fetchTimeInterval,
-                offset: payload.offset + EVENTS_PER_RUN,
+                offset: payload.offset + eventsPerRun,
             }
         }
 
         const nextCursor = payload.timestampCursor + payload.fetchTimeInterval
         let nextFetchInterval = payload.fetchTimeInterval
         // If we're fetching too small of a window at a time, increase window to fetch
-        if (payload.offset === 0 && eventCount < EVENTS_PER_RUN * 0.5) {
+        if (payload.offset === 0 && eventCount < eventsPerRun * 0.5) {
             nextFetchInterval = Math.min(
                 Math.floor(payload.fetchTimeInterval * hub.HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER),
                 TWELVE_HOURS
             )
         }
         // If time window seems too large, reduce it
-        if (payload.offset > 2 * EVENTS_PER_RUN) {
+        if (payload.offset > 2 * eventsPerRun) {
             nextFetchInterval = Math.max(
                 Math.floor(payload.fetchTimeInterval / hub.HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER),
                 TEN_MINUTES

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -83,6 +83,7 @@ export interface TestFunctions {
     progressBar: (progress: number, length?: number) => string
     stopExport: (params: ExportParams, message: string, status: 'success' | 'fail') => Promise<void>
     shouldResume: (status: ExportChunkStatus, now: number) => void
+    eventsPerRun: number
 }
 
 export type ExportHistoricalEventsUpgradeV2 = Plugin<{
@@ -158,7 +159,7 @@ export function addHistoricalEventsExportCapabilityV2(
     hub: Hub,
     pluginConfig: PluginConfig,
     response: PluginConfigVMInternalResponse<PluginMeta<ExportHistoricalEventsUpgradeV2>>
-): void {
+) {
     const { methods, tasks, meta } = response
 
     const currentPublicJobs = pluginConfig.plugin?.public_jobs || {}
@@ -172,7 +173,7 @@ export function addHistoricalEventsExportCapabilityV2(
     // events from ClickHouse will read a much larger amount of data from disk
     // than is required, due to us trying to order the dataset by `timestamp`
     // and this not being included in the `sharded_events` table.
-    const eventsPerRun = pluginConfig.plugin?.name === 'S3 Export' ? 10000 : EVENTS_PER_RUN
+    const eventsPerRun = pluginConfig.plugin?.name === 'S3 Export Plugin' ? 10000 : EVENTS_PER_RUN
 
     // If public job hasn't been registered or has changed, update it!
     if (
@@ -697,6 +698,9 @@ export function addHistoricalEventsExportCapabilityV2(
             progressBar,
             stopExport,
             shouldResume,
+            eventsPerRun,
         }
     }
+
+    return { eventsPerRun }
 }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -83,7 +83,6 @@ export interface TestFunctions {
     progressBar: (progress: number, length?: number) => string
     stopExport: (params: ExportParams, message: string, status: 'success' | 'fail') => Promise<void>
     shouldResume: (status: ExportChunkStatus, now: number) => void
-    eventsPerRun: number
 }
 
 export type ExportHistoricalEventsUpgradeV2 = Plugin<{
@@ -164,7 +163,7 @@ export function addHistoricalEventsExportCapabilityV2(
 
     const currentPublicJobs = pluginConfig.plugin?.public_jobs || {}
 
-    // Returns the number of events to fetch per chunk, defaulting to 10000
+    // Set the number of events to fetch per chunk, defaulting to 10000
     // if the plugin is PostHog S3 Export plugin, otherwise we detault to
     // 500. This is to avoid writting lots of small files to S3.
     //
@@ -172,7 +171,7 @@ export function addHistoricalEventsExportCapabilityV2(
     // it's current implementation the querying logic for pulling pages of
     // events from ClickHouse will read a much larger amount of data from disk
     // than is required, due to us trying to order the dataset by `timestamp`
-    // and this not being included in the `sharded_events` table.
+    // and this not being included in the `sharded_events` table sort key.
     const eventsPerRun = pluginConfig.plugin?.name === 'S3 Export Plugin' ? 10000 : EVENTS_PER_RUN
 
     // If public job hasn't been registered or has changed, update it!
@@ -698,9 +697,9 @@ export function addHistoricalEventsExportCapabilityV2(
             progressBar,
             stopExport,
             shouldResume,
-            eventsPerRun,
         }
     }
 
+    // NOTE: we return the eventsPerRun, purely for testing purposes
     return { eventsPerRun }
 }

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -748,6 +748,15 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 offset: 0,
             })
         })
+
+        it('specifically for the S3 exporter, make sure to use a larger than default batch size', () => {
+            const eventsPerRun = addHistoricalEventsExportCapabilityV2(
+                hub,
+                { plugin: { name: 'S3 Exporter' } } as any,
+                vm
+            )
+            expect(eventsPerRun).expect(10000)
+        })
     })
 
     describe('getTimestampBoundaries()', () => {

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -750,12 +750,23 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
         })
 
         it('specifically for the S3 exporter, make sure to use a larger than default batch size', () => {
-            const eventsPerRun = addHistoricalEventsExportCapabilityV2(
+            // NOTE: this doesn't actually check that this value is used in the
+            // requests to ClickHouse, but :fingercrossed: it's good enough.
+            createVM()
+            let eventsPerRun = addHistoricalEventsExportCapabilityV2(
                 hub,
-                { plugin: { name: 'S3 Exporter' } } as any,
+                { plugin: { name: 'S3 Export Plugin' } } as any,
                 vm
-            )
-            expect(eventsPerRun).expect(10000)
+            ).eventsPerRun
+            expect(eventsPerRun).toEqual(10000)
+
+            // Otherwise it should be the default, 500
+            eventsPerRun = addHistoricalEventsExportCapabilityV2(
+                hub,
+                { plugin: { name: 'foo' } } as any,
+                vm
+            ).eventsPerRun
+            expect(eventsPerRun).toEqual(500)
         })
     })
 


### PR DESCRIPTION
To avoid making too many small files for large exports, we now make the
chunk size 10k instead of 500.

This should also help with optimizing the request we send to ClickHouse
for retrieving the events for export.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
