### PR TITLE
ci(plugin-server): wait for server to be listening before running tests

### DIFF
--- a/plugin-server/functional_tests/exports-v1.test.ts
+++ b/plugin-server/functional_tests/exports-v1.test.ts
@@ -43,7 +43,11 @@ beforeAll(async () => {
             res.end()
         })
     })
-    server.listen()
+
+    await new Promise((resolve) => {
+        server.on('listening', resolve)
+        server.listen()
+    })
 })
 
 afterAll(async () => {

--- a/plugin-server/functional_tests/exports-v2.test.ts
+++ b/plugin-server/functional_tests/exports-v2.test.ts
@@ -48,7 +48,11 @@ beforeAll(async () => {
             res.end()
         })
     })
-    server.listen()
+
+    await new Promise((resolve) => {
+        server.on('listening', resolve)
+        server.listen()
+    })
 })
 
 afterAll(async () => {

--- a/plugin-server/functional_tests/webhooks.test.ts
+++ b/plugin-server/functional_tests/webhooks.test.ts
@@ -52,7 +52,10 @@ test.concurrent(`webhooks: fires slack webhook`, async () => {
     })
 
     try {
-        server.listen()
+        await new Promise((resolve) => {
+            server.on('listening', resolve)
+            server.listen()
+        })
 
         const distinctId = new UUIDT().toString()
 


### PR DESCRIPTION
The export tests seem to be very flaky. Looking through the logs on
GitHub Actions it looks like there are some http connection refused
errors, so I'm additionally adding a wait for the listening event to be
emitted to try to remove some racy behaviour.

I also made some improvements to the ci startup script re. timeouts.

cc @benjackwhite I think you were having some flakiness here as well.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
