### PR TITLE
chore(session-recordings): revert to sending events to old topic

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -27,7 +27,7 @@ from posthog.api.utils import (
 )
 from posthog.exceptions import generate_exception_response
 from posthog.kafka_client.client import KafkaProducer
-from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE, KAFKA_SESSION_RECORDING_EVENTS
+from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE
 from posthog.logging.timing import timed
 from posthog.models.feature_flag import get_all_feature_flags
 from posthog.models.utils import UUIDT
@@ -67,11 +67,16 @@ def log_event(data: Dict, event_name: str, partition_key: Optional[str]):
     # To allow for different quality of service on session recordings and
     # `$performance_event` and other events, we push to a different topic.
     # TODO: split `$performance_event` out to it's own topic.
-    kafka_topic = (
-        KAFKA_SESSION_RECORDING_EVENTS
-        if event_name in ("$snapshot", "$performance_event")
-        else KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
-    )
+    # NOTE: switch back to KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC temporarily
+    # TODO: resolve distinct_id issue and revert back to
+    # KAFKA_SESSION_RECORDING_EVENTS
+    # whilst resolving issue with distinct_ids not being set correctly.
+    # kafka_topic = (
+    #     KAFKA_SESSION_RECORDING_EVENTS
+    #     if event_name in ("$snapshot", "$performance_event")
+    #     else KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
+    # )
+    kafka_topic = KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
 
     logger.debug("logging_event", event_name=event_name, kafka_topic=kafka_topic)
 

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -27,7 +27,6 @@ from rest_framework import status
 
 from posthog.api.capture import get_distinct_id
 from posthog.api.test.mock_sentry import mock_sentry_context_for_tagging
-from posthog.kafka_client.topics import KAFKA_SESSION_RECORDING_EVENTS
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.utils import generate_random_token_personal
@@ -1114,7 +1113,7 @@ class TestCapture(BaseTest):
         self._send_session_recording_event()
         self.assertEqual(kafka_produce.call_count, 1)
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
-        self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
+        self.assertEqual(kafka_topic_used, KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC)
         key = kafka_produce.call_args_list[0][1]["key"]
         self.assertEqual(key, None)
 
@@ -1147,7 +1146,7 @@ class TestCapture(BaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
-        self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
+        self.assertEqual(kafka_topic_used, KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC)
         key = kafka_produce.call_args_list[0][1]["key"]
         self.assertEqual(key, None)
 
@@ -1173,7 +1172,7 @@ class TestCapture(BaseTest):
             event_data=event_data,
         )
         self.assertEqual(kafka_produce.call_count, 1)
-        self.assertEqual(kafka_produce.call_args_list[0][1]["topic"], KAFKA_SESSION_RECORDING_EVENTS)
+        self.assertEqual(kafka_produce.call_args_list[0][1]["topic"], KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC)
         key = kafka_produce.call_args_list[0][1]["key"]
         self.assertEqual(key, None)
         data_sent_to_kafka = json.loads(kafka_produce.call_args_list[0][1]["data"]["data"])
@@ -1241,7 +1240,7 @@ class TestCapture(BaseTest):
         ]  # 512 * 1024 is the max size of a single message and random letters shouldn't be compressible, so this should be at least 2 messages
         self._send_session_recording_event(event_data=data)
         topic_counter = Counter([call[1]["topic"] for call in kafka_produce.call_args_list])
-        self.assertGreater(topic_counter[KAFKA_SESSION_RECORDING_EVENTS], 1)
+        self.assertGreater(topic_counter[KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC], 1)
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_database_unavailable(self, kafka_produce):


### PR DESCRIPTION
There is an issue with setting of distinct_ids on session recordings
with the other consumer, so temp switching back.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
