### PR TITLE
feat(feature-flag): feature flag v3 json payload

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -175,7 +175,7 @@ def _ensure_web_feature_flags_in_properties(
     """If the event comes from web, ensure that it contains property $active_feature_flags."""
     if event["properties"].get("$lib") == "web" and "$active_feature_flags" not in event["properties"]:
         statsd.incr("active_feature_flags_missing")
-        flags, _ = get_active_feature_flags(team_id=ingestion_context.team_id, distinct_id=distinct_id)
+        flags, _, _ = get_active_feature_flags(team_id=ingestion_context.team_id, distinct_id=distinct_id)
         flag_keys = list(flags.keys())
         event["properties"]["$active_feature_flags"] = flag_keys
 

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -155,6 +155,7 @@ def get_decide(request: HttpRequest):
                 property_value_overrides=all_property_overrides,
                 group_property_value_overrides=(data.get("group_properties") or {}),
                 only_active=(api_version < 3),
+                only_string=(api_version < 3),
             )
 
             response["featureFlags"] = feature_flags if api_version >= 2 else list(feature_flags.keys())

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -147,7 +147,7 @@ def get_decide(request: HttpRequest):
                 **(data.get("person_properties") or {}),
             }
 
-            feature_flags, _ = get_feature_flags(
+            feature_flags, _, feature_flag_payloads = get_feature_flags(
                 team.pk,
                 data["distinct_id"],
                 data.get("groups") or {},
@@ -155,10 +155,13 @@ def get_decide(request: HttpRequest):
                 property_value_overrides=all_property_overrides,
                 group_property_value_overrides=(data.get("group_properties") or {}),
                 only_active=(api_version < 3),
-                only_string=(api_version < 3),
             )
 
             response["featureFlags"] = feature_flags if api_version >= 2 else list(feature_flags.keys())
+
+            if api_version >= 3:
+                response["featureFlagPayloads"] = feature_flag_payloads
+
             response["capturePerformance"] = True if team.capture_performance_opt_in else False
 
             if team.session_recording_opt_in and (

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -269,7 +269,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
         if not feature_flag_list:
             return Response(flags)
 
-        matches, _ = FeatureFlagMatcher(feature_flag_list, request.user.distinct_id, groups).get_matches()
+        matches, _, _ = FeatureFlagMatcher(feature_flag_list, request.user.distinct_id, groups).get_matches()
         for feature_flag in feature_flags:
             flags.append(
                 {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -319,7 +319,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
         if not distinct_id:
             raise exceptions.ValidationError(detail="distinct_id is required")
 
-        flags, reasons = get_active_feature_flags(self.team_id, distinct_id, groups)
+        flags, reasons, _ = get_active_feature_flags(self.team_id, distinct_id, groups)
 
         flags_with_evaluation_reasons = {}
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -286,7 +286,7 @@ class TestDecide(BaseTest):
             response = self._post_decide(api_version=3)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual("first-variant", response.json()["featureFlags"]["multivariate-flag"])
-            self.assertEqual({"color": "blue"}, response.json()["featureFlagPayloads"]["first-variant"])
+            self.assertEqual({"color": "blue"}, response.json()["featureFlagPayloads"]["multivariate-flag"])
 
     def test_feature_flags_v2(self):
         self.team.app_urls = ["https://example.com"]

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -260,9 +260,14 @@ class TestDecide(BaseTest):
                 "groups": [{"properties": [], "rollout_percentage": None}],
                 "multivariate": {
                     "variants": [
-                        {"key": {"color": "blue"}, "name": "First Variant", "rollout_percentage": 50},
-                        {"key": {"color": "red"}, "name": "Second Variant", "rollout_percentage": 25},
-                        {"key": {"color": "green"}, "name": "Third Variant", "rollout_percentage": 25},
+                        {
+                            "key": "first-variant",
+                            "name": "First Variant",
+                            "rollout_percentage": 50,
+                            "payload": {"color": "blue"},
+                        },
+                        {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                        {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
                     ]
                 },
             },
@@ -274,13 +279,14 @@ class TestDecide(BaseTest):
         with self.assertNumQueries(2):
             response = self._post_decide(api_version=2)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertNotIn("multivariate", response.json()["featureFlags"])
+            self.assertIn("beta-feature", response.json()["featureFlags"])
+            self.assertEqual("first-variant", response.json()["featureFlags"]["multivariate-flag"])
 
         with self.assertNumQueries(2):
             response = self._post_decide(api_version=3)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertIn("beta-feature", response.json()["featureFlags"])
-            self.assertEqual({"color": "blue"}, response.json()["featureFlags"]["multivariate-flag"])
+            self.assertEqual("first-variant", response.json()["featureFlags"]["multivariate-flag"])
+            self.assertEqual({"color": "blue"}, response.json()["featureFlagPayloads"]["first-variant"])
 
     def test_feature_flags_v2(self):
         self.team.app_urls = ["https://example.com"]

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -239,6 +239,49 @@ class TestDecide(BaseTest):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["featureFlags"], ["default-flag"])
 
+    def test_feature_flags_v3_json(self):
+        self.team.app_urls = ["https://example.com"]
+        self.team.save()
+        self.client.logout()
+        Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
+        FeatureFlag.objects.create(
+            team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            filters={"groups": [{"properties": [], "rollout_percentage": None}]},
+            name="This is a feature flag with default params, no filters.",
+            key="default-flag",
+            created_by=self.user,
+        )  # Should be enabled for everyone
+        FeatureFlag.objects.create(
+            team=self.team,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": None}],
+                "multivariate": {
+                    "variants": [
+                        {"key": {"color": "blue"}, "name": "First Variant", "rollout_percentage": 50},
+                        {"key": {"color": "red"}, "name": "Second Variant", "rollout_percentage": 25},
+                        {"key": {"color": "green"}, "name": "Third Variant", "rollout_percentage": 25},
+                    ]
+                },
+            },
+            name="This is a feature flag with multiple variants.",
+            key="multivariate-flag",
+            created_by=self.user,
+        )
+
+        with self.assertNumQueries(2):
+            response = self._post_decide(api_version=2)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertNotIn("multivariate", response.json()["featureFlags"])
+
+        with self.assertNumQueries(2):
+            response = self._post_decide(api_version=3)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("beta-feature", response.json()["featureFlags"])
+            self.assertEqual({"color": "blue"}, response.json()["featureFlags"]["multivariate-flag"])
+
     def test_feature_flags_v2(self):
         self.team.app_urls = ["https://example.com"]
         self.team.save()

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -125,13 +125,13 @@ class FeatureFlag(models.Model):
         return []
 
     @property
-    def is_string_type(self):
+    def has_json_variant(self):
         is_multivariate = self.get_filters().get("multivariate", None)
         if is_multivariate is not None:
             for variant in self.variants:
                 if not isinstance(variant["key"], str):
-                    return False
-        return True
+                    return True
+        return False
 
     def get_filters(self):
         if "groups" in self.filters:
@@ -667,7 +667,7 @@ def get_active_feature_flags(
     )
 
     if only_string:
-        all_feature_flags = [flag for flag in all_feature_flags if flag.is_string_type]
+        all_feature_flags = [flag for flag in all_feature_flags if not flag.has_json_variant]
 
     flags_have_experience_continuity_enabled = any(
         feature_flag.ensure_experience_continuity for feature_flag in all_feature_flags

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -365,7 +365,7 @@ class FeatureFlagMatcher:
             match=False, reason=highest_priority_evaluation_reason, condition_index=highest_priority_index
         )
 
-    def get_matches(self) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, Optional[Dict]]]:
+    def get_matches(self) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, dict]]:
         flags_enabled = {}
         flag_evaluation_reasons = {}
         flag_payloads = {}
@@ -591,7 +591,7 @@ def _get_active_feature_flags(
     groups: Dict[GroupTypeName, str] = {},
     property_value_overrides: Dict[str, Union[str, int]] = {},
     group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
-) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, Optional[Dict]]]:
+) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, dict]]:
     cache = FlagsMatcherCache(team_id)
 
     if person_id is not None:
@@ -621,7 +621,7 @@ def get_feature_flags(
     property_value_overrides: Dict[str, Union[str, int]] = {},
     group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
     only_active: bool = True,
-) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, Optional[Dict]]]:
+) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, dict]]:
     all_feature_flags = FeatureFlag.objects.filter(team_id=team_id, active=True, deleted=False).only(
         "id", "team_id", "filters", "key", "rollout_percentage", "ensure_experience_continuity"
     )
@@ -653,7 +653,7 @@ def get_active_feature_flags(
     property_value_overrides: Dict[str, Union[str, int]] = {},
     group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
     feature_flags: Optional[QuerySet[FeatureFlag]] = None,
-) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, Optional[Dict]]]:
+) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, dict]]:
 
     all_feature_flags = (
         feature_flags

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -374,8 +374,8 @@ class FeatureFlagMatcher:
                 flag_match = self.get_match(feature_flag)
                 if flag_match.match:
                     flags_enabled[feature_flag.key] = flag_match.variant or True
-                    if flag_match.variant is not None:
-                        flag_payloads[flag_match.variant] = flag_match.payload
+                    if flag_match.payload:
+                        flag_payloads[feature_flag.key] = flag_match.payload
 
                 flag_evaluation_reasons[feature_flag.key] = {
                     "reason": flag_match.reason,

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -907,7 +907,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             },
         )
 
-        self.assertEqual(payloads, {"first-variant": {"color": "blue"}})
+        self.assertEqual(payloads, {"variant": {"color": "blue"}})
 
         with self.assertNumQueries(3), snapshot_postgres_queries_context(
             self
@@ -958,7 +958,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             },
         )
 
-        self.assertEqual(payloads, {"first-variant": {"color": "blue"}})
+        self.assertEqual(payloads, {"variant": {"color": "blue"}})
 
     def test_multi_property_filters(self):
         Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
@@ -1699,7 +1699,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             },
         )
 
-        self.assertEqual(payloads, {"first-variant": None})
+        self.assertEqual(payloads, {})
 
 
 class TestFeatureFlagMatcherConsistency(BaseTest):


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes


- flags can accept `payload` item in filters object now
- decide v3 will return corresponding payloads to matched flag keys
```
{
...
"featureFlagPayloads": {
     <flag-key>: <payload>
}
...
}
```

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
