### PR TITLE
fix: wait all calls to avoid quick start button flickering

### DIFF
--- a/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
+++ b/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
@@ -99,42 +99,42 @@ export const activationLogic = kea<activationLogicType>([
             false,
             {
                 loadMembersSuccess: () => true,
-                loadMembersFailure: () => true,
+                loadMembersFailure: () => false,
             },
         ],
         areInvitesLoaded: [
             false,
             {
                 loadInvitesSuccess: () => true,
-                loadInvitesFailure: () => true,
+                loadInvitesFailure: () => false,
             },
         ],
         arePluginsLoaded: [
             false,
             {
                 loadPluginsSuccess: () => true,
-                loadPluginsFailure: () => true,
+                loadPluginsFailure: () => false,
             },
         ],
         areDashboardsLoaded: [
             false,
             {
                 loadDashboardsSuccess: () => true,
-                loadDashboardsFailure: () => true,
+                loadDashboardsFailure: () => false,
             },
         ],
         areCustomEventsLoaded: [
             false,
             {
                 loadCustomEventsSuccess: () => true,
-                loadCustomEventsFailure: () => true,
+                loadCustomEventsFailure: () => false,
             },
         ],
         areInsightsLoaded: [
             false,
             {
                 loadInsightsSuccess: () => true,
-                loadInsightsFailure: () => true,
+                loadInsightsFailure: () => false,
             },
         ],
     })),

--- a/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
+++ b/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
@@ -56,14 +56,20 @@ export const activationLogic = kea<activationLogicType>([
             ['rawDashboards'],
         ],
         actions: [
+            membersLogic,
+            ['loadMembersSuccess', 'loadMembersFailure'],
             inviteLogic,
-            ['showInviteModal'],
+            ['showInviteModal', 'loadInvitesSuccess', 'loadInvitesFailure'],
+            pluginsLogic,
+            ['loadPluginsSuccess', 'loadPluginsFailure'],
             navigationLogic,
             ['toggleActivationSideBar', 'showActivationSideBar', 'hideActivationSideBar'],
             eventUsageLogic,
             ['reportActivationSideBarShown'],
             savedInsightsLogic,
             ['loadInsights', 'loadInsightsSuccess', 'loadInsightsFailure'],
+            dashboardsModel,
+            ['loadDashboardsSuccess', 'loadDashboardsFailure'],
         ],
     })),
     actions({
@@ -87,6 +93,34 @@ export const activationLogic = kea<activationLogicType>([
             false,
             {
                 setShowSessionRecordingConfig: (_, { value }) => value,
+            },
+        ],
+        areMembersLoaded: [
+            false,
+            {
+                loadMembersSuccess: () => true,
+                loadMembersFailure: () => true,
+            },
+        ],
+        areInvitesLoaded: [
+            false,
+            {
+                loadInvitesSuccess: () => true,
+                loadInvitesFailure: () => true,
+            },
+        ],
+        arePluginsLoaded: [
+            false,
+            {
+                loadPluginsSuccess: () => true,
+                loadPluginsFailure: () => true,
+            },
+        ],
+        areDashboardsLoaded: [
+            false,
+            {
+                loadDashboardsSuccess: () => true,
+                loadDashboardsFailure: () => true,
             },
         ],
         areCustomEventsLoaded: [
@@ -130,8 +164,34 @@ export const activationLogic = kea<activationLogicType>([
     })),
     selectors({
         isReady: [
-            (s) => [s.areCustomEventsLoaded, s.areInsightsLoaded],
-            (areCustomEventsLoaded, areInsightsLoaded) => areCustomEventsLoaded && areInsightsLoaded,
+            (s) => [
+                s.currentTeam,
+                s.areMembersLoaded,
+                s.areInvitesLoaded,
+                s.areDashboardsLoaded,
+                s.arePluginsLoaded,
+                s.areCustomEventsLoaded,
+                s.areInsightsLoaded,
+            ],
+            (
+                currentTeam,
+                areMembersLoaded,
+                areInvitesLoaded,
+                areDashboardsLoaded,
+                arePluginsLoaded,
+                areCustomEventsLoaded,
+                areInsightsLoaded
+            ) => {
+                return (
+                    !!currentTeam &&
+                    areCustomEventsLoaded &&
+                    areInsightsLoaded &&
+                    areMembersLoaded &&
+                    areInvitesLoaded &&
+                    areDashboardsLoaded &&
+                    arePluginsLoaded
+                )
+            },
         ],
         currentTeamSkippedTasks: [
             (s) => [s.skippedTasks, s.currentTeam],


### PR DESCRIPTION
## Problem
In case an organization has already completed all Quick Start actions, the Quick Start button on top of the screen is displayed for a split second before being hidden.

This is because the data we need to calculate the steps completion is loaded asynchronously from different logics, and we don't wait for all calls to be completed.

## Changes
Wait for all calls to be completed before displaying the quick start button.

## How did you test this code?
Tested locally