### PR TITLE
fix(trends): disallow certain interval groupings for WAU and MAU queries

### DIFF
--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -1,6 +1,5 @@
 import { intervalFilterLogic } from './intervalFilterLogic'
 import { useActions, useValues } from 'kea'
-import { intervals } from 'lib/components/IntervalFilter/intervals'
 import { InsightType, IntervalType } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { LemonSelect } from '@posthog/lemon-ui'
@@ -12,8 +11,9 @@ interface InvertalFilterProps {
 
 export function IntervalFilter({ disabled }: InvertalFilterProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { interval } = useValues(intervalFilterLogic(insightProps))
+    const { interval, enabledIntervals } = useValues(intervalFilterLogic(insightProps))
     const { setInterval } = useActions(intervalFilterLogic(insightProps))
+
     return (
         <LemonSelect
             size={'small'}
@@ -26,7 +26,11 @@ export function IntervalFilter({ disabled }: InvertalFilterProps): JSX.Element {
                 }
             }}
             data-attr="interval-filter"
-            options={Object.entries(intervals).map(([value, { label }]) => ({ value, label }))}
+            options={Object.entries(enabledIntervals).map(([value, { label, disabledReason }]) => ({
+                value,
+                label,
+                disabledReason,
+            }))}
         />
     )
 }

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -67,8 +67,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
             if (activeUsersMath) {
                 // Disallow grouping by hour for WAUs/MAUs as it's an expensive query that produces a view that's not useful for users
                 enabledIntervals.hour = {
-                    label: 'Hour',
-                    newDateFrom: 'dStart',
+                    ...enabledIntervals.hour,
                     disabledReason:
                         'Grouping by hour is not supported on insights with weekly or monthly active users series.',
                 }
@@ -76,8 +75,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
                 // Disallow grouping by month for WAUs as the resulting view is misleading to users
                 if (activeUsersMath === BaseMathType.WeeklyActiveUsers) {
                     enabledIntervals.month = {
-                        label: 'Month',
-                        newDateFrom: '-90d',
+                        ...enabledIntervals.month,
                         disabledReason:
                             'Grouping by month is not supported on insights with weekly active users series.',
                     }

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -24,7 +24,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
     }),
     reducers: () => ({
         enabledIntervals: [
-            { ...intervals },
+            { ...intervals } as Intervals,
             {
                 setEnabledIntervals: (_, { enabledIntervals }) => enabledIntervals,
             },

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -1,13 +1,14 @@
 import { kea } from 'kea'
 import { objectsEqual, dateMapping } from 'lib/utils'
 import type { intervalFilterLogicType } from './intervalFilterLogicType'
-import { IntervalKeyType } from 'lib/components/IntervalFilter/intervals'
+import { IntervalKeyType, Intervals, intervals } from 'lib/components/IntervalFilter/intervals'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { InsightLogicProps, IntervalType } from '~/types'
+import { BaseMathType, InsightLogicProps, IntervalType } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { dayjs } from 'lib/dayjs'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { FunnelsQuery, InsightQueryNode, StickinessQuery, TrendsQuery } from '~/queries/schema'
+import { lemonToast } from '../lemonToast'
 
 export const intervalFilterLogic = kea<intervalFilterLogicType>({
     props: {} as InsightLogicProps,
@@ -19,6 +20,15 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
     }),
     actions: () => ({
         setInterval: (interval: IntervalKeyType) => ({ interval }),
+        setEnabledIntervals: (enabledIntervals: Intervals) => ({ enabledIntervals }),
+    }),
+    reducers: () => ({
+        enabledIntervals: [
+            { ...intervals },
+            {
+                setEnabledIntervals: (_, { enabledIntervals }) => enabledIntervals,
+            },
+        ],
     }),
     listeners: ({ values, actions, selectors }) => ({
         setInterval: ({ interval }) => {
@@ -33,6 +43,68 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
         setFilters: ({ filters }, _, __, previousState) => {
             const { date_from, date_to } = filters
             const previousFilters = selectors.filters(previousState)
+
+            let activeUsersMath: BaseMathType.WeeklyActiveUsers | BaseMathType.MonthlyActiveUsers | null = null
+
+            // We disallow grouping by certain intervals for weekly active users and monthly active users views
+            // e.g. WAUs grouped by month. Here, look for the first event/action running WAUs/MAUs math and
+            // pass that down to the interval filter to determine what groupings are allowed.
+            for (const series of [...(values.filters.events || []), ...(values.filters.actions || [])]) {
+                if (series.math === BaseMathType.WeeklyActiveUsers) {
+                    activeUsersMath = BaseMathType.WeeklyActiveUsers
+                    break
+                }
+
+                if (series.math === BaseMathType.MonthlyActiveUsers) {
+                    activeUsersMath = BaseMathType.MonthlyActiveUsers
+                    break
+                }
+            }
+
+            const enabledIntervals: Intervals = { ...intervals }
+
+            if (activeUsersMath) {
+                // Disallow grouping by hour for WAUs/MAUs as it's an expensive query that produces a view that's not useful for users
+                enabledIntervals.hour = {
+                    label: 'Hour',
+                    newDateFrom: 'dStart',
+                    disabledReason:
+                        'Grouping by hour is not supported on insights with weekly and monthly active users.',
+                }
+
+                // Disallow grouping by month for WAUs as the resulting view is misleading to users
+                if (activeUsersMath === BaseMathType.WeeklyActiveUsers) {
+                    enabledIntervals.month = {
+                        label: 'Month',
+                        newDateFrom: '-90d',
+                        disabledReason: 'Grouping by month is not supported on insights with weekly active users.',
+                    }
+                }
+            }
+
+            actions.setEnabledIntervals(enabledIntervals)
+
+            // If the user just flipped an event action to use WAUs/MAUs math and their
+            // current interval is unsupported by the math type, switch their interval
+            // to an appropriate allowed interval and inform them of the change via a toast
+            if (values.interval && !!enabledIntervals[values.interval].disabledReason) {
+                const humanReadableMathType =
+                    activeUsersMath === BaseMathType.MonthlyActiveUsers ? 'Monthly active users' : 'Weekly active users'
+
+                if (values.interval === 'hour') {
+                    lemonToast.info(
+                        `${humanReadableMathType} does not support grouping by hour. Grouping by day instead.`
+                    )
+                    actions.setInterval('day')
+                } else {
+                    lemonToast.info(
+                        `${humanReadableMathType} does not support grouping by month. Grouping by week instead.`
+                    )
+                    actions.setInterval('week')
+                }
+                return
+            }
+
             if (
                 !date_from ||
                 (objectsEqual(date_from, previousFilters.date_from) && objectsEqual(date_to, previousFilters.date_to))

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -9,6 +9,7 @@ import { dayjs } from 'lib/dayjs'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { FunnelsQuery, InsightQueryNode, StickinessQuery, TrendsQuery } from '~/queries/schema'
 import { lemonToast } from '../lemonToast'
+import { BASE_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 
 export const intervalFilterLogic = kea<intervalFilterLogicType>({
     props: {} as InsightLogicProps,
@@ -69,7 +70,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
                     label: 'Hour',
                     newDateFrom: 'dStart',
                     disabledReason:
-                        'Grouping by hour is not supported on insights with weekly and monthly active users.',
+                        'Grouping by hour is not supported on insights with weekly or monthly active users series.',
                 }
 
                 // Disallow grouping by month for WAUs as the resulting view is misleading to users
@@ -77,7 +78,8 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
                     enabledIntervals.month = {
                         label: 'Month',
                         newDateFrom: '-90d',
-                        disabledReason: 'Grouping by month is not supported on insights with weekly active users.',
+                        disabledReason:
+                            'Grouping by month is not supported on insights with weekly active users series.',
                     }
                 }
             }
@@ -87,18 +89,15 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
             // If the user just flipped an event action to use WAUs/MAUs math and their
             // current interval is unsupported by the math type, switch their interval
             // to an appropriate allowed interval and inform them of the change via a toast
-            if (values.interval && !!enabledIntervals[values.interval].disabledReason) {
-                const humanReadableMathType =
-                    activeUsersMath === BaseMathType.MonthlyActiveUsers ? 'Monthly active users' : 'Weekly active users'
-
+            if (activeUsersMath && values.interval && enabledIntervals[values.interval].disabledReason) {
                 if (values.interval === 'hour') {
                     lemonToast.info(
-                        `${humanReadableMathType} does not support grouping by hour. Grouping by day instead.`
+                        `Switched to grouping by day, because "${BASE_MATH_DEFINITIONS[activeUsersMath].name}" does not support grouping by ${values.interval}.`
                     )
                     actions.setInterval('day')
                 } else {
                     lemonToast.info(
-                        `${humanReadableMathType} does not support grouping by month. Grouping by week instead.`
+                        `Switched to grouping by week, because "${BASE_MATH_DEFINITIONS[activeUsersMath].name}" does not support grouping by ${values.interval}.`
                     )
                     actions.setInterval('week')
                 }

--- a/frontend/src/lib/components/IntervalFilter/intervals.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervals.ts
@@ -1,20 +1,32 @@
-export const intervals = {
+export type IntervalKeyType = 'hour' | 'day' | 'week' | 'month'
+
+export type Intervals = {
+    [key in IntervalKeyType]: {
+        label: string
+        newDateFrom?: string
+        disabledReason: string | undefined
+    }
+}
+
+export const intervals: Intervals = {
     hour: {
         label: 'Hour',
         newDateFrom: 'dStart',
+        disabledReason: undefined,
     },
     day: {
         label: 'Day',
         newDateFrom: undefined,
+        disabledReason: undefined,
     },
     week: {
         label: 'Week',
         newDateFrom: '-30d',
+        disabledReason: undefined,
     },
     month: {
         label: 'Month',
         newDateFrom: '-90d',
+        disabledReason: undefined,
     },
 }
-
-export type IntervalKeyType = keyof typeof intervals

--- a/frontend/src/lib/components/IntervalFilter/intervals.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervals.ts
@@ -4,7 +4,7 @@ export type Intervals = {
     [key in IntervalKeyType]: {
         label: string
         newDateFrom?: string
-        disabledReason: string | undefined
+        disabledReason?: string
     }
 }
 
@@ -12,21 +12,17 @@ export const intervals: Intervals = {
     hour: {
         label: 'Hour',
         newDateFrom: 'dStart',
-        disabledReason: undefined,
     },
     day: {
         label: 'Day',
         newDateFrom: undefined,
-        disabledReason: undefined,
     },
     week: {
         label: 'Week',
         newDateFrom: '-30d',
-        disabledReason: undefined,
     },
     month: {
         label: 'Month',
         newDateFrom: '-90d',
-        disabledReason: undefined,
     },
 }


### PR DESCRIPTION
## Problem

#13715 

## Changes

Did the "simplest thing" here. Would love feedback on if this approach makes sense or if I should be doing things differently.

The idea here is that:

a) On an insight that has WAUs/MAUs math, hide certain intervals from "group by"
b) If I switch an event/action to WAUs/MAUs math and already have a disallowed interval set, set the graph to "day" and inform the users via a toast

This should leave existing insights unaffected unless someone then tries to edit them.

## How did you test this code?

Manually
<img width="1507" alt="Screenshot 2023-01-16 at 11 12 02" src="https://user-images.githubusercontent.com/38760734/212699207-2f0f02a5-bbdf-4992-b032-580ce7773707.png">


<img width="1508" alt="Screenshot 2023-01-16 at 11 10 31" src="https://user-images.githubusercontent.com/38760734/212699214-090eb4b2-138b-435b-a69e-e91b97f458ab.png">

