### PR TITLE
fix(dashboards): do not allow adding insight when user does not have …

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -102,7 +102,7 @@ function DashboardScene(): JSX.Element {
             {receivedErrorsFromAPI ? (
                 <InsightErrorState title="There was an error loading this dashboard" />
             ) : !tiles || tiles.length === 0 ? (
-                <EmptyDashboardComponent loading={itemsLoading} />
+                <EmptyDashboardComponent loading={itemsLoading} canEdit={canEditDashboard} />
             ) : (
                 <div>
                     <div className="flex space-x-4 justify-between">

--- a/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
+++ b/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
@@ -75,7 +75,7 @@ function SkeletonCardTwo({ active }: { active: boolean }): JSX.Element {
     )
 }
 
-export function EmptyDashboardComponent({ loading }: { loading: boolean }): JSX.Element {
+export function EmptyDashboardComponent({ loading, canEdit }: { loading: boolean; canEdit: boolean }): JSX.Element {
     const {
         allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
     } = useValues(dashboardLogic)
@@ -95,6 +95,7 @@ export function EmptyDashboardComponent({ loading }: { loading: boolean }): JSX.
                                 icon={<IconPlus />}
                                 center
                                 fullWidth
+                                disabled={!canEdit}
                             >
                                 Add insight
                             </LemonButton>


### PR DESCRIPTION
…permission to

## Problem

On an empty dashboard, a user without permissions is still able to add an insight with this button

<img width="844" alt="Screen Shot 2023-01-12 at 11 54 23 AM" src="https://user-images.githubusercontent.com/25164963/212130430-23e803cc-cf1a-4b96-b8d9-5708473ad140.png">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
