### PR TITLE
fix: log big events captured from apps to help debug KafkaJSProtocolError

### DIFF
--- a/plugin-server/src/worker/vm/extensions/posthog.ts
+++ b/plugin-server/src/worker/vm/extensions/posthog.ts
@@ -40,10 +40,10 @@ async function queueEvent(hub: Hub, pluginConfig: PluginConfig, data: InternalDa
     } as RawEventMessage)
 
     // We currently don't drop or truncate oversized events, although Kafka will reject the messages anyway.
-    // Log these messages so that can dig into what event type triggers KafkaJSProtocolError when we see them.
+    // Log events over 1MB so that can dig into what event type triggers KafkaJSProtocolError when we see them.
     const messageSize = Buffer.from(message).length
     if (messageSize > 1_000_000) {
-        status.warn('⚠️', 'App captured a message over 1MB, writing it to Kafka will probably fail', {
+        status.warn('⚠️', 'App captured an event over 1MB, writing it to Kafka will probably fail', {
             team: pluginConfig.team_id,
             plugin: pluginConfig.plugin?.name,
             event: data.event,

--- a/plugin-server/src/worker/vm/extensions/posthog.ts
+++ b/plugin-server/src/worker/vm/extensions/posthog.ts
@@ -40,7 +40,7 @@ async function queueEvent(hub: Hub, pluginConfig: PluginConfig, data: InternalDa
     } as RawEventMessage)
 
     // We currently don't drop or truncate oversized events, although Kafka will reject the messages anyway.
-    // Log these messages so that we want dig into what even type triggers KafkaJSProtocolError when we see them.
+    // Log these messages so that can dig into what event type triggers KafkaJSProtocolError when we see them.
     const messageSize = Buffer.from(message).length
     if (messageSize > 1_000_000) {
         status.warn('⚠️', 'App captured a message over 1MB, writing it to Kafka will probably fail', {


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/13487 reported failures of the Stripe app, due to oversized messages triggering KafkaJSProtocolErrors. 

## Changes

While still allowing oversized events to pass through to the Kafka producer, check the message size and log big events with the team ID, plugin name and event name.

Hopefully, we will be able to narrow down the issue to one single event type.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
