### PR TITLE
fix(dashboards): Fix wonky combination of empty state and spinner

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -17,9 +17,6 @@
         width: 100%;
         overflow: auto;
     }
-    .insight-empty-state {
-        font-size: 0.875rem;
-    }
 }
 
 .InsightViz {
@@ -37,6 +34,8 @@
         padding: 1rem;
     }
     .insight-empty-state {
+        height: 100%; // Fix wonkiness when SpinnerOverlay is shown
+        font-size: 0.875rem; // Reduce font size
         padding-top: 0;
         padding-bottom: 0;
     }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -560,7 +560,7 @@ input::-ms-clear {
 }
 
 .main-app-content {
-    position: relative; // So that scene-level <Loading/> is positioned correctly.
+    position: relative; // So that scene-level <SpinnerOverlay /> is positioned correctly.
     min-width: 0;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
## Changes

Fix for a minor issue where an insight card empty state was be sized weirdly when the spinner overlay is shown. Noticed in Break the Release when testing dashboards.