### PR TITLE
fix: remove one time condition from unsafe migrations test command

### DIFF
--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -15,7 +15,6 @@ class Command(BaseCommand):
                 sql = call_command("sqlmigrate", results[0], results[1])
                 if (
                     re.findall(r"(?<!DROP) (NOT NULL|DEFAULT)", sql, re.M & re.I)
-                    and len(re.findall(r"(?<!ALTER TABLE).* (ADD CONSTRAINT)", sql)) < 1
                     and "Create model" not in sql
                     and "-- not-null-ignore" not in sql
                 ):


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Added a condition to the migrations not null command check in order to get #13631 merged as the original test command was too aggressive
## Changes
Undo the add as it was for a one time scenario
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
