### PR TITLE
feat(data-exploration): errors in data table

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -49,6 +49,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         toggleAutoLoad: true,
         highlightRows: (rows: any[]) => ({ rows }),
         setElapsedTime: (elapsedTime: number) => ({ elapsedTime }),
+        queryError: (error: string) => ({ error }),
     }),
     loaders(({ actions, cache, values, props }) => ({
         response: [
@@ -69,6 +70,10 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         actions.setElapsedTime(performance.now() - now)
                         return data
                     } catch (e: any) {
+                        if (e.status === 400 && e.detail) {
+                            actions.queryError(e.detail)
+                            return null
+                        }
                         if (e.name === 'AbortError' || e.message?.name === 'AbortError') {
                             return values.response
                         } else {
@@ -159,12 +164,22 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 loadData: () => performance.now(),
                 loadNewData: () => performance.now(),
                 loadNextData: () => performance.now(),
+                queryError: () => null,
             },
         ],
         elapsedTime: [
             null as number | null,
             {
                 setElapsedTime: (_, { elapsedTime }) => elapsedTime,
+                loadData: () => null,
+                loadNewData: () => null,
+                loadNextData: () => null,
+            },
+        ],
+        error: [
+            null as string | null,
+            {
+                queryError: (_, { error }) => error,
                 loadData: () => null,
                 loadNewData: () => null,
                 loadNextData: () => null,

--- a/posthog/hogql/expr_parser.py
+++ b/posthog/hogql/expr_parser.py
@@ -144,10 +144,13 @@ def translate_hql(hql: str, context: Optional[ExprParserContext] = None) -> str:
         hql = re.sub(r"properties\.(\$[$a-zA-Z0-9_\-]+)", r"properties['\1']", hql)
         node = ast.parse(hql)
     except SyntaxError as err:
-        raise ValueError(f"SyntaxError: {err.msg}")
+        raise ValueError(f'Error parsing HogQL expression "{hql}": {err.msg}')
     if not context:
         context = ExprParserContext()
-    return translate_ast(node, [], context)
+    try:
+        return translate_ast(node, [], context)
+    except ValueError as err:
+        raise ValueError(f'Error parsing HogQL expression "{hql}": {err}')
 
 
 def translate_ast(node: ast.AST, stack: List[ast.AST], context: ExprParserContext) -> str:

--- a/posthog/hogql/test/test_expr_parser.py
+++ b/posthog/hogql/test/test_expr_parser.py
@@ -67,9 +67,9 @@ class TestExprParser(APIBaseTest, ClickhouseTestMixin):
     def test_hogql_expr_parse_errors(self):
         self._assert_value_error("", "Module body must contain only one 'Expr'")
         self._assert_value_error("a = 3", "Module body must contain only one 'Expr'")
-        self._assert_value_error("(", "SyntaxError: unexpected EOF while parsing")
-        self._assert_value_error("())", "SyntaxError: unmatched ')'")
-        self._assert_value_error("this makes little sense", "SyntaxError: invalid syntax")
+        self._assert_value_error("(", "unexpected EOF while parsing")
+        self._assert_value_error("())", "unmatched ')'")
+        self._assert_value_error("this makes little sense", "invalid syntax")
         self._assert_value_error("avg(bla)", "Unknown event field 'bla'")
         self._assert_value_error("total(2)", "Aggregation 'total' does not accept any arguments.")
         self._assert_value_error("avg(2,1)", "Aggregation 'avg' expects just one argument.")


### PR DESCRIPTION
## Problem

The data exploration events table swallowed all errors. No longer!

## Changes

Before:

![2023-01-13 11 47 01](https://user-images.githubusercontent.com/53387/212302128-9c189d68-1e05-4ebd-a912-8226cb57a4d0.gif)

After:

![2023-01-13 11 46 09](https://user-images.githubusercontent.com/53387/212302080-1ca382c4-5c15-488e-a24d-d2cfd0f453f4.gif)

## Questions

I don't think we're exposing anything secret by passing on the ClickHouse error. However I don't know. Could we leak credentials or anything else this way? 🤔 

## How did you test this code?

Added tests for the backend. Checked the frontend in the browser.