### PR TITLE
style(dashboards): Make text card modal sleeker

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
@@ -20,7 +20,7 @@ export function TextCardModal({
     textTileId: number | 'new' | null
 }): JSX.Element {
     const modalLogic = textCardModalLogic({ dashboard, textTileId: textTileId ?? 'new', onClose })
-    const { isTextTileSubmitting } = useValues(modalLogic)
+    const { isTextTileSubmitting, textTileValidationErrors } = useValues(modalLogic)
     const { submitTextTile, resetTextTile } = useActions(modalLogic)
 
     const { hasAvailableFeature } = useValues(userLogic)
@@ -38,12 +38,16 @@ export function TextCardModal({
             onClose={handleClose}
             footer={
                 <>
-                    <LemonButton disabled={isTextTileSubmitting} type="secondary" onClick={handleClose}>
+                    <LemonButton
+                        disabledReason={isTextTileSubmitting ? 'Cannot cancel card creation in progress' : null}
+                        type="secondary"
+                        onClick={handleClose}
+                    >
                         Cancel
                     </LemonButton>
                     {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && (
                         <LemonButton
-                            disabled={isTextTileSubmitting}
+                            disabledReason={textTileValidationErrors.body as string | null}
                             loading={isTextTileSubmitting}
                             form="text-tile-form"
                             htmlType="submit"
@@ -67,9 +71,7 @@ export function TextCardModal({
             >
                 <PayGateMini feature={AvailableFeature.DASHBOARD_COLLABORATION}>
                     <Field name="body" label="">
-                        {({ value, onChange }) => (
-                            <LemonTextMarkdown data-attr={'text-card-edit-area'} value={value} onChange={onChange} />
-                        )}
+                        <LemonTextMarkdown data-attr={'text-card-edit-area'} />
                     </Field>
                 </PayGateMini>
             </Form>

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
@@ -50,7 +50,7 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
             } as TextTileForm,
             errors: ({ body }) => {
                 return {
-                    body: !body ? 'A text tile must have text content.' : null,
+                    body: !body ? 'This card would be empty! Type something first' : null,
                 }
             },
             submit: (formValues) => {

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -46,7 +46,7 @@ export interface LemonButtonPropsBase
     /** @deprecated Buttons should never be quietly disabled. Use `disabledReason` to provide an explanation instead. */
     disabled?: boolean
     /** Like plain `disabled`, except we enforce a reason to be shown in the tooltip. */
-    disabledReason?: string
+    disabledReason?: string | null
     noPadding?: boolean
     size?: 'small' | 'medium' | 'large'
     'data-attr'?: string

--- a/frontend/src/lib/components/LemonFileInput/LemonFileInput.scss
+++ b/frontend/src/lib/components/LemonFileInput/LemonFileInput.scss
@@ -1,7 +1,15 @@
 .FileDropTarget {
-    border: 3px dashed transparent;
+    position: relative;
 }
 
-.FileDropTarget--active {
-    border-color: var(--primary);
+.FileDropTarget--active::after {
+    --file-drop-target-padding: 0.5rem;
+    content: '';
+    position: absolute;
+    top: calc(-1 * var(--file-drop-target-padding));
+    left: calc(-1 * var(--file-drop-target-padding));
+    height: calc(100% + var(--file-drop-target-padding) * 2);
+    width: calc(100% + var(--file-drop-target-padding) * 2);
+    border: 3px dashed var(--primary);
+    border-radius: var(--radius);
 }

--- a/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
@@ -64,8 +64,8 @@ export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextArea
 
 interface LemonTextMarkdownProps {
     'data-attr'?: string
-    value: string
-    onChange: (s: string) => void
+    value?: string
+    onChange?: (s: string) => void
 }
 
 export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTextMarkdownProps): JSX.Element {
@@ -89,7 +89,7 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
                 const formData = new FormData()
                 formData.append('image', filesToUpload[0])
                 const media = await api.media.upload(formData)
-                onChange(value + `\n\n![${media.name}](${media.image_location})`)
+                onChange?.(value + `\n\n![${media.name}](${media.image_location})`)
                 posthog.capture('markdown image uploaded', { name: media.name })
             } catch (error) {
                 const errorDetail = (error as any).detail || 'unknown error'
@@ -104,9 +104,10 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
     }, [filesToUpload])
 
     return (
-        <Tabs>
+        // Setting overflow: visible so that the LemonFileInput hover outline isn't clipped
+        <Tabs style={{ overflow: 'visible' }}>
             <Tabs.TabPane tab="Write" key="write-card" destroyInactiveTabPane={true}>
-                <div ref={dropRef} className={clsx('LemonTextMarkdown flex flex-col p-2 space-y-1 rounded')}>
+                <div ref={dropRef} className={clsx('LemonTextMarkdown flex flex-col space-y-1 rounded')}>
                     <LemonTextArea ref={textAreaRef} {...editAreaProps} autoFocus value={value} onChange={onChange} />
                     <div className="text-muted inline-flex items-center space-x-1">
                         <IconMarkdown className={'text-2xl'} />
@@ -139,7 +140,7 @@ export function LemonTextMarkdown({ value, onChange, ...editAreaProps }: LemonTe
                 </div>
             </Tabs.TabPane>
             <Tabs.TabPane tab="Preview" key={'preview-card'}>
-                <TextContent text={value} />
+                {value ? <TextContent text={value} /> : <i>Nothing to preview</i>}
             </Tabs.TabPane>
         </Tabs>
     )


### PR DESCRIPTION
## Changes

| | Before | After |
| --- | --- | --- |
| Empty input | <img width="499" alt="before-empty" src="https://user-images.githubusercontent.com/4550621/212364244-86ca8b16-8667-457f-8a61-795a1974ce7a.png"><br/>then...<br/><img width="430" alt="before-empty-err" src="https://user-images.githubusercontent.com/4550621/212364235-93cc9043-00c6-44e2-9f30-79fa1c0b1067.png"> | <img width="714" alt="after-empty" src="https://user-images.githubusercontent.com/4550621/212364248-222a377e-10da-44de-9908-9a04ca1cf614.png"> |
| Empty preview | <img width="496" alt="before-preview" src="https://user-images.githubusercontent.com/4550621/212364239-0f9ae709-1d65-4cd0-b8ac-e8481392a672.png"> | <img width="499" alt="after-preview" src="https://user-images.githubusercontent.com/4550621/212364253-7adbda7f-ac7c-4321-8c48-599d2e8bcb88.png"> |
| Drag-and-drop | <img width="497" alt="before-file" src="https://user-images.githubusercontent.com/4550621/212364246-27b120a1-d186-4b62-acc9-132f21d9ce22.png"> | <img width="494" alt="after-file" src="https://user-images.githubusercontent.com/4550621/212364254-30b81e0e-592e-41f2-884b-99715b3afd93.png"> |

## How did you test this code?

Only manually. Still in beta. 🤷‍♂️ 😄 