### PR TITLE
chore: gzip more respone

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -245,10 +245,10 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/?api/projects/@current/property_definitions/?$",
                 "^/?api/projects/\\d+/event_definitions/?$",
                 "^/?api/projects/\\d+/insights/(trend|funnel)/?$",
-                # insights API with no ID but with query params
                 "^/?api/projects/\\d+/insights/?$",
                 "^/?api/projects/\\d+/insights/\\d+/?$",
                 "^/?api/projects/\\d+/dashboards/\\d+/?$",
+                "^/?api/projects/\\d+/dashboards/?$",
                 "^/?api/projects/\\d+/actions/?$",
                 "^/?api/projects/\\d+/session_recordings/?$",
                 "^/?api/projects/\\d+/exports/\\d+/content/?$",
@@ -261,6 +261,7 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/api/projects/\\d+/cohorts/?$",
                 "^/api/projects/\\d+/persons/?$",
                 "^/api/organizations/@current/plugins/?$",
+                "^api/projects/@current/feature_flags/my_flags/?$",
             ]
         ),
     )

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -246,7 +246,7 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/?api/projects/\\d+/event_definitions/?$",
                 "^/?api/projects/\\d+/insights/(trend|funnel)/?$",
                 # insights API with no ID but with query params
-                "^/?api/projects/\\d+/insights/??",
+                "^/?api/projects/\\d+/insights/?$",
                 "^/?api/projects/\\d+/insights/\\d+/?$",
                 "^/?api/projects/\\d+/dashboards/\\d+/?$",
                 "^/?api/projects/\\d+/actions/?$",
@@ -257,6 +257,10 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/uploaded_media/.*$",
                 "^/year_in_posthog/.*$",
                 "^/api/element/stats/?$",
+                "^/api/projects/\\d+/groups/property_definitions/?$",
+                "^/api/projects/\\d+/cohorts/?$",
+                "^/api/projects/\\d+/persons/?$",
+                "^/api/organizations/@current/plugins/?$",
             ]
         ),
     )


### PR DESCRIPTION
## Problem

I happen to be working on a slow network. 

<img width="594" alt="Screenshot 2023-01-11 at 16 37 54" src="https://user-images.githubusercontent.com/984817/211864477-623fe07e-1602-485a-b753-3a76685e4d6e.png">

The top 6 slowest responses aren't gzipped. 

2 of them the response time is dominated by download time.

## Changes

Adds them to the gzip allowlist

## How did you test this code?

running it locally
