### PR TITLE
fix: sorted series color choosing fix

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -79,7 +79,7 @@ function InsightLegendRow({
 }): JSX.Element {
     const highlightStyle: Record<string, any> = highlighted
         ? {
-              style: { backgroundColor: getSeriesColor(item.id, false, true) },
+              style: { backgroundColor: getSeriesColor(item.seriesIndex, false, true) },
           }
         : {}
 
@@ -97,14 +97,14 @@ function InsightLegendRow({
             <div className="grow">
                 <LemonCheckbox
                     className="text-xs mr-4"
-                    color={getSeriesColor(item.id, compare)}
+                    color={getSeriesColor(item.seriesIndex, compare)}
                     checked={!hiddenLegendKeys[rowIndex]}
                     onChange={() => toggleVisibility(rowIndex)}
                     fullWidth
                     label={
                         <InsightLabel
                             key={item.id}
-                            seriesColor={getSeriesColor(item.id, compare)}
+                            seriesColor={getSeriesColor(item.seriesIndex, compare)}
                             action={item.action}
                             fallbackName={item.breakdown_value === '' ? 'None' : item.label}
                             hasMultipleSeries={hasMultipleSeries}

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -121,6 +121,7 @@ export const trendsLogic = kea<trendsLogicType>([
             (s) => [s.filters, s.results, s.toggledLifecycles],
             (filters, _results, toggledLifecycles): IndexedTrendResult[] => {
                 let results = _results || []
+                results = results.map((result, index) => ({ ...result, seriesIndex: index }))
                 if (
                     isFilterWithDisplay(filters) &&
                     (filters.display === ChartDisplayType.ActionsBarValue ||
@@ -130,7 +131,7 @@ export const trendsLogic = kea<trendsLogicType>([
                 } else if (isLifecycleFilter(filters)) {
                     results = results.filter((result) => toggledLifecycles.includes(String(result.status)))
                 }
-                return results.map((result, index) => ({ ...result, id: index }))
+                return results.map((result, index) => ({ ...result, id: index } as IndexedTrendResult))
             },
         ],
         aggregationTargetLabel: [

--- a/frontend/src/scenes/trends/types.ts
+++ b/frontend/src/scenes/trends/types.ts
@@ -8,6 +8,9 @@ export interface TrendResponse {
 
 export interface IndexedTrendResult extends TrendResult {
     id: number
+    // if the sorting changes (e.g. for pie chart) we lose the original index
+    // the series index is used for e.g. to get series color correctly
+    seriesIndex: number
 }
 
 export interface TrendActors {

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -24,7 +24,7 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
     function updateData(): void {
         const _data = [...indexedResults].sort((a, b) => b.aggregated_value - a.aggregated_value)
         const days = _data.length > 0 ? _data[0].days : []
-        const colorList = _data.map(({ id }) => getSeriesColor(id))
+        const colorList = _data.map(({ seriesIndex }) => getSeriesColor(seriesIndex))
 
         setData([
             {


### PR DESCRIPTION
## Problem

We choose series color based on the index of the data. But sometimes when we display the data we filter or sort the data and its chosen color gets out of sync with expected

## Changes

Stores the series index before changing the results and uses that to choose color

![sorting-pie-charts](https://user-images.githubusercontent.com/984817/210087745-e3e8fa72-6d49-4068-abbe-472741ae7eee.gif)

## How did you test this code?

running it locally and seeing it work