### PR TITLE
fix: account for an empty resource name when listing performance page views

### DIFF
--- a/ee/api/performance_events.py
+++ b/ee/api/performance_events.py
@@ -150,11 +150,10 @@ class RecentPageViewPerformanceEvents:
             columnized_item = {
                 "session_id": result[0],
                 "pageview_id": result[1],
-                "page_url": result[2],
+                "page_url": result[2] or "(empty string)",
                 "duration": result[3],
                 "timestamp": result[4],
             }
-
             columnized_results.append(columnized_item)
 
         return columnized_results


### PR DESCRIPTION
… views

## Problem

Roughly 3 in 300000 ResourceNavigationTiming events have been received with no name

## Changes

Don't fail the API when the name is empty since it is very rare

## How did you test this code?

🙈 