### PR TITLE
fix(recordings): get correct fcp for each navigation

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -245,14 +245,19 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     !!featureFlags[FEATURE_FLAGS.RECORDINGS_INSPECTOR_PERFORMANCE] &&
                     (tab === SessionRecordingPlayerTab.ALL || tab === SessionRecordingPlayerTab.PERFORMANCE)
                 ) {
-                    for (const event of performanceEvents || []) {
+                    const performanceEventsArr = performanceEvents || []
+                    for (let eventIndex = 0; eventIndex < performanceEventsArr.length; eventIndex++) {
+                        const event = performanceEventsArr[eventIndex]
                         const timestamp = dayjs(event.timestamp)
                         const responseStatus = event.response_status || 200
 
                         // NOTE: Navigtion events are missing the first contentful paint info so we find the relevant first contentful paint event and add it to the navigation event
                         if (event.entry_type === 'navigation' && !event.first_contentful_paint) {
-                            const firstContentfulPaint = (performanceEvents || []).find(
-                                (x) => x.entry_type === 'paint' && x.name === 'first-contentful-paint'
+                            const firstContentfulPaint = performanceEventsArr.find(
+                                (x, index) =>
+                                    index >= eventIndex &&
+                                    x.entry_type === 'paint' &&
+                                    x.name === 'first-contentful-paint'
                             )
                             if (firstContentfulPaint) {
                                 event.first_contentful_paint = firstContentfulPaint.start_time

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -246,16 +246,15 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     (tab === SessionRecordingPlayerTab.ALL || tab === SessionRecordingPlayerTab.PERFORMANCE)
                 ) {
                     const performanceEventsArr = performanceEvents || []
-                    for (let eventIndex = 0; eventIndex < performanceEventsArr.length; eventIndex++) {
-                        const event = performanceEventsArr[eventIndex]
+                    for (const event of performanceEventsArr) {
                         const timestamp = dayjs(event.timestamp)
                         const responseStatus = event.response_status || 200
 
                         // NOTE: Navigtion events are missing the first contentful paint info so we find the relevant first contentful paint event and add it to the navigation event
                         if (event.entry_type === 'navigation' && !event.first_contentful_paint) {
                             const firstContentfulPaint = performanceEventsArr.find(
-                                (x, index) =>
-                                    index >= eventIndex &&
+                                (x) =>
+                                    x.pageview_id === event.pageview_id &&
                                     x.entry_type === 'paint' &&
                                     x.name === 'first-contentful-paint'
                             )


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/13749#issuecomment-1385765915

![Screenshot 2023-01-17 at 12 20 26 PM](https://user-images.githubusercontent.com/13460330/212967812-b56c72e1-e504-400a-93db-4a8046736201.png)

## Changes

Make sure fcp happens after the navigation event when reassigning.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

See that FCP's are now different across different navigation events

![Screenshot 2023-01-17 at 12 29 14 PM](https://user-images.githubusercontent.com/13460330/212969871-f65992b6-2e8d-4922-805a-de087489a06f.png)

