### PR TITLE
chore(flags): make rollout lemon

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -680,7 +680,8 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                     <Col span={3}>
                                         <Field name="rollout_percentage">
                                             {({ value, onChange }) => (
-                                                <InputNumber
+                                                <LemonInput
+                                                    type="number"
                                                     min={0}
                                                     max={100}
                                                     value={value}
@@ -691,12 +692,6 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                                                 onChange(valueInt)
                                                             }
                                                         }
-                                                    }}
-                                                    style={{
-                                                        width: '100%',
-                                                        borderColor: areVariantRolloutsValid
-                                                            ? undefined
-                                                            : 'var(--danger)',
                                                     }}
                                                 />
                                             )}


### PR DESCRIPTION
## Problem

- rollout wasn't a lemon input so the sizing was off
<img width="373" alt="Screen Shot 2023-01-12 at 10 35 45 AM" src="https://user-images.githubusercontent.com/13127476/212110861-c3c5d023-a824-4e08-930d-783139eb57e1.png">

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

After:
<img width="272" alt="Screen Shot 2023-01-12 at 10 36 27 AM" src="https://user-images.githubusercontent.com/13127476/212110928-226c66da-0513-48bb-b25b-c524a26f7107.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
