### PR TITLE
revert "feat: element stats paging"

### DIFF
--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -371,12 +371,11 @@ export function getHeatMapHue(count: number, maxCount: number): number {
 export async function toolbarFetch(
     url: string,
     method: string = 'GET',
-    payload?: Record<string, any>,
-    useProvidedURL?: boolean
+    payload?: Record<string, any>
 ): Promise<Response> {
     const { pathname, searchParams } = combineUrl(url)
     const params = { ...searchParams, temporary_token: toolbarLogic.values.temporaryToken }
-    const fullUrl = useProvidedURL ? url : `${toolbarLogic.values.apiURL}${pathname}${encodeParams(params, '?')}`
+    const fullUrl = `${toolbarLogic.values.apiURL}${pathname}${encodeParams(params, '?')}`
 
     const payloadData = payload
         ? {

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -12,7 +12,6 @@ from posthog.models.element.sql import GET_ELEMENTS, GET_VALUES
 from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.queries.query_date_range import QueryDateRange
-from posthog.utils import format_query_params_absolute_url
 
 
 class ElementSerializer(serializers.ModelSerializer):
@@ -55,22 +54,16 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         date_to, date_to_params = query_date_range.date_to
         date_params.update(date_from_params)
         date_params.update(date_to_params)
-
         try:
-            limit = int(request.query_params.get("limit", 100))
+            limit = int(request.GET.get("limit", 100))
         except ValueError:
             raise ValidationError("Limit must be an integer")
-
-        try:
-            offset = int(request.query_params.get("offset", 0))
-        except ValueError:
-            raise ValidationError("offset must be an integer")
 
         prop_filters, prop_filter_params = parse_prop_grouped_clauses(
             team_id=self.team.pk, property_group=filter.property_groups
         )
         result = sync_execute(
-            GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters, limit=limit, offset=offset),
+            GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters, limit=limit),
             {
                 "team_id": self.team.pk,
                 "timezone": self.team.timezone,
@@ -78,20 +71,16 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 **date_params,
             },
         )
-        serialized_elements = [
-            {
-                "count": elements[1],
-                "hash": None,
-                "elements": [ElementSerializer(element).data for element in chain_to_elements(elements[0])],
-            }
-            for elements in result
-        ]
-
-        _should_paginate = len(serialized_elements) > 0
-        next_url = format_query_params_absolute_url(request, offset + limit) if _should_paginate else None
-        previous_url = format_query_params_absolute_url(request, offset - limit) if offset - limit >= 0 else None
-
-        return response.Response({"results": serialized_elements, "next": next_url, "previous": previous_url})
+        return response.Response(
+            [
+                {
+                    "count": elements[1],
+                    "hash": None,
+                    "elements": [ElementSerializer(element).data for element in chain_to_elements(elements[0])],
+                }
+                for elements in result
+            ]
+        )
 
     @action(methods=["GET"], detail=False)
     def values(self, request: request.Request, **kwargs) -> response.Response:

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -85,15 +85,15 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
             # Django session, PostHog user, PostHog team, PostHog org membership
             # then 2 for inserting person in test setup
             response = self.client.get("/api/element/stats/").json()
-        self.assertEqual(response["results"][0]["count"], 2)
-        self.assertEqual(response["results"][0]["elements"][0]["tag_name"], "a")
-        self.assertEqual(response["results"][1]["count"], 1)
+        self.assertEqual(response[0]["count"], 2)
+        self.assertEqual(response[0]["elements"][0]["tag_name"], "a")
+        self.assertEqual(response[1]["count"], 1)
 
         response = self.client.get(
             "/api/element/stats/?properties=%s"
             % json.dumps([{"key": "$current_url", "value": "http://example.com/demo"}])
         ).json()
-        self.assertEqual(len(response["results"]), 1)
+        self.assertEqual(len(response), 1)
 
     def test_element_stats_clamps_date_from_to_start_of_day(self) -> None:
         event_start = "2012-01-14T03:21:34.000Z"
@@ -131,8 +131,8 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
             response_json = response.json()
-            self.assertEqual(response_json["results"][0]["count"], 2)
-            self.assertEqual(response_json["results"][0]["elements"][0]["tag_name"], "a")
+            self.assertEqual(response_json[0]["count"], 2)
+            self.assertEqual(response_json[0]["elements"][0]["tag_name"], "a")
 
     def test_element_stats_obeys_limit_parameter(self) -> None:
         _create_event(
@@ -161,22 +161,17 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_json = response.json()
-        assert response_json["next"] == "http://testserver/api/element/stats/?offset=100"
-        results = response_json["results"]
-        assert len(results) == 2  # there are 2 events
-        assert [e["count"] for e in results] == [1, 1]  # each of 1 click
-        assert [len(e["elements"]) for e in results] == [2, 2]  # each click has a chain of 2 selectors
+        assert len(response_json) == 2  # there are 2 events
+        assert [e["count"] for e in response_json] == [1, 1]  # each of 1 click
+        assert [len(e["elements"]) for e in response_json] == [2, 2]  # each click has a chain of 2 selectors
 
         response = self.client.get(f"/api/element/stats/?limit=1")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_json = response.json()
-        assert response_json["next"] == "http://testserver/api/element/stats/?limit=1&offset=1"
-        limit_to_one_results = response_json["results"]
-        assert len(limit_to_one_results) == 1  # there is now 1 event
-        assert [e["count"] for e in limit_to_one_results] == [1]  # of 1 click
-        assert [len(e["elements"]) for e in limit_to_one_results] == [2]  # with a chain of 2 selectors
-        assert limit_to_one_results[0]["elements"][0]["href"] == "https://posthog.com/event-1"
+        assert len(response_json) == 1  # there is now 1 events
+        assert [e["count"] for e in response_json] == [1]  # of 1 click
+        assert [len(e["elements"]) for e in response_json] == [2]  # with a chain of 2 selectors
 
     def test_element_stats_does_not_allow_non_numeric_limit(self) -> None:
         response = self.client.get(f"/api/element/stats/?limit=not-a-number")

--- a/posthog/models/element/sql.py
+++ b/posthog/models/element/sql.py
@@ -11,7 +11,7 @@ WHERE
     {query}
 GROUP BY elements_chain
 ORDER BY count DESC
-LIMIT {limit} OFFSET {offset};
+LIMIT {limit};
 """
 
 GET_VALUES = """


### PR DESCRIPTION
Reverts PostHog/posthog#13620

pre-emptive revert

The toolbar js cache hasn't been busted so the heatmap API calls no longer match the JS to read them :/ 