### PR TITLE
fix: Only show V1 billing alert if definitely on V1 Billing

### DIFF
--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -5,12 +5,13 @@ import { IconWarning } from './icons'
 import clsx from 'clsx'
 
 export function BillingAlerts(): JSX.Element | null {
-    const { billing } = useValues(billingLogic)
+    const { billing, billingVersion } = useValues(billingLogic)
     const { alertToShow, percentage, strokeColor } = useValues(billingLogic)
 
-    if (!alertToShow) {
+    if (!alertToShow || billingVersion !== 'v1') {
         return null
     }
+
     let message: JSX.Element | undefined
     let isWarning = false
     let isAlert = false


### PR DESCRIPTION
## Problem

Billing V1 loads immediately whereas V2 take a little time. We should only show the alert once both are properly checked.

## Changes

* Only shows if the billingVersion is v1 (i.e. not v2 or undefined)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
