### PR TITLE
fix: toolbar hover behaviour couldn't cope with adjacent or overlapping elements

### DIFF
--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -73,8 +73,8 @@ export function Elements(): JSX.Element {
                             ...getBoxColors('blue', hoverElement === element || selectedElement === element),
                         }}
                         onClick={() => selectElement(element)}
-                        onMouseOver={() => setHoverElement(element)}
-                        onMouseOut={() => setHoverElement(null)}
+                        onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                        onMouseOut={() => selectedElement === null && setHoverElement(null)}
                     />
                 ))}
 
@@ -96,8 +96,8 @@ export function Elements(): JSX.Element {
                                     ),
                                 }}
                                 onClick={() => selectElement(element)}
-                                onMouseOver={() => setHoverElement(element)}
-                                onMouseOut={() => setHoverElement(null)}
+                                onMouseOver={() => !!selectedElement && setHoverElement(element)}
+                                onMouseOut={() => !!selectedElement && setHoverElement(null)}
                             />
                             <HeatmapLabel
                                 rect={rect}
@@ -116,8 +116,8 @@ export function Elements(): JSX.Element {
                                     )}, 100%, 32%, 1) 0px 1px 5px 1px`,
                                 }}
                                 onClick={() => selectElement(element)}
-                                onMouseOver={() => setHoverElement(element)}
-                                onMouseOut={() => setHoverElement(null)}
+                                onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                                onMouseOut={() => selectedElement === null && setHoverElement(null)}
                             >
                                 {compactNumber(count || 0)}
                             </HeatmapLabel>
@@ -144,8 +144,8 @@ export function Elements(): JSX.Element {
                                     boxShadow: 'hsla(141, 100%, 32%, 1) 0px 1px 5px 1px',
                                 }}
                                 onClick={() => selectElement(element)}
-                                onMouseOver={() => setHoverElement(element)}
-                                onMouseOut={() => setHoverElement(null)}
+                                onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                                onMouseOut={() => selectedElement === null && setHoverElement(null)}
                             >
                                 {(index || loopIndex) + 1}
                             </HeatmapLabel>

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -96,8 +96,8 @@ export function Elements(): JSX.Element {
                                     ),
                                 }}
                                 onClick={() => selectElement(element)}
-                                onMouseOver={() => !!selectedElement && setHoverElement(element)}
-                                onMouseOut={() => !!selectedElement && setHoverElement(null)}
+                                onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                                onMouseOut={() => selectedElement === null && setHoverElement(null)}
                             />
                             <HeatmapLabel
                                 rect={rect}

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -51,6 +51,7 @@ export const elementsLogic = kea<elementsLogicType>({
                 enableInspect: () => null,
                 disableInspect: () => null,
                 createAction: () => null,
+                selectElement: () => null,
             },
         ],
         highlightElement: [
@@ -367,10 +368,10 @@ export const elementsLogic = kea<elementsLogicType>({
             posthog.capture('toolbar mode triggered', { mode: 'inspect', enabled: false })
         },
         selectElement: ({ element }) => {
-            const inpsectForAction =
+            const inspectForAction =
                 actionsTabLogic.values.buttonActionsVisible && actionsTabLogic.values.inspectingElement !== null
 
-            if (inpsectForAction) {
+            if (inspectForAction) {
                 actions.setHoverElement(null)
                 if (element) {
                     actionsTabLogic.actions.inspectElementSelected(element, actionsTabLogic.values.inspectingElement)


### PR DESCRIPTION
## Problem

If toolbar inspector had overlapping or adjacent elements you couldn't interact with a toolbar window.

1. click on an element
2. its `InfoWindow` would be selected
3. move the mouse to interact with the `InfoWindow` e.g. to create an action
4. the overlapping/adjacent element mouseOver would close the selected window

## Changes

Now the selected window stays open until you close it or select another element.

![2023-01-17 15 40 18](https://user-images.githubusercontent.com/984817/212946943-c4f30125-a19e-466a-924f-50e7070857f4.gif)

## How did you test this code?

running it locally and seeing what happens
