### PR TITLE
chore(deps): Remove useless `@types/chart.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
-        "@types/chart.js": "^2.9.34",
         "@types/chartjs-plugin-crosshair": "^1.1.1",
         "@types/clone": "^2.1.1",
         "@types/d3": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,6 @@ specifiers:
   '@testing-library/jest-dom': ^5.16.2
   '@testing-library/react': ^12.1.2
   '@testing-library/user-event': ^13.5.0
-  '@types/chart.js': ^2.9.34
   '@types/chartjs-plugin-crosshair': ^1.1.1
   '@types/clone': ^2.1.1
   '@types/d3': ^7.0.0
@@ -305,7 +304,6 @@ devDependencies:
   '@testing-library/jest-dom': 5.16.5
   '@testing-library/react': 12.1.5_wcqkhtmu7mswc6yz4uyexck3ty
   '@testing-library/user-event': 13.5.0_aaq3sbffpfe3jnxzm2zngsddei
-  '@types/chart.js': 2.9.37
   '@types/chartjs-plugin-crosshair': 1.1.1
   '@types/clone': 2.1.1
   '@types/d3': 7.4.0


### PR DESCRIPTION
## Changes

Turns out we don't need `@types/chart.js` anymore since https://github.com/PostHog/posthog/pull/11888. The types are already included in `chart.js`:
<img width="336" alt="Screenshot 2023-01-11 at 18 27 16" src="https://user-images.githubusercontent.com/4550621/211876175-3fb78770-165b-4ec3-b886-b8bb36ea4e00.png">
