### PR TITLE
refactor(active-users): improve performance of WAUs & MAUs query by reading less data

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -600,7 +600,7 @@
                           person_id,
                           breakdown_value) e
               WHERE e.timestamp <= d.timestamp
-                AND e.timestamp > d.timestamp - INTERVAL 6 DAY
+                AND e.timestamp > d.timestamp - INTERVAL 7 DAY
               GROUP BY d.timestamp,
                        breakdown_value
               ORDER BY d.timestamp)

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -63,11 +63,11 @@ SELECT counts AS total, timestamp AS day_start FROM (
        but this is not possible in ClickHouse as of 2022.10 (ASOF JOIN isn't fit for this either). */
     CROSS JOIN (
         SELECT
-            toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s) AS timestamp,
+            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s)) AS timestamp,
             {aggregator} AS actor_id
         {event_query_base}
         GROUP BY timestamp, actor_id
-    ) e WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
+    ) e WHERE e.timestamp <= d.timestamp AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
     GROUP BY d.timestamp
     ORDER BY d.timestamp
 ) WHERE 1 = 1 {parsed_date_from} {parsed_date_to}

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -105,8 +105,7 @@ def get_active_user_params(filter: Filter, entity: Entity, team_id: int) -> Tupl
     date_to = filter.date_to
 
     format_params = {
-        # Not 7 and 30 because the day of the date marker is included already in the query (`+ INTERVAL 1 DAY`)
-        "prev_interval": "6 DAY" if entity.math == WEEKLY_ACTIVE else "29 DAY",
+        "prev_interval": "7 DAY" if entity.math == WEEKLY_ACTIVE else "30 DAY",
         "parsed_date_from_prev_range": f"AND toDateTime(timestamp, 'UTC') >= toDateTime(%(date_from_active_users_adjusted)s, %(timezone)s)",
     }
     # For time-series display types, we need to adjust date_from to be 7/30 days earlier.


### PR DESCRIPTION
Getting things rolling here. Mostly implementing, testing, and benchmarking a @macobo suggestion.

The WAUs / MAUs query (`ACTIVE_USERS_SQL`) seems to be a bit suboptimal in a few areas. One of those is that we're not aggregating directly in the relevant subquery (I'll look into this next). But another is that we were needlessly selecting data we didn't need to (and streaming that across nodes). 

That was because the subquery was pulling in all distinct timestamps, rather than just the day, which is what we care about. Thus, we can make a simple change by immediately selecting with day granularity. This also required tweaking the intervals, since before we could have a timestamp `2023-01-01 23:59:00` and would need to look up e.g. 6 days into the future. Now that timestamp will equate to `2023-01-01 00:00:00` so we need to read 7 days into the future (and none into the past).

I suspect tests should catch if the new query behaves correctly?

Nevertheless, here are my bits of investigation as for why do this change:

1. I ran the query for both our team and our largest team, getting the same results
2. There was a ~30% reduction in memory usage and query duration on average:

<img width="678" alt="Screenshot 2023-01-09 at 16 15 28" src="https://user-images.githubusercontent.com/38760734/211389389-d403fbff-bde4-418d-b03c-61d1abfd12b1.png">

3. The `EXPLAIN` output shows us the obvious: we're reading less data from other nodes:

```
# before: all unique timestamps in a day
ReadFromRemote (Read from remote replica)                                                                                                                                                                                      
    Header: toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific') DateTime('US/Pacific')                                                                                                                                          
        person_id UUID

# after: just one timestamp per day
ReadFromRemote (Read from remote replica)                                                                                                                                                                                          
    Header: toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) DateTime('US/Pacific')                                                                                                                                
        person_id UUID
```

Submitting this to get feedback and make sure I'm doing things right @macobo but let me know if I'm missing things, should test it more extensively, etc!
