### PR TITLE
feat: highlight 100% released feature flags on table

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -80,7 +80,12 @@ function OverViewTab(): JSX.Element {
             title: 'Release conditions',
             width: 100,
             render: function Render(_, featureFlag: FeatureFlagType) {
-                return groupFilters(featureFlag.filters.groups)
+                const releaseText = groupFilters(featureFlag.filters.groups)
+                return releaseText == '100% of all users' ? (
+                    <LemonTag type="highlight">{releaseText}</LemonTag>
+                ) : (
+                    releaseText
+                )
             },
         },
         {


### PR DESCRIPTION
## Problem

It's hard to tell at a glance which feature flags are fully rolled out and which aren't, causing confusion when rollout conditions change.

## Changes

<img width="1153" alt="Screen Shot 2023-01-12 at 9 52 35 PM" src="https://user-images.githubusercontent.com/25164963/212226411-4eb9650f-18ed-4b99-8534-f3e220d09800.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
