### PR TITLE
chore(session-recordings): add batch size and timestamp metrics

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -1,6 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { StatsD } from 'hot-shots'
 import { EachBatchPayload, Kafka } from 'kafkajs'
+import { exponentialBuckets, Histogram } from 'prom-client'
 
 import { KAFKA_SESSION_RECORDING_EVENTS, KAFKA_SESSION_RECORDING_EVENTS_DLQ } from '../../config/kafka-topics'
 import { PipelineEvent, RawEventMessage } from '../../types'
@@ -11,6 +12,7 @@ import { createPerformanceEvent, createSessionRecordingEvent } from '../../worke
 import { TeamManager } from '../../worker/ingestion/team-manager'
 import { parseEventTimestamp } from '../../worker/ingestion/timestamps'
 import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
+import { latestOffsetTimestampGauge } from './metrics'
 
 export const startSessionRecordingEventsConsumer = async ({
     teamManager,
@@ -38,7 +40,8 @@ export const startSessionRecordingEventsConsumer = async ({
     await producer.connect()
     const producerWrapper = new KafkaProducerWrapper(producer, statsd, { KAFKA_FLUSH_FREQUENCY_MS: 0 } as any)
 
-    const consumer = kafka.consumer({ groupId: 'session-recordings' })
+    const groupId = 'session-recordings'
+    const consumer = kafka.consumer({ groupId: groupId })
     setupEventHandlers(consumer)
 
     status.info('🔁', 'Starting session recordings consumer')
@@ -49,7 +52,7 @@ export const startSessionRecordingEventsConsumer = async ({
         eachBatch: async (payload) => {
             return await instrumentEachBatch(
                 KAFKA_SESSION_RECORDING_EVENTS,
-                eachBatch({ producer: producerWrapper, teamManager }),
+                eachBatch({ producer: producerWrapper, teamManager, groupId }),
                 payload
             )
         },
@@ -59,9 +62,25 @@ export const startSessionRecordingEventsConsumer = async ({
 }
 
 export const eachBatch =
-    ({ producer, teamManager }: { producer: KafkaProducerWrapper; teamManager: TeamManager }) =>
+    ({
+        producer,
+        teamManager,
+        groupId,
+    }: {
+        producer: KafkaProducerWrapper
+        teamManager: TeamManager
+        groupId: string
+    }) =>
     async ({ batch, heartbeat }: Pick<EachBatchPayload, 'batch' | 'heartbeat'>) => {
         status.debug('🔁', 'Processing batch', { size: batch.messages.length })
+
+        consumerBatchSize
+            .labels({
+                topic: batch.topic,
+                groupId,
+            })
+            .observe(batch.messages.length)
+
         for (const message of batch.messages) {
             if (!message.value) {
                 status.warn('⚠️', 'invalid_message', {
@@ -95,6 +114,14 @@ export const eachBatch =
             }
 
             status.debug('⬆️', 'processing_session_recording', { uuid: messagePayload.uuid })
+
+            consumedMessageSizeBytes
+                .labels({
+                    topic: batch.topic,
+                    groupId,
+                    messageType: event.event,
+                })
+                .observe(message.value.length)
 
             if (!messagePayload.team_id && !event.token) {
                 status.warn('⚠️', 'invalid_message', {
@@ -198,5 +225,24 @@ export const eachBatch =
             // to the DLQ.
         }
 
+        const lastBatchMessage = batch.messages[batch.messages.length - 1]
+        latestOffsetTimestampGauge
+            .labels({ partition: batch.partition, topic: batch.topic, groupId })
+            .set(Number.parseInt(lastBatchMessage.timestamp))
+
         status.debug('✅', 'Processed batch', { size: batch.messages.length })
     }
+
+const consumerBatchSize = new Histogram({
+    name: 'consumed_batch_size',
+    help: 'Size of the batch fetched by the consumer',
+    labelNames: ['topic', 'groupId'],
+    buckets: exponentialBuckets(1, 3, 5),
+})
+
+const consumedMessageSizeBytes = new Histogram({
+    name: 'consumed_message_size_bytes',
+    help: 'Size of consumed message value in bytes',
+    labelNames: ['topic', 'groupId', 'messageType'],
+    buckets: exponentialBuckets(1, 8, 4).map((bucket) => bucket * 1024),
+})


### PR DESCRIPTION
The timestamp is a requirement for the alert defined in
https://github.com/PostHog/charts-clickhouse/pull/669

The batch size metric is added because I'm curious about 1. how many
batches we fetch and 2. what effect setting [KafkaJSs
`minBytes`](https://kafka.js.org/docs/consuming#a-name-options-a-options)
might have on the number and size of batches we fetch, perhaps reducing
down the amount of IO we're performing both consuming and on flushing
the producer wrapper. The default value is 1 byte.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
