### PR TITLE
fix(flags): Set precision for blast radius %s

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -998,14 +998,14 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                                 Will match approximately{' '}
                                                 {affectedUsers[index] !== undefined ? (
                                                     <b>
-                                                        {`${humanFriendlyNumber(
+                                                        {`${
                                                             computeBlastRadiusPercentage(
                                                                 group.rollout_percentage,
                                                                 index
-                                                            ).toPrecision(4) * 1
+                                                            ).toPrecision(2) * 1
                                                             // Multiplying by 1 removes trailing zeros after the decimal
                                                             // point added by toPrecision
-                                                        )}% `}
+                                                        }% `}
                                                     </b>
                                                 ) : (
                                                     <Spinner className="mr-1" />

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1002,7 +1002,9 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                                             computeBlastRadiusPercentage(
                                                                 group.rollout_percentage,
                                                                 index
-                                                            )
+                                                            ).toPrecision(4) * 1
+                                                            // Multiplying by 1 removes trailing zeros after the decimal
+                                                            // point added by toPrecision
                                                         )}% `}
                                                     </b>
                                                 ) : (


### PR DESCRIPTION
## Problem

We used to see 0% (1/1000000) because we rounded off to 2 decimal places.

Now, we maintain 4 significant digits, so 12.35677% appears as 12.35%; while 0.00000005% appears as `0.00000005%`

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
