### PR TITLE
chore: Added gzip compression to perf events

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -253,6 +253,8 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/?api/projects/\\d+/session_recordings/.*$",
                 "^/?api/projects/\\d+/session_recording_playlists/?$",
                 "^/?api/projects/\\d+/session_recording_playlists/.*$",
+                "^/?api/projects/\\d+/performance_events/?$",
+                "^/?api/projects/\\d+/performance_events/.*$",
                 "^/?api/projects/\\d+/exports/\\d+/content/?$",
                 "^/?api/projects/\\d+/activity_log/important_changes/?$",
                 "^/?api/projects/\\d+/uploaded_media/?$",


### PR DESCRIPTION
## Problem

Used our own tool to realise that we weren't gzipping our perf events!

## Changes

* Added to the gzip allow list

|Before|After|
|----|----|
|<img width="628" alt="Screenshot 2023-01-17 at 11 27 44" src="https://user-images.githubusercontent.com/2536520/212874973-ac5e3093-7a69-4630-adf4-a1079531895b.png">|<img width="631" alt="Screenshot 2023-01-17 at 11 24 37" src="https://user-images.githubusercontent.com/2536520/212874622-7c13c470-e531-4820-8e67-86d8fab0d9a4.png">|

The payload is nonetheless pretty massive given the number of events that are generated. Probably something to look into....

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
