### PR TITLE
feat(query-performance): track CH and PG query counts/timing in response headers

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -95,7 +95,6 @@ def sync_execute(
             statsd.timing("clickhouse_sync_execution_time", execution_time * 1000.0)
 
             if query_counter := getattr(thread_local_storage, "query_counter", None):
-                query_counter.query_count += 1
                 query_counter.total_query_time += execution_time
 
             if app_settings.SHELL_PLUS_PRINT_SQL:

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -1,5 +1,7 @@
 import json
+import threading
 import types
+from contextlib import contextmanager
 from functools import lru_cache
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Sequence, Union
@@ -19,6 +21,8 @@ from posthog.utils import generate_short_id, patchable
 InsertParams = Union[list, tuple, types.GeneratorType]
 NonInsertParams = Dict[str, Any]
 QueryArgs = Optional[Union[InsertParams, NonInsertParams]]
+
+thread_local_storage = threading.local()
 
 
 @lru_cache(maxsize=1)
@@ -89,6 +93,10 @@ def sync_execute(
             execution_time = perf_counter() - start_time
 
             statsd.timing("clickhouse_sync_execution_time", execution_time * 1000.0)
+
+            if query_counter := getattr(thread_local_storage, "query_counter", None):
+                query_counter.query_count += 1
+                query_counter.total_query_time += execution_time
 
             if app_settings.SHELL_PLUS_PRINT_SQL:
                 print("Execution time: %.6fs" % (execution_time,))  # noqa T201
@@ -222,3 +230,10 @@ def format_sql(rendered_sql, colorize=True):
             pass
 
     return formatted_sql
+
+
+@contextmanager
+def clickhouse_query_counter(query_counter):
+    thread_local_storage.query_counter = query_counter
+    yield
+    thread_local_storage.query_counter = None

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -34,7 +34,6 @@ def reset_query_tags():
 
 class QueryCounter:
     def __init__(self):
-        self.query_count = 0
         self.total_query_time = 0.0
 
     @property
@@ -44,7 +43,6 @@ class QueryCounter:
     def __call__(self, execute, *args, **kwargs):
         import time
 
-        self.query_count += 1
         start_time = time.perf_counter()
 
         try:

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -30,3 +30,24 @@ def tag_queries(**kwargs):
 
 def reset_query_tags():
     thread_local_storage.query_tags = {}
+
+
+class QueryCounter:
+    def __init__(self):
+        self.query_count = 0
+        self.total_query_time = 0.0
+
+    @property
+    def query_time_ms(self):
+        return self.total_query_time * 1000
+
+    def __call__(self, execute, *args, **kwargs):
+        import time
+
+        self.query_count += 1
+        start_time = time.perf_counter()
+
+        try:
+            return execute(*args, **kwargs)
+        finally:
+            self.total_query_time += time.perf_counter() - start_time

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -3,6 +3,7 @@ from typing import List, Optional, cast
 
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
+from django.db import connection
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.middleware.csrf import CsrfViewMiddleware
@@ -11,7 +12,8 @@ from django.utils.cache import add_never_cache_headers
 from statshog.defaults.django import statsd
 
 from posthog.api.decide import get_decide
-from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries
+from posthog.clickhouse.client.execute import clickhouse_query_counter
+from posthog.clickhouse.query_tagging import QueryCounter, reset_query_tags, tag_queries
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Team, User
 
 from .auth import PersonalAPIKeyAuthentication
@@ -206,6 +208,30 @@ class CHQueries:
         if name in request.POST:
             return request.POST[name]
         return None
+
+
+class QueryTimeCountingMiddleware:
+    WHITELISTED_ROUTES = ["dashboard", "insight"]
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest):
+        if not (
+            settings.CAPTURE_TIME_TO_SEE_DATA
+            and "api" in request.path
+            and any(key in request.path for key in self.WHITELISTED_ROUTES)
+        ):
+            return self.get_response(request)
+
+        pg_query_counter, ch_query_counter = QueryCounter(), QueryCounter()
+        with connection.execute_wrapper(pg_query_counter), clickhouse_query_counter(ch_query_counter):
+            response: HttpResponse = self.get_response(request)
+            response.headers["PH-PG-Query-Count"] = str(pg_query_counter.query_count)
+            response.headers["PH-PG-Query-Time"] = str(round(pg_query_counter.query_time_ms))
+            response.headers["PH-CH-Query-Count"] = str(ch_query_counter.query_count)
+            response.headers["PH-CH-Query-Time"] = str(round(ch_query_counter.query_time_ms))
+        return response
 
 
 def shortcircuitmiddleware(f):

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -227,10 +227,9 @@ class QueryTimeCountingMiddleware:
         pg_query_counter, ch_query_counter = QueryCounter(), QueryCounter()
         with connection.execute_wrapper(pg_query_counter), clickhouse_query_counter(ch_query_counter):
             response: HttpResponse = self.get_response(request)
-            response.headers["PH-PG-Query-Count"] = str(pg_query_counter.query_count)
-            response.headers["PH-PG-Query-Time"] = str(round(pg_query_counter.query_time_ms))
-            response.headers["PH-CH-Query-Count"] = str(ch_query_counter.query_count)
-            response.headers["PH-CH-Query-Time"] = str(round(ch_query_counter.query_time_ms))
+            response.headers[
+                "Server-Timing"
+            ] = f"pg;dur={round(pg_query_counter.query_time_ms)}, ch;dur={round(ch_query_counter.query_time_ms)}"
         return response
 
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -211,7 +211,7 @@ class CHQueries:
 
 
 class QueryTimeCountingMiddleware:
-    WHITELISTED_ROUTES = ["dashboard", "insight"]
+    ALLOW_LIST_ROUTES = ["dashboard", "insight"]
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -220,7 +220,7 @@ class QueryTimeCountingMiddleware:
         if not (
             settings.CAPTURE_TIME_TO_SEE_DATA
             and "api" in request.path
-            and any(key in request.path for key in self.WHITELISTED_ROUTES)
+            and any(key in request.path for key in self.ALLOW_LIST_ROUTES)
         ):
             return self.get_response(request)
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -56,6 +56,7 @@ MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "posthog.middleware.CsrfOrKeyViewMiddleware",
+    "posthog.middleware.QueryTimeCountingMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",


### PR DESCRIPTION
This will allow adding these to time_to_see_data dataset.

Note that I'm operating off of a whitelist to limit the performance hit from this.
