### PR TITLE
fix: remove legacy alert

### DIFF
--- a/frontend/src/lib/components/BillingAlerts.stories.tsx
+++ b/frontend/src/lib/components/BillingAlerts.stories.tsx
@@ -35,10 +35,8 @@ const Template = (): JSX.Element => {
             should_setup_billing: false,
             subscription_url: 'https://posthog.com',
 
-            // BillingAlertType.UsageLimitExceeded
             billing_limit_exceeded: false,
 
-            // BillingAlertType.FreeUsageNearLimit
             is_billing_active: true,
             current_usage: 0,
 
@@ -70,11 +68,6 @@ const Template = (): JSX.Element => {
             payload.event_allocation = 100
         }
 
-        if (alertType === BillingAlertType.FreeUsageNearLimit) {
-            payload.is_billing_active = false
-            payload.current_usage = 10000000000000000
-        }
-
         loadBillingSuccess(payload)
     }, [alertType])
 
@@ -87,7 +80,6 @@ const Template = (): JSX.Element => {
                 onChange={setAlertType}
                 options={[
                     { value: BillingAlertType.SetupBilling, label: 'SetupBilling' },
-                    { value: BillingAlertType.FreeUsageNearLimit, label: 'FreeUsageNearLimit' },
                     { value: BillingAlertType.UsageLimitExceeded, label: 'UsageLimitExceeded' },
                     { value: BillingAlertType.UsageNearLimit, label: 'UsageNearLimit' },
                 ]}

--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -15,20 +15,6 @@ export function BillingAlerts(): JSX.Element | null {
     let isWarning = false
     let isAlert = false
 
-    if (percentage && alertToShow === BillingAlertType.FreeUsageNearLimit) {
-        isWarning = true
-        message = (
-            <p>
-                <b>Warning!</b> You have already used <b className="text-warning">{percentage * 100}%</b> of your 1
-                million free events this month.{' '}
-                <Link to="/organization/billing" data-attr="alert_free_usage_near_limit">
-                    {billing?.plan?.custom_setup_billing_message ||
-                        'To avoid losing data or access to it, upgrade your billing plan now.'}
-                </Link>
-            </p>
-        )
-    }
-
     if (billing?.subscription_url && alertToShow === BillingAlertType.SetupBilling) {
         isWarning = true
         message = (

--- a/frontend/src/scenes/billing/billingLogic.test.ts
+++ b/frontend/src/scenes/billing/billingLogic.test.ts
@@ -213,15 +213,6 @@ describe('billingLogic', () => {
             .toMatchValues({
                 alertToShow: BillingAlertType.UsageNearLimit,
             })
-
-        mockBilling(BILLING_NO_PLAN)
-        await expectLogic(logic, () => {
-            logic.actions.loadBilling()
-        })
-            .toFinishAllListeners()
-            .toMatchValues({
-                alertToShow: BillingAlertType.FreeUsageNearLimit,
-            })
     })
     it('reports that billing has been cancelled during onboarding', async () => {
         router.actions.push('/ingestion/billing?reason=cancelled')

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -25,7 +25,6 @@ export enum BillingAlertType {
     SetupBilling = 'setup_billing',
     UsageNearLimit = 'usage_near_limit',
     UsageLimitExceeded = 'usage_limit_exceeded',
-    FreeUsageNearLimit = 'free_usage_near_limit',
 }
 
 export const billingLogic = kea<billingLogicType>([

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -189,11 +189,6 @@ export const billingLogic = kea<billingLogicType>([
                 ) {
                     return BillingAlertType.UsageNearLimit
                 }
-
-                // Priority 4: Users on free account that are almost reaching free events threshold
-                if (!billing?.is_billing_active && billing?.current_usage && percentage > ALLOCATION_THRESHOLD_ALERT) {
-                    return BillingAlertType.FreeUsageNearLimit
-                }
             },
         ],
     }),


### PR DESCRIPTION
## Problem
An old billing v1 alert is flickering when an organization is loading. We can safely remove it as we're moving everybody to v2 and we're eventually going to remove everything v1 from the code.

## Changes
Remove the alert, and everything related to it.

## How did you test this code?
Tested locally