### PR TITLE
fix: Update 0286 migration with IF NOT EXISTS

### DIFF
--- a/posthog/migrations/0286_index_insightcachingstate_lookup.py
+++ b/posthog/migrations/0286_index_insightcachingstate_lookup.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.RunSQL(
             sql="""
             -- not-null-ignore
-            CREATE INDEX CONCURRENTLY posthog_insightcachingstate_lookup ON posthog_insightcachingstate (
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS posthog_insightcachingstate_lookup ON posthog_insightcachingstate (
                 last_refresh DESC NULLS LAST,
                 last_refresh_queued_at DESC NULLS LAST,
                 target_cache_age_seconds,


### PR DESCRIPTION
Slack thread: https://posthog.slack.com/archives/C02E3BKC78F/p1672737102331669

Not sure why this blew up though - smells like trouble around migration execution?