### PR TITLE
fix: person prop parsing && autocomplete on props

### DIFF
--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -41,6 +41,8 @@ function EditTextValueComponent({
             autoFocus
             onBlur={() => onChange(null, false)}
             onPressEnter={(e) => onChange((e.target as HTMLInputElement).value, true)}
+            autoComplete="off"
+            autoCapitalize="off"
         />
     )
 }

--- a/frontend/src/scenes/persons/NewPropertyComponent.tsx
+++ b/frontend/src/scenes/persons/NewPropertyComponent.tsx
@@ -56,6 +56,8 @@ export function NewPropertyComponent({ editProperty }: NewPropertyComponentProps
                         autoFocus
                         placeholder="try email, first_name, is_verified, membership_level, total_revenue"
                         onChange={(e) => setState({ ...state, key: e.target.value })}
+                        autoComplete="off"
+                        autoCapitalize="off"
                     />
                 </div>
                 <div className="input-set">
@@ -111,6 +113,8 @@ export function NewPropertyComponent({ editProperty }: NewPropertyComponentProps
                             onChange={(e) => setState({ ...state, value: e.target.value })}
                             id="propertyValue"
                             onKeyDown={(e) => e.key === 'Enter' && saveProperty()}
+                            autoComplete="off"
+                            autoCapitalize="off"
                         />
                     )}
                 </div>

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -182,7 +182,7 @@ export const personsLogic = kea<personsLogicType>({
                 actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
                 // :KLUDGE: Person properties are updated asynchronosly in the plugin server - the response won't reflect
                 //      the 'updated' properties yet.
-                await api.persons.updateProperty(person.id, key, newValue)
+                await api.persons.updateProperty(person.id, key, parsedValue)
                 lemonToast.success(`Person property ${action}`)
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated(

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -180,8 +180,8 @@ export const personsLogic = kea<personsLogicType>({
                 }
 
                 actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
-                // :KLUDGE: Person properties are updated asynchronosly in the plugin server - the response won't reflect
-                //      the 'updated' properties yet.
+                // :KLUDGE: Person properties are updated asynchronously in the plugin server - the response won't reflect
+                //      the _updated_ properties yet.
                 await api.persons.updateProperty(person.id, key, parsedValue)
                 lemonToast.success(`Person property ${action}`)
 


### PR DESCRIPTION
## Problem

- There was a bug in which we were ignoring the proper parsing of properties when adding/editing from the UI (i.e. `boolean`, `null`, `number`)
- UX issue with autocomplete, browser suggestions for this are way off as these are very specific names.

## Changes
- Saved properties to the DB will now reflect the proper type and not default to string for everything.
- When editing/adding a property, the inputs will no longer autocomplete or autocapitalize.

## How did you test this code?
I'll be honest I didn't. Very straightforward changes imo.

@mariusandra back to PRs over issues 😉 