### PR TITLE
chore: Update CSV polling limit to 300

### DIFF
--- a/frontend/src/lib/components/ExportButton/exporter.tsx
+++ b/frontend/src/lib/components/ExportButton/exporter.tsx
@@ -10,7 +10,7 @@ import { Spinner } from 'lib/components/Spinner/Spinner'
 
 const POLL_DELAY_MS = 1000
 const MAX_PNG_POLL = 10
-const MAX_CSV_POLL = 60
+const MAX_CSV_POLL = 300
 
 function downloadBlob(content: Blob, filename: string): void {
     const anchor = document.createElement('a')


### PR DESCRIPTION
Users were getting failed exports with previous limit. See https://github.com/PostHog/posthog/issues/13638 for more details
