### PR TITLE
chore(CI): fix pipeline for external PRs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -263,9 +263,8 @@ jobs:
     cloud:
         needs: changes
         timeout-minutes: 30
-        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
-
-        name: Django tests – Cloud
+        if: ${{ needs.changes.outputs.backend == 'true' && ! github.event.pull_request.head.repo.fork }} # we can't run this test on forks
+        name: Django tests - Cloud
         runs-on: ubuntu-latest
         steps:
             - name: Fetch posthog-cloud

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -13,7 +13,6 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    # Job that lists and chunks spec file names and caches node modules
     cypress_prep:
         name: Cypress preparation
         runs-on: ubuntu-latest
@@ -22,7 +21,7 @@ jobs:
             specs: ${{ steps.set-specs.outputs.specs }}
 
         steps:
-            - name: Wait for the container image to be ready
+            - name: Wait for the container image cache to be ready
               uses: lewagon/wait-on-check-action@v1.2.0
               with:
                   check-name: Build PostHog
@@ -37,14 +36,15 @@ jobs:
               id: set-specs
               run: echo "specs=$(ls cypress/e2e/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(3) | join("\n")' | jq --slurp -c .)" >> $GITHUB_OUTPUT
 
+
+
+
+
     cypress:
         name: Cypress E2E tests (${{ strategy.job-index }})
         runs-on: ubuntu-latest
         timeout-minutes: 30
         needs: [cypress_prep]
-        permissions:
-            packages: read # allow pull from ghcr.io
-
         strategy:
             # when one test fails, DO NOT cancel the other
             # containers, as there may be other spec failures
@@ -118,11 +118,43 @@ jobs:
                   OBJECT_STORAGE_SECRET_ACCESS_KEY=object_storage_root_password
                   EOT
 
-            - name: Get the PostHog container image of this PR
+            - name: Docker meta
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/posthog # keep this in sync with the 'Container Images CI / Build PostHog' job
+                  images: ghcr.io/posthog/posthog/posthog # keep this in sync with the 'Container Images CI / Build PostHog' job
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@v1
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build container images
+              id: build
+              uses: depot/build-push-action@v1
+              with:
+                  # Why are we re-building the image instead of pulling it from a repository?
+                  # Because PRs from external contributors will not be able to do so. Instead,
+                  # we build the image in the 'Container Images CI / Build PostHog' job, caching
+                  # the layers to the GHA backend so that we can re-use those here.
+                  project: x19jffd9zf # posthog
+                  buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
+                  cache-from: type=gha # always pull the layers from GHA
+                  cache-to: type=gha,mode=max # always push the layers to GHA
+                  push: false
+                  tags: ${{ steps.meta.outputs.tags }}
+                  platforms: linux/amd64,linux/arm64
 
             - name: Start PostHog
               run: |

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -122,7 +122,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/posthog/posthog/posthog
+                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/posthog # keep this in sync with the 'Container Images CI / Build PostHog' job
 
             - name: Start PostHog
               run: |

--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -39,7 +39,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/${{ github.repository }}/codespaces
+                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/codespaces
                   tags: |
                       type=ref,event=branch
                       type=raw,value=master
@@ -51,7 +51,7 @@ jobs:
               id: meta-for-cache
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/${{ github.repository }}/codespaces
+                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/codespaces
                   tags: |
                       type=raw,value=master
 

--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -39,7 +39,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/codespaces
+                  images: ghcr.io/${{ github.repository }}/codespaces
                   tags: |
                       type=ref,event=branch
                       type=raw,value=master
@@ -51,7 +51,7 @@ jobs:
               id: meta-for-cache
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/codespaces
+                  images: ghcr.io/${{ github.repository }}/codespaces
                   tags: |
                       type=raw,value=master
 

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -38,7 +38,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/posthog # keep this in sync with the 'E2E CI / Cypress' job
+                  images: ghcr.io/posthog/posthog/posthog # keep this in sync with the 'E2E CI / Cypress' job
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
@@ -60,11 +60,15 @@ jobs:
               id: build
               uses: depot/build-push-action@v1
               with:
+                  # Why aren't we pushing the images? Because PRs from external contributors
+                  # will not be able to do so. Instead, we are building the image here, cache
+                  # the layers to the GHA backend so that we can re-use those in the
+                  # 'E2E CI / Cypress' job
                   project: x19jffd9zf # posthog
                   buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
                   cache-from: type=gha # always pull the layers from GHA
                   cache-to: type=gha,mode=max # always push the layers to GHA
-                  push: true
+                  push: false
                   tags: ${{ steps.meta.outputs.tags }}
                   platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -38,7 +38,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/posthog/posthog/posthog
+                  images: ghcr.io/${{ github.event.pull_request.head.repo.full_name || github.repository }}/posthog # keep this in sync with the 'E2E CI / Cypress' job
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
@@ -53,7 +53,7 @@ jobs:
               uses: docker/login-action@v2
               with:
                   registry: ghcr.io
-                  username: ${{ github.repository_owner }}
+                  username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build container images
@@ -70,6 +70,7 @@ jobs:
 
     posthog_cloud_build:
         name: Build PostHog Cloud
+        if: ${{ ! github.event.pull_request.head.repo.fork }} # we can't run this test on forks
         runs-on: ubuntu-latest
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
@@ -100,7 +101,7 @@ jobs:
               uses: docker/login-action@v2
               with:
                   registry: ghcr.io
-                  username: ${{ github.repository_owner }}
+                  username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build container images

--- a/ee/api/test/test_feature_flag_role_access.py
+++ b/ee/api/test/test_feature_flag_role_access.py
@@ -32,7 +32,7 @@ class TestFeatureFlagRoleAccessAPI(APILicensedTest):
         self.assertEqual(flag_role_access_create_res.status_code, status.HTTP_201_CREATED)
         flag_role = FeatureFlagRoleAccess.objects.get(id=flag_role_access_create_res.json()["id"])
         self.assertEqual(flag_role.role.name, self.eng_role.name)
-        self.assertEqual(flag_role.feature_flag.id, self.feature_flag.id)
+        self.assertEqual(flag_role.feature_flag_id, self.feature_flag.id)
 
     def test_cannot_add_role_access_if_feature_flags_access_level_too_low_and_not_creator(self):
         OrganizationResourceAccess.objects.create(

--- a/ee/api/test/test_session_recording_playlist.py
+++ b/ee/api/test/test_session_recording_playlist.py
@@ -267,29 +267,21 @@ class TestSessionRecordingPlaylist(APILicensedTest):
             f"/api/projects/{self.team.id}/session_recording_playlists/{playlist1.short_id}/recordings/{recording1_session_id}",
         ).json()
         assert result["success"]
-        assert (
-            SessionRecordingPlaylistItem.objects.filter(
-                playlist_id=playlist1.id, session_id=recording1_session_id
-            ).count()
-            == 0
-        )
+        assert not SessionRecordingPlaylistItem.objects.filter(
+            playlist_id=playlist1.id, session_id=recording1_session_id
+        ).exists()
+
         result = self.client.delete(
             f"/api/projects/{self.team.id}/session_recording_playlists/{playlist1.short_id}/recordings/{recording2_session_id}",
         ).json()
         assert result["success"]
-        assert (
-            SessionRecordingPlaylistItem.objects.filter(
-                playlist_id=playlist1.id, session_id=recording2_session_id
-            ).count()
-            == 0
-        )
+        assert not SessionRecordingPlaylistItem.objects.filter(
+            playlist_id=playlist1.id, session_id=recording2_session_id
+        ).exists()
         result = self.client.delete(
             f"/api/projects/{self.team.id}/session_recording_playlists/{playlist2.short_id}/recordings/{recording2_session_id}",
         ).json()
         assert result["success"]
-        assert (
-            SessionRecordingPlaylistItem.objects.filter(
-                playlist_id=playlist2.id, session_id=recording1_session_id
-            ).count()
-            == 0
-        )
+        assert not SessionRecordingPlaylistItem.objects.filter(
+            playlist_id=playlist2.id, session_id=recording1_session_id
+        ).exists()

--- a/posthog/caching/test/test_insight_caching_state.py
+++ b/posthog/caching/test/test_insight_caching_state.py
@@ -284,7 +284,7 @@ def test_upsert_text_tile_does_not_create_record(mock_active_teams, team: Team, 
     tile = create_tile(team=team, user=user, mock_active_teams=mock_active_teams, text_tile=True)
     upsert(team, tile)
 
-    assert InsightCachingState.objects.filter(team=team).count() == 0
+    assert not InsightCachingState.objects.filter(team=team).exists()
 
 
 @pytest.mark.django_db

--- a/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
@@ -46,7 +46,7 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
 
         # postgres didn't change
         pg_distinct_ids = PersonDistinctId.objects.all()
-        self.assertEqual(len(pg_distinct_ids), 1)
+        self.assertEqual(pg_distinct_ids.count(), 1)
         self.assertEqual(pg_distinct_ids[0].version, 0)
         self.assertEqual(pg_distinct_ids[0].distinct_id, "distinct_id")
         self.assertEqual(pg_distinct_ids[0].person.uuid, person_linked_to_after.uuid)
@@ -106,7 +106,7 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
 
         # postgres
         pg_distinct_ids = PersonDistinctId.objects.all()
-        self.assertEqual(len(pg_distinct_ids), 2)
+        self.assertEqual(pg_distinct_ids.count(), 2)
         self.assertEqual(pg_distinct_ids[0].version, 2500)
         self.assertEqual(pg_distinct_ids[1].version, 2500)
         self.assertEqual(
@@ -162,7 +162,7 @@ class TestFixPersonDistinctIdsAfterDelete(BaseTest, ClickhouseTestMixin):
 
         # postgres
         pg_distinct_ids = PersonDistinctId.objects.all()
-        self.assertEqual(len(pg_distinct_ids), 1)
+        self.assertEqual(pg_distinct_ids.count(), 1)
         self.assertEqual(pg_distinct_ids[0].version, 0)
         self.assertEqual(pg_distinct_ids[0].distinct_id, "distinct_id-1")
         self.assertEqual(pg_distinct_ids[0].person.uuid, person_not_changed_1.uuid)

--- a/posthog/models/test/test_insight_caching_state.py
+++ b/posthog/models/test/test_insight_caching_state.py
@@ -107,5 +107,5 @@ class TestInsightCachingState(BaseTest):
 
     def get_caching_state(self) -> Optional[InsightCachingState]:
         query_set = InsightCachingState.objects.filter(team_id=self.team.pk)
-        assert len(query_set) in (0, 1)
+        assert query_set.count() in (0, 1)
         return query_set.first()

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -210,7 +210,7 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
     # NOTE: This is not ideal as some rows _could_ have different keys
     # Ideally we would extend the csvrenderer to supported keeping the order in place
     if len(all_csv_rows):
-        if not [x for x in all_csv_rows[0].values() if isinstance(x, dict) or isinstance(x, list)]:
+        if not [x for x in all_csv_rows[0].values() if isinstance(x, (dict, list))]:
             # If values are serialised then keep the order of the keys, else allow it to be unordered
             renderer.header = all_csv_rows[0].keys()
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -89,7 +89,7 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
             wait_for_css_selector = ".InsightCard"
             screenshot_width = 1920
         else:
-            raise Exception(f"Export is missing required dashboard or insight ID")
+            raise Exception("Export is missing required dashboard or insight ID")
 
         logger.info("exporting_asset", asset_id=exported_asset.id, render_url=url_to_render)
 


### PR DESCRIPTION
## Problem
I'm opening this from a personal external fork to make sure CI can run without issues on contributor PRs. 

## Changes
* do not run `Django tests – Cloud` on forks as they can't pull our internal repository `posthog/posthog-cloud`
* change the container image tag from the hardcoded `posthog/posthog` to the fork repository name
* change the username used to login to `ghcr.io` from `github.repository_owner` to `github.actor`
* make few improvements across the codebase to make sure the majority of GitHub actions are triggered

## How did you test this code?
CI is ✅  with the exception of `Backend CI / Django tests – FOSS (persons-on-events off), Py 3.8.14` that is also failing on `master`.

Unfortunately, to make CI fully working, forked repo needs to allow read/write permission on workflows (it's a setting at `https://github.com/<username>/posthog/settings/actions`). I'm not sure how do we want to publicise this (maybe directly in the PR template?) EDIT: it is still not working

<img width="806" alt="Screenshot 2023-01-18 at 14 58 26" src="https://user-images.githubusercontent.com/4038041/213190458-58f4447e-5acb-4dba-9678-78a538e5d077.png">
