### PR TITLE
feat: set export batch size based on plugin settings

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -47,7 +47,7 @@
         "@posthog/clickhouse": "^1.7.0",
         "@posthog/piscina": "^3.2.0-posthog",
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "1.3.4",
+        "@posthog/plugin-scaffold": "1.4.0",
         "@sentry/node": "^7.17.4",
         "@sentry/tracing": "^7.17.4",
         "@sentry/utils": "^7.17.4",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -15,7 +15,7 @@ specifiers:
   '@posthog/clickhouse': ^1.7.0
   '@posthog/piscina': ^3.2.0-posthog
   '@posthog/plugin-contrib': ^0.0.5
-  '@posthog/plugin-scaffold': 1.3.4
+  '@posthog/plugin-scaffold': 1.4.0
   '@sentry/node': ^7.17.4
   '@sentry/tracing': ^7.17.4
   '@sentry/types': ^7.17.4
@@ -105,7 +105,7 @@ dependencies:
   '@posthog/clickhouse': 1.7.0
   '@posthog/piscina': 3.2.0-posthog
   '@posthog/plugin-contrib': 0.0.5
-  '@posthog/plugin-scaffold': 1.3.4
+  '@posthog/plugin-scaffold': 1.4.0
   '@sentry/node': 7.17.4
   '@sentry/tracing': 7.17.4
   '@sentry/utils': 7.17.4
@@ -2399,8 +2399,8 @@ packages:
     resolution: {integrity: sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==}
     dev: false
 
-  /@posthog/plugin-scaffold/1.3.4:
-    resolution: {integrity: sha512-69AC7GA3sU/z5X6SVlH7mgj+0XgolvOp9IUtvRNA4CXF/OglFM81SXbTkURxL9VBSNfdAZxRp+8x+h4rmyj4dw==}
+  /@posthog/plugin-scaffold/1.4.0:
+    resolution: {integrity: sha512-vDSc0ElMeeZkCGRjfIqkzTYZxeL7dOc0osw4wbQ0gLt0N2Csy4H/gHtoj0qum/b90ge3cGcHyHYIwld804mrfg==}
     dependencies:
       '@maxmind/geoip2-node': 3.5.0
     dev: false

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -5,6 +5,7 @@ import {
     PluginAttachment,
     PluginConfigSchema,
     PluginEvent,
+    PluginSettings,
     ProcessedPluginEvent,
     Properties,
 } from '@posthog/plugin-scaffold'
@@ -401,6 +402,7 @@ export type WorkerMethods = {
 export type VMMethods = {
     setupPlugin?: () => Promise<void>
     teardownPlugin?: () => Promise<void>
+    getSettings?: () => PluginSettings
     onEvent?: (event: ProcessedPluginEvent) => Promise<void>
     onSnapshot?: (event: ProcessedPluginEvent) => Promise<void>
     exportEvents?: (events: PluginEvent[]) => Promise<void>

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -13,7 +13,7 @@ import { createStorage } from '../../../../../src/worker/vm/extensions/storage'
 import { createUtils } from '../../../../../src/worker/vm/extensions/utilities'
 import {
     addHistoricalEventsExportCapabilityV2,
-    EVENTS_PER_RUN,
+    EVENTS_PER_RUN_SMALL,
     EXPORT_COORDINATION_KEY,
     EXPORT_PARAMETERS_KEY,
     ExportHistoricalEventsJobPayload,
@@ -669,22 +669,22 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
         }
 
         it('increases only offset if more in current time range', () => {
-            expect(nextCursor(defaultPayload, EVENTS_PER_RUN)).toEqual({
+            expect(nextCursor(defaultPayload, EVENTS_PER_RUN_SMALL)).toEqual({
                 timestampCursor: defaultPayload.timestampCursor,
                 fetchTimeInterval: ONE_HOUR,
-                offset: EVENTS_PER_RUN,
+                offset: EVENTS_PER_RUN_SMALL,
             })
         })
         it('increases only offset if more in current time range on a late page', () => {
-            expect(nextCursor({ ...defaultPayload, offset: 5 * EVENTS_PER_RUN }, EVENTS_PER_RUN)).toEqual({
+            expect(nextCursor({ ...defaultPayload, offset: 5 * EVENTS_PER_RUN_SMALL }, EVENTS_PER_RUN_SMALL)).toEqual({
                 timestampCursor: defaultPayload.timestampCursor,
                 fetchTimeInterval: ONE_HOUR,
-                offset: 6 * EVENTS_PER_RUN,
+                offset: 6 * EVENTS_PER_RUN_SMALL,
             })
         })
 
         it('returns existing fetchTimeInterval if time range mostly full', () => {
-            expect(nextCursor(defaultPayload, EVENTS_PER_RUN * 0.9)).toEqual({
+            expect(nextCursor(defaultPayload, EVENTS_PER_RUN_SMALL * 0.9)).toEqual({
                 timestampCursor: defaultPayload.timestampCursor + defaultPayload.fetchTimeInterval,
                 fetchTimeInterval: ONE_HOUR,
                 offset: 0,
@@ -692,7 +692,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
         })
 
         it('increases fetchTimeInterval if time range mostly empty', () => {
-            expect(nextCursor(defaultPayload, EVENTS_PER_RUN * 0.1)).toEqual({
+            expect(nextCursor(defaultPayload, EVENTS_PER_RUN_SMALL * 0.1)).toEqual({
                 timestampCursor: defaultPayload.timestampCursor + defaultPayload.fetchTimeInterval,
                 fetchTimeInterval: ONE_HOUR * hub.HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER,
                 offset: 0,
@@ -704,7 +704,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 ...defaultPayload,
                 fetchTimeInterval: 11.5 * 60 * 60 * 1000, // 11.5 hours
             }
-            expect(nextCursor(payload, EVENTS_PER_RUN * 0.1)).toEqual({
+            expect(nextCursor(payload, EVENTS_PER_RUN_SMALL * 0.1)).toEqual({
                 timestampCursor: payload.timestampCursor + payload.fetchTimeInterval,
                 fetchTimeInterval: 12 * 60 * 60 * 1000,
                 offset: 0,
@@ -712,7 +712,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
         })
 
         it('decreases fetchTimeInterval if on a late page and no more to fetch', () => {
-            expect(nextCursor({ ...defaultPayload, offset: 5 * EVENTS_PER_RUN }, 10)).toEqual({
+            expect(nextCursor({ ...defaultPayload, offset: 5 * EVENTS_PER_RUN_SMALL }, 10)).toEqual({
                 timestampCursor: defaultPayload.timestampCursor + defaultPayload.fetchTimeInterval,
                 fetchTimeInterval: ONE_HOUR / hub.HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER,
                 offset: 0,
@@ -722,7 +722,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
         it('does not decrease fetchTimeInterval below 10 minutes', () => {
             const payload = {
                 ...defaultPayload,
-                offset: 5 * EVENTS_PER_RUN,
+                offset: 5 * EVENTS_PER_RUN_SMALL,
                 fetchTimeInterval: 10.5 * 60 * 1000, // 10.5 minutes
             }
 
@@ -749,18 +749,34 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
             })
         })
 
-        it('specifically for the S3 exporter, make sure to use a larger than default batch size', () => {
+        it('make sure to use a larger batch size if the plugin recommends it', () => {
             // NOTE: this doesn't actually check that this value is used in the
             // requests to ClickHouse, but :fingercrossed: it's good enough.
             createVM()
+
+            // When no settings are returned, the default small batch size is used
             let eventsPerRun = addHistoricalEventsExportCapabilityV2(
+                hub,
+                { plugin: { name: 'S3 Export Plugin' } } as any,
+                vm
+            ).eventsPerRun
+            expect(eventsPerRun).toEqual(500)
+
+            // Set the handlesLargeBatches flag to true and expect a big batch size
+            vm.methods.getSettings = jest.fn().mockReturnValue({
+                handlesLargeBatches: true,
+            })
+            eventsPerRun = addHistoricalEventsExportCapabilityV2(
                 hub,
                 { plugin: { name: 'S3 Export Plugin' } } as any,
                 vm
             ).eventsPerRun
             expect(eventsPerRun).toEqual(10000)
 
-            // Otherwise it should be the default, 500
+            // Keep the default of 500 if the flag is false
+            vm.methods.getSettings = jest.fn().mockReturnValue({
+                handlesLargeBatches: false,
+            })
             eventsPerRun = addHistoricalEventsExportCapabilityV2(
                 hub,
                 { plugin: { name: 'foo' } } as any,


### PR DESCRIPTION
## Problem

Sister PR to https://github.com/PostHog/plugin-scaffold/pull/52 and https://github.com/PostHog/s3-export-plugin/pull/22: exports to blob storage (s3 / gcs / snowflake) should use a higher batch size than the default 500, to improve throughput and reduce cost.

## Changes

https://github.com/PostHog/posthog/pull/13481 hard an ad-hoc solution for s3, we're generalizing it, based on a signal given by the plugin itself.

Cannot deploy yet until the s3 changes are released to prod-us, in the meantime I'll leave it in draft.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
