### PR TITLE
fix: add correct pagination to event api

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -75,8 +75,8 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
         if direction == "next":
             if reverse:
                 params["before"] = timestamp
-                # we can only keep both after and before params if we're moving to next
-                # if we go back to previous, we don't have anymore information about initial time boundary
+                # if the after and before params are mutually exclusive (we called next then previous then again next)
+                # we pop the existing parameter
                 if params.get("after") and parser.parse(params["after"]) >= last_event_timestamp:
                     params.pop("after")
             else:
@@ -86,6 +86,8 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
         elif direction == "previous":
             if reverse:
                 params["after"] = timestamp
+                # we can only keep both after and before params if we're moving to next
+                # if we go back to previous, we don't have anymore information about initial time boundary
                 params.pop("before", None)
             else:
                 params["before"] = timestamp

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -1,7 +1,7 @@
 import json
 import urllib
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 from dateutil import parser
 from django.db.models.query import Prefetch
@@ -77,11 +77,17 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
                 params["before"] = timestamp
                 # if the after and before params are mutually exclusive (we called next then previous then again next)
                 # we pop the existing parameter
-                if params.get("after") and parser.parse(params["after"]) >= last_event_timestamp:
+                if (
+                    params.get("after")
+                    and parser.parse(cast(str, params["after"])).astimezone() >= last_event_timestamp
+                ):
                     params.pop("after")
             else:
                 params["after"] = timestamp
-                if params.get("before") and parser.parse(params["before"]) <= last_event_timestamp:
+                if (
+                    params.get("before")
+                    and parser.parse(cast(str, params["before"])).astimezone() <= last_event_timestamp
+                ):
                     params.pop("before")
         elif direction == "previous":
             if reverse:

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -77,11 +77,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
                 params["before"] = timestamp
                 # we can only keep both after and before params if we're moving to next
                 # if we go back to previous, we don't have anymore information about initial time boundary
-                if (
-                    direction == "next"
-                    and params.get("after")
-                    and parser.parse(params["after"]) >= last_event_timestamp
-                ):
+                if params.get("after") and parser.parse(params["after"]) >= last_event_timestamp:
                     params.pop("after")
             else:
                 params["after"] = timestamp

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -722,7 +722,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                 response,
                 {
                     "columns": ["event", "distinct_id", "properties.key", "concat(event, ' ', properties.key)"],
-                    "hasMore": False,
                     "types": ["String", "String", "String", "String"],
                     "results": [
                         ["sign out", "4", "test_val3", "sign out test_val3"],
@@ -748,7 +747,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                 response,
                 {
                     "columns": ["total()", "event"],
-                    "hasMore": False,
                     "types": ["UInt64", "String"],
                     "results": [[3, "sign out"], [1, "sign up"]],
                 },
@@ -764,7 +762,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                 response,
                 {
                     "columns": ["total()", "event"],
-                    "hasMore": False,
                     "types": ["UInt64", "String"],
                     "results": [[2, "sign out"], [1, "sign up"]],
                 },


### PR DESCRIPTION
## Problem
Closes https://github.com/PostHog/posthog/issues/13508

We don't currently support in the LIST events API endpoint a `previous` parameter for correct pagination, or a `count`.

## Changes
- Adds `previous` and `count` to LIST events API result

## How did you test this code?
- Improved existing tests