### PR TITLE
chore(experiments): Sort table appropriately

### DIFF
--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -197,7 +197,11 @@ export function Experiments(): JSX.Element {
                         columns={columns}
                         rowKey="id"
                         loading={experimentsLoading}
-                        defaultSorting={{ columnKey: 'id', order: 1 }}
+                        defaultSorting={{
+                            columnKey: 'created_at',
+                            order: -1,
+                        }}
+                        noSortingCancellation
                         pagination={{ pageSize: 100 }}
                         nouns={['experiment', 'experiments']}
                         data-attr="experiment-table"

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -250,6 +250,11 @@ function OverViewTab(): JSX.Element {
                 dataSource={searchedFeatureFlags}
                 columns={columns}
                 rowKey="key"
+                defaultSorting={{
+                    columnKey: 'created_at',
+                    order: -1,
+                }}
+                noSortingCancellation
                 loading={featureFlagsLoading}
                 pagination={{ pageSize: 100 }}
                 nouns={['feature flag', 'feature flags']}


### PR DESCRIPTION
## Problem

Makes sure both flags and experiments table is default sorted by creation time

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
