### PR TITLE
chore(utilities): add 0.5 spacing

### DIFF
--- a/frontend/src/styles/functions.scss
+++ b/frontend/src/styles/functions.scss
@@ -1,0 +1,11 @@
+@function escape-number($value) {
+    $int: floor($value);
+    $fract: $value - $int;
+    @if ($fract == 0) {
+        @return $int;
+    }
+    @while ($fract != floor($fract)) {
+        $fract: $fract * 10;
+    }
+    @return $int + '\\.'+ $fract;
+}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -10,6 +10,7 @@ Only 400 (`normal`), 500 (`var(--font-medium)`), 600 (`var(--font-semibold)`), o
 // Global components
 @import '../../../node_modules/react-toastify/dist/ReactToastify';
 @import 'fonts';
+@import 'functions';
 @import 'mixins';
 @import 'utility-legacy';
 @import 'utilities';

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -12,104 +12,104 @@
 
 // TODO: Wrap all of this in a catch for the screen breakpoints like md:foo
 @each $space in $spaces {
-    .space-y-#{$space} {
+    .space-y-#{escape-number($space)} {
         & > * + * {
             margin-top: #{$space * 0.25}rem;
         }
     }
 
-    .space-x-#{$space} {
+    .space-x-#{escape-number($space)} {
         & > * + * {
             margin-left: #{$space * 0.25}rem;
         }
     }
 
-    .gap-#{$space} {
+    .gap-#{escape-number($space)} {
         gap: #{$space * 0.25}rem;
     }
 
-    .gap-x-#{$space} {
+    .gap-x-#{escape-number($space)} {
         column-gap: #{$space * 0.25}rem;
     }
 
-    .gap-y-#{$space} {
+    .gap-y-#{escape-number($space)} {
         row-gap: #{$space * 0.25}rem;
     }
 
-    .w-#{$space} {
+    .w-#{escape-number($space)} {
         width: #{$space * 0.25}rem;
     }
 
-    .h-#{$space} {
+    .h-#{escape-number($space)} {
         height: #{$space * 0.25}rem;
     }
 
-    .max-w-#{$space} {
+    .max-w-#{escape-number($space)} {
         max-width: #{$space * 0.25}rem;
     }
-    .max-h-#{$space} {
+    .max-h-#{escape-number($space)} {
         max-height: #{$space * 0.25}rem;
     }
 
-    .min-w-#{$space} {
+    .min-w-#{escape-number($space)} {
         min-width: #{$space * 0.25}rem;
     }
-    .min-h-#{$space} {
+    .min-h-#{escape-number($space)} {
         min-height: #{$space * 0.25}rem;
     }
 
-    .m-#{$space} {
+    .m-#{escape-number($space)} {
         margin: #{$space * 0.25}rem;
     }
 
-    .-m-#{$space} {
+    .-m-#{escape-number($space)} {
         margin: #{-$space * 0.25}rem;
     }
 
-    .mx-#{$space} {
+    .mx-#{escape-number($space)} {
         margin-left: #{$space * 0.25}rem;
         margin-right: #{$space * 0.25}rem;
     }
 
-    .-mx-#{$space} {
+    .-mx-#{escape-number($space)} {
         margin-left: #{-$space * 0.25}rem;
         margin-right: #{-$space * 0.25}rem;
     }
 
-    .my-#{$space} {
+    .my-#{escape-number($space)} {
         margin-top: #{$space * 0.25}rem;
         margin-bottom: #{$space * 0.25}rem;
     }
 
-    .-my-#{$space} {
+    .-my-#{escape-number($space)} {
         margin-top: #{-$space * 0.25}rem;
         margin-bottom: #{-$space * 0.25}rem;
     }
 
-    .px-#{$space} {
+    .px-#{escape-number($space)} {
         padding-left: #{$space * 0.25}rem;
         padding-right: #{$space * 0.25}rem;
     }
 
-    .py-#{$space} {
+    .py-#{escape-number($space)} {
         padding-top: #{$space * 0.25}rem;
         padding-bottom: #{$space * 0.25}rem;
     }
 
-    .p-#{$space} {
+    .p-#{escape-number($space)} {
         padding: #{$space * 0.25}rem;
     }
 
     @each $side in $sides {
-        .m#{str-slice($side, 0, 1)}-#{$space} {
+        .m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
             margin-#{$side}: #{$space * 0.25}rem;
         }
 
-        .-m#{str-slice($side, 0, 1)}-#{$space} {
+        .-m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
             margin-#{$side}: #{-$space * 0.25}rem;
         }
 
-        .p#{str-slice($side, 0, 1)}-#{$space} {
+        .p#{str-slice($side, 0, 1)}-#{escape-number($space)} {
             padding-#{$side}: #{$space * 0.25}rem;
         }
     }
@@ -652,7 +652,7 @@
 }
 
 @each $space in $spaces {
-    .leading-#{$space} {
+    .leading-#{escape-number($space)} {
         line-height: #{$space * 0.25}rem;
     }
 }

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -12,7 +12,7 @@ $screens: (
     'xxl': $xxl,
 );
 
-$spaces: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 40, 60, 80, 100, 120, 200;
+$spaces: 0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 40, 60, 80, 100, 120, 200;
 $leadings: 3, 4, 5, 6, 7, 8, 9, 10;
 $sides: 'top', 'right', 'bottom', 'left';
 // CSS cursors from https://tailwindcss.com/docs/cursor


### PR DESCRIPTION
## Problem

I needed a more fine-grained margin, thus wanted to add support for 0.5 spacing. Since decimals need to be escaped to be valid css identifiers, I needed to add a helper function as well.

## Changes

This PR adds said helper function and 0.5 to $spaces.

## How did you test this code?

Added `.mr-0.5` to an element and verified, that it has the relevant margin applied.