### PR TITLE
chore(feature-flag): return false instead of none on unmatched flags

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -14,7 +14,7 @@ from posthog.api.utils import get_project_id, get_token
 from posthog.exceptions import RequestParsingError, generate_exception_response
 from posthog.logging.timing import timed
 from posthog.models import Team, User
-from posthog.models.feature_flag import get_active_feature_flags
+from posthog.models.feature_flag import get_feature_flags
 from posthog.plugins.site import get_decide_site_apps
 from posthog.utils import cors_response, get_ip_address, load_data_from_request
 
@@ -147,14 +147,16 @@ def get_decide(request: HttpRequest):
                 **(data.get("person_properties") or {}),
             }
 
-            feature_flags, _ = get_active_feature_flags(
+            feature_flags, _ = get_feature_flags(
                 team.pk,
                 data["distinct_id"],
                 data.get("groups") or {},
                 hash_key_override=data.get("$anon_distinct_id"),
                 property_value_overrides=all_property_overrides,
                 group_property_value_overrides=(data.get("group_properties") or {}),
+                only_active=(api_version < 3),
             )
+
             response["featureFlags"] = feature_flags if api_version >= 2 else list(feature_flags.keys())
             response["capturePerformance"] = True if team.capture_performance_opt_in else False
 

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -647,7 +647,7 @@ def get_active_feature_flags(
 
     all_feature_flags = (
         feature_flags
-        if feature_flags
+        if feature_flags is not None
         else FeatureFlag.objects.filter(team_id=team_id, active=True, deleted=False).only(
             "id", "team_id", "filters", "key", "rollout_percentage", "ensure_experience_continuity"
         )

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -623,13 +623,13 @@ def get_feature_flags(
         hash_key_override,
         property_value_overrides,
         group_property_value_overrides,
-        feature_flags=all_feature_flags,
+        feature_flags=list(all_feature_flags),
     )
 
     if only_active:
         return active_flags, active_flag_reasons
 
-    all_flags_response = {flag.key: False for flag in all_feature_flags}
+    all_flags_response: Dict[str, Union[str, bool]] = {flag.key: False for flag in all_feature_flags}
     all_flags_response.update(active_flags)
     return all_flags_response, active_flag_reasons
 
@@ -693,7 +693,7 @@ def get_active_feature_flags(
             # would fail server side anyway.
 
         if person_id is not None:
-            set_feature_flag_hash_key_overrides(all_feature_flags, team_id, person_id, hash_key_override)
+            set_feature_flag_hash_key_overrides(list(all_feature_flags), team_id, person_id, hash_key_override)
 
     # :TRICKY: Consistency matters only when personIDs exist
     # as overrides are stored on personIDs.
@@ -711,7 +711,7 @@ def get_active_feature_flags(
 
 
 def set_feature_flag_hash_key_overrides(
-    feature_flags: QuerySet, team_id: int, person_id: int, hash_key_override: str
+    feature_flags: List[FeatureFlag], team_id: int, person_id: int, hash_key_override: str
 ) -> None:
 
     existing_flag_overrides = set(

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -611,7 +611,7 @@ def get_feature_flags(
     hash_key_override: Optional[str] = None,
     property_value_overrides: Dict[str, Union[str, int]] = {},
     group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
-    only_active: bool = False,
+    only_active: bool = True,
 ) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict]]:
     all_feature_flags = FeatureFlag.objects.filter(team_id=team_id, active=True, deleted=False).only(
         "id", "team_id", "filters", "key", "rollout_percentage", "ensure_experience_continuity"

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1599,7 +1599,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
         all_feature_flags = FeatureFlag.objects.filter(team_id=self.team.pk)
 
         set_feature_flag_hash_key_overrides(
-            all_feature_flags, team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
+            list(all_feature_flags), team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
         )
 
         with connection.cursor() as cursor:
@@ -1615,7 +1615,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
         all_feature_flags = FeatureFlag.objects.filter(team_id=self.team.pk)
 
         set_feature_flag_hash_key_overrides(
-            all_feature_flags, team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
+            list(all_feature_flags), team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
         )
 
         hash_keys = hash_key_overrides(self.team.pk, self.person.id)
@@ -1639,7 +1639,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
 
         # and now we come to get new overrides
         set_feature_flag_hash_key_overrides(
-            all_feature_flags, team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
+            list(all_feature_flags), team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
         )
 
         with connection.cursor() as cursor:


### PR DESCRIPTION
## Problem

- can't tell if feature flags are enabled and false or disabled
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- returns all flags in decide v3 endpoint
- https://github.com/PostHog/meta/pull/74

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
