### PR TITLE
chore: web performance fangling

### DIFF
--- a/ee/api/performance_events.py
+++ b/ee/api/performance_events.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 import pytz
+from django.utils import timezone
 from rest_framework import request, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -125,7 +126,8 @@ class RecentPageViewPerformanceEvents:
     def query(
         cls,
         team_id: int,
-        number_of_days: int,
+        date_from: datetime,
+        date_to: datetime,
     ) -> List[Dict]:
         query = RECENT_PAGE_VIEWS_SQL
 
@@ -133,7 +135,8 @@ class RecentPageViewPerformanceEvents:
             query,
             {
                 "team_id": team_id,
-                "number_of_days": number_of_days,
+                "date_from": date_from,
+                "date_to": date_to,
             },
         )
 
@@ -153,7 +156,18 @@ class RecentPageViewPerformanceEvents:
 
 
 class RecentPageViewPerformanceEventsQuerySerializer(serializers.Serializer):
-    number_of_days = serializers.IntegerField(max_value=30, default=7, min_value=1, required=False)
+    date_from = serializers.DateTimeField(required=True)
+    date_to = serializers.DateTimeField(required=False, default=timezone.now)
+
+    def validate(self, data: Dict) -> Dict:
+        if data["date_to"] < data["date_from"]:
+            raise serializers.ValidationError("date_to must be after date_from")
+
+        # difference between date_from and date_to must be less than 31 days
+        range_length = data["date_to"] - data["date_from"]
+        if range_length.total_seconds() > (31 * 86400):
+            raise serializers.ValidationError("date_to must be within 31 days of date_from")
+        return data
 
 
 class RecentPageViewPerformanceEventListSerializer(serializers.Serializer):
@@ -214,7 +228,9 @@ class PerformanceEventsViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
         params_serializer.is_valid(raise_exception=True)
         params = params_serializer.validated_data
 
-        results = RecentPageViewPerformanceEvents.query(self.team_id, number_of_days=params.get("number_of_days"))
+        results = RecentPageViewPerformanceEvents.query(
+            self.team_id, date_from=params.get("date_from"), date_to=params.get("date_to")
+        )
 
         serializer = RecentPageViewPerformanceEventListSerializer(data=results, many=True)
         serializer.is_valid(raise_exception=True)

--- a/ee/api/test/test_performance_events.py
+++ b/ee/api/test/test_performance_events.py
@@ -125,14 +125,32 @@ class TestLicensedPerformanceEvents(APILicensedTest):
             timestamp=datetime.datetime.fromisoformat("2008-04-10 11:47:58"),
         )
 
-        res = self.client.get(f"/api/projects/@current/performance_events/recent_pageviews")
+        seven_days_ago = datetime.datetime.now() - datetime.timedelta(days=7)
+        res = self.client.get(
+            f"/api/projects/@current/performance_events/recent_pageviews?date_from={seven_days_ago.isoformat()}"
+        )
+        self.assertEqual(res.status_code, 200, res.json())
         assert [r["session_id"] for r in res.json()["results"]] == ["matching_session_two", "matching_session_one"]
 
-        res = self.client.get(f"/api/projects/@current/performance_events/recent_pageviews?number_of_days=3")
+        three_days_ago = datetime.datetime.now() - datetime.timedelta(days=3)
+        res = self.client.get(
+            f"/api/projects/@current/performance_events/recent_pageviews?date_from={three_days_ago.isoformat()}"
+        )
+        self.assertEqual(res.status_code, 200, res.json())
         assert [r["session_id"] for r in res.json()["results"]] == ["matching_session_two"]
 
     def test_list_recent_pageviews_cannot_request_more_than_thirty_days(self):
-        res = self.client.get(f"/api/projects/@current/performance_events/recent_pageviews?number_of_days=31")
+        thirty_days_ago = datetime.datetime.now() - datetime.timedelta(days=30)
+        thirty_one_days_ago = datetime.datetime.now() - datetime.timedelta(days=31)
+
+        res = self.client.get(
+            f"/api/projects/@current/performance_events/recent_pageviews?date_from={thirty_days_ago.isoformat()}"
+        )
+        assert res.status_code == 200
+
+        res = self.client.get(
+            f"/api/projects/@current/performance_events/recent_pageviews?date_from={thirty_one_days_ago.isoformat()}"
+        )
         assert res.status_code == 400
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -48,6 +48,7 @@ import { EVENT_PROPERTY_DEFINITIONS_PER_PAGE } from 'scenes/data-management/even
 import { ActivityLogItem, ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
 import { ActivityLogProps } from 'lib/components/ActivityLog/ActivityLog'
 import { SavedSessionRecordingPlaylistsResult } from 'scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic'
+import { dayjs } from 'lib/dayjs'
 
 export const ACTIVITY_PAGE_SIZE = 20
 
@@ -416,8 +417,11 @@ class ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('performance_events')
     }
 
-    public recentPageViewPerformanceEvents(teamId?: TeamType['id']): ApiRequest {
-        return this.projectsDetail(teamId).addPathComponent('performance_events').addPathComponent('recent_pageviews')
+    public recentPageViewPerformanceEvents(dateFrom: string, dateTo: string, teamId?: TeamType['id']): ApiRequest {
+        return this.projectsDetail(teamId)
+            .addPathComponent('performance_events')
+            .addPathComponent('recent_pageviews')
+            .withQueryString(toParams({ date_from: dateFrom, date_to: dateTo }))
     }
 
     // Request finalization
@@ -1104,9 +1108,17 @@ const api = {
             return new ApiRequest().performanceEvents(teamId).withQueryString(toParams(params)).get()
         },
         async recentPageViews(
-            teamId: TeamType['id'] = getCurrentTeamId()
+            teamId: TeamType['id'] = getCurrentTeamId(),
+            dateFrom?: string,
+            dateTo?: string
         ): Promise<PaginatedResponse<RecentPerformancePageView>> {
-            return new ApiRequest().recentPageViewPerformanceEvents(teamId).get()
+            return new ApiRequest()
+                .recentPageViewPerformanceEvents(
+                    dateFrom || dayjs().subtract(1, 'day').toISOString(),
+                    dateTo || dayjs().toISOString(),
+                    teamId
+                )
+                .get()
         },
     },
 

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -5,7 +5,7 @@ import { AnyPropertyFilter, PropertyFilterType, PropertyOperator, RecentPerforma
 import { webPerformanceLogic, WebPerformancePage } from 'scenes/performance/webPerformanceLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { WebPerformanceWaterfallChart } from 'scenes/performance/WebPerformanceWaterfallChart'
 import { IconPlay } from 'lib/components/icons'
 import { LemonButton, LemonTable, Link } from '@posthog/lemon-ui'
@@ -16,6 +16,7 @@ import { NodeKind, RecentPerformancePageViewNode } from '~/queries/schema'
 import { humanFriendlyDuration } from 'lib/utils'
 import { LemonTableColumn } from 'lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TZLabel'
+import { useEffect } from 'react'
 
 /*
  * link to SessionRecording from table and chart
@@ -49,8 +50,16 @@ function WaterfallButton(props: { record: RecentPerformancePageView; onClick: ()
 
 const EventsWithPerformanceTable = (): JSX.Element => {
     const { recentPageViews, recentPageViewsLoading } = useValues(webPerformanceLogic)
+    const { loadRecentPageViews } = useActions(webPerformanceLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const featureDataExploration = featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_LIVE_EVENTS]
+
+    useEffect(() => {
+        if (!!recentPageViews.length && !featureDataExploration) {
+            // need to manually load pageviews if data exploration is off
+            loadRecentPageViews()
+        }
+    }, [featureDataExploration])
 
     const oldFashionedColumns: LemonTableColumn<
         RecentPerformancePageView,

--- a/posthog/models/performance/sql.py
+++ b/posthog/models/performance/sql.py
@@ -193,8 +193,8 @@ RECENT_PAGE_VIEWS_SQL = """
 select session_id, pageview_id, name, duration, timestamp
 from performance_events
 prewhere team_id = %(team_id)s
-and timestamp >= now() -interval %(number_of_days)s day
-and timestamp <= now()
+and timestamp >= %(date_from)s
+and timestamp <= %(date_to)s
 and entry_type = 'navigation'
 order by timestamp desc
 """


### PR DESCRIPTION
## Problem

web performance waterfalls had some sharp edges in production

## Changes

* load the recent page views if there are none and the data exploration feature flag is off
* use date_from and date_to in the API call and default to 1 day not 7

(follow-up to add paging / date filtering needed)

## How did you test this code?

developer tests and running locally
