### PR TITLE
fix: dashboard duplication was not skipping deleted tiles

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -148,7 +148,11 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
         elif use_dashboard:
             try:
                 existing_dashboard = Dashboard.objects.get(id=use_dashboard, team=team)
-                existing_tiles = DashboardTile.objects.filter(dashboard=existing_dashboard).select_related("insight")
+                existing_tiles = (
+                    DashboardTile.objects.filter(dashboard=existing_dashboard)
+                    .exclude(deleted=True)
+                    .select_related("insight")
+                )
                 for existing_tile in existing_tiles:
                     if self.initial_data.get("duplicate_tiles", False):
                         self._deep_duplicate_tiles(dashboard, existing_tile)


### PR DESCRIPTION
## Problem

When duplicating a dashboard the queryset of tiles wasn't excluding deleted tiles.

🤦 

## Changes

Now it is

## How did you test this code?

added a developer test and confirmed running locally