### PR TITLE
feat: Simplified summary of performance event

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemPerformanceEvent.tsx
@@ -127,6 +127,11 @@ export function ItemPerformanceEvent({
         }
     }, {} as Record<string, any>)
 
+    const compressionPercentage =
+        item.decoded_body_size && item.encoded_body_size
+            ? ((item.decoded_body_size - item.encoded_body_size) / item.decoded_body_size) * 100
+            : undefined
+
     return (
         <div>
             <LemonButton noPadding onClick={() => setExpanded(!expanded)} status={'primary-alt'} fullWidth>
@@ -206,27 +211,24 @@ export function ItemPerformanceEvent({
                     <CodeSnippet language={Language.Markup} wrap copyDescription="performance event name">
                         {item.name}
                     </CodeSnippet>
-                    <p className="text-sm">
+                    <p>
                         Request started at <b>{humanFriendlyMilliseconds(item.start_time || item.fetch_start)}</b> and
-                        took <b>{humanFriendlyMilliseconds(item.duration)}</b> to complete.
+                        took <b>{humanFriendlyMilliseconds(item.duration)}</b>
+                        {item.decoded_body_size ? (
+                            <>
+                                {' '}
+                                to load <b>{humanizeBytes(item.decoded_body_size)}</b> of data
+                            </>
+                        ) : null}
+                        {compressionPercentage && item.encoded_body_size ? (
+                            <>
+                                , compressed to <b>{humanizeBytes(item.encoded_body_size)}</b> saving{' '}
+                                <b>{compressionPercentage.toFixed(1)}%</b>
+                            </>
+                        ) : null}
+                        .
                     </p>
 
-                    {item.decoded_body_size && item.encoded_body_size ? (
-                        <span>
-                            Resource is {humanizeBytes(item.decoded_body_size)}.
-                            {item.encoded_body_size !== item.decoded_body_size && (
-                                <>
-                                    {' '}
-                                    Was compressed. Sent {humanizeBytes(item.encoded_body_size)}. Saving{' '}
-                                    {(
-                                        ((item.decoded_body_size - item.encoded_body_size) / item.decoded_body_size) *
-                                        100
-                                    ).toFixed(1)}
-                                    %
-                                </>
-                            )}
-                        </span>
-                    ) : null}
                     <LemonDivider dashed />
                     <SimpleKeyValueList item={sanitizedProps} />
                 </div>


### PR DESCRIPTION
## Problem

Simplify the summary of a performance event

## Changes

* Moved it all into one descriptive line

|Before|After|
|----|----|
|<img width="621" alt="Screenshot 2023-01-17 at 13 26 20" src="https://user-images.githubusercontent.com/2536520/212898764-770fbc71-9b75-4111-af0a-d3454283ff3f.png">|<img width="621" alt="Screenshot 2023-01-17 at 13 25 34" src="https://user-images.githubusercontent.com/2536520/212898614-b2afbb2f-26eb-4b6e-a1e9-2425bbca98ef.png">|

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
