### PR TITLE
fix: Fix container build CI step for fork repositories

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -129,6 +129,8 @@ jobs:
                   mkdir -p /tmp/logs
 
                   echo "Starting PostHog using the container image ${{ steps.meta.outputs.tags }}"
+                  docker pull ${{ steps.meta.outputs.tags }} || docker build -t ${{ steps.meta.outputs.tags }}
+
                   DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env ${{ steps.meta.outputs.tags }}"
 
                   $DOCKER_RUN ./bin/migrate

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -56,7 +56,7 @@ jobs:
                   buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
                   cache-from: type=gha # always pull the layers from GHA
                   cache-to: type=gha,mode=max # always push the layers to GHA
-                  push: true
+                  push: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
                   tags: posthog/posthog:latest
                   platforms: linux/amd64,linux/arm64
 
@@ -108,7 +108,7 @@ jobs:
                   buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
                   cache-from: type=gha # always pull the layers from GHA
                   cache-to: type=gha,mode=max # always push the layers to GHA
-                  push: true
+                  push: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
                   tags: ${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:latest
                   platforms: linux/amd64,linux/arm64
                   file: Dockerfile.cloud

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -71,6 +71,7 @@ jobs:
     posthog_cloud_build:
         name: Build PostHog Cloud
         runs-on: ubuntu-latest
+        if: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -64,7 +64,7 @@ jobs:
                   buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
                   cache-from: type=gha # always pull the layers from GHA
                   cache-to: type=gha,mode=max # always push the layers to GHA
-                  push: true
+                  push: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
                   tags: ${{ steps.meta.outputs.tags }}
                   platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
## Problem

Don't try to push if on a fork (will not have permissions)

See https://github.com/PostHog/posthog/actions/runs/3925346182/jobs/6710866925 for example failure for fork PR

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

- [ ] CI passed on fork PR (this one)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
