### PR TITLE
fix: fix ingestion warning link generation

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -104,6 +104,7 @@ export function IngestionWarningsView(): JSX.Element {
                                     <Link
                                         to={`https://posthog.com/manual/data-management#${type
                                             .toLowerCase()
+                                            .replace(',', '')
                                             .split(' ')
                                             .join('-')}`}
                                     >


### PR DESCRIPTION
## Problem

The manual link for the `Ignored an invalid timestamp, event was still ingested` ingestion warning is not consistent with the one generated by the website:

`/manual/data-management#ignored-an-invalid-timestamp,-event-was-still-ingested` should be
`/manual/data-management#ignored-an-invalid-timestamp-event-was-still-ingested`

## Changes

Ad-hoc replace to remove the coma, that replace could be extended with a regex later if we need to filter out more special character.

Ideally, we'd have a dedicated function to generate these anchors, but it's probably fine for now.

## How did you test this code?

good ol' manual QA