### PR TITLE
fix(query-performance): SESSION_DURATION_AGGREGATE_SQL

### DIFF
--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -2508,7 +2508,7 @@
        AND event = 'sign up'
        AND toDateTime(timestamp, 'UTC') >= toStartOfWeek(toDateTime('2019-12-28 00:00:00', 'UTC'), 0)
        AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-     GROUP BY $session_id)
+     GROUP BY sessions.$session_id)
   '
 ---
 # name: TestTrends.test_trends_with_session_property_single_aggregate_math.1
@@ -2531,7 +2531,7 @@
        AND event = 'sign up'
        AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
        AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-     GROUP BY $session_id)
+     GROUP BY sessions.$session_id)
   '
 ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -44,7 +44,7 @@ SESSION_DURATION_AGGREGATE_SQL = """
 SELECT {aggregate_operation} as data FROM (
     SELECT any(session_duration) as session_duration
     {event_query_base}
-    GROUP BY $session_id
+    GROUP BY sessions.$session_id
 )
 """
 


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/3843383227/?project=1899813&query=is%3Aunresolved&referrer=issue-stream

Query in question:
- Average session duration
- Persons-on-events off
- Displayed as number

I wasn't able to reproduce this locally but the change is similar to what is already done in SESSION_DURATION_SQL
