### PR TITLE
fix(funnels): standardize rounding for conversion percentages

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -387,7 +387,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                         },
                                                         {
                                                             title: 'Conversion rate (total)',
-                                                            value: percentage(breakdown.conversionRates.total, 1, true),
+                                                            value: percentage(breakdown.conversionRates.total, 2, true),
                                                         },
                                                         {
                                                             title: `Conversion rate (from step ${
@@ -395,7 +395,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                             })`,
                                                             value: percentage(
                                                                 breakdown.conversionRates.fromPrevious,
-                                                                1,
+                                                                2,
                                                                 true
                                                             ),
                                                             visible: step.order !== 0,
@@ -415,7 +415,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                             title: `Dropoff rate (from step ${previousStep.order + 1})`,
                                                             value: percentage(
                                                                 1 - breakdown.conversionRates.fromPrevious,
-                                                                1,
+                                                                2,
                                                                 true
                                                             ),
                                                             visible:
@@ -462,11 +462,11 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                 },
                                                 {
                                                     title: 'Conversion rate (total)',
-                                                    value: percentage(step.conversionRates.total, 1, true),
+                                                    value: percentage(step.conversionRates.total, 2, true),
                                                 },
                                                 {
                                                     title: `Conversion rate (from step ${previousStep.order + 1})`,
-                                                    value: percentage(step.conversionRates.fromPrevious, 1, true),
+                                                    value: percentage(step.conversionRates.fromPrevious, 2, true),
                                                     visible: step.order !== 0,
                                                 },
                                                 {
@@ -480,7 +480,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                 },
                                                 {
                                                     title: `Dropoff rate (from step ${previousStep.order + 1})`,
-                                                    value: percentage(1 - step.conversionRates.fromPrevious, 1, true),
+                                                    value: percentage(1 - step.conversionRates.fromPrevious, 2, true),
                                                     visible: step.order !== 0 && step.droppedOffFromPrevious > 0,
                                                 },
                                                 {
@@ -525,7 +525,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                             (
                                             {percentage(
                                                 step.order > 0 ? step.count / steps[stepIndex - 1].count : 1,
-                                                1,
+                                                2,
                                                 true
                                             )}
                                             )
@@ -557,7 +557,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                             (
                                             {percentage(
                                                 step.order > 0 ? 1 - step.count / steps[stepIndex - 1].count : 0,
-                                                1,
+                                                2,
                                                 true
                                             )}
                                             )


### PR DESCRIPTION
## Problem

In some places we rounded conversion percentages to 2 decimal points and in other places to 1. This caused some confusion for users.

## Changes

Round all percentages for funnel conversion to 2 decimal points

## How did you test this code?

Manually tested it
