### PR TITLE
fix: Recording persistence of long URLs

### DIFF
--- a/ee/models/test/test_session_recording_extensions.py
+++ b/ee/models/test/test_session_recording_extensions.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
-from unittest.mock import patch
 from secrets import token_urlsafe
+from unittest.mock import patch
 
 from freezegun import freeze_time
 

--- a/posthog/models/session_recording/session_recording.py
+++ b/posthog/models/session_recording/session_recording.py
@@ -81,7 +81,7 @@ class SessionRecording(UUIDModel):
             self.duration = metadata["duration"]
             self.click_count = metadata["click_count"]
             self.keypress_count = metadata["keypress_count"]
-            self.start_url = metadata["urls"][0] if metadata["urls"] else None
+            self.set_start_url_from_urls(metadata["urls"])
 
         return True
 
@@ -208,10 +208,14 @@ class SessionRecording(UUIDModel):
             recording.keypress_count = ch_recording["keypress_count"]
             recording.duration = ch_recording["duration"]
             recording.distinct_id = ch_recording["distinct_id"]
-            recording.start_url = ch_recording["urls"][0] if ch_recording["urls"] else None
+            recording.set_start_url_from_urls(ch_recording["urls"])
             recordings.append(recording)
 
         return recordings
+
+    def set_start_url_from_urls(self, urls: Optional[List[str]] = None):
+        url = urls[0] if urls else None
+        self.start_url = url.split("?")[0][:512] if url else None
 
 
 @receiver(models.signals.post_save, sender=SessionRecording)


### PR DESCRIPTION
## Problem

Thanks to @neilkakkar for spotting this in Sentry 🙌 

We don't truncate the start_url when persisting which is causing postgres errors. Also we don't need to have such verbose URLs for the purpose at hand (all proper querying is done via Pageview events anyways)

## Changes

* Truncates and removes query strings

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests!