### PR TITLE
chore: use pod name as kafka client ID

### DIFF
--- a/plugin-server/tests/helpers/kafka.ts
+++ b/plugin-server/tests/helpers/kafka.ts
@@ -14,14 +14,13 @@ import {
     KAFKA_SESSION_RECORDING_EVENTS,
 } from '../../src/config/kafka-topics'
 import { PluginsServerConfig } from '../../src/types'
-import { UUIDT } from '../../src/utils/utils'
 import { KAFKA_EVENTS_DEAD_LETTER_QUEUE } from './../../src/config/kafka-topics'
 
 /** Clear the Kafka queue and return Kafka object */
 export async function resetKafka(extraServerConfig?: Partial<PluginsServerConfig>): Promise<Kafka> {
     const config = { ...overrideWithEnv(defaultConfig, process.env), ...extraServerConfig }
     const kafka = new Kafka({
-        clientId: `plugin-server-test-${new UUIDT()}`,
+        clientId: `plugin-server-test`,
         brokers: (config.KAFKA_HOSTS || '').split(','),
         logLevel: logLevel.WARN,
     })


### PR DESCRIPTION
## Problem

During incidents, we want to quickly identify what pod is assigned to a given partition, and we currently do not have that information. `plugin-server` passes a random `instanceId` as its client-id when connecting to Kafka. That `instanceId` is also used to tag statsd metrics.

AFAIK, and accordingly to [the kafka-js doc](https://kafka.js.org/docs/configuration#client-id) that client-id does not need to be unique, and is used:

- in kafka logs
- in consumer-group stats (shown for each partition -> **allows to know what pod is consuming it**)
- in quota accounting (having common values would enable per-service quotas, but I don't see us needing that)

## Changes

Simply use `os.hostname()` as the client-id value. It is the pod name in k8s, or the container ID in docker-compose stacks.

One alternative would be to build a `${hostname()}--${instanceId}` string to still keep the instanceId around, but I think that Id won't survive our statsd->prom migration: the pod_name & container_id should be enough.

## How did you test this code?

:send-it:
