### PR TITLE
fix: Shows proper message when filter results are empty

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -231,20 +231,14 @@ const SAVED_INSIGHTS_COPY = {
     [`${SavedInsightsTabs.All}`]: {
         title: 'There are no insights $CONDITION.',
         description: 'Once you create an insight, it will show up here.',
-        descriptionOnEmptyFilter:
-            'Refine your keyword search, or try using other filters such as type, last modified or created by.',
     },
     [`${SavedInsightsTabs.Yours}`]: {
         title: "You haven't created insights $CONDITION.",
         description: 'Once you create an insight, it will show up here.',
-        descriptionOnEmptyFilter:
-            'Refine your keyword search, or try using other filters such as type, last modified or created by.',
     },
     [`${SavedInsightsTabs.Favorites}`]: {
         title: 'There are no favorited insights $CONDITION.',
         description: 'Once you favorite an insight, it will show up here.',
-        descriptionOnEmptyFilter:
-            'Refine your keyword search, or try using other filters such as type, last modified or created by.',
     },
 }
 
@@ -257,7 +251,7 @@ export function SavedInsightsEmptyState(): JSX.Element {
 
     // show the search string that was used to make the results, not what it currently is
     const searchString = insights.filters?.search || null
-    const { title, description, descriptionOnEmptyFilter } = SAVED_INSIGHTS_COPY[tab] ?? {}
+    const { title, description } = SAVED_INSIGHTS_COPY[tab] ?? {}
 
     return (
         <div className="saved-insight-empty-state">
@@ -273,7 +267,10 @@ export function SavedInsightsEmptyState(): JSX.Element {
                         : title.replace('$CONDITION', 'for this project')}
                 </h2>
                 {usingFilters ? (
-                    <p className="empty-state__description">{descriptionOnEmptyFilter}</p>
+                    <p className="empty-state__description">
+                        Refine your keyword search, or try using other filters such as type, last modified or created
+                        by.
+                    </p>
                 ) : (
                     <p className="empty-state__description">{description}</p>
                 )}

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -170,7 +170,7 @@ export function FunnelSingleStepState({ actionable = true }: { actionable?: bool
                         ' Once you have two steps defined, additional changes will recalculate automatically.'}
                 </p>
                 {actionable && (
-                    <div className="mt-4 flex justify-center">
+                    <div className="flex justify-center mt-4">
                         <LemonButton
                             size="large"
                             type="secondary"
@@ -231,14 +231,20 @@ const SAVED_INSIGHTS_COPY = {
     [`${SavedInsightsTabs.All}`]: {
         title: 'There are no insights $CONDITION.',
         description: 'Once you create an insight, it will show up here.',
+        descriptionOnEmptyFilter:
+            'Refine your keyword search, or try using other filters such as type, last modified or created by.',
     },
     [`${SavedInsightsTabs.Yours}`]: {
         title: "You haven't created insights $CONDITION.",
         description: 'Once you create an insight, it will show up here.',
+        descriptionOnEmptyFilter:
+            'Refine your keyword search, or try using other filters such as type, last modified or created by.',
     },
     [`${SavedInsightsTabs.Favorites}`]: {
         title: 'There are no favorited insights $CONDITION.',
         description: 'Once you favorite an insight, it will show up here.',
+        descriptionOnEmptyFilter:
+            'Refine your keyword search, or try using other filters such as type, last modified or created by.',
     },
 }
 
@@ -251,7 +257,7 @@ export function SavedInsightsEmptyState(): JSX.Element {
 
     // show the search string that was used to make the results, not what it currently is
     const searchString = insights.filters?.search || null
-    const { title, description } = SAVED_INSIGHTS_COPY[tab] ?? {}
+    const { title, description, descriptionOnEmptyFilter } = SAVED_INSIGHTS_COPY[tab] ?? {}
 
     return (
         <div className="saved-insight-empty-state">
@@ -266,7 +272,11 @@ export function SavedInsightsEmptyState(): JSX.Element {
                             : title.replace('$CONDITION', `matching these filters`)
                         : title.replace('$CONDITION', 'for this project')}
                 </h2>
-                <p className="empty-state__description">{description}</p>
+                {usingFilters ? (
+                    <p className="empty-state__description">{descriptionOnEmptyFilter}</p>
+                ) : (
+                    <p className="empty-state__description">{description}</p>
+                )}
                 {tab !== SavedInsightsTabs.Favorites && (
                     <Link to={urls.insightNew()}>
                         <Button

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -24,7 +24,7 @@ export function InsightEmptyState(): JSX.Element {
                     <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="" />
                 </div>
                 <h2>There are no matching events for this query</h2>
-                <p className="text-center">Try changing the date range or pick another action, event, or breakdown.</p>
+                <p className="text-center">Try changing the date range, or pick another action, event or breakdown.</p>
             </div>
         </div>
     )
@@ -268,8 +268,8 @@ export function SavedInsightsEmptyState(): JSX.Element {
                 </h2>
                 {usingFilters ? (
                     <p className="empty-state__description">
-                        Refine your keyword search, or try using other filters such as type, last modified or created
-                        by.
+                        Refine your keyword search, or try using other filters such as type, last modified or
+                        created by.
                     </p>
                 ) : (
                     <p className="empty-state__description">{description}</p>


### PR DESCRIPTION
## Problem
This PR fixes #11400 
Currently when filters are applied on **Insights**, the empty state shows a message asking user to create insights. 

## Changes
This pull request doesn't change the heading, However the description shows as `Refine your keyword search, or try using other filters such as type, last modified or created by.` when applied filters show empty results. This behavior is added on all **Tabs**. 

<img width="1439" alt="Screenshot 2023-01-11 at 7 26 28 PM" src="https://user-images.githubusercontent.com/1978381/211824462-2dc5b6de-d062-4511-8593-cc852f8f2f98.png">

## How did you test this code?
I tried running test cases and they ran very inconsistently for me. Sometimes 5 test cases fail and sometimes 7 or more. May be I am missing something when running it. Please shed some light.

I just ran `pnpm test` to run all test cases in frontend. I also ran test cases mentioning only `Insights` folder.

However I haven't written any test cases for this PR. 