### PR TITLE
chore: update web performance schema snapshot

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -198,10 +198,6 @@
   unload_event_end Float64,
   unload_event_start Float64
       
-  , _timestamp DateTime
-  , _offset UInt64
-  , _partition UInt64
-  
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_performance_events_test', 'group1', 'JSONEachRow')
   
   '
@@ -732,10 +728,6 @@
   unload_event_end Float64,
   unload_event_start Float64
       
-  , _timestamp DateTime
-  , _offset UInt64
-  , _partition UInt64
-  
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_performance_events_test', 'group1', 'JSONEachRow')
   
   '


### PR DESCRIPTION
## Problem

The web performance schema snapshots were out-of-date

## Changes

updates them

## How did you test this code?

running the test and seeing the snapshot was as expected