### PR TITLE
feat(data-exploration): date range to events table

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { dateFilterLogic } from './dateFilterLogic'
 import { RollingDateRangeFilter } from './RollingDateRangeFilter'
 import { useActions, useValues } from 'kea'
-import { LemonButtonWithPopup, LemonDivider, LemonButton } from '@posthog/lemon-ui'
+import { LemonButtonWithPopup, LemonDivider, LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
 import { IconCalendar } from '../icons'
 import { LemonCalendarSelect } from 'lib/components/LemonCalendar/LemonCalendarSelect'
 import { LemonCalendarRange } from 'lib/components/LemonCalendarRange/LemonCalendarRange'
@@ -22,6 +22,7 @@ export interface DateFilterProps {
     getPopupContainer?: () => HTMLElement
     dateOptions?: DateMappingOption[]
     isDateFormatted?: boolean
+    size?: LemonButtonProps['size']
 }
 interface RawDateFilterProps extends DateFilterProps {
     dateFrom?: string | null | dayjs.Dayjs
@@ -40,6 +41,7 @@ export function DateFilter({
     dateTo,
     dateOptions = dateMapping,
     isDateFormatted = true,
+    size,
 }: RawDateFilterProps): JSX.Element {
     const key = useRef(uuid()).current
     const logicProps: DateFilterLogicProps = {
@@ -145,7 +147,7 @@ export function DateFilter({
             onClick={isVisible ? close : open}
             disabled={disabled}
             className={className}
-            size={'small'}
+            size={size ?? 'small'}
             type={'secondary'}
             status="stealth"
             popup={{

--- a/frontend/src/queries/nodes/DataNode/DateRange.tsx
+++ b/frontend/src/queries/nodes/DataNode/DateRange.tsx
@@ -1,0 +1,29 @@
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { DataNode, EventsQuery } from '~/queries/schema'
+import { isEventsQuery } from '~/queries/utils'
+
+interface DateRangeProps {
+    query: DataNode
+    setQuery?: (query: EventsQuery) => void
+}
+export function DateRange({ query, setQuery }: DateRangeProps): JSX.Element | null {
+    if (!isEventsQuery(query)) {
+        return null
+    }
+
+    return (
+        <DateFilter
+            size="medium"
+            dateFrom={query.after ?? undefined}
+            dateTo={query.before ?? undefined}
+            onChange={(changedDateFrom, changedDateTo) => {
+                const newQuery: EventsQuery = {
+                    ...query,
+                    after: changedDateFrom ?? undefined,
+                    before: changedDateTo ?? undefined,
+                }
+                setQuery?.(newQuery)
+            }}
+        />
+    )
+}

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -26,6 +26,7 @@ import { PersonPropertyFilters } from '~/queries/nodes/PersonsNode/PersonPropert
 import { PersonsSearch } from '~/queries/nodes/PersonsNode/PersonsSearch'
 import { PersonDeleteModal } from 'scenes/persons/PersonDeleteModal'
 import { ElapsedTime } from '~/queries/nodes/DataNode/ElapsedTime'
+import { DateRange } from '~/queries/nodes/DataNode/DateRange'
 
 interface DataTableProps {
     query: DataTableNode
@@ -63,6 +64,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
 
     const {
         showActions,
+        showDateRange,
         showSearch,
         showEventFilter,
         showPropertyFilter,
@@ -133,6 +135,9 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
     )
 
     const firstRow = [
+        showDateRange && isEventsQuery(query.source) ? (
+            <DateRange query={query.source} setQuery={setQuerySource} />
+        ) : null,
         showEventFilter && isEventsQuery(query.source) ? (
             <EventName query={query.source} setQuery={setQuerySource} />
         ) : null,

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -106,6 +106,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
                         showEventFilter: query.showEventFilter ?? showIfFull,
                         showSearch: query.showSearch ?? showIfFull,
                         showActions: query.showActions ?? true,
+                        showDateRange: query.showDateRange ?? showIfFull,
                         showExport: query.showExport ?? showIfFull,
                         showReload: query.showReload ?? showIfFull,
                         showElapsedTime: query.showElapsedTime ?? (flagQueryRunningTimeEnabled ? showIfFull : false),

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -164,7 +164,7 @@ export function renderColumn(
             </CopyToClipboardInline>
         )
     } else {
-        if (typeof value === 'object') {
+        if (typeof value === 'object' && value !== null) {
             return <ReactJson src={value} name={key} collapsed={1} />
         }
         return String(value)

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -187,6 +187,8 @@ export interface DataTableNode extends Node {
     showPropertyFilter?: boolean
     /** Show the kebab menu at the end of the row */
     showActions?: boolean
+    /** Show date range selector */
+    showDateRange?: boolean
     /** Show the export button */
     showExport?: boolean
     /** Show a reload button */

--- a/frontend/src/scenes/events/eventsSceneLogic.tsx
+++ b/frontend/src/scenes/events/eventsSceneLogic.tsx
@@ -16,6 +16,7 @@ const getDefaultQuery = (): DataTableNode => ({
         kind: NodeKind.EventsQuery,
         select: defaultDataTableColumns(NodeKind.EventsQuery),
         orderBy: ['-timestamp'],
+        after: '-24h',
         limit: 100,
     },
     propertiesViaUrl: true,

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -244,6 +244,17 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         with freeze_time("2020-01-7"):
             event3_uuid = _create_event(team=self.team, event="random other event", distinct_id="2")
 
+        # with relative values
+        with freeze_time("2020-01-11T12:03:03.829294Z"):
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?after=5d&before=1d").json()
+            self.assertEqual(len(response["results"]), 2)
+
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?after=6d&before=2h").json()
+            self.assertEqual(len(response["results"]), 3)
+
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?before=3d").json()
+            self.assertEqual(len(response["results"]), 1)
+
         action = Action.objects.create(team=self.team)
         ActionStep.objects.create(action=action, event="sign up")
 

--- a/posthog/hogql/expr_parser.py
+++ b/posthog/hogql/expr_parser.py
@@ -81,7 +81,7 @@ CLICKHOUSE_FUNCTIONS = {
     # array functions
     "tuple": "tuple",
     # conditional
-    "if": "if",
+    "ifElse": "if",
     "multiIf": "multiIf",
     # rounding
     "round": "round",

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -20,6 +20,7 @@ from posthog.models.event.sql import (
 from posthog.models.event.util import ElementSerializer
 from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.queries.insight import insight_query_with_columns, insight_sync_execute
+from posthog.utils import relative_date_parse
 
 
 # sync with "schema.ts"
@@ -38,11 +39,17 @@ def determine_event_conditions(conditions: Dict[str, Union[None, str, List[str]]
         if not isinstance(v, str):
             continue
         if k == "after":
-            timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
+            try:
+                timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
+            except ValueError:
+                timestamp = relative_date_parse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
             result += "AND timestamp > %(after)s "
             params.update({"after": timestamp})
         elif k == "before":
-            timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
+            try:
+                timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
+            except ValueError:
+                timestamp = relative_date_parse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
             result += "AND timestamp < %(before)s "
             params.update({"before": timestamp})
         elif k == "person_id":

--- a/posthog/settings/geoip.py
+++ b/posthog/settings/geoip.py
@@ -1,5 +1,5 @@
 import os
 
-from django.conf import settings
+from posthog.settings.base_variables import BASE_DIR
 
-GEOIP_PATH = os.path.join(settings.BASE_DIR, "share")
+GEOIP_PATH = os.path.join(BASE_DIR, "share")


### PR DESCRIPTION
## Problem

The "live events" table has a hack that goes like this: "only look through the last 3 days first, and if no events found, query longer".

We can't rely on the same hack if the user is exploring data by using aggregations, or sorting by a different column. 

## Changes

Hence, let's introduce a global date filter for the events table. It's set to "last 24h" by default, but you're free to adjust it as needed. We could add logic that automatically expands it to e.g. "last 3 days" or "last 7 days" if the initial live events query returns no results.

![2023-01-12 15 24 25](https://user-images.githubusercontent.com/53387/212092501-e31836c6-78f1-44c3-8d7f-cf5032ffb65a.gif)

## How did you test this code?

Added a test for the API, and clicking around in the frontend yielded legit results.