### PR TITLE
fix: Playback from file load order

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -532,12 +532,12 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
         }
 
         if (props.sessionRecordingData) {
+            actions.loadRecordingSnapshotsSuccess({
+                snapshotsByWindowId: props.sessionRecordingData.snapshotsByWindowId,
+            })
             actions.loadRecordingMetaSuccess({
                 person: props.sessionRecordingData.person,
                 metadata: props.sessionRecordingData.metadata,
-            })
-            actions.loadRecordingSnapshotsSuccess({
-                snapshotsByWindowId: props.sessionRecordingData.snapshotsByWindowId,
             })
         }
     }),


### PR DESCRIPTION
## Problem

Since some changes with how we load from S3 the file playback order needs to be changed so that snapshot data is loaded first.

## Changes

* Fixes this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Only in the UI. Ideally we have a proper test for this at some point....