### PR TITLE
fix(e2e-vrt): use playwright image

### DIFF
--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -10,6 +10,8 @@ jobs:
     playwright:
         name: Visual Regression Tests
         runs-on: ubuntu-20.04
+        container:
+            image: mcr.microsoft.com/playwright:v1.28.1-focal
         steps:
             - uses: actions/checkout@v3
 
@@ -30,8 +32,8 @@ jobs:
             - name: Build Storybook
               run: pnpm build-storybook --quiet
 
-            - name: Install Playwright Browsers
-              run: pnpm exec playwright install --with-deps
+            # - name: Install Playwright Browsers
+            #   run: pnpm exec playwright install --with-deps
 
             - name: Serve Storybook and run tests
               run: |

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -32,9 +32,6 @@ jobs:
             - name: Build Storybook
               run: pnpm build-storybook --quiet
 
-            # - name: Install Playwright Browsers
-            #   run: pnpm exec playwright install --with-deps
-
             - name: Serve Storybook and run tests
               run: |
                   pnpm dlx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \


### PR DESCRIPTION
## Problem

Azure mirror for apt-get is flaky, which leads to failing tests e.g. https://github.com/PostHog/posthog/actions/runs/3909905087/jobs/6681754499.

This is a known issue that seems to have been fixed by GitHub before and is now popping up again: https://github.com/actions/runner-images/issues/675.

## Changes

This PR uses the playwright docker image for running the visual regression tests. A drawback of this is that we have to keep the version of the image in sync with the version of playwright in package.json.

## How did you test this code?

This PR.