### PR TITLE
docs(API): Remove create/update from person API docs

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -17,7 +17,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import MethodNotAllowed, NotFound
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -417,7 +417,10 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
     @extend_schema(exclude=True)
     def create(self, *args, **kwargs):
-        return Response(status=404)
+        raise MethodNotAllowed(
+            method="POST",
+            detail="Creating persons via this API is not allowed. Please create persons by sending an $identify event. See https://posthog.com/docs/integrate/identifying-user for details.",
+        )
 
     def _set_properties(self, properties, user):
         instance = self.get_object()

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -406,7 +406,6 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         activity_page = load_activity(scope="Person", team_id=self.team_id, item_id=item_id, limit=limit, page=page)
         return activity_page_response(activity_page, limit, page, request)
 
-    @extend_schema(exclude=True)
     def update(self, request, *args, **kwargs):
         """
         Only for setting properties on the person. "properties" from the request data will be updated via a "$set" event.
@@ -415,10 +414,6 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         """
         self._set_properties(request.data["properties"], request.user)
         return Response(status=204)
-
-    @extend_schema(exclude=True)
-    def partial_update(self, *args, **kwargs):
-        return Response(status=404)
 
     @extend_schema(exclude=True)
     def create(self, *args, **kwargs):

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -148,6 +148,10 @@ def get_funnel_actor_class(filter: Filter) -> Callable:
 
 
 class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewSet):
+    """
+    To create or update persons, use a PostHog library of your choice and [use an identify call](/docs/integrate/identifying-users). This API endpoint is only for reading and deleting.
+    """
+
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (csvrenderers.PaginatedCSVRenderer,)
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
@@ -402,6 +406,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         activity_page = load_activity(scope="Person", team_id=self.team_id, item_id=item_id, limit=limit, page=page)
         return activity_page_response(activity_page, limit, page, request)
 
+    @extend_schema(exclude=True)
     def update(self, request, *args, **kwargs):
         """
         Only for setting properties on the person. "properties" from the request data will be updated via a "$set" event.
@@ -410,6 +415,14 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         """
         self._set_properties(request.data["properties"], request.user)
         return Response(status=204)
+
+    @extend_schema(exclude=True)
+    def partial_update(self, *args, **kwargs):
+        return Response(status=404)
+
+    @extend_schema(exclude=True)
+    def create(self, *args, **kwargs):
+        return Response(status=404)
 
     def _set_properties(self, properties, user):
         instance = self.get_object()


### PR DESCRIPTION
## Problem

The right way of creating Persons is through sending identify events, so we shouldn't allow creating via this endpoint

## Changes

Remove and 404 create.

I haven't yet checked whether anyone is using the person create API, if anyone has ideas on how to check that.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
