### PR TITLE
feat: Handle future timestamps in ingestion

### DIFF
--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -43,6 +43,8 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
             offset: data['offset'] ?? '',
             now: data['now'],
             result: parsedTs.toISO(),
+            eventUuid: data['uuid'],
+            eventName: data['event'],
         })
     }
     return parsedTs

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -24,7 +24,7 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
         }
     }
 
-    const parsedTs = handleTimestamp(data, now, sentAt)
+    const parsedTs = handleTimestamp(data, now, sentAt, callback)
     if (!parsedTs.isValid) {
         callback?.('ignored_invalid_timestamp', {
             field: 'timestamp',
@@ -34,9 +34,58 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
         return DateTime.utc()
     }
 
+    return parsedTs
+}
+
+function handleTimestamp(
+    data: PluginEvent,
+    now: DateTime,
+    sentAt: DateTime | null,
+    callback?: IngestionWarningCallback
+): DateTime {
+    let parsedTs: DateTime = now
+    let timestamp: DateTime = now
+
+    if (data['timestamp']) {
+        timestamp = parseDate(data['timestamp'])
+
+        if (!sentAt || !timestamp.isValid) {
+            return timestamp
+        }
+
+        // To handle clock skew between the client and server, we attempt
+        // to compute the skew based on the difference between the
+        // client-generated `sent_at` and the server-generated `now`
+        // filled by the capture endpoint.
+        //
+        // We calculate the skew as:
+        //
+        //      skew = sent_at - now
+        //
+        // And adjust the timestamp accordingly.
+
+        // sent_at - timestamp == now - x
+        // x = now + (timestamp - sent_at)
+        try {
+            // timestamp and sent_at must both be in the same format: either both with or both without timezones
+            // otherwise we can't get a diff to add to now
+            parsedTs = now.plus(timestamp.diff(sentAt))
+        } catch (error) {
+            status.error('⚠️', 'Error when handling timestamp:', { error: error.message })
+            Sentry.captureException(error, { extra: { data, now, sentAt } })
+            return timestamp
+        }
+    }
+
+    if (data['offset']) {
+        parsedTs = now.minus(Duration.fromMillis(data['offset']))
+    }
+
+    const nowDiff = parsedTs.toUTC().diff(now).toMillis()
+
     // Events in the future would indicate an instrumentation bug, lets' ingest them
     // but publish an integration warning to help diagnose such issues.
-    if (now.isValid && parsedTs.toUTC().diff(now).toMillis() > FutureEventHoursCutoffMillis) {
+    if (nowDiff > FutureEventHoursCutoffMillis) {
         callback?.('event_timestamp_in_future', {
             timestamp: data['timestamp'] ?? '',
             sentAt: data['sent_at'] ?? '',
@@ -46,42 +95,11 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
             eventUuid: data['uuid'],
             eventName: data['event'],
         })
+
+        parsedTs = timestamp
     }
+
     return parsedTs
-}
-
-function handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | null): DateTime {
-    if (data['timestamp']) {
-        const timestamp = parseDate(data['timestamp'])
-        if (sentAt && timestamp.isValid) {
-            // To handle clock skew between the client and server, we attempt
-            // to compute the skew based on the difference between the
-            // client-generated `sent_at` and the server-generated `now`
-            // filled by the capture endpoint.
-            //
-            // We calculate the skew as:
-            //
-            //      skew = sent_at - now
-            //
-            // And adjust the timestamp accordingly.
-
-            // sent_at - timestamp == now - x
-            // x = now + (timestamp - sent_at)
-            try {
-                // timestamp and sent_at must both be in the same format: either both with or both without timezones
-                // otherwise we can't get a diff to add to now
-                return now.plus(timestamp.diff(sentAt))
-            } catch (error) {
-                status.error('⚠️', 'Error when handling timestamp:', { error: error.message })
-                Sentry.captureException(error, { extra: { data, now, sentAt } })
-            }
-        }
-        return timestamp
-    }
-    if (data['offset']) {
-        return now.minus(Duration.fromMillis(data['offset']))
-    }
-    return now
 }
 
 export function parseDate(supposedIsoString: string): DateTime {

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -156,6 +156,8 @@ describe('parseEventTimestamp()', () => {
             timestamp: '2021-10-29T02:30:00.000Z',
             sent_at: '2021-10-28T01:00:00.000Z',
             now: '2021-10-29T01:00:00.000Z',
+            event: 'test event name',
+            uuid: '12345678-1234-1234-1234-123456789abc',
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
@@ -169,6 +171,8 @@ describe('parseEventTimestamp()', () => {
                     result: '2021-10-30T02:30:00.000Z',
                     sentAt: '2021-10-28T01:00:00.000Z',
                     timestamp: '2021-10-29T02:30:00.000Z',
+                    eventUuid: '12345678-1234-1234-1234-123456789abc',
+                    eventName: 'test event name',
                 },
             ],
         ])
@@ -180,6 +184,8 @@ describe('parseEventTimestamp()', () => {
         const event = {
             offset: -82860000,
             now: '2021-10-29T01:00:00.000Z',
+            event: 'test event name',
+            uuid: '12345678-1234-1234-1234-123456789abc',
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
@@ -194,6 +200,8 @@ describe('parseEventTimestamp()', () => {
                     result: '2021-10-30T00:01:00.000Z',
                     sentAt: '',
                     timestamp: '',
+                    eventUuid: '12345678-1234-1234-1234-123456789abc',
+                    eventName: 'test event name',
                 },
             ],
         ])

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -177,7 +177,7 @@ describe('parseEventTimestamp()', () => {
             ],
         ])
 
-        expect(timestamp.toISO()).toEqual('2021-10-30T02:30:00.000Z')
+        expect(timestamp.toISO()).toEqual('2021-10-29T02:30:00.000Z')
     })
 
     it('reports event_timestamp_in_future with negative offset', () => {
@@ -206,6 +206,6 @@ describe('parseEventTimestamp()', () => {
             ],
         ])
 
-        expect(timestamp.toISO()).toEqual('2021-10-30T00:01:00.000Z')
+        expect(timestamp.toISO()).toEqual('2021-10-29T01:00:00.000Z')
     })
 })


### PR DESCRIPTION
## Problem

We need more information to identify which events are causing the warning to pop off.

Moreover, as the issue seems to be deep-rooted, we should not let incorrect timestampts propagate into our data stores.

## Changes

Let's add the event UUID and name to the warning to help us identify these events while debugging. However, these changes do not expose the new fields to the UI for the time being, so not frontend changes.

To tackle timestamps in the future, we'll be defaulting to provided `timestamp` fields (if available) or the server ingestion time in the event that the computed timestamp ends up at least a day in the future.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
