### PR TITLE
fix(query-performance): speed up trends queries by reducing amount of data streamed between shards

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -32,7 +32,6 @@
 ---
 # name: TestEventQuery.test_account_filters.2
   '
-  
   SELECT e.timestamp as timestamp,
          pdi.person_id as person_id
   FROM events e
@@ -63,7 +62,6 @@
 ---
 # name: TestEventQuery.test_basic_event_filter
   '
-  
   SELECT e.timestamp as timestamp
   FROM events e
   WHERE team_id = 2
@@ -74,7 +72,6 @@
 ---
 # name: TestEventQuery.test_cohort_filter
   '
-  
   SELECT e.timestamp as timestamp,
          pdi.person_id as person_id
   FROM events e
@@ -111,7 +108,6 @@
 ---
 # name: TestEventQuery.test_denormalised_props
   '
-  
   SELECT e.timestamp as timestamp,
          e."mat_test_prop" as "mat_test_prop"
   FROM events e
@@ -125,7 +121,6 @@
 ---
 # name: TestEventQuery.test_element
   '
-  
   SELECT e.timestamp as timestamp
   FROM events e
   WHERE team_id = 2
@@ -137,7 +132,6 @@
 ---
 # name: TestEventQuery.test_element.1
   '
-  
   SELECT e.timestamp as timestamp
   FROM events e
   WHERE team_id = 2
@@ -149,7 +143,6 @@
 ---
 # name: TestEventQuery.test_entity_filtered_by_cohort
   '
-  
   SELECT e.timestamp as timestamp,
          pdi.person_id as person_id
   FROM events e
@@ -186,7 +179,6 @@
 ---
 # name: TestEventQuery.test_entity_filtered_by_multiple_session_duration_filters
   '
-  
   SELECT e.timestamp as timestamp,
          sessions.session_duration as session_duration,
          sessions.$session_id as $session_id
@@ -210,7 +202,6 @@
 ---
 # name: TestEventQuery.test_entity_filtered_by_session_duration
   '
-  
   SELECT e.timestamp as timestamp,
          sessions.session_duration as session_duration,
          sessions.$session_id as $session_id
@@ -233,7 +224,6 @@
 ---
 # name: TestEventQuery.test_event_properties_filter
   '
-  
   SELECT e.timestamp as timestamp,
          e."properties" as "properties"
   FROM events e
@@ -246,7 +236,6 @@
 ---
 # name: TestEventQuery.test_event_properties_filter.1
   '
-  
   SELECT e.timestamp as timestamp
   FROM events e
   WHERE team_id = 2
@@ -258,7 +247,6 @@
 ---
 # name: TestEventQuery.test_groups_filters
   '
-  
   SELECT e.timestamp as timestamp
   FROM events e
   INNER JOIN
@@ -285,7 +273,6 @@
 ---
 # name: TestEventQuery.test_groups_filters_mixed
   '
-  
   SELECT e.timestamp as timestamp,
          pdi.person_id as person_id
   FROM events e
@@ -324,7 +311,6 @@
 ---
 # name: TestEventQuery.test_static_cohort_filter
   '
-  
   SELECT e.timestamp as timestamp,
          pdi.person_id as person_id
   FROM events e
@@ -354,7 +340,6 @@
 ---
 # name: TestEventQuery.test_unique_session_math_filtered_by_session_duration
   '
-  
   SELECT e.timestamp as timestamp,
          e."$session_id" as "$session_id",
          sessions.session_duration as session_duration

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -2,13 +2,11 @@
   '
   /* user_id:0 request:_snapshot_ */
   SELECT count(*) as data
-  FROM
-    (SELECT e.timestamp as timestamp
-     FROM events e
-     WHERE team_id = 2
-       AND event = '$pageview'
-       AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-       AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') ) events
+  FROM events e
+  WHERE team_id = 2
+    AND event = '$pageview'
+    AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+    AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_aggregate.1
@@ -48,32 +46,29 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-15 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), toDateTime('2012-01-15 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
+        UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_basic.1

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -113,7 +113,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-15 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), toDateTime('2012-01-15 23:59:59', 'UTC')))
@@ -121,18 +121,15 @@
                          toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e."properties" as "properties"
-           FROM events e
-           WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-             AND (has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))) )
+        FROM events e
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
+          AND (has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', '')))
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_clean_arg.1
@@ -174,7 +171,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-15 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), toDateTime('2012-01-15 23:59:59', 'UTC')))
@@ -182,16 +179,14 @@
                          toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp
-           FROM events e
-           WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.1
@@ -343,36 +338,33 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-15 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), toDateTime('2012-01-15 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
-                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
+        UNION ALL SELECT COUNT(DISTINCT actor_id) as data,
+                         toStartOfDay(toTimeZone(toDateTime(first_seen_timestamp, 'UTC'), 'UTC')) as date
         FROM
-          (SELECT person_id,
-                  min(timestamp) as timestamp
-           FROM
-             (SELECT e.timestamp as timestamp,
-                     pdi.person_id as person_id
-              FROM events e
-              INNER JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+          (SELECT person_id AS actor_id,
+                  min(timestamp) AS first_seen_timestamp
+           FROM events e
+           INNER JOIN
+             (SELECT distinct_id,
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
               WHERE team_id = 2
-                AND event = '$pageview'
-                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-                AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
-           GROUP BY person_id)
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+           WHERE team_id = 2
+             AND event = '$pageview'
+             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
+           GROUP BY actor_id)
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.3
@@ -681,32 +673,29 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-15 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), toDateTime('2012-01-15 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
+        UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrendsCaching.test_insight_trends_merging.1
@@ -717,32 +706,29 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-15 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-14 00:00:00', 'UTC')), toDateTime('2012-01-15 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2012-01-14 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
+        UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrendsCaching.test_insight_trends_merging_skipped_interval
@@ -753,32 +739,29 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-14 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2011-12-31 00:00:00', 'UTC')), toDateTime('2012-01-14 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2011-12-31 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
+        UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2011-12-31 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2011-12-31 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrendsCaching.test_insight_trends_merging_skipped_interval.1
@@ -789,32 +772,29 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2012-01-16 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-02 00:00:00', 'UTC')), toDateTime('2012-01-16 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2012-01-02 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
+        UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-02 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-16 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-02 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2012-01-16 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrendsGroups.test_aggregating_by_group
@@ -825,7 +805,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-12 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-12 23:59:59', 'UTC')))
@@ -833,19 +813,16 @@
                          toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC'))
         UNION ALL SELECT count(DISTINCT "$group_0") as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e."$group_0" as "$group_0"
-           FROM events e
-           WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
-             AND (NOT has([''], "$group_0"))
-             AND "$group_0" != '' )
+        FROM events e
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
+          AND (NOT has([''], "$group_0"))
+          AND "$group_0" != ''
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrendsGroups.test_aggregating_by_group.1
@@ -879,7 +856,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-12 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-12 23:59:59', 'UTC')))
@@ -887,17 +864,14 @@
                          toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC'))
         UNION ALL SELECT count(DISTINCT "$session_id") as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e."$session_id" as "$session_id"
-           FROM events e
-           WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: ClickhouseTestTrendsGroups.test_aggregating_by_session.1

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -342,7 +342,7 @@
         UNION ALL SELECT COUNT(DISTINCT actor_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(first_seen_timestamp, 'UTC'), 'UTC')) as date
         FROM
-          (SELECT person_id AS actor_id,
+          (SELECT e.person_id AS actor_id,
                   min(timestamp) AS first_seen_timestamp
            FROM events e
            INNER JOIN

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -857,7 +857,7 @@
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-12 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT "$session_id") as data,
+        UNION ALL SELECT count(DISTINCT e."$session_id") as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
         FROM events e
         WHERE team_id = 2

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -758,7 +758,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-12 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-12 23:59:59', 'UTC')))
@@ -766,34 +766,31 @@
                          toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT group_key,
-                     argMax(group_properties, _timestamp) AS group_properties_0
-              FROM groups
-              WHERE team_id = 2
-                AND group_type_index = 0
-              GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-           INNER JOIN
-             (SELECT group_key,
-                     argMax(group_properties, _timestamp) AS group_properties_2
-              FROM groups
-              WHERE team_id = 2
-                AND group_type_index = 2
-              GROUP BY group_key) groups_2 ON "$group_2" == groups_2.group_key
+        FROM events e
+        INNER JOIN
+          (SELECT group_key,
+                  argMax(group_properties, _timestamp) AS group_properties_0
+           FROM groups
            WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
-             AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
-                  AND has(['six'], replaceRegexpAll(JSONExtractRaw(group_properties_2, 'name'), '^"|"$', '')))
-             AND e.person_id != toUUIDOrZero('') )
+             AND group_type_index = 0
+           GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+        INNER JOIN
+          (SELECT group_key,
+                  argMax(group_properties, _timestamp) AS group_properties_2
+           FROM groups
+           WHERE team_id = 2
+             AND group_type_index = 2
+           GROUP BY group_key) groups_2 ON "$group_2" == groups_2.group_key
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
+          AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
+               AND has(['six'], replaceRegexpAll(JSONExtractRaw(group_properties_2, 'name'), '^"|"$', '')))
+          AND e.person_id != toUUIDOrZero('')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_filtering_by_multiple_groups_person_on_events.1
@@ -843,7 +840,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-12 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-12 23:59:59', 'UTC')))
@@ -851,28 +848,24 @@
                          toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e.person_id as person_id,
-                  e."person_properties" as "person_properties"
-           FROM events e
-           INNER JOIN
-             (SELECT group_key,
-                     argMax(group_properties, _timestamp) AS group_properties_0
-              FROM groups
-              WHERE team_id = 2
-                AND group_type_index = 0
-              GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+        FROM events e
+        INNER JOIN
+          (SELECT group_key,
+                  argMax(group_properties, _timestamp) AS group_properties_0
+           FROM groups
            WHERE team_id = 2
-             AND event = '$pageview'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
-             AND ((has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
-                  AND (has(['value'], replaceRegexpAll(JSONExtractRaw(e.person_properties, 'key'), '^"|"$', ''))))
-             AND e.person_id != toUUIDOrZero('') )
+             AND group_type_index = 0
+           GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+        WHERE team_id = 2
+          AND event = '$pageview'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
+          AND ((has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+               AND (has(['value'], replaceRegexpAll(JSONExtractRaw(e.person_properties, 'key'), '^"|"$', ''))))
+          AND e.person_id != toUUIDOrZero('')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_person_property_filtering
@@ -883,7 +876,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -891,36 +884,33 @@
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-           INNER JOIN
-             (SELECT id
-              FROM person
-              WHERE team_id = 2
-                AND id IN
-                  (SELECT id
-                   FROM person
-                   WHERE team_id = 2
-                     AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
-              GROUP BY id
-              HAVING max(is_deleted) = 0
-              AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = 'watched movie'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND event = 'watched movie'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property
@@ -931,7 +921,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -939,36 +929,33 @@
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-           INNER JOIN
-             (SELECT id
-              FROM person
-              WHERE team_id = 2
-                AND id IN
-                  (SELECT id
-                   FROM person
-                   WHERE team_id = 2
-                     AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
-              GROUP BY id
-              HAVING max(is_deleted) = 0
-              AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = 'watched movie'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND event = 'watched movie'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property.1
@@ -979,7 +966,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -987,18 +974,15 @@
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e."properties" as "properties"
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'watched movie'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-             AND (has(['1'], replaceRegexpAll(JSONExtractRaw(e.properties, 'name'), '^"|"$', ''))) )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'watched movie'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+          AND (has(['1'], replaceRegexpAll(JSONExtractRaw(e.properties, 'name'), '^"|"$', '')))
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property_materialized
@@ -1009,7 +993,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -1017,36 +1001,33 @@
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-           INNER JOIN
-             (SELECT id
-              FROM person
-              WHERE team_id = 2
-                AND id IN
-                  (SELECT id
-                   FROM person
-                   WHERE team_id = 2
-                     AND (has(['person1'], person."pmat_name")) )
-              GROUP BY id
-              HAVING max(is_deleted) = 0
-              AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = 'watched movie'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (has(['person1'], person."pmat_name")) )
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND event = 'watched movie'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property_materialized.1
@@ -1057,7 +1038,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -1065,18 +1046,15 @@
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e."mat_name" as "mat_name"
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'watched movie'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-             AND (has(['1'], "mat_name")) )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'watched movie'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+          AND (has(['1'], "mat_name"))
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_person_property_filtering_materialized
@@ -1087,7 +1065,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -1095,36 +1073,33 @@
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-           INNER JOIN
-             (SELECT id
-              FROM person
-              WHERE team_id = 2
-                AND id IN
-                  (SELECT id
-                   FROM person
-                   WHERE team_id = 2
-                     AND (has(['person1'], person."pmat_name")) )
-              GROUP BY id
-              HAVING max(is_deleted) = 0
-              AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = 'watched movie'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (has(['person1'], person."pmat_name")) )
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND event = 'watched movie'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezone_weekly
@@ -1135,7 +1110,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfWeek(toDateTime('2020-01-25 23:59:59', 'US/Pacific') - toIntervalWeek(number), 0) AS day_start
         FROM numbers(dateDiff('week', toStartOfWeek(toDateTime('2020-01-11 00:00:00', 'US/Pacific'), 0), toDateTime('2020-01-25 23:59:59', 'US/Pacific')))
@@ -1143,16 +1118,14 @@
                          toStartOfWeek(toDateTime('2020-01-11 00:00:00', 'US/Pacific'), 0)
         UNION ALL SELECT count(*) as data,
                          toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific'), 0) as date
-        FROM
-          (SELECT e.timestamp as timestamp
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2020-01-11 00:00:00', 'US/Pacific'), 0)
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-25 23:59:59', 'US/Pacific') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2020-01-11 00:00:00', 'US/Pacific'), 0)
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-25 23:59:59', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones
@@ -1163,7 +1136,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-05 23:59:59', 'US/Pacific') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), toDateTime('2020-01-05 23:59:59', 'US/Pacific')))
@@ -1171,16 +1144,14 @@
                          toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as date
-        FROM
-          (SELECT e.timestamp as timestamp
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), 'US/Pacific')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), 'US/Pacific')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones.1
@@ -1191,32 +1162,29 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-05 23:59:59', 'US/Pacific') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-22 00:00:00', 'US/Pacific')), toDateTime('2020-01-05 23:59:59', 'US/Pacific')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2019-12-22 00:00:00', 'US/Pacific'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
+        UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'US/Pacific')), 'US/Pacific')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'US/Pacific')), 'US/Pacific')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones.2
@@ -1227,7 +1195,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-05 23:59:59', 'US/Pacific') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), toDateTime('2020-01-05 23:59:59', 'US/Pacific')))
@@ -1237,33 +1205,27 @@
                          timestamp AS day_start
         FROM
           (SELECT d.timestamp,
-                  COUNT(DISTINCT person_id) AS counts
+                  COUNT(DISTINCT e.person_id) AS counts
            FROM
              (SELECT toStartOfDay(toDateTime('2020-01-05 23:59:59', 'US/Pacific') - toIntervalDay(number)) AS timestamp
               FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-22 00:00:00', 'US/Pacific')), toDateTime('2020-01-05 23:59:59', 'US/Pacific')))) d
            CROSS JOIN
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific') AS timestamp,
-                     person_id
-              FROM
-                (SELECT e.timestamp as timestamp,
-                        pdi.person_id as person_id
-                 FROM events e
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                     e.person_id
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND event = 'sign up'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'US/Pacific')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific') ) events
-              WHERE 1 = 1
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+              WHERE team_id = 2
+                AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'US/Pacific')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific')
               GROUP BY timestamp,
-                       person_id) e
+                       e.person_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -1271,8 +1233,8 @@
         WHERE 1 = 1
           AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), 'US/Pacific')
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific') )
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones.3
@@ -1283,7 +1245,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-05 23:59:59', 'US/Pacific') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), toDateTime('2020-01-05 23:59:59', 'US/Pacific')))
@@ -1291,16 +1253,14 @@
                          toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as date
-        FROM
-          (SELECT e.timestamp as timestamp
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), 'US/Pacific')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-29 00:00:00', 'US/Pacific')), 'US/Pacific')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones.4
@@ -1382,7 +1342,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfHour(toDateTime('2020-01-03 23:59:59', 'US/Pacific') - toIntervalHour(number)) AS day_start
         FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-03 00:00:00', 'US/Pacific')), toDateTime('2020-01-03 23:59:59', 'US/Pacific')))
@@ -1390,16 +1350,14 @@
                          toStartOfHour(toDateTime('2020-01-03 00:00:00', 'US/Pacific'))
         UNION ALL SELECT count(*) as data,
                          toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as date
-        FROM
-          (SELECT e.timestamp as timestamp
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-03 00:00:00', 'US/Pacific')), 'US/Pacific')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'US/Pacific') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-03 00:00:00', 'US/Pacific')), 'US/Pacific')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones.7
@@ -1410,7 +1368,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-03 23:59:59', 'US/Pacific') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'US/Pacific')), toDateTime('2020-01-03 23:59:59', 'US/Pacific')))
@@ -1418,16 +1376,14 @@
                          toStartOfDay(toDateTime('2020-01-03 00:00:00', 'US/Pacific'))
         UNION ALL SELECT count(*) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as date
-        FROM
-          (SELECT e.timestamp as timestamp
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'US/Pacific')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'US/Pacific') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'US/Pacific')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones_hourly
@@ -1438,32 +1394,29 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfHour(toDateTime('2020-01-05 10:02:01', 'US/Pacific') - toIntervalHour(number)) AS day_start
         FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific')), toDateTime('2020-01-05 10:02:01', 'US/Pacific')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific'))
-        UNION ALL SELECT count(DISTINCT person_id) as data,
+        UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                          toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific')), 'US/Pacific')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 10:02:01', 'US/Pacific') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific')), 'US/Pacific')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 10:02:01', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_timezones_hourly.1
@@ -1503,7 +1456,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfHour(toDateTime('2020-01-05 10:02:01', 'US/Pacific') - toIntervalHour(number)) AS day_start
         FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific')), toDateTime('2020-01-05 10:02:01', 'US/Pacific')))
@@ -1511,16 +1464,14 @@
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific'))
         UNION ALL SELECT count(*) as data,
                          toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as date
-        FROM
-          (SELECT e.timestamp as timestamp
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific')), 'US/Pacific')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 10:02:01', 'US/Pacific') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'US/Pacific')), 'US/Pacific')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 10:02:01', 'US/Pacific')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trend_actors_person_on_events_pagination_with_alias_inconsistencies
@@ -1531,7 +1482,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -1539,18 +1490,15 @@
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
         UNION ALL SELECT count(DISTINCT person_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e.person_id as person_id
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-             AND e.person_id != toUUIDOrZero('') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+          AND e.person_id != toUUIDOrZero('')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trend_actors_person_on_events_pagination_with_alias_inconsistencies.1
@@ -1856,25 +1804,22 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2019-12-31 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), toDateTime('2019-12-31 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT distinct_id) as data,
+        UNION ALL SELECT count(DISTINCT e.distinct_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  e.distinct_id as distinct_id
-           FROM events e
-           WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') )
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.1
@@ -1885,45 +1830,41 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2019-12-31 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), toDateTime('2019-12-31 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT distinct_id) as data,
+        UNION ALL SELECT count(DISTINCT e.distinct_id) as data,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id,
-                  e.distinct_id as distinct_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-           INNER JOIN
-             (SELECT id
-              FROM person
-              WHERE team_id = 2
-                AND id IN
-                  (SELECT id
-                   FROM person
-                   WHERE team_id = 2
-                     AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))) )
-              GROUP BY id
-              HAVING max(is_deleted) = 0
-              AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) person ON person.id = pdi.person_id
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
            WHERE team_id = 2
-             AND event = 'sign up'
-             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') )
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))) )
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.2
@@ -2026,7 +1967,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2019-12-31 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), toDateTime('2019-12-31 23:59:59', 'UTC')))
@@ -2036,26 +1977,20 @@
                          timestamp AS day_start
         FROM
           (SELECT d.timestamp,
-                  COUNT(DISTINCT distinct_id) AS counts
+                  COUNT(DISTINCT e.distinct_id) AS counts
            FROM
              (SELECT toStartOfDay(toDateTime('2019-12-31 23:59:59', 'UTC') - toIntervalDay(number)) AS timestamp
               FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-11-24 00:00:00', 'UTC')), toDateTime('2019-12-31 23:59:59', 'UTC')))) d
            CROSS JOIN
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
-                     distinct_id
-              FROM
-                (SELECT e.timestamp as timestamp,
-                        e.distinct_id as distinct_id
-                 FROM events e
-                 WHERE team_id = 2
-                   AND event = 'sign up'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') ) events
-              WHERE 1 = 1
+                     e.distinct_id
+              FROM events e
+              WHERE team_id = 2
+                AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
               GROUP BY timestamp,
-                       distinct_id) e
+                       e.distinct_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 29 DAY
            GROUP BY d.timestamp
@@ -2063,8 +1998,8 @@
         WHERE 1 = 1
           AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') )
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.5
@@ -2075,7 +2010,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2019-12-31 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), toDateTime('2019-12-31 23:59:59', 'UTC')))
@@ -2085,26 +2020,20 @@
                          timestamp AS day_start
         FROM
           (SELECT d.timestamp,
-                  COUNT(DISTINCT distinct_id) AS counts
+                  COUNT(DISTINCT e.distinct_id) AS counts
            FROM
              (SELECT toStartOfDay(toDateTime('2019-12-31 23:59:59', 'UTC') - toIntervalDay(number)) AS timestamp
               FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-17 00:00:00', 'UTC')), toDateTime('2019-12-31 23:59:59', 'UTC')))) d
            CROSS JOIN
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
-                     distinct_id
-              FROM
-                (SELECT e.timestamp as timestamp,
-                        e.distinct_id as distinct_id
-                 FROM events e
-                 WHERE team_id = 2
-                   AND event = 'sign up'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-17 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') ) events
-              WHERE 1 = 1
+                     e.distinct_id
+              FROM events e
+              WHERE team_id = 2
+                AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-17 00:00:00', 'UTC')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
               GROUP BY timestamp,
-                       distinct_id) e
+                       e.distinct_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -2112,8 +2041,8 @@
         WHERE 1 = 1
           AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') )
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.6
@@ -2307,15 +2236,12 @@
   FROM
     (SELECT COUNT(*) AS intermediate_count,
             "$group_0"
-     FROM
-       (SELECT e.timestamp as timestamp,
-               e."$group_0" as "$group_0"
-        FROM events e
-        WHERE team_id = 2
-          AND event = 'viewed video'
-          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC')
-          AND "$group_0" != '' )
+     FROM events e
+     WHERE team_id = 2
+       AND event = 'viewed video'
+       AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC')
+       AND "$group_0" != ''
      GROUP BY "$group_0") events
   '
 ---
@@ -2327,7 +2253,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-07 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-07 23:59:59', 'UTC')))
@@ -2338,19 +2264,16 @@
           (SELECT COUNT(*) AS intermediate_count,
                   "$group_0",
                   toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
-           FROM
-             (SELECT e.timestamp as timestamp,
-                     e."$group_0" as "$group_0"
-              FROM events e
-              WHERE team_id = 2
-                AND event = 'viewed video'
-                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC')
-                AND "$group_0" != '' )
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'viewed video'
+             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC')
+             AND "$group_0" != ''
            GROUP BY "$group_0", date)
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_count_per_user_average_aggregated
@@ -2359,29 +2282,26 @@
   SELECT avg(intermediate_count) as data
   FROM
     (SELECT COUNT(*) AS intermediate_count,
-            person_id
-     FROM
-       (SELECT e.timestamp as timestamp,
-               pdi.person_id as person_id
-        FROM events e
-        INNER JOIN
-          (SELECT distinct_id,
-                  argMax(person_id, version) as person_id
-           FROM person_distinct_id2
-           WHERE team_id = 2
-           GROUP BY distinct_id
-           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-        INNER JOIN
-          (SELECT id
-           FROM person
-           WHERE team_id = 2
-           GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+            e.person_id
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
         WHERE team_id = 2
-          AND event = 'viewed video'
-          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC') )
-     GROUP BY person_id) events
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     WHERE team_id = 2
+       AND event = 'viewed video'
+       AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC')
+     GROUP BY e.person_id) events
   '
 ---
 # name: TestTrends.test_trends_count_per_user_average_daily
@@ -2392,7 +2312,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-07 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-07 23:59:59', 'UTC')))
@@ -2401,30 +2321,27 @@
         UNION ALL SELECT avg(intermediate_count) AS data, date
         FROM
           (SELECT COUNT(*) AS intermediate_count,
-                  person_id,
+                  e.person_id,
                   toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
-           FROM
-             (SELECT e.timestamp as timestamp,
-                     pdi.person_id as person_id
-              FROM events e
-              INNER JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-              INNER JOIN
-                (SELECT id
-                 FROM person
-                 WHERE team_id = 2
-                 GROUP BY id
-                 HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           FROM events e
+           INNER JOIN
+             (SELECT distinct_id,
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
               WHERE team_id = 2
-                AND event = 'viewed video'
-                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC') )
-           GROUP BY person_id, date)
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+           INNER JOIN
+             (SELECT id
+              FROM person
+              WHERE team_id = 2
+              GROUP BY id
+              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           WHERE team_id = 2
+             AND event = 'viewed video'
+             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC')
+           GROUP BY e.person_id, date)
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
@@ -2482,7 +2399,6 @@
           AND event = 'sign up'
           AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-          AND e.person_id != toUUIDOrZero('')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
@@ -2582,25 +2498,20 @@
   SELECT quantile(0.50)(session_duration) as data
   FROM
     (SELECT any(session_duration) as session_duration
-     FROM
-       (SELECT e.timestamp as timestamp,
-               e."properties" as "properties",
-               sessions.session_duration as session_duration,
-               sessions.$session_id as $session_id
-        FROM events e
-        INNER JOIN
-          (SELECT $session_id,
-                  dateDiff('second', min(timestamp), max(timestamp)) as session_duration
-           FROM events
-           WHERE $session_id != ''
-             AND team_id = 2
-             AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
-           GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2019-12-28 00:00:00', 'UTC'), 0)
-          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') ) events
+     FROM events e
+     INNER JOIN
+       (SELECT $session_id,
+               dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+        FROM events
+        WHERE $session_id != ''
+          AND team_id = 2
+          AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
+        GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
+     WHERE team_id = 2
+       AND event = 'sign up'
+       AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2019-12-28 00:00:00', 'UTC'), 0)
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
      GROUP BY $session_id)
   '
 ---
@@ -2610,25 +2521,20 @@
   SELECT quantile(0.50)(session_duration) as data
   FROM
     (SELECT any(session_duration) as session_duration
-     FROM
-       (SELECT e.timestamp as timestamp,
-               e."properties" as "properties",
-               sessions.session_duration as session_duration,
-               sessions.$session_id as $session_id
-        FROM events e
-        INNER JOIN
-          (SELECT $session_id,
-                  dateDiff('second', min(timestamp), max(timestamp)) as session_duration
-           FROM events
-           WHERE $session_id != ''
-             AND team_id = 2
-             AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
-             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
-           GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') ) events
+     FROM events e
+     INNER JOIN
+       (SELECT $session_id,
+               dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+        FROM events
+        WHERE $session_id != ''
+          AND team_id = 2
+          AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
+        GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
+     WHERE team_id = 2
+       AND event = 'sign up'
+       AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
      GROUP BY $session_id)
   '
 ---
@@ -2640,7 +2546,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfWeek(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalWeek(number), 0) AS day_start
         FROM numbers(dateDiff('week', toStartOfWeek(toDateTime('2019-12-28 00:00:00', 'UTC'), 0), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -2649,30 +2555,25 @@
         UNION ALL SELECT quantile(0.50)(session_duration) as data, date
         FROM
           (SELECT toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0) as date,
-                  any(session_duration) as session_duration
-           FROM
-             (SELECT e.timestamp as timestamp,
-                     e."properties" as "properties",
-                     sessions.session_duration as session_duration,
-                     sessions.$session_id as $session_id
-              FROM events e
-              INNER JOIN
-                (SELECT $session_id,
-                        dateDiff('second', min(timestamp), max(timestamp)) as session_duration
-                 FROM events
-                 WHERE $session_id != ''
-                   AND team_id = 2
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
-                 GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
-              WHERE team_id = 2
-                AND event = 'sign up'
-                AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2019-12-28 00:00:00', 'UTC'), 0)
-                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
-           GROUP BY $session_id, date)
+                  any(sessions.session_duration) as session_duration
+           FROM events e
+           INNER JOIN
+             (SELECT $session_id,
+                     dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+              FROM events
+              WHERE $session_id != ''
+                AND team_id = 2
+                AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
+              GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
+           WHERE team_id = 2
+             AND event = 'sign up'
+             AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2019-12-28 00:00:00', 'UTC'), 0)
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+           GROUP BY sessions.$session_id, date)
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math.1
@@ -2683,7 +2584,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
@@ -2692,30 +2593,25 @@
         UNION ALL SELECT quantile(0.50)(session_duration) as data, date
         FROM
           (SELECT toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date,
-                  any(session_duration) as session_duration
-           FROM
-             (SELECT e.timestamp as timestamp,
-                     e."properties" as "properties",
-                     sessions.session_duration as session_duration,
-                     sessions.$session_id as $session_id
-              FROM events e
-              INNER JOIN
-                (SELECT $session_id,
-                        dateDiff('second', min(timestamp), max(timestamp)) as session_duration
-                 FROM events
-                 WHERE $session_id != ''
-                   AND team_id = 2
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
-                 GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
-              WHERE team_id = 2
-                AND event = 'sign up'
-                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
-           GROUP BY $session_id, date)
+                  any(sessions.session_duration) as session_duration
+           FROM events e
+           INNER JOIN
+             (SELECT $session_id,
+                     dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+              FROM events
+              WHERE $session_id != ''
+                AND team_id = 2
+                AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC') - INTERVAL 24 HOUR
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') + INTERVAL 24 HOUR
+              GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
+           WHERE team_id = 2
+             AND event = 'sign up'
+             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+           GROUP BY sessions.$session_id, date)
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math_with_breakdowns
@@ -2954,48 +2850,36 @@
 # name: TestTrends.test_weekly_active_users_aggregated_range_narrower_than_week
   '
   
-  SELECT count(DISTINCT person_id) AS total
-  FROM
-    (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id
-     FROM events e
-     INNER JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2
-        WHERE team_id = 2
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+  SELECT count(DISTINCT pdi.person_id) AS total
+  FROM events e
+  INNER JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
      WHERE team_id = 2
-       AND event = '$pageview'
-       AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-05 23:59:59', 'UTC')
-       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC') ) events
-  WHERE 1 = 1
-    AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-05 23:59:59', 'UTC') - INTERVAL 6 DAY
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+  WHERE team_id = 2
+    AND event = '$pageview'
+    AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-05 23:59:59', 'UTC')
     AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   '
 ---
 # name: TestTrends.test_weekly_active_users_aggregated_range_wider_than_week
   '
   
-  SELECT count(DISTINCT person_id) AS total
-  FROM
-    (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id
-     FROM events e
-     INNER JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2
-        WHERE team_id = 2
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+  SELECT count(DISTINCT pdi.person_id) AS total
+  FROM events e
+  INNER JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
      WHERE team_id = 2
-       AND event = '$pageview'
-       AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 23:59:59', 'UTC')
-       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') ) events
-  WHERE 1 = 1
-    AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 23:59:59', 'UTC') - INTERVAL 6 DAY
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+  WHERE team_id = 2
+    AND event = '$pageview'
+    AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 23:59:59', 'UTC')
     AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   '
 ---
@@ -3007,7 +2891,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfDay(toDateTime('2020-01-19 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), toDateTime('2020-01-19 23:59:59', 'UTC')))
@@ -3017,33 +2901,27 @@
                          timestamp AS day_start
         FROM
           (SELECT d.timestamp,
-                  COUNT(DISTINCT person_id) AS counts
+                  COUNT(DISTINCT e.person_id) AS counts
            FROM
              (SELECT toStartOfDay(toDateTime('2020-01-19 23:59:59', 'UTC') - toIntervalDay(number)) AS timestamp
               FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), toDateTime('2020-01-19 23:59:59', 'UTC')))) d
            CROSS JOIN
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
-                     person_id
-              FROM
-                (SELECT e.timestamp as timestamp,
-                        pdi.person_id as person_id
-                 FROM events e
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                     e.person_id
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-19 23:59:59', 'UTC') ) events
-              WHERE 1 = 1
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+              WHERE team_id = 2
+                AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-19 23:59:59', 'UTC')
               GROUP BY timestamp,
-                       person_id) e
+                       e.person_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -3051,8 +2929,8 @@
         WHERE 1 = 1
           AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-19 23:59:59', 'UTC') )
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_weekly_active_users_hourly
@@ -3063,7 +2941,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfHour(toDateTime('2020-01-09 17:00:00', 'UTC') - toIntervalHour(number)) AS day_start
         FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-09 06:00:00', 'UTC')), toDateTime('2020-01-09 17:00:00', 'UTC')))
@@ -3073,33 +2951,27 @@
                          timestamp AS day_start
         FROM
           (SELECT d.timestamp,
-                  COUNT(DISTINCT person_id) AS counts
+                  COUNT(DISTINCT e.person_id) AS counts
            FROM
              (SELECT toStartOfHour(toDateTime('2020-01-09 17:00:00', 'UTC') - toIntervalHour(number)) AS timestamp
               FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 06:00:00', 'UTC')), toDateTime('2020-01-09 17:00:00', 'UTC')))) d
            CROSS JOIN
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
-                     person_id
-              FROM
-                (SELECT e.timestamp as timestamp,
-                        pdi.person_id as person_id
-                 FROM events e
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                     e.person_id
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-02 06:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-09 17:00:00', 'UTC') ) events
-              WHERE 1 = 1
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+              WHERE team_id = 2
+                AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-02 06:00:00', 'UTC')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-09 17:00:00', 'UTC')
               GROUP BY timestamp,
-                       person_id) e
+                       e.person_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -3107,8 +2979,8 @@
         WHERE 1 = 1
           AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-09 06:00:00', 'UTC')), 'UTC')
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-09 17:00:00', 'UTC') )
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_weekly_active_users_monthly
@@ -3119,7 +2991,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfMonth(toDateTime('2020-02-29 23:59:59', 'UTC') - toIntervalMonth(number)) AS day_start
         FROM numbers(dateDiff('month', toStartOfMonth(toDateTime('2019-12-01 00:00:00', 'UTC')), toDateTime('2020-02-29 23:59:59', 'UTC')))
@@ -3129,33 +3001,27 @@
                          timestamp AS day_start
         FROM
           (SELECT d.timestamp,
-                  COUNT(DISTINCT person_id) AS counts
+                  COUNT(DISTINCT e.person_id) AS counts
            FROM
              (SELECT toStartOfMonth(toDateTime('2020-02-29 23:59:59', 'UTC') - toIntervalMonth(number)) AS timestamp
               FROM numbers(dateDiff('month', toStartOfMonth(toDateTime('2019-11-24 00:00:00', 'UTC')), toDateTime('2020-02-29 23:59:59', 'UTC')))) d
            CROSS JOIN
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
-                     person_id
-              FROM
-                (SELECT e.timestamp as timestamp,
-                        pdi.person_id as person_id
-                 FROM events e
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                     e.person_id
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-02-29 23:59:59', 'UTC') ) events
-              WHERE 1 = 1
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+              WHERE team_id = 2
+                AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-02-29 23:59:59', 'UTC')
               GROUP BY timestamp,
-                       person_id) e
+                       e.person_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -3163,8 +3029,8 @@
         WHERE 1 = 1
           AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfMonth(toDateTime('2019-12-01 00:00:00', 'UTC')), 'UTC')
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-02-29 23:59:59', 'UTC') )
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_weekly_active_users_weekly
@@ -3175,7 +3041,7 @@
   FROM
     (SELECT SUM(total) AS count,
             day_start
-     from
+     FROM
        (SELECT toUInt16(0) AS total,
                toStartOfWeek(toDateTime('2020-01-18 23:59:59', 'UTC') - toIntervalWeek(number), 0) AS day_start
         FROM numbers(dateDiff('week', toStartOfWeek(toDateTime('2019-12-29 00:00:00', 'UTC'), 0), toDateTime('2020-01-18 23:59:59', 'UTC')))
@@ -3185,33 +3051,27 @@
                          timestamp AS day_start
         FROM
           (SELECT d.timestamp,
-                  COUNT(DISTINCT person_id) AS counts
+                  COUNT(DISTINCT e.person_id) AS counts
            FROM
              (SELECT toStartOfWeek(toDateTime('2020-01-18 23:59:59', 'UTC') - toIntervalWeek(number), 0) AS timestamp
               FROM numbers(dateDiff('week', toStartOfWeek(toDateTime('2019-12-22 00:00:00', 'UTC'), 0), toDateTime('2020-01-18 23:59:59', 'UTC')))) d
            CROSS JOIN
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
-                     person_id
-              FROM
-                (SELECT e.timestamp as timestamp,
-                        pdi.person_id as person_id
-                 FROM events e
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                     e.person_id
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC') ) events
-              WHERE 1 = 1
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+              WHERE team_id = 2
+                AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC')
               GROUP BY timestamp,
-                       person_id) e
+                       e.person_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -3219,7 +3079,7 @@
         WHERE 1 = 1
           AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2019-12-29 00:00:00', 'UTC'), 0)
           AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC') )
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -2426,8 +2426,66 @@
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC') )
            GROUP BY person_id, date)
         GROUP BY date)
-     group by day_start
-     order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
+  '
+---
+# name: TestTrends.test_trends_groups_per_day_cumulative
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) as data
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-06 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-30 00:00:00', 'UTC')), toDateTime('2020-01-06 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-30 00:00:00', 'UTC'))
+        UNION ALL SELECT COUNT(DISTINCT actor_id) as data,
+                         toStartOfDay(toTimeZone(toDateTime(first_seen_timestamp, 'UTC'), 'UTC')) as date
+        FROM
+          (SELECT "$group_0" AS actor_id,
+                  min(timestamp) AS first_seen_timestamp
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'viewed video'
+             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-30 00:00:00', 'UTC')), 'UTC')
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-06 23:59:59', 'UTC')
+             AND "$group_0" != ''
+           GROUP BY actor_id)
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
+  '
+---
+# name: TestTrends.test_trends_per_day_cumulative
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) as data
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
+        UNION ALL SELECT count(*) as data,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+          AND e.person_id != toUUIDOrZero('')
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
 # name: TestTrends.test_trends_person_breakdown_with_session_property_single_aggregate_math_and_breakdown

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -144,6 +144,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         _create_action(team=self.team, name="no events")
         sign_up_action = _create_action(team=self.team, name="sign up")
 
+        flush_persons_and_events()
+
         return sign_up_action, person
 
     def _create_breakdown_events(self):

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -7,7 +7,8 @@ GROUP BY date
 """
 
 VOLUME_AGGREGATE_SQL = """
-SELECT {aggregate_operation} as data FROM ({event_query}) events
+SELECT {aggregate_operation} as data
+{event_base_query}
 """
 
 VOLUME_PER_ACTOR_SQL = """

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -38,7 +38,9 @@ SELECT {aggregate_operation} as data, date FROM (
 
 SESSION_DURATION_AGGREGATE_SQL = """
 SELECT {aggregate_operation} as data FROM (
-    SELECT any(session_duration) as session_duration FROM ({event_query}) events GROUP BY $session_id
+    SELECT any(session_duration) as session_duration
+    {event_base_query}
+    GROUP BY $session_id
 )
 """
 

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -22,7 +22,7 @@ SELECT {aggregate_operation} AS data, date FROM (
 VOLUME_PER_ACTOR_AGGREGATE_SQL = """
 SELECT {aggregate_operation} as data FROM (
     SELECT COUNT(*) AS intermediate_count, {aggregator}
-    FROM ({event_query})
+    {event_base_query}
     GROUP BY {aggregator}
 ) events
 """
@@ -74,8 +74,7 @@ SELECT counts AS total, timestamp AS day_start FROM (
 ACTIVE_USERS_AGGREGATE_SQL = """
 SELECT
     {aggregate_operation} AS total
-FROM ({event_query}) events
-WHERE 1 = 1 {parsed_date_from_prev_range} - INTERVAL {prev_interval} {parsed_date_to}
+{event_base_query}
 """
 
 FINAL_TIME_SERIES_SQL = """

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -70,13 +70,13 @@ WHERE 1 = 1 {parsed_date_from_prev_range} - INTERVAL {prev_interval} {parsed_dat
 FINAL_TIME_SERIES_SQL = """
 SELECT groupArray(day_start) as date, groupArray({aggregate}) as data FROM (
     SELECT {smoothing_operation} AS count, day_start
-    from (
+    FROM (
         {null_sql}
         UNION ALL
         {content_sql}
     )
-    group by day_start
-    order by day_start
+    GROUP BY day_start
+    ORDER BY day_start
 )
 SETTINGS timeout_before_checking_execution_speed = 60
 """

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -1,5 +1,7 @@
 VOLUME_SQL = """
-SELECT {aggregate_operation} as data, {interval}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) {start_of_week_fix}) as date FROM ({event_query}) GROUP BY date
+SELECT {aggregate_operation} as data, {interval}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) {start_of_week_fix}) as date
+{event_base_query}
+GROUP BY date
 """
 
 VOLUME_AGGREGATE_SQL = """

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -2,19 +2,19 @@ VOLUME_SQL = """
 SELECT
     {aggregate_operation} as data,
     {interval}(toTimeZone(toDateTime({timestamp_column}, 'UTC'), %(timezone)s) {start_of_week_fix}) as date
-{event_base_query}
+{event_query_base}
 GROUP BY date
 """
 
 VOLUME_AGGREGATE_SQL = """
 SELECT {aggregate_operation} as data
-{event_base_query}
+{event_query_base}
 """
 
 VOLUME_PER_ACTOR_SQL = """
 SELECT {aggregate_operation} AS data, date FROM (
     SELECT COUNT(*) AS intermediate_count, {aggregator}, {interval}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) {start_of_week_fix}) AS date
-    {event_base_query}
+    {event_query_base}
     GROUP BY {aggregator}, date
 ) GROUP BY date
 """
@@ -22,7 +22,7 @@ SELECT {aggregate_operation} AS data, date FROM (
 VOLUME_PER_ACTOR_AGGREGATE_SQL = """
 SELECT {aggregate_operation} as data FROM (
     SELECT COUNT(*) AS intermediate_count, {aggregator}
-    {event_base_query}
+    {event_query_base}
     GROUP BY {aggregator}
 ) events
 """
@@ -32,7 +32,7 @@ SELECT {aggregate_operation} as data, date FROM (
     SELECT
         {interval}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) {start_of_week_fix}) as date,
         any(sessions.session_duration) as session_duration
-    {event_base_query}
+    {event_query_base}
     GROUP BY sessions.$session_id, date
 ) GROUP BY date
 """
@@ -40,7 +40,7 @@ SELECT {aggregate_operation} as data, date FROM (
 SESSION_DURATION_AGGREGATE_SQL = """
 SELECT {aggregate_operation} as data FROM (
     SELECT any(session_duration) as session_duration
-    {event_base_query}
+    {event_query_base}
     GROUP BY $session_id
 )
 """
@@ -62,7 +62,7 @@ SELECT counts AS total, timestamp AS day_start FROM (
         SELECT
             toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) AS timestamp,
             {aggregator}
-        {event_base_query}
+        {event_query_base}
         GROUP BY timestamp, {aggregator}
     ) e WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
     GROUP BY d.timestamp
@@ -73,7 +73,7 @@ SELECT counts AS total, timestamp AS day_start FROM (
 ACTIVE_USERS_AGGREGATE_SQL = """
 SELECT
     {aggregate_operation} AS total
-{event_base_query}
+{event_query_base}
 """
 
 FINAL_TIME_SERIES_SQL = """
@@ -92,7 +92,7 @@ SETTINGS timeout_before_checking_execution_speed = 60
 
 CUMULATIVE_SQL = """
 SELECT {actor_expression} AS actor_id, min(timestamp) AS first_seen_timestamp
-{event_base_query}
+{event_query_base}
 GROUP BY actor_id
 """
 

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -28,9 +28,11 @@ SELECT {aggregate_operation} as data FROM (
 
 SESSION_DURATION_SQL = """
 SELECT {aggregate_operation} as data, date FROM (
-    SELECT {interval}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) {start_of_week_fix}) as date, any(session_duration) as session_duration
-    FROM ({event_query})
-    GROUP BY $session_id, date
+    SELECT
+        {interval}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) {start_of_week_fix}) as date,
+        any(sessions.session_duration) as session_duration
+    {event_base_query}
+    GROUP BY sessions.$session_id, date
 ) GROUP BY date
 """
 

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -62,8 +62,7 @@ SELECT counts AS total, timestamp AS day_start FROM (
         SELECT
             toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) AS timestamp,
             {aggregator}
-        FROM ({event_query}) events
-        WHERE 1 = 1 {parsed_date_from_prev_range} {parsed_date_to}
+        {event_base_query}
         GROUP BY timestamp, {aggregator}
     ) e WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
     GROUP BY d.timestamp

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -13,7 +13,7 @@ SELECT {aggregate_operation} as data FROM ({event_query}) events
 VOLUME_PER_ACTOR_SQL = """
 SELECT {aggregate_operation} AS data, date FROM (
     SELECT COUNT(*) AS intermediate_count, {aggregator}, {interval}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) {start_of_week_fix}) AS date
-    FROM ({event_query})
+    {event_base_query}
     GROUP BY {aggregator}, date
 ) GROUP BY date
 """

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -9,57 +9,50 @@
      FROM
        (SELECT SUM(total) AS count,
                day_start
-        from
+        FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
            FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
                             toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
-           UNION ALL SELECT count(DISTINCT "$session_id") as data,
+           UNION ALL SELECT count(DISTINCT e."$session_id") as data,
                             toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-           FROM
-             (SELECT e.timestamp as timestamp,
-                     e."$session_id" as "$session_id"
-              FROM events e
-              WHERE team_id = 2
-                AND event = 'session start'
-                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
            GROUP BY date)
-        group by day_start
-        order by day_start) SETTINGS timeout_before_checking_execution_speed = 60) as sub_A
+        GROUP BY day_start
+        ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60) as sub_A
   CROSS JOIN
     (SELECT groupArray(day_start) as date,
             groupArray(count) as data
      FROM
        (SELECT SUM(total) AS count,
                day_start
-        from
+        FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
            FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
                             toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
-           UNION ALL SELECT count(DISTINCT person_id) as data,
+           UNION ALL SELECT count(DISTINCT pdi.person_id) as data,
                             toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as date
-           FROM
-             (SELECT e.timestamp as timestamp,
-                     e."$session_id" as "$session_id",
-                     pdi.person_id as person_id
-              FROM events e
-              INNER JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+           FROM events e
+           INNER JOIN
+             (SELECT distinct_id,
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
               WHERE team_id = 2
-                AND event = 'session start'
-                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+             AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
            GROUP BY date)
-        group by day_start
-        order by day_start) SETTINGS timeout_before_checking_execution_speed = 60) as sub_B
+        GROUP BY day_start
+        ORDER BY day_start) SETTINGS timeout_before_checking_execution_speed = 60) as sub_B
   '
 ---

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -128,8 +128,11 @@ class TrendsTotalVolume:
                     event_query=event_query, start_of_week_fix=start_of_week_fix(filter.interval), **content_sql_params
                 )
             else:
+                event_query, _ = trend_event_query.get_base_query()
                 content_sql = VOLUME_SQL.format(
-                    event_query=event_query, start_of_week_fix=start_of_week_fix(filter.interval), **content_sql_params
+                    event_base_query=event_query,
+                    start_of_week_fix=start_of_week_fix(filter.interval),
+                    **content_sql_params,
                 )
 
             null_sql = NULL_SQL.format(

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -48,6 +48,7 @@ class TrendsTotalVolume:
         aggregate_operation, join_condition, math_params = process_math(
             entity,
             team,
+            event_table_alias=TrendsEventQuery.EVENT_TABLE_ALIAS,
             person_id_alias=f"person_id" if team.person_on_events_querying_enabled else "pdi.person_id",
         )
 

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -126,8 +126,9 @@ class TrendsTotalVolume:
             elif entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS:
                 # Calculate average number of events per actor
                 # (only including actors with at least one matching event in a period)
+                event_query, _ = trend_event_query.get_base_query()
                 content_sql = VOLUME_PER_ACTOR_SQL.format(
-                    event_query=event_query,
+                    event_base_query=event_query,
                     start_of_week_fix=start_of_week_fix(filter.interval),
                     aggregator=determine_aggregator(entity, team),
                     **content_sql_params,

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -95,7 +95,8 @@ class TrendsTotalVolume:
                     aggregator=determine_aggregator(entity, team),
                 )
             else:
-                content_sql = VOLUME_AGGREGATE_SQL.format(event_query=event_query, **content_sql_params)
+                event_query, _ = trend_event_query.get_base_query()
+                content_sql = VOLUME_AGGREGATE_SQL.format(event_base_query=event_query, **content_sql_params)
 
             return (content_sql, params, self._parse_aggregate_volume_result(filter, entity, team.id))
         else:

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -136,8 +136,11 @@ class TrendsTotalVolume:
             elif entity.math_property == "$session_duration":
                 # TODO: When we add more person/group properties to math_property,
                 # generalise this query to work for everything, not just sessions.
+                event_query, _ = trend_event_query.get_base_query()
                 content_sql = SESSION_DURATION_SQL.format(
-                    event_query=event_query, start_of_week_fix=start_of_week_fix(filter.interval), **content_sql_params
+                    event_base_query=event_query,
+                    start_of_week_fix=start_of_week_fix(filter.interval),
+                    **content_sql_params,
                 )
             else:
                 event_query, _ = trend_event_query.get_base_query()

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -61,7 +61,7 @@ class TrendsTotalVolume:
             else False,
             using_person_on_events=team.person_on_events_querying_enabled,
         )
-        event_query, event_query_params = trend_event_query.get_query()
+        event_base_query, event_query_params = trend_event_query.get_base_query()
 
         content_sql_params = {
             "aggregate_operation": aggregate_operation,
@@ -74,9 +74,8 @@ class TrendsTotalVolume:
 
         if filter.display in NON_TIME_SERIES_DISPLAY_TYPES:
             if entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
-                event_query, _ = trend_event_query.get_base_query()
                 content_sql = ACTIVE_USERS_AGGREGATE_SQL.format(
-                    event_base_query=event_query,
+                    event_base_query=event_base_query,
                     aggregator="distinct_id" if team.aggregate_users_by_distinct_id else "person_id",
                     start_of_week_fix=start_of_week_fix(filter.interval),
                     **content_sql_params,
@@ -85,26 +84,24 @@ class TrendsTotalVolume:
             elif entity.math in PROPERTY_MATH_FUNCTIONS and entity.math_property == "$session_duration":
                 # TODO: When we add more person/group properties to math_property,
                 # generalise this query to work for everything, not just sessions.
-                event_query, _ = trend_event_query.get_base_query()
-                content_sql = SESSION_DURATION_AGGREGATE_SQL.format(event_base_query=event_query, **content_sql_params)
+                content_sql = SESSION_DURATION_AGGREGATE_SQL.format(
+                    event_base_query=event_base_query, **content_sql_params
+                )
             elif entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS:
-                event_query, _ = trend_event_query.get_base_query()
                 content_sql = VOLUME_PER_ACTOR_AGGREGATE_SQL.format(
-                    event_base_query=event_query,
+                    event_base_query=event_base_query,
                     **content_sql_params,
                     aggregator=determine_aggregator(entity, team),
                 )
             else:
-                event_query, _ = trend_event_query.get_base_query()
-                content_sql = VOLUME_AGGREGATE_SQL.format(event_base_query=event_query, **content_sql_params)
+                content_sql = VOLUME_AGGREGATE_SQL.format(event_base_query=event_base_query, **content_sql_params)
 
             return (content_sql, params, self._parse_aggregate_volume_result(filter, entity, team.id))
         else:
 
             if entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
-                event_query, _ = trend_event_query.get_base_query()
                 content_sql = ACTIVE_USERS_SQL.format(
-                    event_base_query=event_query,
+                    event_base_query=event_base_query,
                     parsed_date_to=trend_event_query.parsed_date_to,
                     parsed_date_from=trend_event_query.parsed_date_from,
                     aggregator=determine_aggregator(entity, team),  # TODO: Support groups officialy and with tests
@@ -113,11 +110,10 @@ class TrendsTotalVolume:
                     **trend_event_query.active_user_params,
                 )
             elif filter.display == TRENDS_CUMULATIVE and entity.math in (UNIQUE_USERS, UNIQUE_GROUPS):
-                event_query, _ = trend_event_query.get_base_query()
                 # :TODO: Consider using bitmap-per-date to speed this up
                 cumulative_sql = CUMULATIVE_SQL.format(
                     actor_expression=determine_aggregator(entity, team),
-                    event_base_query=event_query,
+                    event_base_query=event_base_query,
                 )
                 content_sql_params["aggregate_operation"] = "COUNT(DISTINCT actor_id)"
                 content_sql = VOLUME_SQL.format(
@@ -129,9 +125,8 @@ class TrendsTotalVolume:
             elif entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS:
                 # Calculate average number of events per actor
                 # (only including actors with at least one matching event in a period)
-                event_query, _ = trend_event_query.get_base_query()
                 content_sql = VOLUME_PER_ACTOR_SQL.format(
-                    event_base_query=event_query,
+                    event_base_query=event_base_query,
                     start_of_week_fix=start_of_week_fix(filter.interval),
                     aggregator=determine_aggregator(entity, team),
                     **content_sql_params,
@@ -139,17 +134,15 @@ class TrendsTotalVolume:
             elif entity.math_property == "$session_duration":
                 # TODO: When we add more person/group properties to math_property,
                 # generalise this query to work for everything, not just sessions.
-                event_query, _ = trend_event_query.get_base_query()
                 content_sql = SESSION_DURATION_SQL.format(
-                    event_base_query=event_query,
+                    event_base_query=event_base_query,
                     start_of_week_fix=start_of_week_fix(filter.interval),
                     **content_sql_params,
                 )
             else:
-                event_query, _ = trend_event_query.get_base_query()
                 content_sql = VOLUME_SQL.format(
                     timestamp_column="timestamp",
-                    event_base_query=event_query,
+                    event_base_query=event_base_query,
                     start_of_week_fix=start_of_week_fix(filter.interval),
                     **content_sql_params,
                 )

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -110,7 +110,6 @@ class TrendsTotalVolume:
                     **trend_event_query.active_user_params,
                 )
             elif filter.display == TRENDS_CUMULATIVE and entity.math in (UNIQUE_USERS, UNIQUE_GROUPS):
-                # TODO: for groups aggregation as well
                 event_query, _ = trend_event_query.get_base_query()
                 # :TODO: Consider using bitmap-per-date to speed this up
                 cumulative_sql = CUMULATIVE_SQL.format(

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -74,13 +74,12 @@ class TrendsTotalVolume:
 
         if filter.display in NON_TIME_SERIES_DISPLAY_TYPES:
             if entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
+                event_query, _ = trend_event_query.get_base_query()
                 content_sql = ACTIVE_USERS_AGGREGATE_SQL.format(
-                    event_query=event_query,
-                    **content_sql_params,
-                    parsed_date_to=trend_event_query.parsed_date_to,
-                    parsed_date_from=trend_event_query.parsed_date_from,
+                    event_base_query=event_query,
                     aggregator="distinct_id" if team.aggregate_users_by_distinct_id else "person_id",
                     start_of_week_fix=start_of_week_fix(filter.interval),
+                    **content_sql_params,
                     **trend_event_query.active_user_params,
                 )
             elif entity.math in PROPERTY_MATH_FUNCTIONS and entity.math_property == "$session_duration":
@@ -89,8 +88,9 @@ class TrendsTotalVolume:
                 event_query, _ = trend_event_query.get_base_query()
                 content_sql = SESSION_DURATION_AGGREGATE_SQL.format(event_base_query=event_query, **content_sql_params)
             elif entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS:
+                event_query, _ = trend_event_query.get_base_query()
                 content_sql = VOLUME_PER_ACTOR_AGGREGATE_SQL.format(
-                    event_query=event_query,
+                    event_base_query=event_query,
                     **content_sql_params,
                     aggregator=determine_aggregator(entity, team),
                 )

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -102,13 +102,14 @@ class TrendsTotalVolume:
         else:
 
             if entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
+                event_query, _ = trend_event_query.get_base_query()
                 content_sql = ACTIVE_USERS_SQL.format(
-                    event_query=event_query,
-                    **content_sql_params,
+                    event_base_query=event_query,
                     parsed_date_to=trend_event_query.parsed_date_to,
                     parsed_date_from=trend_event_query.parsed_date_from,
                     aggregator=determine_aggregator(entity, team),  # TODO: Support groups officialy and with tests
                     start_of_week_fix=start_of_week_fix(filter.interval),
+                    **content_sql_params,
                     **trend_event_query.active_user_params,
                 )
             elif filter.display == TRENDS_CUMULATIVE and entity.math in (UNIQUE_USERS, UNIQUE_GROUPS):

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -44,7 +44,11 @@ class TrendsTotalVolume:
 
         trunc_func = get_trunc_func_ch(filter.interval)
         interval_func = get_interval_func_ch(filter.interval)
-        aggregate_operation, join_condition, math_params = process_math(entity, team, person_id_alias="person_id")
+        aggregate_operation, join_condition, math_params = process_math(
+            entity,
+            team,
+            person_id_alias=f"person_id" if team.person_on_events_querying_enabled else "pdi.person_id",
+        )
 
         trend_event_query = TrendsEventQuery(
             filter=filter,

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -86,7 +86,8 @@ class TrendsTotalVolume:
             elif entity.math in PROPERTY_MATH_FUNCTIONS and entity.math_property == "$session_duration":
                 # TODO: When we add more person/group properties to math_property,
                 # generalise this query to work for everything, not just sessions.
-                content_sql = SESSION_DURATION_AGGREGATE_SQL.format(event_query=event_query, **content_sql_params)
+                event_query, _ = trend_event_query.get_base_query()
+                content_sql = SESSION_DURATION_AGGREGATE_SQL.format(event_base_query=event_query, **content_sql_params)
             elif entity.math in COUNT_PER_ACTOR_MATH_FUNCTIONS:
                 content_sql = VOLUME_PER_ACTOR_AGGREGATE_SQL.format(
                     event_query=event_query,

--- a/posthog/queries/trends/trends_event_query.py
+++ b/posthog/queries/trends/trends_event_query.py
@@ -111,10 +111,11 @@ class TrendsEventQuery(EventQuery):
         return query, self.params
 
     def _determine_should_join_persons(self) -> None:
-        EventQuery._determine_should_join_persons(self)
         if self._using_person_on_events:
             self._should_join_distinct_ids = False
             self._should_join_persons = False
+        else:
+            EventQuery._determine_should_join_persons(self)
 
     def _get_extra_person_columns(self) -> str:
         if self._using_person_on_events:

--- a/posthog/queries/trends/trends_event_query.py
+++ b/posthog/queries/trends/trends_event_query.py
@@ -1,27 +1,10 @@
 from typing import Any, Dict, Tuple
 
-from posthog.constants import MONTHLY_ACTIVE, UNIQUE_USERS, WEEKLY_ACTIVE, PropertyOperatorType
-from posthog.models import Entity
-from posthog.models.entity.util import get_entity_filtering_params
-from posthog.models.filters.filter import Filter
-from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.property.util import get_property_string_expr
-from posthog.models.team.team import groups_on_events_querying_enabled
-from posthog.models.utils import PersonPropertiesMode
-from posthog.queries.event_query import EventQuery
-from posthog.queries.person_query import PersonQuery
-from posthog.queries.query_date_range import QueryDateRange
-from posthog.queries.trends.util import get_active_user_params
+from posthog.queries.trends.trends_event_query_base import TrendsEventQueryBase
 
 
-class TrendsEventQuery(EventQuery):
-    _entity: Entity
-    _filter: Filter
-
-    def __init__(self, entity: Entity, *args, **kwargs):
-        self._entity = entity
-        super().__init__(*args, **kwargs)
-
+class TrendsEventQuery(TrendsEventQueryBase):
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
         _fields = (
             f"{self.EVENT_TABLE_ALIAS}.timestamp as timestamp"
@@ -62,60 +45,9 @@ class TrendsEventQuery(EventQuery):
             + (self._get_extra_person_columns())
         )
 
-        if self._using_person_on_events:
-            for column_name in sorted(self._column_optimizer.person_on_event_columns_to_query):
-                _fields += f', {self.EVENT_TABLE_ALIAS}."{column_name}" as "{column_name}"'
+        base_query, params = super().get_query()
 
-        if self._using_person_on_events and groups_on_events_querying_enabled():
-            for column_name in sorted(self._column_optimizer.group_on_event_columns_to_query):
-                _fields += f', {self.EVENT_TABLE_ALIAS}."{column_name}" as "{column_name}"'
-
-        date_query, date_params = self._get_date_filter()
-        self.params.update(date_params)
-
-        prop_query, prop_params = self._get_prop_groups(
-            self._filter.property_groups.combine_property_group(PropertyOperatorType.AND, self._entity.property_groups),
-            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self._using_person_on_events
-            else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
-            person_id_joined_alias=f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id",
-        )
-
-        self.params.update(prop_params)
-
-        entity_query, entity_params = self._get_entity_query()
-        self.params.update(entity_params)
-
-        person_query, person_params = self._get_person_query()
-        self.params.update(person_params)
-
-        groups_query, groups_params = self._get_groups_query()
-        self.params.update(groups_params)
-
-        session_query, session_params = self._get_sessions_query()
-        self.params.update(session_params)
-
-        query = f"""
-            SELECT {_fields} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
-            {person_query}
-            {groups_query}
-            {session_query}
-            WHERE team_id = %(team_id)s
-            {entity_query}
-            {date_query}
-            {prop_query}
-            {self._get_not_null_actor_condition()}
-        """
-
-        return query, self.params
-
-    def _determine_should_join_persons(self) -> None:
-        if self._using_person_on_events:
-            self._should_join_distinct_ids = False
-            self._should_join_persons = False
-        else:
-            EventQuery._determine_should_join_persons(self)
+        return f"SELECT {_fields} {base_query}", params
 
     def _get_extra_person_columns(self) -> str:
         if self._using_person_on_events:
@@ -139,70 +71,3 @@ class TrendsEventQuery(EventQuery):
                 f", {self.PERSON_TABLE_ALIAS}.{column_name} as {column_name}"
                 for column_name in self._extra_person_fields
             )
-
-    def _determine_should_join_distinct_ids(self) -> None:
-        is_entity_per_user = self._entity.math in (UNIQUE_USERS, WEEKLY_ACTIVE, MONTHLY_ACTIVE)
-        if (
-            is_entity_per_user and not self._aggregate_users_by_distinct_id
-        ) or self._column_optimizer.is_using_cohort_propertes:
-            self._should_join_distinct_ids = True
-
-    def _get_not_null_actor_condition(self) -> str:
-        if self._entity.math_group_type_index is None:
-            # If aggregating by person, exclude events with null/zero person IDs
-            return f"AND {self.EVENT_TABLE_ALIAS}.person_id != toUUIDOrZero('')" if self._using_person_on_events else ""
-        else:
-            # If aggregating by group, exclude events that aren't associated with a group
-            return f"""AND "$group_{self._entity.math_group_type_index}" != ''"""
-
-    def _get_date_filter(self) -> Tuple[str, Dict]:
-        date_filter = ""
-        query_params: Dict[str, Any] = {}
-        query_date_range = QueryDateRange(self._filter, self._team)
-        parsed_date_from, date_from_params = query_date_range.date_from
-        parsed_date_to, date_to_params = query_date_range.date_to
-
-        query_params.update(date_from_params)
-        query_params.update(date_to_params)
-
-        self.parsed_date_from = parsed_date_from
-        self.parsed_date_to = parsed_date_to
-
-        if self._entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
-            active_user_format_params, active_user_query_params = get_active_user_params(
-                self._filter, self._entity, self._team_id
-            )
-            self.active_user_params = active_user_format_params
-            query_params.update(active_user_query_params)
-
-            date_filter = "{parsed_date_from_prev_range} {parsed_date_to}".format(
-                **active_user_format_params, parsed_date_to=parsed_date_to
-            )
-        else:
-            date_filter = "{parsed_date_from} {parsed_date_to}".format(
-                parsed_date_from=parsed_date_from, parsed_date_to=parsed_date_to
-            )
-
-        return date_filter, query_params
-
-    def _get_entity_query(self) -> Tuple[str, Dict]:
-        entity_params, entity_format_params = get_entity_filtering_params(
-            allowed_entities=[self._entity],
-            team_id=self._team_id,
-            table_name=self.EVENT_TABLE_ALIAS,
-            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
-            if self._using_person_on_events
-            else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
-        )
-
-        return entity_format_params["entity_query"], entity_params
-
-    @cached_property
-    def _person_query(self):
-        return PersonQuery(
-            self._filter,
-            self._team_id,
-            self._column_optimizer,
-            extra_fields=self._extra_person_fields,
-            entity=self._entity,
-        )

--- a/posthog/queries/trends/trends_event_query.py
+++ b/posthog/queries/trends/trends_event_query.py
@@ -45,7 +45,7 @@ class TrendsEventQuery(TrendsEventQueryBase):
             + (self._get_extra_person_columns())
         )
 
-        base_query, params = super().get_base_query()
+        base_query, params = super().get_query_base()
 
         return f"SELECT {_fields} {base_query}", params
 

--- a/posthog/queries/trends/trends_event_query.py
+++ b/posthog/queries/trends/trends_event_query.py
@@ -45,7 +45,7 @@ class TrendsEventQuery(TrendsEventQueryBase):
             + (self._get_extra_person_columns())
         )
 
-        base_query, params = super().get_query()
+        base_query, params = super().get_base_query()
 
         return f"SELECT {_fields} {base_query}", params
 

--- a/posthog/queries/trends/trends_event_query_base.py
+++ b/posthog/queries/trends/trends_event_query_base.py
@@ -20,7 +20,11 @@ class TrendsEventQueryBase(EventQuery):
         self._entity = entity
         super().__init__(*args, **kwargs)
 
-    def get_base_query(self) -> Tuple[str, Dict[str, Any]]:
+    def get_query_base(self) -> Tuple[str, Dict[str, Any]]:
+        """
+        Returns part of the event query with only FROM, JOINs and WHERE clauses.
+        """
+
         date_query, date_params = self._get_date_filter()
         self.params.update(date_params)
 

--- a/posthog/queries/trends/trends_event_query_base.py
+++ b/posthog/queries/trends/trends_event_query_base.py
@@ -20,7 +20,7 @@ class TrendsEventQueryBase(EventQuery):
         self._entity = entity
         super().__init__(*args, **kwargs)
 
-    def get_query(self) -> Tuple[str, Dict[str, Any]]:
+    def get_base_query(self) -> Tuple[str, Dict[str, Any]]:
         date_query, date_params = self._get_date_filter()
         self.params.update(date_params)
 

--- a/posthog/queries/trends/trends_event_query_base.py
+++ b/posthog/queries/trends/trends_event_query_base.py
@@ -1,0 +1,136 @@
+from typing import Any, Dict, Tuple
+
+from posthog.constants import MONTHLY_ACTIVE, UNIQUE_USERS, WEEKLY_ACTIVE, PropertyOperatorType
+from posthog.models import Entity
+from posthog.models.entity.util import get_entity_filtering_params
+from posthog.models.filters.filter import Filter
+from posthog.models.filters.mixins.utils import cached_property
+from posthog.models.utils import PersonPropertiesMode
+from posthog.queries.event_query import EventQuery
+from posthog.queries.person_query import PersonQuery
+from posthog.queries.query_date_range import QueryDateRange
+from posthog.queries.trends.util import get_active_user_params
+
+
+class TrendsEventQueryBase(EventQuery):
+    _entity: Entity
+    _filter: Filter
+
+    def __init__(self, entity: Entity, *args, **kwargs):
+        self._entity = entity
+        super().__init__(*args, **kwargs)
+
+    def get_query(self) -> Tuple[str, Dict[str, Any]]:
+        date_query, date_params = self._get_date_filter()
+        self.params.update(date_params)
+
+        prop_query, prop_params = self._get_prop_groups(
+            self._filter.property_groups.combine_property_group(PropertyOperatorType.AND, self._entity.property_groups),
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self._using_person_on_events
+            else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
+            person_id_joined_alias=f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id",
+        )
+
+        self.params.update(prop_params)
+
+        entity_query, entity_params = self._get_entity_query()
+        self.params.update(entity_params)
+
+        person_query, person_params = self._get_person_query()
+        self.params.update(person_params)
+
+        groups_query, groups_params = self._get_groups_query()
+        self.params.update(groups_params)
+
+        session_query, session_params = self._get_sessions_query()
+        self.params.update(session_params)
+
+        query = f"""
+            FROM events {self.EVENT_TABLE_ALIAS}
+            {self._get_distinct_id_query()}
+            {person_query}
+            {groups_query}
+            {session_query}
+            WHERE team_id = %(team_id)s
+            {entity_query}
+            {date_query}
+            {prop_query}
+            {self._get_not_null_actor_condition()}
+        """
+
+        return query, self.params
+
+    def _determine_should_join_persons(self) -> None:
+        if self._using_person_on_events:
+            self._should_join_distinct_ids = False
+            self._should_join_persons = False
+        else:
+            EventQuery._determine_should_join_persons(self)
+
+    def _determine_should_join_distinct_ids(self) -> None:
+        is_entity_per_user = self._entity.math in (UNIQUE_USERS, WEEKLY_ACTIVE, MONTHLY_ACTIVE)
+        if (
+            is_entity_per_user and not self._aggregate_users_by_distinct_id
+        ) or self._column_optimizer.is_using_cohort_propertes:
+            self._should_join_distinct_ids = True
+
+    def _get_not_null_actor_condition(self) -> str:
+        if self._entity.math_group_type_index is None:
+            # If aggregating by person, exclude events with null/zero person IDs
+            return f"AND {self.EVENT_TABLE_ALIAS}.person_id != toUUIDOrZero('')" if self._using_person_on_events else ""
+        else:
+            # If aggregating by group, exclude events that aren't associated with a group
+            return f"""AND "$group_{self._entity.math_group_type_index}" != ''"""
+
+    def _get_date_filter(self) -> Tuple[str, Dict]:
+        date_filter = ""
+        query_params: Dict[str, Any] = {}
+        query_date_range = QueryDateRange(self._filter, self._team)
+        parsed_date_from, date_from_params = query_date_range.date_from
+        parsed_date_to, date_to_params = query_date_range.date_to
+
+        query_params.update(date_from_params)
+        query_params.update(date_to_params)
+
+        self.parsed_date_from = parsed_date_from
+        self.parsed_date_to = parsed_date_to
+
+        if self._entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
+            active_user_format_params, active_user_query_params = get_active_user_params(
+                self._filter, self._entity, self._team_id
+            )
+            self.active_user_params = active_user_format_params
+            query_params.update(active_user_query_params)
+
+            date_filter = "{parsed_date_from_prev_range} {parsed_date_to}".format(
+                **active_user_format_params, parsed_date_to=parsed_date_to
+            )
+        else:
+            date_filter = "{parsed_date_from} {parsed_date_to}".format(
+                parsed_date_from=parsed_date_from, parsed_date_to=parsed_date_to
+            )
+
+        return date_filter, query_params
+
+    def _get_entity_query(self) -> Tuple[str, Dict]:
+        entity_params, entity_format_params = get_entity_filtering_params(
+            allowed_entities=[self._entity],
+            team_id=self._team_id,
+            table_name=self.EVENT_TABLE_ALIAS,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self._using_person_on_events
+            else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
+        )
+
+        return entity_format_params["entity_query"], entity_params
+
+    @cached_property
+    def _person_query(self):
+        return PersonQuery(
+            self._filter,
+            self._team_id,
+            self._column_optimizer,
+            extra_fields=self._extra_person_fields,
+            entity=self._entity,
+        )

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -154,7 +154,7 @@ def determine_aggregator(entity: Entity, team: Team) -> str:
     """Return the relevant actor column."""
     if entity.math_group_type_index is not None:
         return f'"$group_{entity.math_group_type_index}"'
-    return "distinct_id" if team.aggregate_users_by_distinct_id else "person_id"
+    return "e.distinct_id" if team.aggregate_users_by_distinct_id else "e.person_id"
 
 
 def is_series_group_based(entity: Entity) -> bool:


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/13315 and https://github.com/PostHog/posthog/issues/13486

## Changes

## Benchmarks

I tested this change out in production on the largest client we have. Results:

| | query_duration_ms | data streamed from other shard | 
| --- | --- | --- |
| `master` branch | 14216 | 41.39 GiB |
| this branch | 4996 (65% faster) | 384.00 B (115 million times less) |


[Metabase](https://metabase.posthog.net/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiItLSBzZWxlY3QgKiBmcm9tIG1ldHJpY3NfcXVlcnlfbG9nIHdoZXJlIHRlYW1faWQgPSAyNjM1IGFuZCBxdWVyeV90eXBlID0gJ3RyZW5kc190b3RhbF92b2x1bWUnIGFuZCBraW5kID0gJ3JlcXVlc3QnIGFuZCB0aW1lc3RhbXAgPiAnMjAyMi0xMi0yNycgYW5kIHF1ZXJ5X2R1cmF0aW9uX21zID4gMTAwMDAgYW5kIGlzX2luaXRpYWxfcXVlcnlcblxuU0VMRUNUIFxuICBnZXRNYWNybygncmVwbGljYScpLFxuICBldmVudF90aW1lLFxuICBxdWVyeV9kdXJhdGlvbl9tcyxcbiAgaXNfaW5pdGlhbF9xdWVyeSxcbiAgcmVhZF9yb3dzLFxuICBmb3JtYXRSZWFkYWJsZVNpemUocmVhZF9ieXRlcyksXG4gIGZvcm1hdFJlYWRhYmxlU2l6ZShyZXN1bHRfYnl0ZXMpLFxuICByZXN1bHRfYnl0ZXMsXG4gIGZvcm1hdFJlYWRhYmxlU2l6ZShtZW1vcnlfdXNhZ2UpLFxuICBQcm9maWxlRXZlbnRzXG5GUk9NIGNsdXN0ZXJBbGxSZXBsaWNhcygncG9zdGhvZycsIHN5c3RlbSwgcXVlcnlfbG9nKVxuV0hFUkUgSlNPTkV4dHJhY3RTdHJpbmcobG9nX2NvbW1lbnQsICdraW5kJykgPSAnYmVuY2htYXJraW5nJ1xuICBBTkQgZXZlbnRfdGltZSA-ICcyMDIyLTEyLTI4JyBhbmQgZXZlbnRfdGltZSA8ICcyMDIyLTEyLTI4IDEwOjAwOjAwJ1xuICBBTkQgdHlwZSA-IDFcbk9SREVSIEJZIGV2ZW50X3RpbWUiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo0fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)

## How did you test this code?

Relying on existing test coverage + manually verifying each if/else branch in total_volume.py