### PR TITLE
chore: advertise export apps

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
@@ -1,12 +1,12 @@
 import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
 import { IconExport } from 'lib/components/icons'
-import { Popconfirm } from 'antd'
 import { triggerExport } from 'lib/components/ExportButton/exporter'
 import { ExporterFormat } from '~/types'
 import { DataNode, DataTableNode } from '~/queries/schema'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { isEventsQuery, isPersonsNode } from '~/queries/utils'
 import { getEventsEndpoint, getPersonsEndpoint } from '~/queries/query'
+import { ExportWithConfirmation } from '~/queries/nodes/DataTable/ExportWithConfirmation'
 
 const EXPORT_LIMIT_EVENTS = 3500
 const EXPORT_LIMIT_PERSONS = 10000
@@ -66,10 +66,11 @@ export function DataTableExport({ query }: DataTableExportProps): JSX.Element | 
                     <ExportWithConfirmation
                         key={1}
                         placement={'topRight'}
-                        query={query}
                         onConfirm={() => {
                             startDownload(query, true)
                         }}
+                        actor={isPersonsNode(query.source) ? 'persons' : 'events'}
+                        limit={isPersonsNode(query.source) ? EXPORT_LIMIT_PERSONS : EXPORT_LIMIT_EVENTS}
                     >
                         <LemonButton fullWidth status="stealth">
                             Export current columns
@@ -78,8 +79,9 @@ export function DataTableExport({ query }: DataTableExportProps): JSX.Element | 
                     <ExportWithConfirmation
                         key={0}
                         placement={'bottomRight'}
-                        query={query}
                         onConfirm={() => startDownload(query, false)}
+                        actor={isPersonsNode(query.source) ? 'persons' : 'events'}
+                        limit={isPersonsNode(query.source) ? EXPORT_LIMIT_PERSONS : EXPORT_LIMIT_EVENTS}
                     >
                         <LemonButton fullWidth status="stealth">
                             Export all columns
@@ -92,33 +94,5 @@ export function DataTableExport({ query }: DataTableExportProps): JSX.Element | 
         >
             Export{filterCount > 0 ? ` (${filterCount} filter${filterCount === 1 ? '' : 's'})` : ''}
         </LemonButtonWithPopup>
-    )
-}
-
-interface ExportWithConfirmationProps {
-    placement: 'topRight' | 'bottomRight'
-    onConfirm: (e?: React.MouseEvent<HTMLElement>) => void
-    query: DataTableNode
-    children: React.ReactNode
-}
-
-function ExportWithConfirmation({ query, placement, onConfirm, children }: ExportWithConfirmationProps): JSX.Element {
-    const actor = isPersonsNode(query.source) ? 'events' : 'persons'
-    const limit = isPersonsNode(query.source) ? EXPORT_LIMIT_EVENTS : EXPORT_LIMIT_PERSONS
-    return (
-        <Popconfirm
-            placement={placement}
-            title={
-                <>
-                    Exporting by csv is limited to {limit} {actor}.
-                    <br />
-                    To return more, please use <a href={`https://posthog.com/docs/api/${actor}`}>the API</a>. Do you
-                    want to export by CSV?
-                </>
-            }
-            onConfirm={onConfirm}
-        >
-            {children}
-        </Popconfirm>
     )
 }

--- a/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
+++ b/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
@@ -1,4 +1,5 @@
 import { Popconfirm } from 'antd'
+import { Link } from 'lib/components/Link'
 
 interface ExportWithConfirmationProps {
     placement: 'topRight' | 'bottomRight'
@@ -24,11 +25,13 @@ export function ExportWithConfirmation({
                     <br />
                     {actor === 'events' && (
                         <>
-                            The best way to export is to use <a href="https://posthog.com/apps">our app ecosystem</a>.
+                            The best way to export is to use{' '}
+                            <Link to="https://posthog.com/apps">our app ecosystem</Link>.
                             <br />
                         </>
                     )}
-                    For larger, infrequent exports you can use <a href="https://posthog.com/docs/api/events">the API</a>
+                    For larger, infrequent exports you can use{' '}
+                    <Link to="https://posthog.com/docs/api/events">the API</Link>
                     .
                     <br />
                     Do you want to export by CSV?

--- a/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
+++ b/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
@@ -29,7 +29,7 @@ export function ExportWithConfirmation({
                         <>
                             <br />
                             The best way to export events is to use{' '}
-                            <Link to="https://posthog.com/apps">our app ecosystem</Link>.
+                            <Link to="https://posthog.com/apps?filter=type&value=data-out">our app ecosystem</Link>.
                         </>
                     )}
                     <br />

--- a/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
+++ b/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
@@ -1,0 +1,42 @@
+import { Popconfirm } from 'antd'
+
+interface ExportWithConfirmationProps {
+    placement: 'topRight' | 'bottomRight'
+    onConfirm: (e?: React.MouseEvent<HTMLElement>) => void
+    actor: 'events' | 'persons'
+    limit: number
+    children: React.ReactNode
+}
+
+export function ExportWithConfirmation({
+    placement,
+    onConfirm,
+    children,
+    actor,
+    limit,
+}: ExportWithConfirmationProps): JSX.Element {
+    return (
+        <Popconfirm
+            placement={placement}
+            title={
+                <>
+                    Exporting by csv is limited to {limit} {actor}.
+                    <br />
+                    {actor === 'events' && (
+                        <>
+                            The best way to export is to use <a href="https://posthog.com/apps">our app ecosystem</a>.
+                            <br />
+                        </>
+                    )}
+                    For larger, infrequent exports you can use <a href="https://posthog.com/docs/api/events">the API</a>
+                    .
+                    <br />
+                    Do you want to export by CSV?
+                </>
+            }
+            onConfirm={onConfirm}
+        >
+            {children}
+        </Popconfirm>
+    )
+}

--- a/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
+++ b/frontend/src/queries/nodes/DataTable/ExportWithConfirmation.tsx
@@ -23,16 +23,15 @@ export function ExportWithConfirmation({
                 <>
                     Exporting by csv is limited to {limit} {actor}.
                     <br />
+                    For larger, ad-hoc exports you can use{' '}
+                    <Link to={`https://posthog.com/docs/api/${actor}`}>the API</Link>.
                     {actor === 'events' && (
                         <>
-                            The best way to export is to use{' '}
-                            <Link to="https://posthog.com/apps">our app ecosystem</Link>.
                             <br />
+                            The best way to export events is to use{' '}
+                            <Link to="https://posthog.com/apps">our app ecosystem</Link>.
                         </>
                     )}
-                    For larger, infrequent exports you can use{' '}
-                    <Link to="https://posthog.com/docs/api/events">the API</Link>
-                    .
                     <br />
                     Do you want to export by CSV?
                 </>

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { useActions, useValues } from 'kea'
 import { EventDetails } from 'scenes/events/EventDetails'
 import { Link } from 'lib/components/Link'
-import { Popconfirm } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
 import { autoCaptureEventToDescription } from 'lib/utils'
@@ -41,6 +40,7 @@ import { EventBufferNotice } from './EventBufferNotice'
 import { LemonDivider } from '@posthog/lemon-ui'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { SessionPlayerModal } from 'scenes/session-recordings/player/modal/SessionPlayerModal'
+import { ExportWithConfirmation } from '~/queries/nodes/DataTable/ExportWithConfirmation'
 
 export interface FixedFilters {
     action_id?: ActionType['id']
@@ -67,31 +67,6 @@ interface EventsTableProps {
     showPersonColumn?: boolean
     linkPropertiesToFilters?: boolean
     'data-attr'?: string
-}
-
-interface ExportWithConfirmationProps {
-    placement: 'topRight' | 'bottomRight'
-    onConfirm: (e?: React.MouseEvent<HTMLElement>) => void
-    children: React.ReactNode
-}
-
-function ExportWithConfirmation({ placement, onConfirm, children }: ExportWithConfirmationProps): JSX.Element {
-    return (
-        <Popconfirm
-            placement={placement}
-            title={
-                <>
-                    Exporting by csv is limited to 3,500 events.
-                    <br />
-                    To return more, please use <a href="https://posthog.com/docs/api/events">the API</a>. Do you want to
-                    export by CSV?
-                </>
-            }
-            onConfirm={onConfirm}
-        >
-            {children}
-        </Popconfirm>
-    )
 }
 
 export function EventsTable({
@@ -275,7 +250,7 @@ export function EventsTable({
     }, [tableWidth])
 
     const columns = useMemo(() => {
-        let columnsSoFar: LemonTableColumn<EventsTableRowItem, keyof EventsTableRowItem | undefined>[] = []
+        let columnsSoFar: LemonTableColumn<EventsTableRowItem, keyof EventsTableRowItem | undefined>[]
         if (selectedColumns === 'DEFAULT') {
             columnsSoFar = [...defaultColumns]
         } else {
@@ -529,7 +504,7 @@ export function EventsTable({
                                     defaultColumns={defaultColumns.map((e) => e.key || '')}
                                 />
                             )}
-                            {showExport ? (
+                            {showExport && (
                                 <LemonButtonWithPopup
                                     popup={{
                                         sameWidth: false,
@@ -541,6 +516,8 @@ export function EventsTable({
                                                 onConfirm={() => {
                                                     startDownload(exportColumns)
                                                 }}
+                                                actor={'events'}
+                                                limit={3500}
                                             >
                                                 <LemonButton fullWidth={true} status="stealth">
                                                     Export current columns
@@ -550,6 +527,8 @@ export function EventsTable({
                                                 key={0}
                                                 placement={'bottomRight'}
                                                 onConfirm={() => startDownload()}
+                                                actor={'events'}
+                                                limit={3500}
                                             >
                                                 <LemonButton fullWidth={true} status="stealth">
                                                     Export all columns
@@ -562,27 +541,6 @@ export function EventsTable({
                                 >
                                     Export
                                 </LemonButtonWithPopup>
-                            ) : (
-                                <Popconfirm
-                                    placement="topRight"
-                                    title={
-                                        <>
-                                            Exporting by csv is limited to 3,500 events.
-                                            <br />
-                                            To return more, please use{' '}
-                                            <a href="https://posthog.com/docs/api/events">the API</a>. Do you want to
-                                            export by CSV?
-                                        </>
-                                    }
-                                    onConfirm={() => startDownload()}
-                                >
-                                    <LemonButton
-                                        type="secondary"
-                                        icon={<IconExport style={{ color: 'var(--primary)' }} />}
-                                    >
-                                        Export
-                                    </LemonButton>
-                                </Popconfirm>
                             )}
                         </div>
                     </div>


### PR DESCRIPTION
## Problem

When someone is exporting events or persons to CSV we direct them to using the API when we should direct them to the app ecosystem

## Changes

* adds text directing exports to the app ecosystem
* flips the logic in the data exploration export with confirmation (which was the wrong way around)
* shares `ExportWithConfirmation` between `DataTable` and `EventsTable`

NB the before events and persons are flipped in the UI

||before|after|
|-|-|-|
|events|<img width="532" alt="Screenshot 2022-12-29 at 19 13 34" src="https://user-images.githubusercontent.com/984817/209999087-e73e45fb-d2c0-4d70-bb62-1cf40b466d78.png">|<img width="461" alt="Screenshot 2022-12-29 at 19 20 44" src="https://user-images.githubusercontent.com/984817/210001343-43ed210d-f1b1-434a-852e-eea59243f905.png">|
|persons|<img width="518" alt="Screenshot 2022-12-29 at 19 13 45" src="https://user-images.githubusercontent.com/984817/209999142-563a11a6-7c50-42fe-a520-7fdf077a6bea.png">|<img width="387" alt="Screenshot 2022-12-29 at 19 20 22" src="https://user-images.githubusercontent.com/984817/210001430-72e2d725-ff2e-4a7b-898e-0be09b086fc8.png">|

## How did you test this code?

running it locally and seeing what happened
