### PR TITLE
feat: Added recording metrics to system status

### DIFF
--- a/ee/clickhouse/test/test_system_status.py
+++ b/ee/clickhouse/test/test_system_status.py
@@ -8,6 +8,8 @@ def test_system_status(db):
         "clickhouse_event_count",
         "clickhouse_event_count_last_month",
         "clickhouse_event_count_month_to_date",
+        "clickhouse_session_recordings_count_month_to_date",
+        "clickhouse_session_recordings_events_count_month_to_date",
         "clickhouse_disk_0_free_space",
         "clickhouse_disk_0_total_space",
         "clickhouse_table_sizes",
@@ -17,5 +19,5 @@ def test_system_status(db):
         "dead_letter_queue_events_last_day",
         "dead_letter_queue_ratio_ok",
     ]
-    assert len(results[6]["subrows"]["rows"]) > 0
-    assert len(results[7]["subrows"]["rows"]) > 0
+    assert len(results[8]["subrows"]["rows"]) > 0
+    assert len(results[9]["subrows"]["rows"]) > 0

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -17,6 +17,10 @@ from posthog.cache_utils import cache_for
 from posthog.clickhouse.client.connection import make_ch_pool
 from posthog.client import query_with_columns, sync_execute
 from posthog.models.event.util import get_event_count, get_event_count_for_last_month, get_event_count_month_to_date
+from posthog.models.session_recording_event.util import (
+    get_recording_count_month_to_date,
+    get_recording_events_count_month_to_date,
+)
 from posthog.settings import CLICKHOUSE_PASSWORD, CLICKHOUSE_STABLE_HOST, CLICKHOUSE_USER
 
 SLOW_THRESHOLD_MS = 10000
@@ -45,6 +49,18 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
         "key": "clickhouse_event_count_month_to_date",
         "metric": "Events recorded month to date",
         "value": get_event_count_month_to_date(),
+    }
+
+    yield {
+        "key": "session_recordings_count_month_to_date",
+        "metric": "Session recordings month to date",
+        "value": get_recording_count_month_to_date(),
+    }
+
+    yield {
+        "key": "session_recordings_events_count_month_to_date",
+        "metric": "Session recordings events month to date",
+        "value": get_recording_events_count_month_to_date(),
     }
 
     disk_status = sync_execute(

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -16,6 +16,7 @@ from posthog.api.dead_letter_queue import get_dead_letter_queue_events_last_24h,
 from posthog.cache_utils import cache_for
 from posthog.clickhouse.client.connection import make_ch_pool
 from posthog.client import query_with_columns, sync_execute
+from posthog.cloud_utils import is_cloud
 from posthog.models.event.util import get_event_count, get_event_count_for_last_month, get_event_count_month_to_date
 from posthog.models.session_recording_event.util import (
     get_recording_count_month_to_date,
@@ -51,17 +52,19 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
         "value": get_event_count_month_to_date(),
     }
 
-    yield {
-        "key": "clickhouse_session_recordings_count_month_to_date",
-        "metric": "Session recordings month to date",
-        "value": get_recording_count_month_to_date(),
-    }
+    if not is_cloud():
+        # NOTE: These metrics can be quite expensive to calculate and are only really interesting to self-hosted customers
+        yield {
+            "key": "clickhouse_session_recordings_count_month_to_date",
+            "metric": "Session recordings month to date",
+            "value": get_recording_count_month_to_date(),
+        }
 
-    yield {
-        "key": "clickhouse_session_recordings_events_count_month_to_date",
-        "metric": "Session recordings events month to date",
-        "value": get_recording_events_count_month_to_date(),
-    }
+        yield {
+            "key": "clickhouse_session_recordings_events_count_month_to_date",
+            "metric": "Session recordings events month to date",
+            "value": get_recording_events_count_month_to_date(),
+        }
 
     disk_status = sync_execute(
         "SELECT formatReadableSize(total_space), formatReadableSize(free_space) FROM system.disks"

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -52,13 +52,13 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
     }
 
     yield {
-        "key": "session_recordings_count_month_to_date",
+        "key": "clickhouse_session_recordings_count_month_to_date",
         "metric": "Session recordings month to date",
         "value": get_recording_count_month_to_date(),
     }
 
     yield {
-        "key": "session_recordings_events_count_month_to_date",
+        "key": "clickhouse_session_recordings_events_count_month_to_date",
         "metric": "Session recordings events month to date",
         "value": get_recording_events_count_month_to_date(),
     }

--- a/posthog/models/session_recording_event/util.py
+++ b/posthog/models/session_recording_event/util.py
@@ -23,10 +23,9 @@ def get_recording_count_for_team_and_period(
 def get_recording_count_month_to_date() -> int:
     result = sync_execute(
         """
-        -- count of recordings month to date
         SELECT count(distinct session_id) as freq
         FROM session_recording_events
-        WHERE toStartOfMonth(timestamp) = toStartOfMonth(now());
+        WHERE toStartOfMonth(timestamp) = toStartOfMonth(now())
     """
     )[0][0]
     return result
@@ -35,10 +34,9 @@ def get_recording_count_month_to_date() -> int:
 def get_recording_events_count_month_to_date() -> int:
     result = sync_execute(
         """
-        -- count of recordings events month to date
-        SELECT count(1) freq
+        SELECT count() freq
         FROM session_recording_events
-        WHERE toStartOfMonth(timestamp) = toStartOfMonth(now());
+        WHERE toStartOfMonth(timestamp) = toStartOfMonth(now())
     """
     )[0][0]
     return result

--- a/posthog/models/session_recording_event/util.py
+++ b/posthog/models/session_recording_event/util.py
@@ -18,3 +18,27 @@ def get_recording_count_for_team_and_period(
         {"team_id": str(team_id), "begin": begin, "end": end},
     )[0][0]
     return result
+
+
+def get_recording_count_month_to_date() -> int:
+    result = sync_execute(
+        """
+        -- count of recordings month to date
+        SELECT count(distinct session_id) as freq
+        FROM session_recording_events
+        WHERE toStartOfMonth(timestamp) = toStartOfMonth(now());
+    """
+    )[0][0]
+    return result
+
+
+def get_recording_events_count_month_to_date() -> int:
+    result = sync_execute(
+        """
+        -- count of recordings events month to date
+        SELECT count(1) freq
+        FROM session_recording_events
+        WHERE toStartOfMonth(timestamp) = toStartOfMonth(now());
+    """
+    )[0][0]
+    return result


### PR DESCRIPTION
## Problem

Some customers are requesting to see how many recordings they have used, the same as they see event metrics in instance status. Whilst we are waiting for more visibility at the Billing level, this is an easy add.

## Changes

* Adds the recording count for month to date and the count of individual events to the instance status page

<img width="871" alt="Screenshot 2023-01-12 at 09 14 48" src="https://user-images.githubusercontent.com/2536520/212013434-cd1d9b3d-0852-44bf-8108-7d3341bdcdec.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
