### PR TITLE
fix: Hide upgrade modal once clicked

### DIFF
--- a/frontend/src/scenes/UpgradeModal.tsx
+++ b/frontend/src/scenes/UpgradeModal.tsx
@@ -22,7 +22,10 @@ export function UpgradeModal(): JSX.Element {
                     <LemonButton
                         type="primary"
                         to={urls.organizationBilling()}
-                        onClick={() => posthog.capture('upgrade modal pricing interaction')}
+                        onClick={() => {
+                            hideUpgradeModal()
+                            posthog.capture('upgrade modal pricing interaction')
+                        }}
                     >
                         Upgrade now
                     </LemonButton>


### PR DESCRIPTION
## Problem

We don't hide the upgrade modal when we navigate away to the billing page

## Changes

* Hides this

NOTE: Probably an idea for the future to add an "hideOnNavigate" property or something (maybe even have that default true...)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
