### PR TITLE
fix: improve person API doc

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -213,7 +213,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             OpenApiParameter(
                 "delete_events",
                 OpenApiTypes.BOOL,
-                description="If true, all events associated with this person will be deleted",
+                description="If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately but is processed on the cron pattern set by CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON",
                 default=False,
             ),
         ],

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -172,7 +172,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
                 description="Filter persons by email (exact match)",
                 examples=[OpenApiExample(name="email", value="test@test.com")],
             ),
-            OpenApiParameter("distinct_id", OpenApiTypes.INT, description="Filter list by distinct id."),
+            OpenApiParameter("distinct_id", OpenApiTypes.STR, description="Filter list by distinct id."),
             OpenApiParameter(
                 "search",
                 OpenApiTypes.STR,
@@ -208,6 +208,16 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
         return Response({"results": serialized_actors, "next": next_url, "previous": previous_url})
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "delete_events",
+                OpenApiTypes.BOOL,
+                description="If true, all events associated with this person will be deleted",
+                default=False,
+            ),
+        ],
+    )
     def destroy(self, request: request.Request, pk=None, **kwargs):  # type: ignore
         try:
             person = self.get_object()

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -213,7 +213,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             OpenApiParameter(
                 "delete_events",
                 OpenApiTypes.BOOL,
-                description="If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately and instead is batched together and run once a week",
+                description="If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately and instead is batched together and at 5AM UTC every Sunday",
                 default=False,
             ),
         ],

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -213,7 +213,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             OpenApiParameter(
                 "delete_events",
                 OpenApiTypes.BOOL,
-                description="If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately and instead is batched together and at 5AM UTC every Sunday",
+                description="If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately and instead is batched together and at 5AM UTC every Sunday (controlled by environment variable CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON)",
                 default=False,
             ),
         ],

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -213,7 +213,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             OpenApiParameter(
                 "delete_events",
                 OpenApiTypes.BOOL,
-                description="If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately but is processed on the cron pattern set by CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON",
+                description="If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately and instead is batched together and run once a week",
                 default=False,
             ),
         ],


### PR DESCRIPTION
## Problem
The API docs for Persons correctly state that `distinct_id` in the GET Person endpoint is an integers, but it's a string.
It also doesn't show the `delete_events` query parameter on the DELETE endpoint.

## Changes
Fixes the above by correcting the OpenApi schema

## How did you test this code?
Tested locally that the schema is correct
