### PR TITLE
fix: load less insight data for recently viewed on home page

### DIFF
--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.test.ts
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.test.ts
@@ -23,8 +23,8 @@ describe('projectHomepageLogic', () => {
         logic.mount()
     })
 
-    it('loads recent insights onMount', async () => {
-        await expectLogic(logic).toDispatchActions(['loadRecentInsights', 'loadRecentInsightsSuccess'])
+    it('does not load recent insights onMount', async () => {
+        await expectLogic(logic).toNotHaveDispatchedActions(['loadRecentInsights', 'loadRecentInsightsSuccess'])
     })
     it('loads persons onMount', async () => {
         await expectLogic(logic).toDispatchActions(['loadPersons', 'loadPersonsSuccess'])

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -28,7 +28,8 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
         recentInsights: [
             [] as InsightModel[],
             {
-                loadRecentInsights: async () => {
+                loadRecentInsights: async (_, breakpoint) => {
+                    await breakpoint(100)
                     const response = await api.get(
                         `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&order=-my_last_viewed_at&basic=true`
                     )

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -28,8 +28,7 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
         recentInsights: [
             [] as InsightModel[],
             {
-                loadRecentInsights: async (_, breakpoint) => {
-                    await breakpoint(100)
+                loadRecentInsights: async () => {
                     const response = await api.get(
                         `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&order=-my_last_viewed_at&basic=true`
                     )
@@ -49,7 +48,6 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
     })),
 
     afterMount(({ actions }) => {
-        actions.loadRecentInsights()
         actions.loadPersons()
     }),
 ])

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -30,7 +30,7 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
             {
                 loadRecentInsights: async () => {
                     const response = await api.get(
-                        `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&order=-my_last_viewed_at`
+                        `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&order=-my_last_viewed_at&basic=true`
                     )
                     return response.results
                 },


### PR DESCRIPTION
## Problem

When you list insights the results are included. This isn't always what you want, so we are able to add `basic=true` to the API call to exclude results

The recently viewed list of insights on the home page does not have the `basic=true` param and so we're spending time calculating results

(what's worse, we make the API call twice when loading the dashboard once!)

## Changes

* Add `basic-true` and so don't load the results 

### in prod without this fix we see

on the API call https://app.posthog.com/api/projects/2/insights/?my_last_viewed=true&order=-my_last_viewed_at

response header of: `server-timing: pg;dur=1220, ch;dur=0`

### locally we can see

before: `Server-Timing: pg;dur=92, ch;dur=0`
after: `Server-Timing: pg;dur=47, ch;dur=0`

## without basic

<img width="1163" alt="Screenshot 2022-12-30 at 18 03 38" src="https://user-images.githubusercontent.com/984817/210099841-3753e9c6-2ed0-4265-a309-b611275a7a51.png">

## with basic

<img width="1168" alt="Screenshot 2022-12-30 at 18 03 15" src="https://user-images.githubusercontent.com/984817/210099857-1639fe26-f23d-48c6-ab02-457f28629259.png">


## How did you test this code?

running it locally and seeing it change