### PR TITLE
refactor(funnels): Use Lemon `Spinner` instead of Ant `Spin`

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -412,7 +412,9 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                                 breakdown.droppedOffFromPrevious > 0,
                                                         },
                                                         {
-                                                            title: `Dropoff rate (from step ${previousStep.order + 1})`,
+                                                            title: `Drop-off rate (from step ${
+                                                                previousStep.order + 1
+                                                            })`,
                                                             value: percentage(
                                                                 1 - breakdown.conversionRates.fromPrevious,
                                                                 2,
@@ -479,7 +481,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                     visible: step.order !== 0 && step.droppedOffFromPrevious > 0,
                                                 },
                                                 {
-                                                    title: `Dropoff rate (from step ${previousStep.order + 1})`,
+                                                    title: `Drop-off rate (from step ${previousStep.order + 1})`,
                                                     value: percentage(1 - step.conversionRates.fromPrevious, 2, true),
                                                     visible: step.order !== 0 && step.droppedOffFromPrevious > 0,
                                                 },

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.scss
@@ -2,6 +2,7 @@
     margin-top: 1rem;
     border: 1px solid var(--border);
     border-radius: var(--radius);
+    overflow: hidden;
 
     .ant-table {
         thead th {
@@ -12,28 +13,24 @@
     .funnel-correlation-header {
         background: #f2f2f2;
         display: flex;
+        align-items: center;
         align-self: stretch;
+        padding: 0.25rem 0.5rem;
         justify-content: space-between;
         align-content: space-between;
         border-top-left-radius: var(--radius);
         border-top-right-radius: var(--radius);
-        padding-bottom: 5px;
 
         .table-header {
             font-style: normal;
             font-weight: bold;
             font-size: 11px;
             line-height: 16px;
-            padding-bottom: 4px;
-
             display: flex;
             align-items: center;
             letter-spacing: 0.02em;
             text-transform: uppercase;
-
             color: var(--default);
-            margin-left: 1rem;
-            margin-top: 0.5rem;
         }
 
         .table-options {
@@ -41,7 +38,6 @@
             flex-grow: 1;
             justify-content: flex-end;
             align-items: center;
-            margin-top: 5px;
 
             .title {
                 font-family: Inter;
@@ -74,20 +70,6 @@
         border-radius: var(--radius);
         thead th {
             border-bottom: 1px solid var(--border);
-        }
-    }
-
-    .nested-properties-loading {
-        text-align: center;
-        padding: 2rem 0;
-
-        h3 {
-            font-size: 1rem;
-            font-weight: bold;
-            margin-bottom: 0;
-            p {
-                color: var(--muted-alt);
-            }
         }
     }
 }

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Row, Spin, Table } from 'antd'
+import { Row, Table } from 'antd'
 import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
 import { RiseOutlined, FallOutlined, EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons'
@@ -18,6 +18,7 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { Popup } from 'lib/components/Popup/Popup'
 import { CorrelationMatrix } from './CorrelationMatrix'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 export function FunnelCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -79,11 +80,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
         return (
             <>
                 <h4>
-                    {is_success ? (
-                        <RiseOutlined style={{ color: 'green' }} />
-                    ) : (
-                        <FallOutlined style={{ color: 'red' }} />
-                    )}{' '}
+                    {is_success ? <RiseOutlined className="text-success" /> : <FallOutlined className="text-danger" />}{' '}
                     <PropertyKeyInfo value={first_value} />
                     {second_value !== undefined && (
                         <>
@@ -137,17 +134,17 @@ export function FunnelCorrelationTable(): JSX.Element | null {
     const renderNestedTable = (eventName: string): JSX.Element => {
         if (eventWithPropertyCorrelationsLoading) {
             return (
-                <div className="nested-properties-loading">
-                    <Spin />
-                    <h3>Loading correlation results</h3>
-                    <p>This process can take up to 20 seconds. </p>
+                <div className="flex flex-col items-center py-2">
+                    <Spinner className="text-2xl mb-2" />
+                    <h3 className="mb-1 text-md font-semibold">Loading correlation results…</h3>
+                    <p className="m-0 text-xs text-muted">This process can take up to 20 seconds.</p>
                 </div>
             )
         }
 
         return (
             <div>
-                <h4 style={{ paddingLeft: 16 }}>Correlated properties</h4>
+                <h4 className="pl-4">Correlated properties</h4>
                 <Table
                     dataSource={eventWithPropertyCorrelationsValues[eventName]}
                     rowKey={(record: FunnelCorrelation) => record.event.event}
@@ -202,48 +199,31 @@ export function FunnelCorrelationTable(): JSX.Element | null {
             <div className="funnel-correlation-table">
                 <span className="funnel-correlation-header">
                     <span className="table-header">
-                        <IconSelectEvents style={{ marginRight: 4, fontSize: 24, opacity: 0.5 }} />
+                        <IconSelectEvents className="mr-1 text-2xl opacity-50" />
                         CORRELATED EVENTS
                     </span>
                     <span className="table-options">
                         <p className="title">CORRELATION</p>
                         <div
                             className="tab-btn ant-btn"
-                            style={{
-                                paddingTop: '1px',
-                                paddingBottom: '1px',
-                                borderTopRightRadius: 0,
-                                borderBottomRightRadius: 0,
-                            }}
                             onClick={() => onClickCorrelationType(FunnelCorrelationType.Success)}
                         >
                             <Checkbox
                                 checked={correlationTypes.includes(FunnelCorrelationType.Success)}
-                                style={{
-                                    pointerEvents: 'none',
-                                }}
+                                className="pointer-events-none"
                             >
                                 Success
                             </Checkbox>
                         </div>
                         <div
                             className="tab-btn ant-btn"
-                            style={{
-                                marginRight: '8px',
-                                paddingTop: '1px',
-                                paddingBottom: '1px',
-                                borderTopLeftRadius: 0,
-                                borderBottomLeftRadius: 0,
-                            }}
                             onClick={() => onClickCorrelationType(FunnelCorrelationType.Failure)}
                         >
                             <Checkbox
                                 checked={correlationTypes.includes(FunnelCorrelationType.Failure)}
-                                style={{
-                                    pointerEvents: 'none',
-                                }}
+                                className="pointer-events-none"
                             >
-                                Dropoff
+                                Drop-off
                             </Checkbox>
                         </div>
                     </span>
@@ -270,29 +250,32 @@ export function FunnelCorrelationTable(): JSX.Element | null {
                             }
                             return expanded ? (
                                 <Tooltip title="Collapse">
-                                    <div
-                                        style={{ cursor: 'pointer', opacity: 0.5, fontSize: 24 }}
+                                    <LemonButton
+                                        icon={<IconUnfoldLess />}
+                                        status="stealth"
+                                        type="tertiary"
+                                        active
+                                        noPadding
                                         onClick={(e) => {
                                             removeNestedTableExpandedKey(record.event.event)
                                             onExpand(record, e)
                                         }}
-                                    >
-                                        <IconUnfoldLess />
-                                    </div>
+                                    />
                                 </Tooltip>
                             ) : (
                                 <Tooltip title="Expand to see correlated properties for this event">
-                                    <div
-                                        style={{ cursor: 'pointer', opacity: 0.5, fontSize: 24 }}
+                                    <LemonButton
+                                        icon={<IconUnfoldMore />}
+                                        status="stealth"
+                                        type="tertiary"
+                                        noPadding
                                         onClick={(e) => {
                                             !eventHasPropertyCorrelations(record.event.event) &&
                                                 loadEventWithPropertyCorrelations(record.event.event)
                                             addNestedTableExpandedKey(record.event.event)
                                             onExpand(record, e)
                                         }}
-                                    >
-                                        <IconUnfoldMore />
-                                    </div>
+                                    />
                                 </Tooltip>
                             )
                         },
@@ -400,10 +383,7 @@ const CorrelationActionsCell = ({ record }: { record: FunnelCorrelation }): JSX.
                 }
             >
                 <LemonButton status="stealth" onClick={() => setPopoverOpen(!popoverOpen)}>
-                    <EllipsisOutlined
-                        style={{ color: 'var(--primary)', fontSize: 24 }}
-                        className="insight-dropdown-actions"
-                    />
+                    <EllipsisOutlined className="insight-dropdown-actions" />
                 </LemonButton>
             </Popup>
         </Row>

--- a/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
@@ -192,7 +192,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                                         pointerEvents: 'none',
                                     }}
                                 >
-                                    Dropoff
+                                    Drop-off
                                 </Checkbox>
                             </div>
                         </Row>
@@ -306,10 +306,7 @@ const CorrelationActionsCell = ({ record }: { record: FunnelCorrelation }): JSX.
                 }
             >
                 <LemonButton status="stealth" onClick={() => setPopoverOpen(!popoverOpen)}>
-                    <EllipsisOutlined
-                        style={{ color: 'var(--primary)', fontSize: 24 }}
-                        className="insight-dropdown-actions"
-                    />
+                    <EllipsisOutlined className="insight-dropdown-actions" />
                 </LemonButton>
             </Popup>
         </Row>

--- a/frontend/src/scenes/saved-insights/SavedInsights.scss
+++ b/frontend/src/scenes/saved-insights/SavedInsights.scss
@@ -25,6 +25,7 @@
     }
     .insight-dropdown-actions {
         font-size: 24px;
+        color: var(--primary);
         &:hover {
             background: rgba(83, 117, 255, 0.05);
         }


### PR DESCRIPTION
## Changes

Addresses the `Spin` item from #13624, by replacing the Ant component.

| Before | After |
| --- | --- |
| <img width="944" alt="ant" src="https://user-images.githubusercontent.com/4550621/211769623-bee2b1ea-122e-4b19-8a9b-dc028b37940f.png"> | <img width="955" alt="lemon-2" src="https://user-images.githubusercontent.com/4550621/211769618-a68699d7-5ff8-4c9f-9418-9f8f3cf2c032.png"> |
