### PR TITLE
fix(demo): wait until demo data is ready before redirecting

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -129,7 +129,6 @@ export const FEATURE_FLAGS = {
     WEBSITE_ANALYTICS_TEMPLATE: 'website-analytics-template', // owner: @pauldambra
     VARIANT_OVERRIDES: 'variant-overrides', // owner: @neilkakkar
     ONBOARDING_V2_EXPERIMENT: 'onboarding-v2-experiment', // owner: #team-growth
-    ONBOARDING_DEMO_EXPERIMENT: 'onboarding-demo-experiment', // owner: #team-growth
     FEATURE_FLAG_ROLLOUT_UX: 'feature-flag-rollout-ux', // owner: @neilkakkar
     ROLE_BASED_ACCESS: 'role-based-access', // owner: #team-experiments, @liyiy
     DASHBOARD_TEMPLATES: 'dashboard-templates', // owner @pauldambra

--- a/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
@@ -293,7 +293,7 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
                 setState: (_, { generatingDemoData }) => generatingDemoData,
             },
         ],
-        interval: [
+        demoDataInterval: [
             null as null | number,
             {
                 setDemoDataInterval: (_, { demoDataInterval }) => demoDataInterval,

--- a/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
+++ b/frontend/src/scenes/ingestion/v2/ingestionLogicV2.ts
@@ -16,6 +16,7 @@ import { BillingType, TeamType } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import type { ingestionLogicV2Type } from './ingestionLogicV2Type'
+import api from 'lib/api'
 
 export enum INGESTION_STEPS {
     START = 'Get started',
@@ -168,7 +169,12 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
             inviteLogic,
             ['isInviteModalShown'],
         ],
-        actions: [teamLogic, ['updateCurrentTeamSuccess'], inviteLogic, ['inviteTeamMembersSuccess']],
+        actions: [
+            teamLogic,
+            ['updateCurrentTeamSuccess', 'createTeamSuccess'],
+            inviteLogic,
+            ['inviteTeamMembersSuccess'],
+        ],
     }),
     actions({
         setState: ({
@@ -201,6 +207,8 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         onBack: true,
         goToView: (view: INGESTION_VIEWS) => ({ view }),
         setSidebarSteps: (steps: string[]) => ({ steps }),
+        setIsDemoDataReady: (isDemoDataReady: boolean) => ({ isDemoDataReady }),
+        setDemoDataInterval: (demoDataInterval: number) => ({ demoDataInterval }),
     }),
     windowValues({
         isSmallScreen: (window: Window) => window.innerWidth < getBreakpoint('md'),
@@ -283,6 +291,18 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
             false as boolean | null,
             {
                 setState: (_, { generatingDemoData }) => generatingDemoData,
+            },
+        ],
+        interval: [
+            null as null | number,
+            {
+                setDemoDataInterval: (_, { demoDataInterval }) => demoDataInterval,
+                setIsDemoDataReady: (current, { isDemoDataReady }) => {
+                    if (isDemoDataReady && current) {
+                        clearInterval(current)
+                    }
+                    return null
+                },
             },
         ],
     }),
@@ -512,6 +532,24 @@ export const ingestionLogicV2 = kea<ingestionLogicV2Type>([
         inviteTeamMembersSuccess: () => {
             if (router.values.location.pathname.includes('/ingestion')) {
                 actions.setState(viewToState(INGESTION_VIEWS.TEAM_INVITED, values.currentState as IngestionState))
+            }
+        },
+        createTeamSuccess: ({ currentTeam }) => {
+            if (window.location.href.includes(urls.ingestion()) && currentTeam.is_demo) {
+                const interval = window.setInterval(async () => {
+                    const res = await api.get('api/projects/@current/is_generating_demo_data')
+                    if (!res.is_generating_demo_data) {
+                        actions.setIsDemoDataReady(true)
+                    }
+                }, 1000)
+                actions.setDemoDataInterval(interval)
+            } else {
+                window.location.href = urls.ingestion()
+            }
+        },
+        setIsDemoDataReady: ({ isDemoDataReady }) => {
+            if (isDemoDataReady) {
+                window.location.href = urls.default()
             }
         },
     })),

--- a/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/InviteTeamPanel.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useActions } from 'kea'
 import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
@@ -7,14 +7,11 @@ import { IconChevronRight } from 'lib/components/icons'
 import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DemoProjectButton } from './PanelComponents'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export function InviteTeamPanel(): JSX.Element {
     const { next } = useActions(ingestionLogicV2)
     const { showInviteModal } = useActions(inviteLogic)
     const { reportInviteMembersButtonClicked } = useActions(eventUsageLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <div>
@@ -59,12 +56,10 @@ export function InviteTeamPanel(): JSX.Element {
                         </p>
                     </div>
                 </LemonButton>
-                {featureFlags[FEATURE_FLAGS.ONBOARDING_DEMO_EXPERIMENT] === 'test' ? (
-                    <DemoProjectButton
-                        text="I just want to try PostHog with some demo data."
-                        subtext="Explore insights, create dashboards, try out cohorts, and more."
-                    />
-                ) : null}
+                <DemoProjectButton
+                    text="I just want to try PostHog with some demo data."
+                    subtext="Explore insights, create dashboards, try out cohorts, and more."
+                />
             </div>
         </div>
     )

--- a/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
+++ b/frontend/src/scenes/ingestion/v2/panels/TeamInvitedPanel.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useActions } from 'kea'
 import { ingestionLogicV2 } from 'scenes/ingestion/v2/ingestionLogicV2'
 import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
@@ -6,13 +6,10 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 import { IconChevronRight } from 'lib/components/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DemoProjectButton } from './PanelComponents'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export function TeamInvitedPanel(): JSX.Element {
     const { completeOnboarding } = useActions(ingestionLogicV2)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <div>
@@ -20,12 +17,10 @@ export function TeamInvitedPanel(): JSX.Element {
             <p className="prompt-text">You can still explore PostHog while you wait for your team members to join.</p>
             <LemonDivider thick dashed className="my-6" />
             <div className="flex flex-col mb-6">
-                {featureFlags[FEATURE_FLAGS.ONBOARDING_DEMO_EXPERIMENT] === 'test' ? (
-                    <DemoProjectButton
-                        text="Quickly try PostHog with some demo data."
-                        subtext="Explore insights, create dashboards, try out cohorts, and more."
-                    />
-                ) : null}
+                <DemoProjectButton
+                    text="Quickly try PostHog with some demo data."
+                    subtext="Explore insights, create dashboards, try out cohorts, and more."
+                />
                 <LemonButton
                     onClick={() => {
                         completeOnboarding()

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -11,6 +11,7 @@ import { IconSwapHoriz } from 'lib/components/icons'
 import { loaders } from 'kea-loaders'
 import { OrganizationMembershipLevel } from '../lib/constants'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { urls } from './urls'
 
 const parseUpdatedAttributeName = (attr: string | null): string => {
     if (attr === 'slack_incoming_webhook') {
@@ -148,10 +149,8 @@ export const teamLogic = kea<teamLogicType>([
             lemonToast.success('Project has been deleted')
         },
         createTeamSuccess: ({ currentTeam }) => {
-            if (window.location.href.includes('/ingestion') && currentTeam.is_demo) {
-                window.location.href = '/'
-            } else {
-                window.location.href = '/ingestion'
+            if (!window.location.href.includes(urls.ingestion()) && !currentTeam.is_demo) {
+                window.location.href = urls.ingestion()
             }
         },
     })),

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -11,7 +11,6 @@ import { IconSwapHoriz } from 'lib/components/icons'
 import { loaders } from 'kea-loaders'
 import { OrganizationMembershipLevel } from '../lib/constants'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { urls } from './urls'
 
 const parseUpdatedAttributeName = (attr: string | null): string => {
     if (attr === 'slack_incoming_webhook') {
@@ -147,11 +146,6 @@ export const teamLogic = kea<teamLogicType>([
         },
         deleteTeamSuccess: () => {
             lemonToast.success('Project has been deleted')
-        },
-        createTeamSuccess: ({ currentTeam }) => {
-            if (!window.location.href.includes(urls.ingestion()) && !currentTeam.is_demo) {
-                window.location.href = urls.ingestion()
-            }
         },
     })),
     events(({ actions }) => ({

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -153,7 +153,9 @@ class TeamSerializer(serializers.ModelSerializer):
         organization = self.context["view"].organization  # Use the org we used to validate permissions
         if validated_data.get("is_demo", False):
             team = Team.objects.create(**validated_data, organization=organization)
-            create_data_for_demo_team.delay(team.pk, request.user.pk)
+            cache_key = f"is_generating_demo_data_{team.pk}"
+            cache.set(cache_key, "True")  # create an item in the cache that we can use to see if the demo data is ready
+            create_data_for_demo_team.delay(team.pk, request.user.pk, cache_key)
         else:
             team = Team.objects.create_with_data(**validated_data, organization=organization)
         request.user.current_team = team
@@ -279,3 +281,16 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         team.api_token = generate_random_token_project()
         team.save()
         return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data)
+
+    @action(
+        methods=["GET"],
+        detail=True,
+        permission_classes=[
+            permissions.IsAuthenticated,
+            ProjectMembershipNecessaryPermissions,
+        ],
+    )
+    def is_generating_demo_data(self, request: request.Request, id: str, **kwargs) -> response.Response:
+        team = self.get_object()
+        cache_key = f"is_generating_demo_data_{team.pk}"
+        return response.Response({"is_generating_demo_data": cache.get(cache_key) == "True"})

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -253,6 +253,17 @@ class TestTeamAPI(APIBaseTest):
         # Verify cache was deleted
         self.assertEqual(cache.get(response["filters_hash"]), None)
 
+    def test_is_generating_demo_data(self):
+        cache_key = f"is_generating_demo_data_{self.team.pk}"
+        cache.set(cache_key, "True")
+        response = self.client.get(f"/api/projects/{self.team.id}/is_generating_demo_data/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"is_generating_demo_data": True})
+        cache.delete(cache_key)
+        response = self.client.get(f"/api/projects/{self.team.id}/is_generating_demo_data/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"is_generating_demo_data": False})
+
 
 def create_team(organization: Organization, name: str = "Test team") -> Team:
     """

--- a/posthog/tasks/demo_create_data.py
+++ b/posthog/tasks/demo_create_data.py
@@ -1,5 +1,4 @@
 from celery import shared_task
-from sentry_sdk import capture_exception
 
 from posthog.demo.matrix import manager
 from posthog.demo.products.hedgebox.matrix import HedgeboxMatrix
@@ -12,8 +11,4 @@ def create_data_for_demo_team(team_id: int, user_id: int) -> None:
     team = Team.objects.get(pk=team_id)
     user = User.objects.get(pk=user_id)
     if team and user:
-        try:
-            manager.MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, user)
-        except Exception as e:  # TODO: Remove this after 2022-12-22, the except is just temporary for debugging
-            capture_exception(e)
-            raise e
+        manager.MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, user)

--- a/posthog/tasks/demo_create_data.py
+++ b/posthog/tasks/demo_create_data.py
@@ -1,4 +1,5 @@
 from celery import shared_task
+from django.core.cache import cache
 
 from posthog.demo.matrix import manager
 from posthog.demo.products.hedgebox.matrix import HedgeboxMatrix
@@ -7,8 +8,9 @@ from posthog.models.user import User
 
 
 @shared_task(ignore_result=True)
-def create_data_for_demo_team(team_id: int, user_id: int) -> None:
+def create_data_for_demo_team(team_id: int, user_id: int, cache_key: str) -> None:
     team = Team.objects.get(pk=team_id)
     user = User.objects.get(pk=user_id)
     if team and user:
         manager.MatrixManager(HedgeboxMatrix(), use_pre_save=True).run_on_team(team, user)
+        cache.delete(cache_key)


### PR DESCRIPTION
## Problem

Now that demo data copying actually works, we need to make sure users aren't redirected to the demo project until the demo data is done being copied.

## Changes

* Adds an item to the cache when the demo data copy process starts
* Deletes the item after the copy process finishes
* Adds an endpoint that allows us to retrieve the item
* After demo team is created, polls the endpoint every second until the cache key no longer exists, then redirects to the project/team

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test for the endpoint. Still need to add a suite of cypress tests for the onboarding flow but will do that in another pull.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
