### PR TITLE
fix: Respond with BAD_REQUEST on JSON dumped batch data

### DIFF
--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -149,6 +149,8 @@ def is_unchunked_snapshot(event: Dict) -> bool:
         is_snapshot = event["event"] == "$snapshot"
     except KeyError:
         raise ValueError('All events must have the event name field "event"!')
+    except TypeError:
+        raise ValueError(f"All events must be dictionaries not '{type(event).__name__}'!")
     try:
         return is_snapshot and "chunk_id" not in event["properties"]["$snapshot_data"]
     except KeyError:


### PR DESCRIPTION
## Problem

This could happen when request batch data is dumped before creating the data dictionary:

```python
batch = json.dumps([{"event": "$groupidentify", "distinct_id": "2", "properties": {}}])
requests.post("/batch/", data={"api_key": "123", "batch": batch})
```

Notice batch already points to a str as we called json.dumps on it before calling requests.post.

This is an error as requests.post would call json.dumps itself on the data dictionary. Once we get the request, as json.loads does not recurse on strings, we load the batch as a string, instead of a list of dictionaries (events). We should report to the user that their data is not as expected.

NOTE: This example is in Python, however any client and client library may dump JSON twice in a similar fashion.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Accounts for data not being parsed properly and a TypeError being raised by informing the client their requests are malformed with a `status.HTTP_400_BAD_REQUEST`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
