### PR TITLE
fix(frontend): dashboards not full width

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -562,6 +562,7 @@ input::-ms-clear {
 .main-app-content {
     position: relative; // So that scene-level <Loading/> is positioned correctly.
     min-width: 0;
+    width: 100%;
     height: 100%;
     padding: 0 1rem 1rem;
 


### PR DESCRIPTION
## Problem

Multiple users have reported that dashboards are squished. ~~And they are, but only on FireFox.~~

## Changes

`width: 100%`

## How did you test this code?

Looked at it in firefox and chrome. 