### PR TITLE
fix: Use import to avoid circular import in generate_demo_data

### DIFF
--- a/posthog/tasks/demo_create_data.py
+++ b/posthog/tasks/demo_create_data.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from sentry_sdk import capture_exception
 
-import posthog.demo.matrix.manager as manager
+from posthog.demo.matrix import manager```
 from posthog.demo.products.hedgebox.matrix import HedgeboxMatrix
 from posthog.models.team.team import Team
 from posthog.models.user import User

--- a/posthog/tasks/demo_create_data.py
+++ b/posthog/tasks/demo_create_data.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from sentry_sdk import capture_exception
 
-from posthog.demo.matrix import manager```
+from posthog.demo.matrix import manager
 from posthog.demo.products.hedgebox.matrix import HedgeboxMatrix
 from posthog.models.team.team import Team
 from posthog.models.user import User

--- a/posthog/tasks/demo_create_data.py
+++ b/posthog/tasks/demo_create_data.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from sentry_sdk import capture_exception
 
-from posthog.demo.matrix.manager import MatrixManager
+import posthog.demo.matrix.manager as manager
 from posthog.demo.products.hedgebox.matrix import HedgeboxMatrix
 from posthog.models.team.team import Team
 from posthog.models.user import User
@@ -13,7 +13,7 @@ def create_data_for_demo_team(team_id: int, user_id: int) -> None:
     user = User.objects.get(pk=user_id)
     if team and user:
         try:
-            MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, user)
+            manager.MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, user)
         except Exception as e:  # TODO: Remove this after 2022-12-22, the except is just temporary for debugging
             capture_exception(e)
             raise e


### PR DESCRIPTION
## Problem

The `demo_create_data` submodule is loaded upon initializing the `tasks` module, as `tasks` uses a `from . import demo_create_data` statement.

This causes the `demo_create_data` submodule to also run its import statements, including attempting to `from posthog.demo.matrix.manager import MatrixManager`.

This produces an import cycle when running `generate_demo_data` as the `manager` submodule (required by the `generate_demo_data` command) imports a task from the `tasks` module.

## Changes

Using `import posthog.demo.matrix.manager as manager` instead of `from posthog.demo.matrix.manager import MatrixManager` avoids the cycle, at the cost of an alias. 

This is probably the simplest solution, but a more comprehensive one would have refactored the initialization of the `tasks` module to use `import ...` instead of `from . import ...`. However that would have required more understanding of where are the submodules exposed by `tasks` used, and higher risk overall.

## How did you test this code?

Follow the [Develop Locally documentation](https://posthog.com/handbook/engineering/developing-locally) until you get to step 6 and run the recommended command to generate test data:

```sh
DEBUG=1 ./manage.py generate_demo_data -h
```

Or just run the command if you have already setup PostHog locally.

`master` branch fails with a:

```sh
File "/home/tomasfarias/src/github.com/PostHog/posthog/posthog/tasks/demo_create_data.py", line 4, in <module>
    from posthog.demo.matrix.manager import MatrixManager
ImportError: cannot import name 'MatrixManager' from partially initialized module 'posthog.demo.matrix.manager' (most likely due to a circular import) (/home/tomasfarias/src/github.com/PostHog/posthog/posthog/demo/matrix/manager.py)
```

Where as patch works as expected.

A unit test that uses `call_command` could be added, however when running the full testing pipeline the import error is missed. Only when the test is running alone does it pop up. This is likely due to `MatrixManager` being imported by a test running before, so Python can avoid the cycle by using this instead. Perhaps looking into deleting the module from `sys.modules` could work...