### PR TITLE
feat(data-exploration): improved editing UX

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -11,6 +11,7 @@ import { PaginationAuto, PaginationControl, PaginationManual, usePagination } fr
 import { useScrollable } from 'lib/hooks/useScrollable'
 import { LemonSkeleton } from '../LemonSkeleton'
 import { LemonTableLoader } from './LemonTableLoader'
+import { More } from 'lib/components/LemonButton/More'
 
 /**
  * Determine the column's key, using `dataIndex` as fallback.
@@ -277,6 +278,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                     style={{ justifyContent: column.align }}
                                                 >
                                                     {column.title}
+                                                    {column.more && <More overlay={column.more} />}
                                                     {column.sorter && (
                                                         <Tooltip
                                                             title={() => {

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -260,7 +260,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                 )}
                                                 style={{ textAlign: column.align }}
                                                 onClick={
-                                                    column.sorter
+                                                    column.sorter && !column.more
                                                         ? () => {
                                                               const nextSorting = getNextSorting(
                                                                   currentSorting,
@@ -278,7 +278,6 @@ export function LemonTable<T extends Record<string, any>>({
                                                     style={{ justifyContent: column.align }}
                                                 >
                                                     {column.title}
-                                                    {column.more && <More overlay={column.more} />}
                                                     {column.sorter && (
                                                         <Tooltip
                                                             title={() => {
@@ -307,6 +306,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                             {/* this non-breaking space lets antd's tooltip work*/}{' '}
                                                         </Tooltip>
                                                     )}
+                                                    {column.more && <More overlay={column.more} />}
                                                 </div>
                                             </th>
                                         ))

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -306,7 +306,9 @@ export function LemonTable<T extends Record<string, any>>({
                                                             {/* this non-breaking space lets antd's tooltip work*/}{' '}
                                                         </Tooltip>
                                                     )}
-                                                    {column.more && <More overlay={column.more} />}
+                                                    {column.more && (
+                                                        <More overlay={column.more} data-attr="table-header-more" />
+                                                    )}
                                                 </div>
                                             </th>
                                         ))

--- a/frontend/src/lib/components/LemonTable/sorting.tsx
+++ b/frontend/src/lib/components/LemonTable/sorting.tsx
@@ -25,9 +25,16 @@ export function getNextSorting(
     }
 }
 
-export function SortingIndicator({ order }: { order: Sorting['order'] | null }): JSX.Element {
+export function SortingIndicator({
+    order,
+    className,
+}: {
+    order: Sorting['order'] | null
+    className?: string | null
+}): JSX.Element {
     return (
         <div
+            className={className}
             style={{
                 fontSize: 10,
                 marginLeft: 8,

--- a/frontend/src/lib/components/LemonTable/sorting.tsx
+++ b/frontend/src/lib/components/LemonTable/sorting.tsx
@@ -30,7 +30,7 @@ export function SortingIndicator({
     className,
 }: {
     order: Sorting['order'] | null
-    className?: string | null
+    className?: string
 }): JSX.Element {
     return (
         <div

--- a/frontend/src/lib/components/LemonTable/types.ts
+++ b/frontend/src/lib/components/LemonTable/types.ts
@@ -22,6 +22,8 @@ export interface LemonTableColumn<T extends Record<string, any>, D extends keyof
     render?: (dataValue: D extends keyof T ? T[D] : undefined, record: T, recordIndex: number) => TableCellRenderResult
     /** Sorting function. Set to `true` if using manual pagination, in which case you'll also have to provide `sorting` on the table. */
     sorter?: ((a: T, b: T) => number) | true
+    /** Popup overlay in table header */
+    more?: JSX.Element
     className?: string
     /** Column content alignment. Left by default. Set to right for numerical values (amounts, days ago etc.) */
     align?: 'left' | 'right' | 'center'

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -1,9 +1,13 @@
 import './TaxonomicFilter.scss'
 import { useEffect, useMemo, useRef } from 'react'
-import { useValues, useActions, BindLogic } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { InfiniteSelectResults } from './InfiniteSelectResults'
 import { taxonomicFilterLogic } from './taxonomicFilterLogic'
-import { TaxonomicFilterLogicProps, TaxonomicFilterProps } from 'lib/components/TaxonomicFilter/types'
+import {
+    TaxonomicFilterGroupType,
+    TaxonomicFilterLogicProps,
+    TaxonomicFilterProps,
+} from 'lib/components/TaxonomicFilter/types'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { IconKeyboard } from '../icons'
 import { Tooltip } from '../Tooltip'
@@ -53,7 +57,9 @@ export function TaxonomicFilter({
     const { setSearchQuery, moveUp, moveDown, tabLeft, tabRight, selectSelected } = useActions(logic)
 
     useEffect(() => {
-        window.setTimeout(() => focusInput(), 1)
+        if (groupType !== TaxonomicFilterGroupType.HogQLExpression) {
+            window.setTimeout(() => focusInput(), 1)
+        }
     }, [])
 
     const style = {

--- a/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.tsx
+++ b/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.tsx
@@ -2,7 +2,12 @@ import './TaxonomicPopup.scss'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import { useEffect, useState } from 'react'
-import { LemonButton, LemonButtonWithPopup, LemonButtonWithPopupProps } from 'lib/components/LemonButton'
+import {
+    LemonButton,
+    LemonButtonProps,
+    LemonButtonWithPopup,
+    LemonButtonWithPopupProps,
+} from 'lib/components/LemonButton'
 import { IconArrowDropDown, IconClose } from 'lib/components/icons'
 
 export interface TaxonomicPopupProps<ValueType = TaxonomicFilterValue>
@@ -19,6 +24,7 @@ export interface TaxonomicPopupProps<ValueType = TaxonomicFilterValue>
     dropdownMatchSelectWidth?: boolean
     allowClear?: boolean
     style?: React.CSSProperties
+    buttonProps?: Omit<LemonButtonProps, 'onClick'>
 }
 
 /** Like TaxonomicPopup, but convenient when you know you will only use string values */
@@ -43,6 +49,7 @@ export function TaxonomicPopup({
     eventNames = [],
     placeholder = 'Please select',
     fullWidth = true,
+    buttonProps,
 }: TaxonomicPopupProps): JSX.Element {
     const [visible, setVisible] = useState(false)
 
@@ -69,6 +76,7 @@ export function TaxonomicPopup({
             onClick={() => setVisible(!visible)}
             fullWidth={fullWidth}
             type={'secondary'}
+            {...buttonProps}
         >
             <span className="TaxonomicPopup__button__label text-overflow">
                 {value ? renderValue?.(value) ?? String(value) : <em>{placeholder}</em>}

--- a/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
+++ b/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
@@ -34,7 +34,7 @@ export function InlineHogQLEditor({ value, onChange }: InlineHogQLEditorProps): 
                 disabled={!localValue}
                 center
             >
-                Add expression
+                {value ? 'Edit HogQL expression' : 'Add HogQL expression'}
             </LemonButton>
         </div>
     )

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -34,12 +34,12 @@ interface ColumnConfiguratorProps {
 }
 
 export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps): JSX.Element {
-    const { columns } = useValues(dataTableLogic)
+    const { columnsInQuery } = useValues(dataTableLogic)
 
     const [key] = useState(() => String(uniqueNode++))
     const columnConfiguratorLogicProps: ColumnConfiguratorLogicProps = {
         key,
-        columns,
+        columns: columnsInQuery,
         setColumns: (columns: string[]) => {
             if (isEventsQuery(query.source)) {
                 setQuery?.({

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -19,7 +19,7 @@ import { columnConfiguratorLogic, ColumnConfiguratorLogicProps } from './columnC
 import { defaultDataTableColumns, extractExpressionComment } from '../utils'
 import { DataTableNode, NodeKind } from '~/queries/schema'
 import { LemonModal } from 'lib/components/LemonModal'
-import { isEventsQuery } from '~/queries/utils'
+import { isEventsQuery, taxonomicFilterToHogQl } from '~/queries/utils'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { PropertyFilterIcon } from 'lib/components/PropertyFilters/components/PropertyFilterIcon'
@@ -42,26 +42,13 @@ export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps)
         columns,
         setColumns: (columns: string[]) => {
             if (isEventsQuery(query.source)) {
-                // We removed the timestamp column, and can't order by it anymore.
-                if (!columns.includes('timestamp') && query.source.orderBy?.includes('-timestamp')) {
-                    setQuery?.({
-                        ...query,
-                        source: {
-                            ...query.source,
-                            orderBy: [],
-                            select: columns,
-                        },
-                        allowSorting: true,
-                    })
-                } else {
-                    setQuery?.({
-                        ...query,
-                        source: {
-                            ...query.source,
-                            select: columns,
-                        },
-                    })
-                }
+                setQuery?.({
+                    ...query,
+                    source: {
+                        ...query.source,
+                        select: columns,
+                    },
+                })
             } else {
                 setQuery?.({ ...query, columns })
             }
@@ -237,17 +224,9 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                                         ]}
                                         value={undefined}
                                         onChange={(group, value) => {
-                                            if (group.type === TaxonomicFilterGroupType.EventProperties) {
-                                                selectColumn(`properties.${value}`)
-                                            }
-                                            if (group.type === TaxonomicFilterGroupType.PersonProperties) {
-                                                selectColumn(`person.properties.${value}`)
-                                            }
-                                            if (group.type === TaxonomicFilterGroupType.EventFeatureFlags) {
-                                                selectColumn(`properties.${value}`)
-                                            }
-                                            if (group.type === TaxonomicFilterGroupType.HogQLExpression && value) {
-                                                selectColumn(String(value))
+                                            const column = taxonomicFilterToHogQl(group.type, value)
+                                            if (column !== null) {
+                                                selectColumn(column)
                                             }
                                         }}
                                         popoverEnabled={false}

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -149,6 +149,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                 <LemonButton
                                     fullWidth
                                     status={query.source?.orderBy?.[0] === key ? 'primary' : 'stealth'}
+                                    data-attr="datatable-sort-asc"
                                     onClick={() => {
                                         setQuery?.({
                                             ...query,
@@ -164,6 +165,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                 <LemonButton
                                     fullWidth
                                     status={query.source?.orderBy?.[0] === `-${key}` ? 'primary' : 'stealth'}
+                                    data-attr="datatable-sort-desc"
                                     onClick={() => {
                                         setQuery?.({
                                             ...query,
@@ -183,6 +185,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                             groupType={TaxonomicFilterGroupType.EventProperties}
                             value={''}
                             placeholder={<span className="not-italic">Add column left</span>}
+                            data-attr="datatable-add-column-left"
                             onChange={(v, g) => {
                                 const hogQl = taxonomicFilterToHogQl(g, v)
                                 if (hogQl && isEventsQuery(query.source)) {
@@ -207,6 +210,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                             groupType={TaxonomicFilterGroupType.EventProperties}
                             value={''}
                             placeholder={<span className="not-italic">Add column right</span>}
+                            data-attr="datatable-add-column-right"
                             onChange={(v, g) => {
                                 const hogQl = taxonomicFilterToHogQl(g, v)
                                 if (hogQl && isEventsQuery(query.source)) {
@@ -233,6 +237,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                 <LemonButton
                                     fullWidth
                                     status="danger"
+                                    data-attr="datatable-remove-column"
                                     onClick={() => {
                                         setQuery?.({
                                             ...query,

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -38,6 +38,13 @@ interface DataTableProps {
     context?: QueryContext
 }
 
+const groupTypes = [
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.PersonProperties,
+    TaxonomicFilterGroupType.EventFeatureFlags,
+    TaxonomicFilterGroupType.HogQLExpression,
+]
+
 let uniqueNode = 0
 
 export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Element {
@@ -57,12 +64,9 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
     } = useValues(builtDataNodeLogic)
 
     const dataTableLogicProps: DataTableLogicProps = { query, key }
-    const {
-        resultsWithLabelRows,
-        columns: columnsFromQuery,
-        queryWithDefaults,
-        canSort,
-    } = useValues(dataTableLogic(dataTableLogicProps))
+    const { resultsWithLabelRows, columnsInQuery, columnsInResponse, queryWithDefaults, canSort } = useValues(
+        dataTableLogic(dataTableLogicProps)
+    )
 
     const {
         showActions,
@@ -78,15 +82,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
         expandable,
     } = queryWithDefaults
 
-    const columnsInResponse: string[] | null =
-        response &&
-        'columns' in response &&
-        Array.isArray(response.columns) &&
-        !response.columns.find((c) => typeof c !== 'string')
-            ? (response?.columns as string[])
-            : null
-
-    const columns: string[] = columnsInResponse ?? columnsFromQuery
+    const columns: string[] = columnsInResponse ?? columnsInQuery
     const actionsColumnShown = showActions && isEventsQuery(query.source) && columns.includes('*')
     const lemonColumns: LemonTableColumn<Record<string, any> | any[], any>[] = [
         ...columns.map((key, index) => ({
@@ -165,12 +161,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                     })
                                 }
                             }}
-                            groupTypes={[
-                                TaxonomicFilterGroupType.EventProperties,
-                                TaxonomicFilterGroupType.PersonProperties,
-                                TaxonomicFilterGroupType.EventFeatureFlags,
-                                TaxonomicFilterGroupType.HogQLExpression,
-                            ]}
+                            groupTypes={groupTypes}
                             buttonProps={{ type: undefined }}
                         />
                         <LemonDivider />
@@ -195,12 +186,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                     })
                                 }
                             }}
-                            groupTypes={[
-                                TaxonomicFilterGroupType.EventProperties,
-                                TaxonomicFilterGroupType.PersonProperties,
-                                TaxonomicFilterGroupType.EventFeatureFlags,
-                                TaxonomicFilterGroupType.HogQLExpression,
-                            ]}
+                            groupTypes={groupTypes}
                             buttonProps={{ type: undefined }}
                         />
                         <TaxonomicPopup
@@ -224,12 +210,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                     })
                                 }
                             }}
-                            groupTypes={[
-                                TaxonomicFilterGroupType.EventProperties,
-                                TaxonomicFilterGroupType.PersonProperties,
-                                TaxonomicFilterGroupType.EventFeatureFlags,
-                                TaxonomicFilterGroupType.HogQLExpression,
-                            ]}
+                            groupTypes={groupTypes}
                             buttonProps={{ type: undefined }}
                         />
                         {columns.filter((c) => c !== '*').length > 1 ? (
@@ -253,9 +234,7 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                     Remove column
                                 </LemonButton>
                             </>
-                        ) : (
-                            <></>
-                        )}
+                        ) : null}
                     </>
                 ) : undefined,
         })),

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
@@ -126,7 +126,7 @@ describe('dataTableLogic', () => {
         })
         logic.mount()
         await expectLogic(logic).toMatchValues({
-            columns: ['*', 'event', 'timestamp'],
+            columnsInQuery: ['*', 'event', 'timestamp'],
         })
 
         // change props
@@ -142,7 +142,7 @@ describe('dataTableLogic', () => {
         })
 
         await expectLogic(logic).toMatchValues({
-            columns: ['*', 'event', 'timestamp', 'properties.foobar'],
+            columnsInQuery: ['*', 'event', 'timestamp', 'properties.foobar'],
         })
     })
 

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -4,7 +4,6 @@ import { DataTableNode, EventsQuery, HogQLExpression, NodeKind } from '~/queries
 import { getColumnsForQuery, removeExpressionComment } from './utils'
 import { objectsEqual, sortedKeys } from 'lib/utils'
 import { isDataTableNode, isEventsQuery } from '~/queries/utils'
-import { Sorting } from 'lib/components/LemonTable'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -119,23 +118,6 @@ export const dataTableLogic = kea<dataTableLogicType>([
         canSort: [
             (s) => [s.queryWithDefaults],
             (query: DataTableNode): boolean => isEventsQuery(query.source) && !!query.allowSorting,
-        ],
-        sorting: [
-            (s) => [s.canSort, s.queryWithDefaults, s.orderBy],
-            (canSort, query, orderBy): Sorting | null => {
-                if (canSort && isEventsQuery(query.source) && orderBy && orderBy.length > 0) {
-                    return orderBy[0] === '-'
-                        ? {
-                              columnKey: orderBy[0].substring(1),
-                              order: -1,
-                          }
-                        : {
-                              columnKey: orderBy[0],
-                              order: 1,
-                          }
-                }
-                return null
-            },
         ],
     }),
     propsChanged(({ actions, props }, oldProps) => {

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -40,8 +40,8 @@ export function renderColumnMeta(key: string, query: DataTableNode, context?: Qu
 
     if (isEventsQuery(query.source) && !query.allowSorting) {
         const sortKey = isEventsQuery(query.source) ? query.source?.orderBy?.[0] : null
-        const sortOrder = key === sortKey ? 1 : `-${key}` === sortKey ? -1 : null
-        if (sortOrder !== null) {
+        const sortOrder = key === sortKey ? 1 : `-${key}` === sortKey ? -1 : undefined
+        if (sortOrder) {
             title = (
                 <>
                     {title}

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -3,6 +3,7 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { QueryContext, DataTableNode } from '~/queries/schema'
 import { isEventsQuery } from '~/queries/utils'
 import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
+import { SortingIndicator } from 'lib/components/LemonTable/sorting'
 
 export interface ColumnMeta {
     title?: JSX.Element | string
@@ -10,26 +11,48 @@ export interface ColumnMeta {
 }
 
 export function renderColumnMeta(key: string, query: DataTableNode, context?: QueryContext): ColumnMeta {
+    let width: number | undefined
+    let title: JSX.Element | string | undefined
+
     if (key === 'timestamp') {
-        return { title: 'Time' }
+        title = 'Time'
     } else if (key === 'created_at') {
-        return { title: 'First seen' }
+        title = 'First seen'
     } else if (key === 'event') {
-        return { title: 'Event' }
+        title = 'Event'
     } else if (key === 'person') {
-        return { title: 'Person' }
+        title = 'Person'
     } else if (key === 'url') {
-        return { title: 'URL / Screen' }
+        title = 'URL / Screen'
     } else if (key.startsWith('properties.')) {
-        return { title: <PropertyKeyInfo value={key.substring(11)} type={PropertyFilterType.Event} disableIcon /> }
+        title = <PropertyKeyInfo value={key.substring(11)} type={PropertyFilterType.Event} disableIcon />
     } else if (key.startsWith('context.columns.')) {
-        return { title: context?.columns?.[key.substring(16)]?.title ?? key.substring(16).replace('_', ' ') }
+        title = context?.columns?.[key.substring(16)]?.title ?? key.substring(16).replace('_', ' ')
     } else if (key === 'person.$delete') {
-        return { title: '', width: 0 }
+        title = ''
+        width = 0
     } else if (key.startsWith('person.properties.')) {
         // NOTE: PropertyFilterType.Event is not a mistake. PropertyKeyInfo only knows events vs elements ¯\_(ツ)_/¯
-        return { title: <PropertyKeyInfo value={key.substring(18)} type={PropertyFilterType.Event} disableIcon /> }
+        title = <PropertyKeyInfo value={key.substring(18)} type={PropertyFilterType.Event} disableIcon />
     } else {
-        return { title: isEventsQuery(query.source) ? extractExpressionComment(key) : key }
+        title = isEventsQuery(query.source) ? extractExpressionComment(key) : key
+    }
+
+    if (isEventsQuery(query.source) && !query.allowSorting) {
+        const sortKey = isEventsQuery(query.source) ? query.source?.orderBy?.[0] : null
+        const sortOrder = key === sortKey ? 1 : `-${key}` === sortKey ? -1 : null
+        if (sortOrder !== null) {
+            title = (
+                <>
+                    {title}
+                    <SortingIndicator order={sortOrder} className="mx-1" />
+                </>
+            )
+        }
+    }
+
+    return {
+        title,
+        ...(typeof width !== 'undefined' ? { width } : {}),
     }
 }

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -1,28 +1,29 @@
 import {
-    EventsNode,
     ActionsNode,
     DataTableNode,
-    LegacyQuery,
-    TrendsQuery,
-    FunnelsQuery,
-    RetentionQuery,
-    PathsQuery,
-    StickinessQuery,
-    LifecycleQuery,
-    UnimplementedQuery,
-    Node,
-    NodeKind,
-    InsightQueryNode,
-    PersonsNode,
-    InsightVizNode,
+    EventsNode,
     EventsQuery,
-    TimeToSeeDataSessionsQuery,
-    TimeToSeeDataQuery,
-    RecentPerformancePageViewNode,
-    SupportedNodeKind,
+    FunnelsQuery,
     InsightFilter,
     InsightFilterProperty,
+    InsightQueryNode,
+    InsightVizNode,
+    LegacyQuery,
+    LifecycleQuery,
+    Node,
+    NodeKind,
+    PathsQuery,
+    PersonsNode,
+    RecentPerformancePageViewNode,
+    RetentionQuery,
+    StickinessQuery,
+    SupportedNodeKind,
+    TimeToSeeDataQuery,
+    TimeToSeeDataSessionsQuery,
+    TrendsQuery,
+    UnimplementedQuery,
 } from '~/queries/schema'
+import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 
 export function isDataNode(node?: Node): node is EventsQuery | PersonsNode | TimeToSeeDataSessionsQuery {
     return isEventsQuery(node) || isPersonsNode(node) || isTimeToSeeDataSessionsQuery(node)
@@ -135,4 +136,47 @@ export function filterForQuery(node: InsightQueryNode): InsightFilter | undefine
     }
     const filterProperty = filterPropertyForQuery(node)
     return node[filterProperty]
+}
+
+export function taxonomicFilterToHogQl(
+    groupType: TaxonomicFilterGroupType,
+    value: TaxonomicFilterValue
+): string | null {
+    if (groupType === TaxonomicFilterGroupType.EventProperties) {
+        return `properties.${value}`
+    }
+    if (groupType === TaxonomicFilterGroupType.PersonProperties) {
+        return `person.properties.${value}`
+    }
+    if (groupType === TaxonomicFilterGroupType.EventFeatureFlags) {
+        return `properties.${value}`
+    }
+    if (groupType === TaxonomicFilterGroupType.HogQLExpression && value) {
+        return String(value)
+    }
+    return null
+}
+
+export function hogQlToTaxonomicFilter(hogQl: string): [TaxonomicFilterGroupType, TaxonomicFilterValue] {
+    if (hogQl.startsWith('person.properties.')) {
+        return [TaxonomicFilterGroupType.PersonProperties, hogQl.substring(18)]
+    }
+    if (hogQl.startsWith('properties.$feature/')) {
+        return [TaxonomicFilterGroupType.EventFeatureFlags, hogQl.substring(11)]
+    }
+    if (hogQl.startsWith('properties.')) {
+        return [TaxonomicFilterGroupType.EventProperties, hogQl.substring(11)]
+    }
+    return [TaxonomicFilterGroupType.HogQLExpression, hogQl]
+}
+
+export function isHogQlAggregation(hogQl: string): boolean {
+    return (
+        hogQl.includes('total(') ||
+        hogQl.includes('any(') ||
+        hogQl.includes('sum(') ||
+        hogQl.includes('avg(') ||
+        hogQl.includes('min(') ||
+        hogQl.includes('max(')
+    )
 }

--- a/frontend/src/scenes/events/eventsSceneLogic.tsx
+++ b/frontend/src/scenes/events/eventsSceneLogic.tsx
@@ -20,7 +20,6 @@ const getDefaultQuery = (): DataTableNode => ({
         limit: 100,
     },
     propertiesViaUrl: true,
-    allowSorting: false,
 })
 
 export const eventsSceneLogic = kea<eventsSceneLogicType>([


### PR DESCRIPTION
## Problem

Currently you can only edit data exploration columns via the "column configurator" view

## Changes

Adds a submenu at the end of each column header, letting you sort, edit, add and delete columns:

![2023-01-16 11 54 56](https://user-images.githubusercontent.com/53387/212662064-b06d6ca3-48a0-4834-a9ca-76de1ab2b8b2.gif)

I don't know what should be in the scope of this PR and what should go in a followup. There are still many obvious changes we can make to this interface. I'd be very happy to hear thoughts on how can we improve this further, and what is blocking in this round :).

## How did you test this code?

Played around with the columns.