### PR TITLE
chore: load only an hour of web perf page views

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1114,7 +1114,7 @@ const api = {
         ): Promise<PaginatedResponse<RecentPerformancePageView>> {
             return new ApiRequest()
                 .recentPageViewPerformanceEvents(
-                    dateFrom || dayjs().subtract(1, 'day').toISOString(),
+                    dateFrom || dayjs().subtract(1, 'hour').toISOString(),
                     dateTo || dayjs().toISOString(),
                     teamId
                 )


### PR DESCRIPTION
## Problem

The web performance page loads a day of pageviews. This turns out to be an awful lot of data™️ 

## Changes

In lieu of adding filtering and pagination let's load less data for now

## How did you test this code?

ran it locally
