### PR TITLE
refactor(lemon-ui): Consistently use Day.js for date handling

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -61,10 +61,10 @@ export function DateFilter({
     const popupOverlay =
         view === DateFilterView.FixedRange ? (
             <LemonCalendarRange
-                value={[(rangeDateTo ?? dayjs()).format('YYYY-MM-DD'), (rangeDateTo ?? dayjs()).format('YYYY-MM-DD')]}
+                value={[rangeDateTo ?? dayjs(), rangeDateTo ?? dayjs()]}
                 onChange={([from, to]) => {
-                    setRangeDateFrom(from ? dayjs(from) : null)
-                    setRangeDateTo(to ? dayjs(to) : null)
+                    setRangeDateFrom(from)
+                    setRangeDateTo(to)
                     applyRange()
                 }}
                 onClose={open}
@@ -72,9 +72,9 @@ export function DateFilter({
             />
         ) : view === DateFilterView.DateToNow ? (
             <LemonCalendarSelect
-                value={(rangeDateFrom as any) ?? dayjs().format('YYYY-MM-DD')}
+                value={rangeDateFrom ?? dayjs()}
                 onChange={(date) => {
-                    setRangeDateFrom(dayjs(date))
+                    setRangeDateFrom(date)
                     setRangeDateTo(null)
                     applyRange()
                 }}

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendar.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendar.stories.tsx
@@ -8,7 +8,7 @@ export default {
     parameters: { chromatic: { disableSnapshot: false } },
     argTypes: {
         onClick: {
-            defaultValue: (date: string) => {
+            defaultValue: (date: dayjs.Dayjs) => {
                 console.log(`Clicked: ${date}`)
             },
         },
@@ -32,9 +32,9 @@ CustomStyles.args = {
     getLemonButtonProps: ({ date, props }) => {
         return {
             ...props,
-            active: dayjs(date).day() % 2 === 0,
-            status: dayjs(date).date() % 10 === 0 ? 'primary' : 'stealth',
-            type: dayjs(date).date() % 10 === 0 ? 'primary' : undefined,
+            active: date.day() % 2 === 0,
+            status: date.date() % 10 === 0 ? 'primary' : 'stealth',
+            type: date.date() % 10 === 0 ? 'primary' : undefined,
         }
     },
 }

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendar.test.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendar.test.tsx
@@ -11,7 +11,7 @@ describe('LemonCalendar', () => {
 
         const { container } = render(
             <LemonCalendar
-                leftmostMonth="2020-02-01"
+                leftmostMonth={dayjs('2020-02-01')}
                 months={1}
                 onLeftmostMonthChanged={onLeftmostMonthChanged}
                 onDateClick={onDateClick}
@@ -33,26 +33,26 @@ describe('LemonCalendar', () => {
         // go to January 2020
         const previousMonth = getByDataAttr(container, 'lemon-calendar-month-previous')
         userEvent.click(previousMonth)
-        expect(onLeftmostMonthChanged).toHaveBeenCalledWith('2020-01-01')
+        expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-01-01'))
         expect(await within(calendar).findByText('January 2020')).toBeDefined()
 
         // click on 15
         let fifteenth = await within(container).findByText('15')
         userEvent.click(fifteenth)
-        expect(onDateClick).toHaveBeenCalledWith('2020-01-15', '2020-01-01')
+        expect(onDateClick).toHaveBeenCalledWith(dayjs('2020-01-15'))
 
         // go to March 2020
         const nextMonth = getByDataAttr(container, 'lemon-calendar-month-next')
         userEvent.click(nextMonth)
         userEvent.click(nextMonth)
-        expect(onLeftmostMonthChanged).toHaveBeenCalledWith('2020-02-01')
-        expect(onLeftmostMonthChanged).toHaveBeenCalledWith('2020-03-01')
+        expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-02-01'))
+        expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-03-01'))
         expect(await within(calendar).findByText('March 2020')).toBeDefined()
 
         // click on 15
         fifteenth = await within(container).findByText('15') // the cell moved
         userEvent.click(fifteenth)
-        expect(onDateClick).toHaveBeenCalledWith('2020-03-15', '2020-03-01')
+        expect(onDateClick).toHaveBeenCalledWith(dayjs('2020-03-15'))
     })
 
     test('click and move between months with two months showing', async () => {
@@ -61,7 +61,7 @@ describe('LemonCalendar', () => {
 
         const { container } = render(
             <LemonCalendar
-                leftmostMonth="2020-02-01"
+                leftmostMonth={dayjs('2020-02-01')}
                 months={2}
                 onLeftmostMonthChanged={onLeftmostMonthChanged}
                 onDateClick={onDateClick}
@@ -80,28 +80,28 @@ describe('LemonCalendar', () => {
         // go to January 2020
         const previousMonth = getByDataAttr(container, 'lemon-calendar-month-previous')
         userEvent.click(previousMonth)
-        expect(onLeftmostMonthChanged).toHaveBeenCalledWith('2020-01-01')
+        expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-01-01'))
         expect(await within(cal1).findByText('January 2020')).toBeDefined()
         expect(await within(cal2).findByText('February 2020')).toBeDefined()
 
         // click on 15
         let fifteenth = await within(cal1).findByText('15')
         userEvent.click(fifteenth)
-        expect(onDateClick).toHaveBeenCalledWith('2020-01-15', '2020-01-01')
+        expect(onDateClick).toHaveBeenCalledWith(dayjs('2020-01-15'))
 
         // go to March 2020
         const nextMonth = getByDataAttr(container, 'lemon-calendar-month-next')
         userEvent.click(nextMonth)
         userEvent.click(nextMonth)
-        expect(onLeftmostMonthChanged).toHaveBeenCalledWith('2020-02-01')
-        expect(onLeftmostMonthChanged).toHaveBeenCalledWith('2020-03-01')
+        expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-02-01'))
+        expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-03-01'))
         expect(await within(cal1).findByText('March 2020')).toBeDefined()
         expect(await within(cal2).findByText('April 2020')).toBeDefined()
 
         // click on 15
         fifteenth = await within(cal1).findByText('15') // the cell moved
         userEvent.click(fifteenth)
-        expect(onDateClick).toHaveBeenCalledWith('2020-03-15', '2020-03-01')
+        expect(onDateClick).toHaveBeenCalledWith(dayjs('2020-03-15'))
     })
 
     test('renders many months', async () => {
@@ -127,55 +127,55 @@ describe('LemonCalendar', () => {
         const calls: any = []
         const { container } = render(
             <LemonCalendar
-                leftmostMonth="2020-02-20"
-                getLemonButtonProps={({ date, month, props: defaultProps }) => {
+                leftmostMonth={dayjs('2020-02-20')}
+                getLemonButtonProps={({ date, props: defaultProps }) => {
                     const props = { ...defaultProps }
-                    if (date === '2020-02-14') {
+                    if (date.isSame('2020-02-14')) {
                         props['data-attr'] = 's6brap2ev'
                         props['className'] = 'yolo'
                     }
-                    calls.push([date, month, props])
+                    calls.push([date, props])
                     return props
                 }}
             />
         )
         expect(calls.length).toBe(35)
         expect(calls).toEqual([
-            ['2020-01-27', '2020-02-01', { className: 'flex-col opacity-25' }],
-            ['2020-01-28', '2020-02-01', { className: 'flex-col opacity-25' }],
-            ['2020-01-29', '2020-02-01', { className: 'flex-col opacity-25' }],
-            ['2020-01-30', '2020-02-01', { className: 'flex-col opacity-25' }],
-            ['2020-01-31', '2020-02-01', { className: 'flex-col opacity-25' }],
-            ['2020-02-01', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-02', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-03', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-04', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-05', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-06', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-07', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-08', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-09', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-10', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-11', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-12', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-13', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-14', '2020-02-01', { className: 'yolo', 'data-attr': 's6brap2ev' }],
-            ['2020-02-15', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-16', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-17', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-18', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-19', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-20', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-21', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-22', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-23', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-24', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-25', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-26', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-27', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-28', '2020-02-01', { className: 'flex-col' }],
-            ['2020-02-29', '2020-02-01', { className: 'flex-col' }],
-            ['2020-03-01', '2020-02-01', { className: 'flex-col opacity-25' }],
+            [dayjs('2020-01-27'), { className: 'flex-col opacity-25' }],
+            [dayjs('2020-01-28'), { className: 'flex-col opacity-25' }],
+            [dayjs('2020-01-29'), { className: 'flex-col opacity-25' }],
+            [dayjs('2020-01-30'), { className: 'flex-col opacity-25' }],
+            [dayjs('2020-01-31'), { className: 'flex-col opacity-25' }],
+            [dayjs('2020-02-01'), { className: 'flex-col' }],
+            [dayjs('2020-02-02'), { className: 'flex-col' }],
+            [dayjs('2020-02-03'), { className: 'flex-col' }],
+            [dayjs('2020-02-04'), { className: 'flex-col' }],
+            [dayjs('2020-02-05'), { className: 'flex-col' }],
+            [dayjs('2020-02-06'), { className: 'flex-col' }],
+            [dayjs('2020-02-07'), { className: 'flex-col' }],
+            [dayjs('2020-02-08'), { className: 'flex-col' }],
+            [dayjs('2020-02-09'), { className: 'flex-col' }],
+            [dayjs('2020-02-10'), { className: 'flex-col' }],
+            [dayjs('2020-02-11'), { className: 'flex-col' }],
+            [dayjs('2020-02-12'), { className: 'flex-col' }],
+            [dayjs('2020-02-13'), { className: 'flex-col' }],
+            [dayjs('2020-02-14'), { className: 'yolo', 'data-attr': 's6brap2ev' }],
+            [dayjs('2020-02-15'), { className: 'flex-col' }],
+            [dayjs('2020-02-16'), { className: 'flex-col' }],
+            [dayjs('2020-02-17'), { className: 'flex-col' }],
+            [dayjs('2020-02-18'), { className: 'flex-col' }],
+            [dayjs('2020-02-19'), { className: 'flex-col' }],
+            [dayjs('2020-02-20'), { className: 'flex-col' }],
+            [dayjs('2020-02-21'), { className: 'flex-col' }],
+            [dayjs('2020-02-22'), { className: 'flex-col' }],
+            [dayjs('2020-02-23'), { className: 'flex-col' }],
+            [dayjs('2020-02-24'), { className: 'flex-col' }],
+            [dayjs('2020-02-25'), { className: 'flex-col' }],
+            [dayjs('2020-02-26'), { className: 'flex-col' }],
+            [dayjs('2020-02-27'), { className: 'flex-col' }],
+            [dayjs('2020-02-28'), { className: 'flex-col' }],
+            [dayjs('2020-02-29'), { className: 'flex-col' }],
+            [dayjs('2020-03-01'), { className: 'flex-col opacity-25' }],
         ])
         const fourteen = getByDataAttr(container, 's6brap2ev')
         expect(fourteen).toBeDefined()

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.stories.tsx
@@ -13,7 +13,7 @@ export default {
 } as ComponentMeta<typeof LemonCalendarSelect>
 
 const BasicTemplate: ComponentStory<typeof LemonCalendarSelect> = (props: LemonCalendarSelectProps) => {
-    const [value, setValue] = useState(dayjs().subtract(10, 'day').format('YYYY-MM-DD'))
+    const [value, setValue] = useState(dayjs().subtract(10, 'day'))
     const [visible, setVisible] = useState(true)
 
     return (
@@ -36,7 +36,7 @@ const BasicTemplate: ComponentStory<typeof LemonCalendarSelect> = (props: LemonC
                 onClickOutside={() => setVisible(false)}
             >
                 <LemonButton type="secondary" onClick={() => setVisible(!visible)}>
-                    {formatDate(dayjs(value))}
+                    {formatDate(value)}
                 </LemonButton>
             </Popup>
         </div>

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.test.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.test.tsx
@@ -3,6 +3,7 @@ import { render, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { getByDataAttr } from '~/test/byDataAttr'
 import { LemonCalendarSelect } from 'lib/components/LemonCalendar/LemonCalendarSelect'
+import { dayjs } from 'lib/dayjs'
 
 describe('LemonCalendarSelect', () => {
     test('select various dates', async () => {
@@ -10,7 +11,7 @@ describe('LemonCalendarSelect', () => {
         const onChange = jest.fn()
 
         function TestSelect(): JSX.Element {
-            const [value, setValue] = useState('2022-02-10')
+            const [value, setValue] = useState(dayjs('2022-02-10'))
             return (
                 <LemonCalendarSelect
                     months={1}
@@ -39,11 +40,11 @@ describe('LemonCalendarSelect', () => {
 
         // click on 15
         await clickOn('15')
-        expect(onChange).toHaveBeenCalledWith('2022-02-15')
+        expect(onChange).toHaveBeenCalledWith(dayjs('2022-02-15'))
 
         // click on 27
         await clickOn('27')
-        expect(onChange).toHaveBeenCalledWith('2022-02-27')
+        expect(onChange).toHaveBeenCalledWith(dayjs('2022-02-27'))
 
         userEvent.click(getByDataAttr(container, 'lemon-calendar-select-cancel'))
         expect(onClose).toHaveBeenCalled()

--- a/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.tsx
+++ b/frontend/src/lib/components/LemonCalendar/LemonCalendarSelect.tsx
@@ -5,15 +5,14 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { IconClose } from 'lib/components/icons'
 
 export interface LemonCalendarSelectProps {
-    value?: string | null
-    onChange: (date: string) => void
+    value?: dayjs.Dayjs | null
+    onChange: (date: dayjs.Dayjs) => void
     months?: number
     onClose?: () => void
 }
 
 export function LemonCalendarSelect({ value, onChange, months, onClose }: LemonCalendarSelectProps): JSX.Element {
-    const parsedValue = value ? dayjs(value).format('YYYY-MM-DD') : undefined
-    const [selectValue, setSelectValue] = useState(parsedValue)
+    const [selectValue, setSelectValue] = useState<dayjs.Dayjs | null>(value ? value.startOf('day') : null)
 
     return (
         <div className="LemonCalendarSelect" data-attr="lemon-calendar-select">
@@ -32,10 +31,10 @@ export function LemonCalendarSelect({ value, onChange, months, onClose }: LemonC
             <div className="p-2">
                 <LemonCalendar
                     onDateClick={setSelectValue}
-                    leftmostMonth={selectValue}
+                    leftmostMonth={selectValue?.startOf('month')}
                     months={months}
                     getLemonButtonProps={({ date, props }) => {
-                        if (date === selectValue) {
+                        if (date.isSame(selectValue, 'd')) {
                             return { ...props, status: 'primary', type: 'primary' }
                         }
                         return props

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.stories.tsx
@@ -13,7 +13,7 @@ export default {
 } as ComponentMeta<typeof LemonCalendarRange>
 
 const BasicTemplate: ComponentStory<typeof LemonCalendarRange> = (props: LemonCalendarRangeProps) => {
-    const [value, setValue] = useState(['2022-08-11', '2022-08-26'] as [string, string] | null)
+    const [value, setValue] = useState([dayjs('2022-08-11'), dayjs('2022-08-26')] as LemonCalendarRangeProps['value'])
     const [visible, setVisible] = useState(true)
 
     return (
@@ -36,7 +36,7 @@ const BasicTemplate: ComponentStory<typeof LemonCalendarRange> = (props: LemonCa
                 onClickOutside={() => setVisible(false)}
             >
                 <LemonButton type="secondary" onClick={() => setVisible(!visible)}>
-                    {value ? formatDateRange(dayjs(value[0]), dayjs(value[1])) : ''}
+                    {value ? formatDateRange(...value) : ''}
                 </LemonButton>
             </Popup>
         </div>

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.test.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.test.tsx
@@ -3,6 +3,7 @@ import { render, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { getByDataAttr } from '~/test/byDataAttr'
 import { LemonCalendarRange } from 'lib/components/LemonCalendarRange/LemonCalendarRange'
+import { dayjs } from 'lib/dayjs'
 
 describe('LemonCalendarRange', () => {
     test('select various ranges', async () => {
@@ -10,7 +11,7 @@ describe('LemonCalendarRange', () => {
         const onChange = jest.fn()
 
         function TestRange(): JSX.Element {
-            const [value, setValue] = useState(['2022-02-10', '2022-02-28'] as [string, string])
+            const [value, setValue] = useState([dayjs('2022-02-10'), dayjs('2022-02-28')] as [dayjs.Dayjs, dayjs.Dayjs])
             return (
                 <LemonCalendarRange
                     months={1}
@@ -39,31 +40,31 @@ describe('LemonCalendarRange', () => {
 
         // click on 15
         await clickOn('15')
-        expect(onChange).toHaveBeenCalledWith(['2022-02-15', '2022-02-28'])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-15'), dayjs('2022-02-28')])
 
         // click on 27
         await clickOn('27')
-        expect(onChange).toHaveBeenCalledWith(['2022-02-15', '2022-02-27'])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-15'), dayjs('2022-02-27')])
 
         // click on 16
         await clickOn('16')
-        expect(onChange).toHaveBeenCalledWith(['2022-02-16', '2022-02-27'])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-16'), dayjs('2022-02-27')])
 
         // click on 26
         await clickOn('26')
-        expect(onChange).toHaveBeenCalledWith(['2022-02-16', '2022-02-26'])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-16'), dayjs('2022-02-26')])
 
         // click on 10
         await clickOn('10')
-        expect(onChange).toHaveBeenCalledWith(['2022-02-10', '2022-02-26'])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-10'), dayjs('2022-02-26')])
 
         // click on 28
         await clickOn('28')
-        expect(onChange).toHaveBeenCalledWith(['2022-02-10', '2022-02-28'])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-10'), dayjs('2022-02-28')])
 
         // click on 20
         await clickOn('20')
-        expect(onChange).toHaveBeenCalledWith(['2022-02-20', '2022-02-28'])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-20'), dayjs('2022-02-28')])
 
         userEvent.click(getByDataAttr(container, 'lemon-calendar-range-cancel'))
         expect(onClose).toHaveBeenCalled()

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRange.tsx
@@ -6,19 +6,18 @@ import { formatDate, formatDateRange } from 'lib/utils'
 import { LemonCalendarRangeInline } from './LemonCalendarRangeInline'
 
 export interface LemonCalendarRangeProps {
-    value?: [string, string] | null
-    onChange: (date: [string, string]) => void
+    value?: [dayjs.Dayjs, dayjs.Dayjs] | null
+    onChange: (range: [dayjs.Dayjs, dayjs.Dayjs]) => void
     months?: number
     onClose?: () => void
 }
 
 export function LemonCalendarRange({ value, onChange, onClose, months }: LemonCalendarRangeProps): JSX.Element {
     // Keep a sanitised and cached copy of the selected range
-    const [valueStart, valueEnd] = [
-        value?.[0] ? dayjs(value[0]).format('YYYY-MM-DD') : null,
-        value?.[1] ? dayjs(value[1]).format('YYYY-MM-DD') : null,
-    ]
-    const [[rangeStart, rangeEnd], setRange] = useState([valueStart, valueEnd])
+    const [[rangeStart, rangeEnd], setRange] = useState([
+        value?.[0] ? value[0].startOf('day') : null,
+        value?.[1] ? value[1].startOf('day') : null,
+    ])
 
     return (
         <div className="LemonCalendarRange" data-attr="lemon-calendar-range">
@@ -42,9 +41,9 @@ export function LemonCalendarRange({ value, onChange, onClose, months }: LemonCa
                     <div className="flex-1">
                         <span className="text-muted">Selected period:</span>{' '}
                         <span>
-                            {rangeStart === rangeEnd
-                                ? formatDate(dayjs(rangeStart))
-                                : formatDateRange(dayjs(rangeStart), dayjs(rangeEnd))}
+                            {rangeStart.isSame(rangeEnd, 'd')
+                                ? formatDate(rangeStart)
+                                : formatDateRange(rangeStart, rangeEnd)}
                         </span>
                     </div>
                 )}

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRangeInline.stories.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRangeInline.stories.tsx
@@ -12,7 +12,7 @@ export default {
 } as ComponentMeta<typeof LemonCalendarRangeInline>
 
 const BasicTemplate: ComponentStory<typeof LemonCalendarRangeInline> = (props: LemonCalendarRangeProps) => {
-    const [value, setValue] = useState(['2022-08-11', '2022-08-26'] as [string, string] | null)
+    const [value, setValue] = useState([dayjs('2022-08-11'), dayjs('2022-08-26')] as [dayjs.Dayjs, dayjs.Dayjs] | null)
 
     return (
         <>
@@ -24,7 +24,7 @@ const BasicTemplate: ComponentStory<typeof LemonCalendarRangeInline> = (props: L
                 }}
             />
 
-            <p className="mt-2">Value is: {value ? formatDateRange(dayjs(value[0]), dayjs(value[1])) : ''}</p>
+            <p className="mt-2">Value is: {value ? formatDateRange(...value) : ''}</p>
         </>
     )
 }

--- a/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRangeInline.tsx
+++ b/frontend/src/lib/components/LemonCalendarRange/LemonCalendarRangeInline.tsx
@@ -9,19 +9,21 @@ const WIDTH_OF_ONE_CALENDAR_MONTH = 300
 /** Number of calendars to display if `typeof window === undefined` */
 const CALENDARS_IF_NO_WINDOW = 2
 
+type RangeState = [dayjs.Dayjs | null, dayjs.Dayjs | null, 'start' | 'end']
+
 export function LemonCalendarRangeInline({
     value,
     onChange,
     months,
 }: Omit<LemonCalendarRangeProps, 'onClose'>): JSX.Element {
     // Keep a sanitised and cached copy of the selected range
-    const [valueStart, valueEnd] = [
-        value?.[0] ? dayjs(value[0]).format('YYYY-MM-DD') : null,
-        value?.[1] ? dayjs(value[1]).format('YYYY-MM-DD') : null,
-    ]
-    const [[rangeStart, rangeEnd, lastChanged], _setRange] = useState([valueStart, valueEnd, 'end' as 'start' | 'end'])
+    const [[rangeStart, rangeEnd, lastChanged], _setRange] = useState<RangeState>([
+        value?.[0] ?? null,
+        value?.[1] ?? null,
+        'end',
+    ])
 
-    function setRange([rangeStart, rangeEnd, lastChanged]: [string | null, string | null, 'start' | 'end']): void {
+    function setRange([rangeStart, rangeEnd, lastChanged]: RangeState): void {
         _setRange([rangeStart, rangeEnd, lastChanged])
         if (rangeStart && rangeEnd) {
             onChange([rangeStart, rangeEnd])
@@ -48,22 +50,19 @@ export function LemonCalendarRangeInline({
     // What months exactly are shown on the calendar
     const shownMonths = months ?? autoMonthCount
     const rangeMonthDiff =
-        rangeStart && rangeEnd ? dayjs(rangeEnd).startOf('month').diff(dayjs(rangeStart).startOf('month'), 'month') : 0
-    const leftmostMonthForRange = dayjs(rangeStart ?? rangeEnd ?? undefined)
+        rangeStart && rangeEnd ? rangeEnd.startOf('month').diff(rangeStart.startOf('month'), 'month') : 0
+    const leftmostMonthForRange = (rangeStart ?? rangeEnd ?? dayjs())
         .subtract(Math.max(0, shownMonths - 1 - rangeMonthDiff), 'month')
         .startOf('month')
-        .format('YYYY-MM-DD')
     const [leftmostMonth, setLeftmostMonth] = useState(leftmostMonthForRange)
 
     // If the range changes via props and is not in view, update the first month
     useEffect(() => {
-        const lastMonthForRange = dayjs(leftmostMonthForRange)
-            .add(shownMonths - 1, 'month')
-            .endOf('month')
+        const lastMonthForRange = leftmostMonthForRange.add(shownMonths - 1, 'month').endOf('month')
         if (
             rangeStart &&
             rangeEnd &&
-            (dayjs(rangeStart).isAfter(lastMonthForRange) || dayjs(rangeEnd).isBefore(dayjs(leftmostMonthForRange)))
+            (rangeStart.isAfter(lastMonthForRange) || rangeEnd.isBefore(leftmostMonthForRange))
         ) {
             setLeftmostMonth(leftmostMonthForRange)
         }
@@ -96,15 +95,15 @@ export function LemonCalendarRangeInline({
             onLeftmostMonthChanged={setLeftmostMonth}
             months={shownMonths}
             getLemonButtonProps={({ date, props, dayIndex }) => {
-                if (date === rangeStart || date === rangeEnd) {
+                if (date.isSame(rangeStart, 'd') || date.isSame(rangeEnd, 'd')) {
                     return {
                         ...props,
                         className:
-                            date === rangeStart && date === rangeEnd
+                            date.isSame(rangeStart, 'd') && date.isSame(rangeEnd, 'd')
                                 ? props.className
                                 : clsx(props.className, {
-                                      'rounded-r-none': date === rangeStart && dayIndex < 6,
-                                      'rounded-l-none': date === rangeEnd && dayIndex > 0,
+                                      'rounded-r-none': date.isSame(rangeStart, 'd') && dayIndex < 6,
+                                      'rounded-l-none': date.isSame(rangeEnd, 'd') && dayIndex > 0,
                                   }),
                         status: 'primary',
                         type: 'primary',

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { PlayCircleOutlined, CheckOutlined, CloseOutlined, SettingOutlined } from '@ant-design/icons'
-import { Tooltip, Radio, InputNumber, DatePicker } from 'antd'
+import { Tooltip, Radio, InputNumber } from 'antd'
 import { ChildFunctionProps, Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
 import MonacoEditor from '@monaco-editor/react'
@@ -9,12 +9,12 @@ import { userLogic } from 'scenes/userLogic'
 import { JobPayloadFieldOptions } from '~/types'
 import { interfaceJobsLogic, InterfaceJobsProps } from './interfaceJobsLogic'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
-import moment from 'moment'
 import { LemonModal } from 'lib/components/LemonModal'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonCalendarRangeInline } from 'lib/components/LemonCalendarRange/LemonCalendarRangeInline'
 import { dayjs } from 'lib/dayjs'
 import { formatDate, formatDateRange } from 'lib/utils'
+import { DatePicker } from 'lib/components/DatePicker'
 
 // keep in sync with plugin-server's export-historical-events.ts
 export const HISTORICAL_EXPORT_JOB_NAME = 'Export historical events'
@@ -143,15 +143,20 @@ function FieldInput({
                     suffixIcon={null}
                     use12Hours
                     showTime
-                    value={value ? moment(value) : null}
-                    onChange={(date: moment.Moment | null) => onChange(date?.toISOString())}
+                    value={value ? dayjs(value) : null}
+                    onChange={(date) => onChange(date?.toISOString())}
                 />
             )
         case 'daterange':
             return (
                 <div className="border rounded p-4">
                     <div className="pb-4">
-                        <LemonCalendarRangeInline value={value || null} onChange={onChange} />
+                        <LemonCalendarRangeInline
+                            value={value ? [dayjs(value[0]), dayjs(value[1])] : null}
+                            onChange={([rangeStart, rangeEnd]) =>
+                                onChange([rangeStart.format('YYYY-MM-DD'), rangeEnd.format('YYYY-MM-DD')])
+                            }
+                        />
                     </div>
                     <div className="border-t pt-4">
                         <span className="text-muted">Selected period:</span>{' '}

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
         "kea-waitfor": "^0.2.1",
         "kea-window-values": "^3.0.0",
         "md5": "^2.3.0",
-        "moment": "^2.29.4",
         "monaco-editor": "^0.23.0",
         "posthog-js": "1.39.2",
         "posthog-js-lite": "2.0.0-alpha5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,7 +129,6 @@ specifiers:
   lint-staged: ~10.2.13
   md5: ^2.3.0
   mockdate: ^3.0.5
-  moment: ^2.29.4
   monaco-editor: ^0.23.0
   msw: ^0.47.3
   path-browserify: ^1.0.1
@@ -235,7 +234,6 @@ dependencies:
   kea-waitfor: 0.2.1_kea@3.1.0
   kea-window-values: 3.0.0_kea@3.1.0
   md5: 2.3.0
-  moment: 2.29.4
   monaco-editor: 0.23.0
   posthog-js: 1.39.2
   posthog-js-lite: 2.0.0-alpha5


### PR DESCRIPTION
## Problem

We've been using ISO date strings for dates in `LemonCalendar` and its derivatives, and Moment.js in one Ant `DatePicker` call site. Meanwhile, practically everywhere else in the frontend, we use Day.js. We need those discrepancies resolved for two reasons:
- We need to support hour-picking in `LemonCalendarSelect`, but that'd be a mess if we were to stick with ISO date strings! We'd need to start supporting both date and datetime strings, which anyway require lots and lots of `dayjs()` parsing
- We're not using Moment.js anywhere else, and we want it gone as part of https://github.com/PostHog/posthog/issues/13624 (though it'll still be in the bundle as long as we're using Ant)

## Changes

Refactors `LemonCalendar`, `LemonCalendarSelect`, and `LemonCalendarRange` to use Day.js in their API (they've already been relying on it internally).
Also removes the remaining explicit mention of Moment.js.
Also made a small UI fix to `LemonCalendar` next/previous month buttons – they weren't styled properly, because they placed the icon in `children` and not in `icon`.

## How did you test this code?

Adjusted all the existing tests.