### PR TITLE
fix: Account for missing type key in snapshot data

### DIFF
--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -107,7 +107,7 @@ def test_compression_and_chunking(raw_snapshot_events, mocker: MockerFixture):
                     "chunk_count": 1,
                     "data": "H4sIAAAAAAAC/2WMywpAUABEz6fori28k1+RhQVlIYoN8uuY+9hpaprONPM+LReGnYOVQakhIiOWWzoxi25KvdIa+pSSgoqcRKqde91u+X/Mw+PIInlmONXbZ6Ndxwc14H+ijAAAAA==",
                     "compression": "gzip-base64",
-                    "data": "H4sIAAAAAAAC//v/L5qhmkGJoYShkqGAIRXIsmJQYDBi0AGSINFMhlygaDGQlQhkFUDlDRlMGUwYzBiMGQyA0AJMQmAtWCemicYUmBjLAAABQ+l7pgAAAA==",
+                    "data": "H4sIAAAAAAAC//v/L5qhmkGJoYShkqGAIRXIsmJQYDBi0AGSINFMhlygaDGQlQhkFUDlDRlMGUwYzBiMGQyA0AJMQmAtWCemicZUMZG+emMZANpPzJceAQAA",
                     "has_full_snapshot": True,
                     "events_summary": [
                         {"timestamp": MILLISECOND_TIMESTAMP, "type": 2, "data": {}},
@@ -123,13 +123,11 @@ def test_compression_and_chunking(raw_snapshot_events, mocker: MockerFixture):
 def test_decompression_results_in_same_data(raw_snapshot_events):
     assert len(list(compress_and_chunk_snapshots(raw_snapshot_events, 1000))) == 1
     assert compress_decompress_and_extract(raw_snapshot_events, 1000) == [
-        raw_snapshot_events[0]["properties"]["$snapshot_data"],
-        raw_snapshot_events[1]["properties"]["$snapshot_data"],
+        event["properties"]["$snapshot_data"] for event in raw_snapshot_events
     ]
     assert len(list(compress_and_chunk_snapshots(raw_snapshot_events, 100))) == 2
     assert compress_decompress_and_extract(raw_snapshot_events, 100) == [
-        raw_snapshot_events[0]["properties"]["$snapshot_data"],
-        raw_snapshot_events[1]["properties"]["$snapshot_data"],
+        event["properties"]["$snapshot_data"] for event in raw_snapshot_events
     ]
 
 
@@ -519,6 +517,24 @@ def raw_snapshot_events():
                 "$session_id": "1234",
                 "$window_id": "1",
                 "$snapshot_data": {"type": 3, "timestamp": MILLISECOND_TIMESTAMP},
+                "distinct_id": "abc123",
+            },
+        },
+        {
+            "event": "$snapshot",
+            "properties": {
+                "$session_id": "1234",
+                "$window_id": "1",
+                "$snapshot_data": {"timestamp": MILLISECOND_TIMESTAMP},
+                "distinct_id": "abc123",
+            },
+        },
+        {
+            "event": "$snapshot",
+            "properties": {
+                "$session_id": "1234",
+                "$window_id": "1",
+                "$snapshot_data": {"timestamp": MILLISECOND_TIMESTAMP},
                 "distinct_id": "abc123",
             },
         },

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -109,7 +109,9 @@ def preprocess_session_recording_events_for_clickhouse(events: List[Event]) -> L
 def compress_and_chunk_snapshots(events: List[Event], chunk_size=512 * 1024) -> Generator[Event, None, None]:
     data_list = [event["properties"]["$snapshot_data"] for event in events]
     session_id = events[0]["properties"]["$session_id"]
-    has_full_snapshot = any(snapshot_data["type"] == RRWEB_MAP_EVENT_TYPE.FullSnapshot for snapshot_data in data_list)
+    has_full_snapshot = any(
+        snapshot_data.get("type", None) == RRWEB_MAP_EVENT_TYPE.FullSnapshot for snapshot_data in data_list
+    )
     window_id = events[0]["properties"].get("$window_id")
 
     compressed_data = compress_to_string(json.dumps(data_list))


### PR DESCRIPTION
## Problem

Given that:
* Snapshot data is not precisely typed (in Python, is typed as Dict[str, Any], in Django models is treated as a JSON field)
* Event summary ignores snapshot data with missing type (meaning it accounts for this case)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

We also account for missing "type" key in compress_and_chunk_snapshot_data by treating the key as optional. This deals with KeyErrors bubbling up to Sentry.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a couple of test events in unit tests that have a missing `"type"` key in their `"snapshot_data"`.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
