### PR TITLE
fix: Remove batch break-up by distinct-id

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -150,32 +150,28 @@ describe('eachBatchX', () => {
             )
         })
 
-        it('breaks up by teamId:distinctId for enabled teams', async () => {
+        it('breaks up by batches of worker concurrency * tasks per worker ', async () => {
             const batch = createBatchWithMultipleEvents([
                 { ...captureEndpointEvent, offset: 1, team_id: 3 },
-                { ...captureEndpointEvent, offset: 2, team_id: 3 }, // repeat
-                { ...captureEndpointEvent, offset: 3, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 2, team_id: 3 },
+                { ...captureEndpointEvent, offset: 3, team_id: 3 },
                 { ...captureEndpointEvent, offset: 4, team_id: 3, distinct_id: 'id2' },
                 { ...captureEndpointEvent, offset: 5, team_id: 4 },
                 { ...captureEndpointEvent, offset: 6, team_id: 5 },
                 { ...captureEndpointEvent, offset: 7 },
-                { ...captureEndpointEvent, offset: 8, team_id: 3, distinct_id: 'id2' }, // repeat
+                { ...captureEndpointEvent, offset: 8, team_id: 3, distinct_id: 'id2' },
                 { ...captureEndpointEvent, offset: 9, team_id: 4 },
-                { ...captureEndpointEvent, offset: 10, team_id: 4 }, // repeat
+                { ...captureEndpointEvent, offset: 10, team_id: 4 },
                 { ...captureEndpointEvent, offset: 11, team_id: 3 },
                 { ...captureEndpointEvent, offset: 12 },
-                { ...captureEndpointEvent, offset: 13 }, // repeat
+                { ...captureEndpointEvent, offset: 13 },
             ])
 
             await eachBatchIngestion(batch, queue)
 
             // Check the breakpoints in the batches matching repeating teamId:distinctId
-            expect(batch.resolveOffset).toBeCalledTimes(6)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(1)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(2)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(7)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(9)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(12)
+            expect(batch.resolveOffset).toBeCalledTimes(2)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(10)
             expect(batch.resolveOffset).toHaveBeenCalledWith(13)
 
             expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
@@ -185,7 +181,7 @@ describe('eachBatchX', () => {
                     key: 'ingestion',
                 }
             )
-            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 6, {
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 2, {
                 key: 'ingestion',
             })
         })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Hot partitions causing ingestion lag - this makes the hot partition hotter as we don't do any parallel processing for the events with the same distinct id. We've discussed not partitioning by distinct ID, if we don't partition by distinct id then this code loses it's goal completely as we'll anyway be partitioning in parallel.

Potential problems this causes:
1. person properties get overridden with later values (note that we anyway have a policy around person properties shouldn't be changed often.
2. person creation conflicts: currently we add to the cache before we actually create a person (see `isNewPerson`), we should likely do this after the person is already created, which will cause multiple attempts to create the person (which we already handle), but won't fail close by other requests we currently do (also when postgres was down) - we should consider fixing this before shipping this PR. TODO: validate that we really update properties if another thread won creation race (`createPersonIfDistinctIdIsNew`).

Note that merges already happen in transactions, so that part shouldn't have any integrity problems there.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
