### PR TITLE
fix: disable scale licenses on self hosted

### DIFF
--- a/frontend/src/scenes/billing/v2/control/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/control/Billing.tsx
@@ -46,9 +46,17 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
         }
     }, [!!billing])
 
+    useEffect(() => {
+        if (!preflight?.cloud) {
+            setEnterprisePackage(true)
+        }
+    })
+
     if (!billing && billingLoading) {
         return <SpinnerOverlay />
     }
+
+    const plan = !preflight?.cloud ? 'enterprise-self-hosted' : enterprisePackage ? 'enterprise' : 'standard'
 
     const supportLink = (
         <Link
@@ -168,9 +176,7 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
                         ) : (
                             <div className="space-y-4">
                                 <LemonButton
-                                    to={`/api/billing-v2/activation?plan=${
-                                        enterprisePackage ? 'enterprise' : 'standard'
-                                    }&redirect_path=${redirectPath}`}
+                                    to={`/api/billing-v2/activation?plan=${plan}&redirect_path=${redirectPath}`}
                                     type="primary"
                                     size="large"
                                     fullWidth
@@ -180,20 +186,22 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
                                     Setup payment
                                 </LemonButton>
 
-                                <div className="space-y-2">
-                                    <div className="flex items-center justify-between">
-                                        <LemonLabel>Enterprise package</LemonLabel>
-                                        <LemonSwitch
-                                            className="flex items-center justify-between"
-                                            checked={enterprisePackage}
-                                            onChange={setEnterprisePackage}
-                                        />
+                                {preflight?.cloud && (
+                                    <div className="space-y-2">
+                                        <div className="flex items-center justify-between">
+                                            <LemonLabel>Enterprise package</LemonLabel>
+                                            <LemonSwitch
+                                                className="flex items-center justify-between"
+                                                checked={enterprisePackage}
+                                                onChange={setEnterprisePackage}
+                                            />
+                                        </div>
+                                        <p>
+                                            Starts at <b>$450/mo</b> and comes with SSO, advanced permissions, and a
+                                            dedicated Slack channel for support
+                                        </p>
                                     </div>
-                                    <p>
-                                        Starts at <b>$450/mo</b> and comes with SSO, advanced permissions, and a
-                                        dedicated Slack channel for support
-                                    </p>
-                                </div>
+                                )}
                             </div>
                         )}
 

--- a/frontend/src/scenes/billing/v2/control/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/control/Billing.tsx
@@ -217,7 +217,7 @@ export function BillingV2({ redirectPath = '' }: BillingV2Props): JSX.Element {
                             </div>
                         ) : null}
 
-                        {!preflight?.cloud && !billing?.has_active_subscription ? (
+                        {!preflight?.cloud && !billing?.has_active_subscription && !billing?.license?.plan ? (
                             <LemonButton
                                 fullWidth
                                 center


### PR DESCRIPTION
## Problem
Needs https://github.com/PostHog/billing/pull/71 to be released for maximum effect

We have a new pricing on self-hosted, this PR removes the option to buy a scale license on self-hosted instances, and requests/sets pricing for an `enterprise-self-hosted` plan

## Changes
- Force enterprise option if self-hosted, by hiding the enterprise toggle and setting the value to `true` by default
- Sets the plan to `enterprise-self-hosted`
- Hides the license key input if there's already a license (UX bug)


## How did you test this code?
Locally