### PR TITLE
fix(plugins-api): make rearrange endpoint work by checking context content

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -496,7 +496,7 @@ class PluginConfigSerializer(serializers.ModelSerializer):
         return new_plugin_config
 
     def get_plugin_info(self, plugin_config: PluginConfig):
-        if self.context["view"].action == "retrieve":
+        if "view" in self.context and self.context["view"].action == "retrieve":
             return PluginSerializer(instance=plugin_config.plugin).data
         else:
             return None


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/12217 seems to have broken the `/rearrange` endpoint as `context` doesn't have view when the serializer is initialized