### PR TITLE
fix: make my_last_viewed_at simpler

### DIFF
--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -29,10 +29,7 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
             [] as InsightModel[],
             {
                 loadRecentInsights: async () => {
-                    const response = await api.get(
-                        `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&order=-my_last_viewed_at&basic=true`
-                    )
-                    return response.results
+                    return await api.get(`api/projects/${values.currentTeamId}/insights/my_last_viewed`)
                 },
             },
         ],

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1608,21 +1608,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                 datetime(2022, 3, 23, 0, 0, tzinfo=pytz.UTC),
             )
 
-    def test_cant_create_insight_viewed_for_another_team(self) -> None:
-        other_team = Team.objects.create(organization=self.organization, name="other team")
-        filter_dict = {"events": [{"id": "$pageview"}]}
-        insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(),
-            team=self.team,
-            short_id="12345678",
-        )
-
-        response = self.client.post(f"/api/projects/{other_team.id}/insights/{insight.id}/viewed")
-
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(InsightViewed.objects.count(), 0)
-
-    def test_cant_create_insight_viewed_for_insight_in_another_team(self) -> None:
+    def test_cant_view_insight_viewed_for_insight_in_another_team(self) -> None:
         other_team = Team.objects.create(organization=self.organization, name="other team")
         filter_dict = {"events": [{"id": "$pageview"}]}
         insight = Insight.objects.create(
@@ -1637,31 +1623,19 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(InsightViewed.objects.count(), 0)
 
     def test_get_recently_viewed_insights(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}]}
+        insight_1_id, _ = self.dashboard_api.create_insight({"short_id": "12345678"})
 
-        insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(),
-            team=self.team,
-            short_id="12345678",
-        )
-
-        self.client.post(f"/api/projects/{self.team.id}/insights/{insight.id}/viewed")
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_1_id}/viewed")
 
         response = self.client.get(f"/api/projects/{self.team.id}/insights/my_last_viewed")
         response_data = response.json()
 
         # No results if no insights have been viewed
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        assert [r["id"] for r in response_data] == [insight.id]
+        assert [r["id"] for r in response_data] == [insight_1_id]
 
     def test_get_recently_viewed_insights_when_no_insights_viewed(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}]}
-
-        Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(),
-            team=self.team,
-            short_id="12345678",
-        )
+        insight_1_id, _ = self.dashboard_api.create_insight({"short_id": "12345678"})
 
         response = self.client.get(f"/api/projects/{self.team.id}/insights/my_last_viewed")
         response_data = response.json()
@@ -1674,11 +1648,16 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         insight_2_id, _ = self.dashboard_api.create_insight({"short_id": "98765432"})
         insight_3_id, _ = self.dashboard_api.create_insight({"short_id": "43219876"})
 
+        # multiple views of a single don't drown out other views
         self.client.post(f"/api/projects/{self.team.id}/insights/{insight_1_id}/viewed")
-        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_2_id}/viewed")
-        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_3_id}/viewed")
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_1_id}/viewed")
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_1_id}/viewed")
 
+        # soft-deleted insights aren't shown
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_3_id}/viewed")
         self.dashboard_api.soft_delete(insight_3_id, "insights")
+
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_2_id}/viewed")
 
         response = self.client.get(f"/api/projects/{self.team.id}/insights/my_last_viewed")
         response_data = response.json()
@@ -1697,18 +1676,13 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         assert [r["id"] for r in response_data] == [insight_1_id, insight_2_id]
 
     def test_another_user_viewing_an_insight_does_not_impact_the_list(self) -> None:
-        filter_dict = {"events": [{"id": "$pageview"}]}
+        insight_1_id, _ = self.dashboard_api.create_insight({"short_id": "12345678"})
 
-        insight = Insight.objects.create(
-            filters=Filter(data=filter_dict).to_dict(),
-            team=self.team,
-            short_id="12345678",
-        )
         another_user = User.objects.create_and_join(self.organization, "team2@posthog.com", None)
         InsightViewed.objects.create(
             team=self.team,
             user=another_user,
-            insight=insight,
+            insight_id=insight_1_id,
             last_viewed_at=timezone.now(),
         )
 


### PR DESCRIPTION
## Problem

Even without including Insight results in the API the my_last_viewed_at API call is surprisingly slow (consistently 6 seconds for me)

I'm a bear of little brain and couldn't grok the previous mechanism for querying them.

## Changes

Make a simpler mechanism for querying them and try and lean on the ORM to load the data as fast as possible

## How did you test this code?

Updating the developer tests and running locally to see it still works