### PR TITLE
chore(CI/CD): split workflows to test, build and push container images

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -1,0 +1,120 @@
+#
+# Build and push PostHog and PostHog Cloud container images
+#
+# - posthog_build: build and push the PostHog container image to DockerHub
+#
+# - posthog_cloud_build: build the PostHog Cloud container image using
+#   as base image the container image from the previous step. The image is
+#   then pushed to AWS ECR.
+#
+name: Container Images CD
+
+on:
+    push:
+        branches:
+            - master
+            - main
+
+concurrency: ${{ github.workflow }} # ensure only one of this runs at a time
+
+jobs:
+    posthog_build:
+        name: Build and push PostHog
+        if: github.repository == 'PostHog/posthog'
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # allow issuing OIDC tokens for this workflow run
+            contents: read # allow at least reading the repo contents, add other permissions if necessary
+            packages: write # allow push to ghcr.io
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Update git SHA
+              run: echo "GIT_SHA = '${GITHUB_SHA}'" > posthog/gitsha.py
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@v1
+
+            - name: Login to DockerHub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push container images
+              id: build
+              uses: depot/build-push-action@v1
+              with:
+                  project: x19jffd9zf # posthog
+                  buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
+                  cache-from: type=gha # always pull the layers from GHA
+                  cache-to: type=gha,mode=max # always push the layers to GHA
+                  push: true
+                  tags: posthog/posthog:latest
+                  platforms: linux/amd64,linux/arm64
+
+    posthog_cloud_build:
+        name: Build and push PostHog Cloud
+        if: github.repository == 'PostHog/posthog'
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # allow issuing OIDC tokens for this workflow run
+            contents: read # allow at least reading the repo contents, add other permissions if necessary
+            packages: read # allow pull from ghcr.io
+        needs: [posthog_build]
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@v1
+
+            - name: Checkout PostHog Cloud code
+              run: |
+                  mkdir cloud/
+                  cd cloud/
+                  curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: aws-ecr
+              uses: aws-actions/amazon-ecr-login@v1
+
+            - name: Build container images
+              id: build
+              uses: depot/build-push-action@v1
+              with:
+                  project: 1stsk4xt19 # posthog-cloud
+                  buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
+                  cache-from: type=gha # always pull the layers from GHA
+                  cache-to: type=gha,mode=max # always push the layers to GHA
+                  push: true
+                  tags: ${{ steps.login-ecr.outputs.registry }}/posthog-cloud:latest
+                  platforms: linux/amd64,linux/arm64
+                  file: Dockerfile.cloud
+                  context: cloud
+                  # Use the non-cloud image as base image and extend it with
+                  # the posthog-cloud code we've checked out.
+                  build-args: |
+                      BASE_IMAGE=posthog/posthog:latest

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -28,6 +28,7 @@ jobs:
 
         outputs:
             container_image_tags: ${{ steps.meta.outputs.tags }}
+            container_image_version: ${{ steps.meta.outputs.version }}
 
         steps:
             - name: Checkout code

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -1,0 +1,120 @@
+#
+# Make sure PostHog and PostHog Cloud container images can be built
+# successfully.
+#
+# - posthog_build: build and push the PostHog container image to the
+#   GitHub Container Registry
+#
+# - posthog_cloud_build: build the PostHog Cloud container image using
+#   as base image the container image from the previous step
+#
+name: Container Images CI
+
+on:
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    posthog_build:
+        name: Build PostHog
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # allow issuing OIDC tokens for this workflow run
+            contents: read # allow at least reading the repo contents, add other permissions if necessary
+            packages: write # allow push to ghcr.io
+
+        outputs:
+            container_image_tags: ${{ steps.meta.outputs.tags }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@v4
+              with:
+                  images: ghcr.io/posthog/posthog/posthog
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@v1
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build container images
+              id: build
+              uses: depot/build-push-action@v1
+              with:
+                  project: x19jffd9zf # posthog
+                  buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
+                  cache-from: type=gha # always pull the layers from GHA
+                  cache-to: type=gha,mode=max # always push the layers to GHA
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  platforms: linux/amd64,linux/arm64
+
+    posthog_cloud_build:
+        name: Build PostHog Cloud
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # allow issuing OIDC tokens for this workflow run
+            contents: read # allow at least reading the repo contents, add other permissions if necessary
+            packages: read # allow pull from ghcr.io
+        needs: [posthog_build]
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@v1
+
+            - name: Checkout PostHog Cloud code
+              run: |
+                  mkdir cloud/
+                  cd cloud/
+                  curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build container images
+              id: build
+              uses: depot/build-push-action@v1
+              with:
+                  project: 1stsk4xt19 # posthog-cloud
+                  buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
+                  cache-from: type=gha # always pull the layers from GHA
+                  cache-to: type=gha,mode=max # always push the layers to GHA
+                  push: false
+                  platforms: linux/amd64,linux/arm64
+                  file: Dockerfile.cloud
+                  context: cloud
+                  # Use the non-cloud image as base image and extend it with
+                  # the posthog-cloud code we've checked out.
+                  build-args: |
+                      BASE_IMAGE=ghcr.io/posthog/posthog/posthog:${{ needs.posthog_build.outputs.container_image_version }}


### PR DESCRIPTION
## Changes
* `.github/workflows/container-images-ci.yml` setup a new CI pipeline to only test container image build. This will deprecate a good chunk of `ci-e2e.yml` that is currently building and pushing images, triggering deploys and cypress tests (we will split those into multiple tests).
  
* `.github/workflows/container-images-cd.yml` setup a new CD pipeline to build and push container images on main/master merge. This will publish a new `posthog/posthog:latest` image on DockerHub and `posthog/posthog-cloud:latest` on AWS ECR.

## How did you test this code?
CI is ✅ . It should be generally safe to merge as `ci-e2e.yml` is still the one responsible for deploys.