### PR TITLE
refactor: Replace `Badge` with `LemonBadge`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -138,6 +138,10 @@ module.exports = {
                         element: 'Spin',
                         message: 'use Spinner instead',
                     },
+                    {
+                        element: 'Badge',
+                        message: 'use LemonBadge instead',
+                    },
                 ],
             },
         ],

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.scss
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.scss
@@ -3,13 +3,14 @@
     --lemon-badge-size: 1.5rem;
     --lemon-badge-font-size: 0.75rem;
     --lemon-badge-position-offset: 0.5rem;
+    --lemon-badge-border-width: 0.125rem;
 
     flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     color: var(--white);
-    border: 0.125rem solid var(--bg-light);
+    border: var(--lemon-badge-border-width) solid var(--bg-light);
     background: var(--lemon-badge-color);
     width: fit-content;
     min-width: var(--lemon-badge-size); // This is a minimum to accomodate multiple digits
@@ -27,9 +28,17 @@
 
     > * {
         // For non-text content, make sure that content fills up the whole badge, and that the badge stays round
-        width: calc(var(--lemon-badge-size) - 0.25rem);
-        height: calc(var(--lemon-badge-size) - 0.25rem);
+        width: calc(var(--lemon-badge-size) - var(--lemon-badge-border-width) * 2);
+        height: calc(var(--lemon-badge-size) - var(--lemon-badge-border-width) * 2);
         margin: calc(-1 * var(--lemon-badge-size) / 8);
+    }
+
+    &.LemonBadge--success {
+        --lemon-badge-color: var(--success);
+    }
+
+    &.LemonBadge--warning {
+        --lemon-badge-color: var(--warning);
     }
 
     &.LemonBadge--danger {
@@ -72,6 +81,12 @@
     &.LemonBadge--large {
         --lemon-badge-size: 1.75rem;
         --lemon-badge-font-size: 0.875rem;
+    }
+
+    &.LemonBadge--dot {
+        min-width: 0;
+        width: calc(var(--lemon-badge-size) * 0.5 + var(--lemon-badge-border-width));
+        height: calc(var(--lemon-badge-size) * 0.5 + var(--lemon-badge-border-width));
     }
 
     &.LemonBadge--active {

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
@@ -7,14 +7,14 @@ interface LemonBadgePropsBase {
     size?: 'small' | 'medium' | 'large'
     position?: 'none' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
     className?: string
-    status?: 'primary' | 'danger' | 'muted'
+    status?: 'primary' | 'success' | 'warning' | 'danger' | 'muted'
     active?: boolean
     style?: React.CSSProperties
     title?: string
 }
 
 export interface LemonBadgeProps extends LemonBadgePropsBase {
-    content: string | JSX.Element
+    content?: string | JSX.Element
     visible?: boolean
 }
 
@@ -41,6 +41,7 @@ export function LemonBadge({
             <span
                 className={clsx(
                     'LemonBadge',
+                    !content && 'LemonBadge--dot',
                     `LemonBadge--${size}`,
                     `LemonBadge--${status}`,
                     `LemonBadge--position-${position}`,

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -150,8 +150,8 @@ export function PluginCard({
                         <PluginImage pluginType={pluginType} icon={icon} url={url} />
                     </Col>
                     <Col style={{ flex: 1 }}>
-                        <div>
-                            <strong style={{ marginRight: 8 }}>
+                        <div className="flex items-center">
+                            <strong className="flex items-center mr-2 gap-1">
                                 {showAppMetricsForPlugin(plugin) && pluginConfig?.id && (
                                     <SuccessRateBadge
                                         deliveryRate={pluginConfig.delivery_rate_24h ?? null}

--- a/frontend/src/scenes/plugins/plugin/SuccessRateBadge.tsx
+++ b/frontend/src/scenes/plugins/plugin/SuccessRateBadge.tsx
@@ -1,9 +1,7 @@
-import { Badge } from 'antd'
 import { Tooltip } from 'lib/components/Tooltip'
 import { urls } from 'scenes/urls'
 import { Link } from 'lib/components/Link'
-
-type BadgeColor = 'green' | 'yellow' | 'red' | 'grey'
+import { LemonBadge, LemonBadgeProps } from '@posthog/lemon-ui'
 
 export function SuccessRateBadge({
     deliveryRate,
@@ -12,25 +10,27 @@ export function SuccessRateBadge({
     deliveryRate: number | null
     pluginConfigId: number
 }): JSX.Element {
-    const [color, tooltip] = successRateSummary(deliveryRate)
+    const [status, tooltip] = successRateSummary(deliveryRate)
     return (
         <Tooltip title={tooltip}>
             <Link to={urls.appMetrics(pluginConfigId)}>
-                <Badge color={color} />
+                <LemonBadge status={status} />
             </Link>
         </Tooltip>
     )
 }
 
-function successRateSummary(deliveryRate: number | null): [BadgeColor, string] {
+function successRateSummary(deliveryRate: number | null): [NonNullable<LemonBadgeProps['status']>, string] {
     if (deliveryRate === null) {
-        return ['grey', 'No events processed by this app in the past 24 hours']
+        return ['muted', 'No events processed by this app in the past 24 hours']
     } else {
-        let color: BadgeColor = 'red'
+        let color: NonNullable<LemonBadgeProps['status']>
         if (deliveryRate >= 0.99) {
-            color = 'green'
+            color = 'success'
         } else if (deliveryRate >= 0.75) {
-            color = 'yellow'
+            color = 'warning'
+        } else {
+            color = 'danger'
         }
         return [color, `Success rate for past 24 hours: ${Math.floor(deliveryRate * 1000) / 10}%`]
     }


### PR DESCRIPTION
## Changes

Straightforward replacement of the only `Badge` call site with `LemonBadge`. Part of https://github.com/PostHog/posthog/issues/13624.

| Before | After |
| --- | --- |
| <img width="348" alt="before" src="https://user-images.githubusercontent.com/4550621/213008683-f665c702-b70d-46c4-8d54-38d59f39a4a9.png"> | <img width="360" alt="after" src="https://user-images.githubusercontent.com/4550621/213008676-d142caf2-d82e-44f3-947c-81080a9e423b.png"> |