### PR TITLE
feat(property-filtering): Track time-to-see-data for values, abort controller

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { AutoComplete } from 'antd'
-import { useThrottledCallback } from 'use-debounce'
-import api from 'lib/api'
 import { isOperatorDate, isOperatorFlag, isOperatorMulti, toString } from 'lib/utils'
 import { PropertyOperator, PropertyType } from '~/types'
-import { propertyDefinitionsModel, PropValue } from '~/models/propertyDefinitionsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { useActions, useValues } from 'kea'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
 import { DurationPicker } from 'lib/components/DurationPicker/DurationPicker'
@@ -53,7 +51,7 @@ export function PropertyValue({
     const autoCompleteRef = useRef<HTMLElement>(null)
 
     const { formatPropertyValueForDisplay, describeProperty, options } = useValues(propertyDefinitionsModel)
-    const { setOptions, setOptionsLoading } = useActions(propertyDefinitionsModel)
+    const { loadOptions } = useActions(propertyDefinitionsModel)
 
     const isMultiSelect = operator && isOperatorMulti(operator)
     const isDateTimeProperty = operator && isOperatorDate(operator)
@@ -73,21 +71,9 @@ export function PropertyValue({
         }
     }, [value])
 
-    const loadPropertyValues = useThrottledCallback((newInput) => {
-        if (['cohort', 'session'].includes(type)) {
-            return
-        }
-        if (!propertyKey) {
-            return
-        }
-        const key = propertyKey.split('__')[0]
-        setOptionsLoading(propertyKey)
-        api.get(endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')).then(
-            (propValues: PropValue[]) => {
-                setOptions(propertyKey, propValues)
-            }
-        )
-    }, 300)
+    const loadPropertyValues = (newInput: string | undefined): void => {
+        loadOptions({ endpoint, type, newInput, propertyKey })
+    }
 
     function setValue(newValue: PropertyValueProps['value']): void {
         onSet(newValue)

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -51,7 +51,7 @@ export function PropertyValue({
     const autoCompleteRef = useRef<HTMLElement>(null)
 
     const { formatPropertyValueForDisplay, describeProperty, options } = useValues(propertyDefinitionsModel)
-    const { loadOptions } = useActions(propertyDefinitionsModel)
+    const { loadPropertyValues } = useActions(propertyDefinitionsModel)
 
     const isMultiSelect = operator && isOperatorMulti(operator)
     const isDateTimeProperty = operator && isOperatorDate(operator)
@@ -71,8 +71,8 @@ export function PropertyValue({
         }
     }, [value])
 
-    const loadPropertyValues = (newInput: string | undefined): void => {
-        loadOptions({ endpoint, type, newInput, propertyKey })
+    const load = (newInput: string | undefined): void => {
+        loadPropertyValues({ endpoint, type, newInput, propertyKey })
     }
 
     function setValue(newValue: PropertyValueProps['value']): void {
@@ -83,7 +83,7 @@ export function PropertyValue({
     }
 
     useEffect(() => {
-        loadPropertyValues('')
+        load('')
     }, [propertyKey])
 
     useEffect(() => {
@@ -101,7 +101,7 @@ export function PropertyValue({
         onSearch: (newInput: string) => {
             setInput(newInput)
             if (!Object.keys(options).includes(newInput) && !(operator && isOperatorFlag(operator))) {
-                loadPropertyValues(newInput)
+                load(newInput)
             }
         },
         ['data-attr']: 'prop-val',

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -34,7 +34,6 @@ export interface PropertyValueProps {
     onSet: CallableFunction
     value?: string | number | Array<string | number> | null
     operator: PropertyOperator
-    outerOptions?: Option[] // If no endpoint provided, options are given here
     autoFocus?: boolean
     allowCustom?: boolean
 }
@@ -56,7 +55,6 @@ export function PropertyValue({
     onSet,
     value,
     operator,
-    outerOptions = undefined,
     autoFocus = false,
     allowCustom = true,
 }: PropertyValueProps): JSX.Element {
@@ -97,27 +95,17 @@ export function PropertyValue({
         }
         const key = propertyKey.split('__')[0]
         setOptions({ ...options, [propertyKey]: { ...options[propertyKey], status: 'loading' } })
-        if (outerOptions) {
-            setOptions({
-                ...options,
-                [propertyKey]: {
-                    values: [...Array.from(new Set(outerOptions))],
-                    status: 'loaded',
-                },
-            })
-        } else {
-            api.get(endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')).then(
-                (propValues: PropValue[]) => {
-                    setOptions({
-                        ...options,
-                        [propertyKey]: {
-                            values: [...Array.from(new Set(propValues))],
-                            status: 'loaded',
-                        },
-                    })
-                }
-            )
-        }
+        api.get(endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')).then(
+            (propValues: PropValue[]) => {
+                setOptions({
+                    ...options,
+                    [propertyKey]: {
+                        values: [...Array.from(new Set(propValues))],
+                        status: 'loaded',
+                    },
+                })
+            }
+        )
     }, 300)
 
     function setValue(newValue: PropertyValueProps['value']): void {

--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -3,7 +3,7 @@ import api, { getJSONOrThrow } from 'lib/api'
 import { getResponseBytes } from 'scenes/insights/utils'
 
 export interface TimeToSeeDataPayload {
-    type: 'dashboard_load' | 'insight_load' | 'properties_timeline_load' | 'property_load'
+    type: 'dashboard_load' | 'insight_load' | 'properties_timeline_load' | 'property_values_load' | 'properties_load'
     context: 'dashboard' | 'insight' | 'actors_modal' | 'filters'
     time_to_see_data_ms: number
     primary_interaction_id: string

--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -3,8 +3,8 @@ import api, { getJSONOrThrow } from 'lib/api'
 import { getResponseBytes } from 'scenes/insights/utils'
 
 export interface TimeToSeeDataPayload {
-    type: 'dashboard_load' | 'insight_load' | 'properties_timeline_load' // TODO: Track `actors_load` too
-    context: 'dashboard' | 'insight' | 'actors_modal'
+    type: 'dashboard_load' | 'insight_load' | 'properties_timeline_load' | 'property_load'
+    context: 'dashboard' | 'insight' | 'actors_modal' | 'filters'
     time_to_see_data_ms: number
     primary_interaction_id: string
     query_id?: string
@@ -13,8 +13,8 @@ export interface TimeToSeeDataPayload {
     api_url?: string
     insight?: string
     action?: string
-    insights_fetched: number
-    insights_fetched_cached: number
+    insights_fetched?: number
+    insights_fetched_cached?: number
     min_last_refresh?: string | null
     max_last_refresh?: string | null
     // Signifies whether the action was user-initiated or a secondary effect

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -73,6 +73,13 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
         updatePropertyDefinitions: (propertyDefinitions: PropertyDefinition[] | PropertyDefinitionStorage) => ({
             propertyDefinitions,
         }),
+        // PropertyValue
+        loadOptions: (payload: {
+            endpoint: string | undefined
+            type: string
+            newInput: string | undefined
+            propertyKey: string
+        }) => payload,
         setOptionsLoading: (key: string) => ({ key }),
         setOptions: (key: string, values: PropValue[]) => ({ key, values }),
         // internal
@@ -176,6 +183,24 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             if (values.pendingProperties.length > 0) {
                 actions.fetchAllPendingDefinitions()
             }
+        },
+
+        loadOptions: async ({ endpoint, type, newInput, propertyKey }, breakpoint) => {
+            if (['cohort', 'session'].includes(type)) {
+                return
+            }
+            if (!propertyKey) {
+                return
+            }
+
+            await breakpoint(300)
+            const key = propertyKey.split('__')[0]
+            actions.setOptionsLoading(propertyKey)
+            const propValues: PropValue[] = await api.get(
+                endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')
+            )
+            breakpoint()
+            actions.setOptions(propertyKey, propValues)
         },
     })),
     selectors({

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -39,6 +39,18 @@ export const updatePropertyDefinitions = (
     propertyDefinitionsModel.findMounted()?.actions.updatePropertyDefinitions(propertyDefinitions)
 }
 
+export type PropValue = {
+    id?: number
+    name?: string | boolean
+}
+
+export type Option = {
+    label?: string
+    name?: string
+    status?: 'loading' | 'loaded'
+    values?: PropValue[]
+}
+
 /** Schedules an immediate background task, that fetches property definitions after a 10ms debounce */
 const checkOrLoadPropertyDefinition = (
     propertyName: BreakdownKeyType | undefined,
@@ -61,6 +73,8 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
         updatePropertyDefinitions: (propertyDefinitions: PropertyDefinition[] | PropertyDefinitionStorage) => ({
             propertyDefinitions,
         }),
+        setOptionsLoading: (key: string) => ({ key }),
+        setOptions: (key: string, values: PropValue[]) => ({ key, values }),
         // internal
         fetchAllPendingDefinitions: true,
     }),
@@ -73,6 +87,19 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                     ...(Array.isArray(propertyDefinitions)
                         ? Object.fromEntries(propertyDefinitions.map((p) => [p.name, p]))
                         : propertyDefinitions),
+                }),
+            },
+        ],
+        options: [
+            {} as Record<string, Option>,
+            {
+                setOptionsLoading: (state, { key }) => ({ ...state, [key]: { ...state[key], status: 'loading' } }),
+                setOptions: (state, { key, values }) => ({
+                    ...state,
+                    [key]: {
+                        values: [...Array.from(new Set(values))],
+                        status: 'loaded',
+                    },
                 }),
             },
         ],

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -217,9 +217,8 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             cache.abortController = null
 
             await captureTimeToSeeData(teamLogic.values.currentTeamId, {
-                type: 'property_load',
+                type: 'property_values_load',
                 context: 'filters',
-                action: 'load_property_values',
                 primary_interaction_id: '',
                 status: 'success',
                 time_to_see_data_ms: Math.floor(performance.now() - start),


### PR DESCRIPTION
Related to sprint goal: We now track how long it takes to use property modals.