### PR TITLE
feat(data-exploration): rename total()->count(), add distinct

### DIFF
--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -50,7 +50,7 @@ const EventsTableFull: DataTableNode = {
 
 const TotalEvents: EventsQuery = {
     kind: NodeKind.EventsQuery,
-    select: ['total()'],
+    select: ['count()'],
 }
 
 const TotalEventsTable: DataTableNode = {
@@ -85,10 +85,10 @@ const EventAggregations: DataTableNode = {
         select: [
             "concat(properties['$geoip_city_name'], ' ', 'Rocks') # City",
             'event',
-            'total() + 100000 # Inflamed total',
+            'count() + 100000 # Inflamed total',
             '1 + 2',
         ],
-        orderBy: ['-total()'],
+        orderBy: ['-count()'],
     },
 }
 

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -241,14 +241,24 @@ export function DataTable({ query, setQuery, context }: DataTableProps): JSX.Ele
                                             status="danger"
                                             data-attr="datatable-remove-column"
                                             onClick={() => {
+                                                const cleanColumnKey = removeExpressionComment(key)
+                                                const newSource: EventsQuery = {
+                                                    ...(query.source as EventsQuery),
+                                                    select: (query.source as EventsQuery).select.filter(
+                                                        (_, i) => i !== index
+                                                    ),
+                                                    // remove the current column from orderBy if it's there
+                                                    orderBy: (query.source as EventsQuery).orderBy?.find(
+                                                        (orderKey) =>
+                                                            removeExpressionComment(orderKey) === cleanColumnKey ||
+                                                            removeExpressionComment(orderKey) === `-${cleanColumnKey}`
+                                                    )
+                                                        ? undefined
+                                                        : (query.source as EventsQuery).orderBy,
+                                                }
                                                 setQuery?.({
                                                     ...query,
-                                                    source: {
-                                                        ...query.source,
-                                                        select: (query.source as EventsQuery).select.filter(
-                                                            (_, i) => i !== index
-                                                        ),
-                                                    } as EventsQuery,
+                                                    source: newSource,
                                                 })
                                             }}
                                         >

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -172,7 +172,7 @@ export function hogQlToTaxonomicFilter(hogQl: string): [TaxonomicFilterGroupType
 
 export function isHogQlAggregation(hogQl: string): boolean {
     return (
-        hogQl.includes('total(') ||
+        hogQl.includes('count(') ||
         hogQl.includes('any(') ||
         hogQl.includes('sum(') ||
         hogQl.includes('avg(') ||

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -129,8 +129,8 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
             if len(order_by) == 0:
                 if not select or "*" in select or "timestamp" in select:
                     order_by = ["-timestamp"]
-                elif "total()" in select:
-                    order_by = ["-total()"]
+                elif "count()" in select:
+                    order_by = ["-count()"]
 
             query_result = query_events_list(
                 filter=filter,

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -752,28 +752,28 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             self.assertIsInstance(response["results"][0][0], dict)
             self.assertIsInstance(response["results"][0][1], str)
 
-            select = ["total()", "event"]
+            select = ["count()", "event"]
             response = self.client.get(f"/api/projects/{self.team.id}/events/?select={json.dumps(select)}").json()
             self.assertEqual(
                 response,
                 {
-                    "columns": ["total()", "event"],
+                    "columns": ["count()", "event"],
                     "hasMore": False,
                     "types": ["UInt64", "String"],
                     "results": [[3, "sign out"], [1, "sign up"]],
                 },
             )
 
-            select = ["total()", "event"]
+            select = ["count()", "event"]
             where = ['event == "sign up" or like(properties.key, "%val2")']
-            orderBy = ["-total()", "event"]
+            orderBy = ["-count()", "event"]
             response = self.client.get(
                 f"/api/projects/{self.team.id}/events/?select={json.dumps(select)}&where={json.dumps(where)}&orderBy={json.dumps(orderBy)}"
             ).json()
             self.assertEqual(
                 response,
                 {
-                    "columns": ["total()", "event"],
+                    "columns": ["count()", "event"],
                     "hasMore": False,
                     "types": ["UInt64", "String"],
                     "results": [[2, "sign out"], [1, "sign up"]],


### PR DESCRIPTION
## Problem

- The aggregation `total()` is non-standard
- You can't ask for distinct values

## Changes

- renames `total()` to `count()`
- adds support for one argument in `count(thing)`, which translates to the clickhouse sql `count(distinct thing)`
- fixed a bug removing table columns when those columns are used in the `orderBy` clause together with an aggregation in the querty

<img width="1596" alt="image" src="https://user-images.githubusercontent.com/53387/213217423-4176d398-7335-47e2-a8df-44e1ae19406e.png">

## How did you test this code?

Created the table in the screenshot. Looked about right.