### PR TITLE
feat(saml): expose some useful vars

### DIFF
--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
@@ -7,10 +7,14 @@ import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { LemonTextArea } from 'lib/components/LemonTextArea/LemonTextArea'
 import { LemonModal } from 'lib/components/LemonModal'
 import { Form } from 'kea-forms'
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 export function ConfigureSAMLModal(): JSX.Element {
     const { configureSAMLModalId, isSamlConfigSubmitting, samlConfig } = useValues(verifiedDomainsLogic)
     const { setConfigureSAMLModalId } = useActions(verifiedDomainsLogic)
+    const { preflight } = useValues(preflightLogic)
+    const siteUrl = preflight?.site_url ?? window.location.origin
 
     const samlReady = samlConfig.saml_acs_url && samlConfig.saml_entity_id && samlConfig.saml_x509_cert
 
@@ -26,14 +30,18 @@ export function ConfigureSAMLModal(): JSX.Element {
                     <h3>Configure SAML authentication and provisioning</h3>
                 </LemonModal.Header>
                 <LemonModal.Content className="space-y-2">
+                    <Field label="ACS Consumer URL" name="_ACSConsumerUrl">
+                        <CopyToClipboardInline>{`${siteUrl}/complete/saml`}</CopyToClipboardInline>
+                    </Field>
+                    <Field label="RelayState" name="_RelayState">
+                        <CopyToClipboardInline>{configureSAMLModalId ?? undefined}</CopyToClipboardInline>
+                    </Field>
                     <Field name="saml_acs_url" label="SAML ACS URL">
                         <LemonInput className="ph-ignore-input" placeholder="Your IdP's ACS or single sign-on URL." />
                     </Field>
-
                     <Field name="saml_entity_id" label="SAML Entity ID">
                         <LemonInput className="ph-ignore-input" placeholder="Entity ID provided by your IdP." />
                     </Field>
-
                     <Field name="saml_x509_cert" label="SAML X.509 Certificate">
                         <LemonTextArea
                             className="ph-ignore-input"


### PR DESCRIPTION
## Problem

Exposes some parameters that are useful when configuring SAML

## Changes

Before:

![Screenshot 2023-01-05 at 15 32 54](https://user-images.githubusercontent.com/53387/210807443-85d9a61a-a285-4466-a295-c2aec9bd4b92.png)

After:

![Screenshot 2023-01-05 at 15 45 56](https://user-images.githubusercontent.com/53387/210807457-9a01c9b6-9138-41a3-bf96-7d9e4c3d1dfb.png)

## How did you test this code?

Locally the variables got exposed, and using the newly exposed RelayState helped a customer properly connect to our SAML.