### PR TITLE
fix: a few unified panel bugs

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -449,6 +449,11 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             },
         ],
 
+        playbackIndicatorIndexStop: [
+            (s) => [s.playbackIndicatorIndex, s.items],
+            (playbackIndicatorIndex, items): number => (items.length + playbackIndicatorIndex) % items.length,
+        ],
+
         fuse: [
             (s) => [s.allItems],
             (allItems): Fuse =>

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -111,10 +111,8 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
         ],
 
         syncScroll: [
-            true,
+            false,
             {
-                setTab: () => true,
-                setMiniFilter: () => true,
                 setSyncScroll: (_, { syncScroll }) => syncScroll,
                 setItemExpanded: () => false,
             },

--- a/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorList.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { UnverifiedEvent, IconTerminal, IconGauge } from 'lib/components/icons'
-import { colonDelimitedDuration } from 'lib/utils'
+import { ceilMsToClosestSecond, colonDelimitedDuration } from 'lib/utils'
 import { useEffect, useMemo, useRef } from 'react'
 import { List, ListRowRenderer } from 'react-virtualized/dist/es/List'
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized/dist/es/CellMeasurer'
@@ -122,8 +122,9 @@ function PlayerInspectorListItem({
                     noPadding
                     status="primary-alt"
                     onClick={() => {
-                        // NOTE: We offset by 1 second so that the playback startsjust before the event occurs
-                        seekToTime(item.timeInRecording - 1000)
+                        // NOTE: We offset by 1 second so that the playback starts just before the event occurs.
+                        // Ceiling second is used since this is what's displayed to the user.
+                        seekToTime(ceilMsToClosestSecond(item.timeInRecording) - 1000)
                     }}
                 >
                     <span className="p-1 text-xs">
@@ -186,7 +187,11 @@ export function PlayerInspectorList(props: SessionRecordingPlayerLogicProps): JS
 
     useEffect(() => {
         if (listRef.current) {
-            const offset = range(playbackIndicatorIndex).reduce((acc, x) => acc + cellMeasurerCache.getHeight(x, 0), 0)
+            const offset = range((items.length + playbackIndicatorIndex) % items.length).reduce(
+                (acc, x) => acc + cellMeasurerCache.getHeight(x, 0),
+                0
+            )
+            console.log('OFFSET', offset, playbackIndicatorIndex, range(playbackIndicatorIndex), syncScroll)
             document
                 .getElementById('PlayerInspectorListMarker')
                 ?.setAttribute('style', `transform: translateY(${offset}px)`)

--- a/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorList.tsx
@@ -152,7 +152,9 @@ function PlayerInspectorListItem({
 }
 
 export function PlayerInspectorList(props: SessionRecordingPlayerLogicProps): JSX.Element {
-    const { items, playbackIndicatorIndex, syncScroll, tab, loading } = useValues(playerInspectorLogic(props))
+    const { items, playbackIndicatorIndex, playbackIndicatorIndexStop, syncScroll, tab, loading } = useValues(
+        playerInspectorLogic(props)
+    )
     const { setSyncScroll } = useActions(playerInspectorLogic(props))
     const { currentTeam } = useValues(teamLogic)
     const { hasAvailableFeature } = useValues(userLogic)
@@ -187,11 +189,10 @@ export function PlayerInspectorList(props: SessionRecordingPlayerLogicProps): JS
 
     useEffect(() => {
         if (listRef.current) {
-            const offset = range((items.length + playbackIndicatorIndex) % items.length).reduce(
+            const offset = range(playbackIndicatorIndexStop).reduce(
                 (acc, x) => acc + cellMeasurerCache.getHeight(x, 0),
                 0
             )
-            console.log('OFFSET', offset, playbackIndicatorIndex, range(playbackIndicatorIndex), syncScroll)
             document
                 .getElementById('PlayerInspectorListMarker')
                 ?.setAttribute('style', `transform: translateY(${offset}px)`)


### PR DESCRIPTION
## Problem

- [x] synced scrolling is turned on automatically could create a strobing effect and affect for accessibility
- [x] clicking a timestamp that is within a second of the previous event's timestamp takes you to the point in time before the previous event
- [x] synced scrolling setting keeps getting reset to true when tab or mini filter changes
- [x] when the event indicator gets to the last event, it will loop back to the beginning of the list

## Changes

- fixes all the bugs above!

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👁️ 
