### PR TITLE
fix(chore): math round and flip sign of first paint duration

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -214,7 +214,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
             if (values.chunkPaginationIndex === 1) {
                 cache.firstPaintDurationRow = {
                     size: Object.keys(values.sessionPlayerSnapshotData.snapshotsByWindowId).length,
-                    duration: cache.snapshotsStartTime - performance.now(),
+                    duration: Math.round(performance.now() - cache.snapshotsStartTime),
                 }
 
                 actions.reportUsage(SessionRecordingUsageType.VIEWED)


### PR DESCRIPTION
## Problem

Seeing that first paint metrics are negative and buggy here: https://app.posthog.com/dashboard/58567

## Changes

Take absolute value of first paint load time and round it.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
