### PR TITLE
chore: show a warning when test account  filters are including

### DIFF
--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -6,11 +6,12 @@ import { AnyPropertyFilter } from '~/types'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupsModel } from '~/models/groupsModel'
 import { LemonSwitch } from '@posthog/lemon-ui'
+import { AlertMessage } from 'lib/components/AlertMessage'
 
 export function TestAccountFiltersConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
-    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading, testAccountFilterWarning } = useValues(teamLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const handleChange = (filters: AnyPropertyFilter[]): void => {
@@ -21,6 +22,11 @@ export function TestAccountFiltersConfig(): JSX.Element {
     return (
         <div className="mb-4 flex flex-col gap-2">
             <div className="mb-4">
+                {!!testAccountFilterWarning && (
+                    <AlertMessage type="warning" className={'m-2'}>
+                        {testAccountFilterWarning}
+                    </AlertMessage>
+                )}
                 {currentTeam && (
                     <PropertyFilters
                         pageKey="testaccountfilters"

--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -23,22 +23,20 @@ export function TestAccountFiltersConfig(): JSX.Element {
         <div className="mb-4 flex flex-col gap-2">
             <div className="mb-4">
                 {!!testAccountFilterWarningLabels && testAccountFilterWarningLabels.length > 0 && (
-                    <AlertMessage type="warning" className={'m-2'}>
-                        <>
-                            <p>
-                                Positive filters here mean only events or persons matching these filters will be
-                                included. Internal and test account filters are normally excluding filters like does not
-                                equal or does not contain.
-                            </p>
-                            <p>Positive filters are currently set for the following properties: </p>
-                            <ul className={'list-disc'}>
-                                {testAccountFilterWarningLabels.map((l, i) => (
-                                    <li key={i} className={'ml-4'}>
-                                        {l}
-                                    </li>
-                                ))}
-                            </ul>
-                        </>
+                    <AlertMessage type="warning" className="m-2">
+                        <p>
+                            Positive filters here mean only events or persons matching these filters will be included.
+                            Internal and test account filters are normally excluding filters like does not equal or does
+                            not contain.
+                        </p>
+                        <p>Positive filters are currently set for the following properties: </p>
+                        <ul className={'list-disc'}>
+                            {testAccountFilterWarningLabels.map((l, i) => (
+                                <li key={i} className={'ml-4'}>
+                                    {l}
+                                </li>
+                            ))}
+                        </ul>
                     </AlertMessage>
                 )}
                 {currentTeam && (

--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -11,7 +11,7 @@ import { AlertMessage } from 'lib/components/AlertMessage'
 export function TestAccountFiltersConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
-    const { currentTeam, currentTeamLoading, testAccountFilterWarning } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading, testAccountFilterWarningLabels } = useValues(teamLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const handleChange = (filters: AnyPropertyFilter[]): void => {
@@ -22,9 +22,23 @@ export function TestAccountFiltersConfig(): JSX.Element {
     return (
         <div className="mb-4 flex flex-col gap-2">
             <div className="mb-4">
-                {!!testAccountFilterWarning && (
+                {!!testAccountFilterWarningLabels && (
                     <AlertMessage type="warning" className={'m-2'}>
-                        {testAccountFilterWarning}
+                        <>
+                            <p>
+                                Positive filters here mean only events or persons matching these filters will be
+                                included. Internal and test account filters are normally excluding filters like does not
+                                equal or does not contain.
+                            </p>
+                            <p>Positive filters are currently set for the following properties: </p>
+                            <ul className={'list-disc'}>
+                                {testAccountFilterWarningLabels.map((l, i) => (
+                                    <li key={i} className={'ml-4'}>
+                                        {l}
+                                    </li>
+                                ))}
+                            </ul>
+                        </>
                     </AlertMessage>
                 )}
                 {currentTeam && (

--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -22,7 +22,7 @@ export function TestAccountFiltersConfig(): JSX.Element {
     return (
         <div className="mb-4 flex flex-col gap-2">
             <div className="mb-4">
-                {!!testAccountFilterWarningLabels && (
+                {!!testAccountFilterWarningLabels && testAccountFilterWarningLabels.length > 0 && (
                     <AlertMessage type="warning" className={'m-2'}>
                         <>
                             <p>

--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -30,9 +30,9 @@ export function TestAccountFiltersConfig(): JSX.Element {
                             not contain.
                         </p>
                         <p>Positive filters are currently set for the following properties: </p>
-                        <ul className={'list-disc'}>
+                        <ul className="list-disc">
                             {testAccountFilterWarningLabels.map((l, i) => (
-                                <li key={i} className={'ml-4'}>
+                                <li key={i} className="ml-4">
                                     {l}
                                 </li>
                             ))}

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -137,7 +137,11 @@ export const teamLogic = kea<teamLogicType>([
         testAccountFilterWarning: [
             (selectors) => [selectors.currentTeam],
             (currentTeam): JSX.Element | null => {
-                const positiveFilterOperators = [PropertyOperator.IContains, PropertyOperator.Regex]
+                const positiveFilterOperators = [
+                    PropertyOperator.Exact,
+                    PropertyOperator.IContains,
+                    PropertyOperator.Regex,
+                ]
                 const positiveFilters = []
                 for (const filter of currentTeam.test_account_filters) {
                     if (

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -134,9 +134,9 @@ export const teamLogic = kea<teamLogicType>([
                 !!currentTeam?.effective_membership_level &&
                 currentTeam.effective_membership_level >= OrganizationMembershipLevel.Admin,
         ],
-        testAccountFilterWarning: [
+        testAccountFilterWarningLabels: [
             (selectors) => [selectors.currentTeam],
-            (currentTeam): JSX.Element | null => {
+            (currentTeam) => {
                 if (!currentTeam) {
                     return null
                 }
@@ -155,40 +155,20 @@ export const teamLogic = kea<teamLogicType>([
                         positiveFilters.push(filter)
                     }
                 }
-                if (positiveFilters.length > 0) {
-                    const labels = positiveFilters.map((filter) => {
-                        if (!!filter.type && !!filter.key) {
-                            // person properties can be checked for a label as if they were event properties
-                            // so, we can check each acceptable type and see if it returns a value
-                            return (
-                                getPropertyLabel(filter.key, 'event') ||
-                                getPropertyLabel(filter.key, 'element') ||
-                                filter.key
-                            )
-                        } else {
-                            return filter.key
-                        }
-                    })
-                    return (
-                        <>
-                            <p>
-                                Positive filters here mean only events or persons matching these filters will be
-                                included. Internal and test account filters are normally excluding filters like does not
-                                equal or does not contain.
-                            </p>
-                            <p>Positive filters are currently set for the following properties: </p>
-                            <ul className={'list-disc'}>
-                                {labels.map((l, i) => (
-                                    <li key={i} className={'ml-4'}>
-                                        {l}
-                                    </li>
-                                ))}
-                            </ul>
-                        </>
-                    )
-                } else {
-                    return null
-                }
+
+                return positiveFilters.map((filter) => {
+                    if (!!filter.type && !!filter.key) {
+                        // person properties can be checked for a label as if they were event properties
+                        // so, we can check each acceptable type and see if it returns a value
+                        return (
+                            getPropertyLabel(filter.key, 'event') ||
+                            getPropertyLabel(filter.key, 'element') ||
+                            filter.key
+                        )
+                    } else {
+                        return filter.key
+                    }
+                })
             },
         ],
     }),

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -11,7 +11,7 @@ import { IconSwapHoriz } from 'lib/components/icons'
 import { loaders } from 'kea-loaders'
 import { OrganizationMembershipLevel } from '../lib/constants'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { getKeyMapping } from 'lib/components/PropertyKeyInfo'
+import { getPropertyLabel } from 'lib/components/PropertyKeyInfo'
 
 const parseUpdatedAttributeName = (attr: string | null): string => {
     if (attr === 'slack_incoming_webhook') {
@@ -137,6 +137,9 @@ export const teamLogic = kea<teamLogicType>([
         testAccountFilterWarning: [
             (selectors) => [selectors.currentTeam],
             (currentTeam): JSX.Element | null => {
+                if (!currentTeam) {
+                    return null
+                }
                 const positiveFilterOperators = [
                     PropertyOperator.Exact,
                     PropertyOperator.IContains,
@@ -153,9 +156,19 @@ export const teamLogic = kea<teamLogicType>([
                     }
                 }
                 if (positiveFilters.length > 0) {
-                    const labels = positiveFilters.map(
-                        (filter) => getKeyMapping(filter.key, filter.type)?.label || filter.key
-                    )
+                    const labels = positiveFilters.map((filter) => {
+                        if (!!filter.type && !!filter.key) {
+                            // person properties can be checked for a label as if they were event properties
+                            // so, we can check each acceptable type and see if it returns a value
+                            return (
+                                getPropertyLabel(filter.key, 'event') ||
+                                getPropertyLabel(filter.key, 'element') ||
+                                filter.key
+                            )
+                        } else {
+                            return filter.key
+                        }
+                    })
                     return (
                         <>
                             <p>

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -144,6 +144,7 @@ export const teamLogic = kea<teamLogicType>([
                     PropertyOperator.Exact,
                     PropertyOperator.IContains,
                     PropertyOperator.Regex,
+                    PropertyOperator.IsSet,
                 ]
                 const positiveFilters = []
                 for (const filter of currentTeam.test_account_filters) {


### PR DESCRIPTION
## Problem

Relatively frequently people get confused by the test/internal account filter and set it to something like "email contains mycompanydomain.com"

When they should set it to "email _does not contain_"

## Changes

Warns them when they may have done that

![Screenshot 2023-01-16 at 17 07 37](https://user-images.githubusercontent.com/984817/212733054-1352eeb3-40b0-4e41-9aa9-a7a0a1371e05.png)

## How did you test this code?

Running it locally