### PR TITLE
fix(insights): stickiness monthly view

### DIFF
--- a/posthog/models/filters/mixins/stickiness.py
+++ b/posthog/models/filters/mixins/stickiness.py
@@ -71,7 +71,9 @@ class TotalIntervalsDerivedMixin(IntervalMixin, StickinessDateMixin):
         elif self.interval == "week":
             _num_intervals = (self.date_to - self.date_from).days // 7
         elif self.interval == "month":
-            _num_intervals = (self.date_to.year - self.date_from.year) + (self.date_to.month - self.date_from.month)
+            _num_intervals = (self.date_to.year - self.date_from.year) * 12 + (
+                self.date_to.month - self.date_from.month
+            )
         else:
             raise ValidationError(f"{self.interval} not supported")
         _num_intervals += 2


### PR DESCRIPTION
## Problem

The stickiness graph didn't work in the monthly view

## Changes

Fixes it

## How did you test this code?

Loaded the chart again, it worked this time.