### PR TITLE
chore: set default mocks for storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,10 +3,10 @@ import './storybook.scss'
 import type { Meta } from '@storybook/react'
 import { worker } from '~/mocks/browser'
 import { loadPostHogJS } from '~/loadPostHogJS'
-
 import { getStorybookAppContext } from './app-context'
 import { withKea } from './decorators/withKea'
 import { withMockDate } from './decorators/withMockDate'
+import { defaultMocks } from '~/mocks/handlers'
 
 const setupMsw = () => {
     // Make sure the msw worker is started
@@ -58,6 +58,9 @@ export const parameters = {
     // auto-expand code blocks in docs
     docs: {
         source: { state: 'closed' },
+    },
+    msw: {
+        mocks: defaultMocks,
     },
 }
 

--- a/frontend/src/mocks/browser.tsx
+++ b/frontend/src/mocks/browser.tsx
@@ -1,16 +1,28 @@
-import { setupWorker } from 'msw'
+import { rest, setupWorker } from 'msw'
 import { handlers } from '~/mocks/handlers'
 import { Mocks, mocksToHandlers } from '~/mocks/utils'
+import { DecoratorFunction } from '@storybook/addons'
 
 // Default handlers ensure no request is unhandled by msw
 export const worker = setupWorker(...handlers)
 
 export const useStorybookMocks = (mocks: Mocks): void => worker.use(...mocksToHandlers(mocks))
-export const mswDecorator = (mocks: Mocks): ((Story: () => JSX.Element) => JSX.Element) =>
-    function StoryMock(Story): JSX.Element {
-        useStorybookMocks(mocks)
+export const mswDecorator = (mocks: Mocks): DecoratorFunction<JSX.Element> => {
+    return function StoryMock(Story, { parameters }): JSX.Element {
+        // merge the default mocks provided in `preview.tsx` with any provided by the story
+        // allow the story to override defaults
+        const mergedMocks: Mocks = {}
+        Object.keys(rest).forEach((restKey) => {
+            mergedMocks[restKey] = {
+                ...(parameters.msw?.mocks?.[restKey] || {}),
+                ...(mocks?.[restKey] || {}),
+            }
+        })
+
+        useStorybookMocks(mergedMocks)
         return <Story />
     }
+}
 
 export const useFeatureFlags = (featureFlags: string[]): void => {
     ;(window as any).POSTHOG_APP_CONTEXT.persisted_feature_flags = featureFlags

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -38,7 +38,7 @@ export const defaultMocks: Mocks = {
         '/api/projects/:team_id/persons/properties/': apiResults(MOCK_PERSON_PROPERTIES),
         '/api/personal_api_keys/': [],
         '/api/license/': apiResults([MOCK_DEFAULT_LICENSE]),
-        '/api/users/@me/': [
+        '/api/users/@me/': (): MockSignature => [
             200,
             {
                 ...MOCK_DEFAULT_USER,

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { mocksToHandlers } from './utils'
+import { Mocks, MockSignature, mocksToHandlers } from './utils'
 import {
     MOCK_DEFAULT_LICENSE,
     MOCK_DEFAULT_ORGANIZATION,
@@ -14,7 +14,7 @@ import { getAvailableFeatures } from '~/mocks/features'
 const API_NOOP = { count: 0, results: [] as any[], next: null, previous: null }
 const apiResults = (results: any[]): typeof API_NOOP => ({ count: results.length, results, next: null, previous: null })
 
-export const handlers = mocksToHandlers({
+export const defaultMocks: Mocks = {
     get: {
         '/api/projects/:team_id/actions/': API_NOOP,
         '/api/projects/:team_id/annotations/': API_NOOP,
@@ -26,16 +26,19 @@ export const handlers = mocksToHandlers({
         '/api/projects/:team_id/property_definitions/': API_NOOP,
         '/api/projects/:team_id/feature_flags/': API_NOOP,
         '/api/projects/:team_id/explicit_members/': [],
-        '/api/organizations/@current/': () => [
+        '/api/organizations/@current/': (): MockSignature => [
             200,
             { ...MOCK_DEFAULT_ORGANIZATION, available_features: getAvailableFeatures() },
         ],
         '/api/organizations/@current/members/': apiResults([MOCK_DEFAULT_ORGANIZATION_MEMBER]),
         '/api/organizations/@current/invites/': apiResults([MOCK_DEFAULT_ORGANIZATION_INVITE]),
+        '/api/organizations/@current/plugins/': apiResults([]),
         '/api/projects/@current/persons/properties/': apiResults(MOCK_PERSON_PROPERTIES),
+        '/api/projects/:team_id/persons': apiResults([]),
+        '/api/projects/:team_id/persons/properties/': apiResults(MOCK_PERSON_PROPERTIES),
         '/api/personal_api_keys/': [],
         '/api/license/': apiResults([MOCK_DEFAULT_LICENSE]),
-        '/api/users/@me/': () => [
+        '/api/users/@me/': [
             200,
             {
                 ...MOCK_DEFAULT_USER,
@@ -43,15 +46,22 @@ export const handlers = mocksToHandlers({
             },
         ],
         '/api/projects/@current/': MOCK_DEFAULT_TEAM,
-        '/api/billing-v2/': () => [200, {}],
+        '/api/billing-v2/': (): MockSignature => [200, {}],
         '/_preflight': require('./fixtures/_preflight.json'),
         '/_system_status': require('./fixtures/_system_status.json'),
         '/api/instance_status': require('./fixtures/_instance_status.json'),
+        '/api/plugin_config/': apiResults([]),
+        'https://update.posthog.com/': [{ version: '1.42.0', release_date: '2022-11-30' }],
     },
     post: {
-        '/e/': () => [200, 'ok'],
-        'https://app.posthog.com/decide/': () => [200, 'ok'],
-        'https://app.posthog.com/engage/': () => [200, 'ok'],
-        'https://app.posthog.com/e/': () => [200, 'ok'],
+        '/e/': (): MockSignature => [200, 'ok'],
+        'https://app.posthog.com/decide/': (): MockSignature => [200, 'ok'],
+        '/decide/': (): MockSignature => [200, 'ok'],
+        'https://app.posthog.com/engage/': (): MockSignature => [200, 'ok'],
+        'https://app.posthog.com/e/': (): MockSignature => [200, 'ok'],
     },
-})
+    patch: {
+        '/api/prompts/my_prompts': (): MockSignature => [200, {}],
+    },
+}
+export const handlers = mocksToHandlers(defaultMocks)


### PR DESCRIPTION
## Problem

When you visit storybook pages you get a number of error toasts because some default API calls are not mocked

<img width="542" alt="Screenshot 2023-01-10 at 00 30 06" src="https://user-images.githubusercontent.com/984817/211435208-9d8e36f5-5cc0-4bdc-a689-48b4e70d3472.png">

Yuck!

## Changes

* Adds a hook  in `preview.tsx` where global storybook mocks could be added
* passes the same default mocks that are used in Jest tests into that hook
* merges those mocks with any provided by the `mswDecorator` for a particular story

## How did you test this code?

running it locally and seeing no/fewer error toasts