### PR TITLE
feat: plugin server env for dropping events or snapshots

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -105,6 +105,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         APP_METRICS_GATHERED_FOR_ALL: isDevEnv() ? true : false,
         MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR: 0,
         USE_KAFKA_FOR_SCHEDULED_TASKS: true,
+        DROP_EVENTS_TEAMS: '',
+        DROP_SNAPSHOTS_TEAMS: '',
     }
 }
 

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -60,14 +60,10 @@ export async function ingestEvent(
         ) {
             server.statsd?.increment('kafka_queue_ingest_event_hit', {
                 pipeline: 'droppedBadActor',
-                team_id: event.team_id.toString(),
-                isSnapshot: String(isSnapshot),
             })
         } else {
             server.statsd?.increment('kafka_queue_ingest_event_hit', {
                 pipeline: 'runEventPipeline',
-                team_id: event.team_id.toString(),
-                isSnapshot: String(isSnapshot),
             })
             // we've confirmed team_id exists so can assert event as PluginEvent
             await workerMethods.runEventPipeline(event as PluginEvent)

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -53,16 +53,25 @@ export async function ingestEvent(
     if (event.team_id) {
         // Sometimes bad actors could cause us trouble, this allows us to drop all events or all snapshots for
         // a specific team
+        const isSnapshot = event.event == '$snapshot'
         if (
-            (event.event == '$snapshot' && server.dropSnapshotsTeams.has(event.team_id)) ||
-            (event.event != '$snapshot' && server.dropEventsTeams.has(event.team_id))
+            (isSnapshot && server.dropSnapshotsTeams.has(event.team_id)) ||
+            (!isSnapshot && server.dropEventsTeams.has(event.team_id))
         ) {
-            server.statsd?.increment('kafka_queue_ingest_event_hit', { pipeline: 'droppedBadActor' })
+            server.statsd?.increment('kafka_queue_ingest_event_hit', {
+                pipeline: 'droppedBadActor',
+                team_id: event.team_id.toString(),
+                isSnapshot: String(isSnapshot),
+            })
+        } else {
+            server.statsd?.increment('kafka_queue_ingest_event_hit', {
+                pipeline: 'runEventPipeline',
+                team_id: event.team_id.toString(),
+                isSnapshot: String(isSnapshot),
+            })
+            // we've confirmed team_id exists so can assert event as PluginEvent
+            await workerMethods.runEventPipeline(event as PluginEvent)
         }
-
-        server.statsd?.increment('kafka_queue_ingest_event_hit', { pipeline: 'runEventPipeline' })
-        // we've confirmed team_id exists so can assert event as PluginEvent
-        await workerMethods.runEventPipeline(event as PluginEvent)
     } else {
         server.statsd?.increment('kafka_queue_ingest_event_hit', {
             pipeline: 'runLightweightCaptureEndpointEventPipeline',

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -53,12 +53,10 @@ export async function ingestEvent(
     if (event.team_id) {
         // Sometimes bad actors could cause us trouble, this allows us to drop all events or all snapshots for
         // a specific team
-        // TODO: use the env
         if (
             (event.event == '$snapshot' && server.dropSnapshotsTeams.has(event.team_id)) ||
             (event.event != '$snapshot' && server.dropEventsTeams.has(event.team_id))
         ) {
-            // ?.split(',').includes(event.team_id.toString())) {
             server.statsd?.increment('kafka_queue_ingest_event_hit', { pipeline: 'droppedBadActor' })
         }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -161,6 +161,8 @@ export interface PluginsServerConfig extends Record<string, any> {
     APP_METRICS_GATHERED_FOR_ALL: boolean
     MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR: number
     USE_KAFKA_FOR_SCHEDULED_TASKS: boolean
+    DROP_EVENTS_TEAMS: string
+    DROP_SNAPSHOTS_TEAMS: string
 }
 
 export interface Hub extends PluginsServerConfig {
@@ -204,6 +206,8 @@ export interface Hub extends PluginsServerConfig {
     lastActivityType: string
     statelessVms: StatelessVmMap
     conversionBufferEnabledTeams: Set<number>
+    dropSnapshotsTeams: Set<number>
+    dropEventsTeams: Set<number>
 }
 
 export interface PluginServerCapabilities {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -77,6 +77,8 @@ export async function createHub(
     const conversionBufferEnabledTeams = new Set(
         serverConfig.CONVERSION_BUFFER_ENABLED_TEAMS.split(',').filter(String).map(Number)
     )
+    const dropEventsTeams = new Set(serverConfig.DROP_EVENTS_TEAMS.split(',').filter(String).map(Number))
+    const dropSnapshotsTeams = new Set(serverConfig.DROP_SNAPSHOTS_TEAMS.split(',').filter(String).map(Number))
 
     if (serverConfig.STATSD_HOST) {
         status.info('🤔', `Connecting to StatsD...`)
@@ -289,6 +291,8 @@ export async function createHub(
         actionManager,
         actionMatcher: new ActionMatcher(db, actionManager, statsd),
         conversionBufferEnabledTeams,
+        dropSnapshotsTeams,
+        dropEventsTeams,
     }
 
     // :TODO: This is only used on worker threads, not main


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Quick way to drop events or snapshots per team - would allow us to potentially mitigate incidents.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
