### PR TITLE
refactor(queries): yeet substitute_params

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -424,11 +424,12 @@ class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
         if join_person_tables:
             person_query = PersonQuery(filter, self.team.pk)
             person_subquery, person_join_params = person_query.get_query()
+            pdi_query, pdi_query_params = get_team_distinct_ids_query(self.team.pk)
             joins = f"""
-                INNER JOIN ({get_team_distinct_ids_query(self.team.pk)}) AS pdi ON events.distinct_id = pdi.distinct_id
+                INNER JOIN ({pdi_query}) AS pdi ON events.distinct_id = pdi.distinct_id
                 INNER JOIN ({person_subquery}) person ON pdi.person_id = person.id
             """
-            params.update(person_join_params)
+            params = { **params, **person_join_params, **pdi_query_params}
 
         final_query = f"SELECT uuid FROM events {joins} WHERE team_id = %(team_id)s {query}"
         # Make sure we don't accidentally use json on the properties field

--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -295,9 +295,10 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
                 person_id_joined_alias=f"{self.EVENT_TABLE_ALIAS}.person_id",
             )
 
+        distinct_id_query, distinct_id_query_params = self._get_distinct_id_query()
         new_query = f"""
         SELECT {", ".join(_inner_fields)} FROM events AS {self.EVENT_TABLE_ALIAS}
-        {self._get_distinct_id_query()}
+        {distinct_id_query}
         WHERE team_id = %(team_id)s
         AND event IN %({event_param_name})s
         {date_condition}
@@ -316,7 +317,7 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         """
         return (
             outer_query,
-            {"team_id": self._team_id, event_param_name: self._events, **params, **person_prop_params},
+            {"team_id": self._team_id, event_param_name: self._events, **params, **person_prop_params, **distinct_id_query_params},
             self.FUNNEL_QUERY_ALIAS,
         )
 

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -435,8 +435,10 @@ class FunnelCorrelation:
             """
 
         else:
+            pdi_query, _ = get_team_distinct_ids_query(self._team.pk)
+            pdi_query = pdi_query % {"team_id": self._team.pk}
             aggregation_person_join = f"""
-                JOIN ({get_team_distinct_ids_query(self._team.pk)}) AS pdi
+                JOIN ({pdi_query}) AS pdi
                         ON pdi.distinct_id = events.distinct_id
 
                     -- NOTE: I would love to right join here, so we count get total

--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -41,19 +41,22 @@ class RelatedActorsQuery:
         if not self.is_aggregating_by_groups:
             return []
 
+        distinct_ids_join, distinct_ids_join_params = self._distinct_ids_join()
+
         # :KLUDGE: We need to fetch distinct_id + person properties to be able to link to user properly.
         person_ids = self._take_first(
             sync_execute(
                 f"""
             SELECT DISTINCT {self.DISTINCT_ID_TABLE_ALIAS}.person_id
             FROM events e
-            {self._distinct_ids_join}
+            {distinct_ids_join}
             WHERE team_id = %(team_id)s
               AND timestamp > %(after)s
               AND timestamp < %(before)s
               AND {self._filter_clause}
             """,
                 self._params,
+                **distinct_ids_join_params
             )
         )
 
@@ -64,12 +67,14 @@ class RelatedActorsQuery:
         if group_type_index == self.group_type_index:
             return []
 
+        
+        distinct_ids_join, distinct_ids_join_params = self._distinct_ids_join()
         group_ids = self._take_first(
             sync_execute(
                 f"""
             SELECT DISTINCT $group_{group_type_index} AS group_key
             FROM events e
-            {'' if self.is_aggregating_by_groups else self._distinct_ids_join}
+            {'' if self.is_aggregating_by_groups else distinct_ids_join}
             JOIN (
                 SELECT group_key
                 FROM groups
@@ -83,7 +88,7 @@ class RelatedActorsQuery:
               AND {self._filter_clause}
             ORDER BY group_key
             """,
-                {**self._params, "group_type_index": group_type_index},
+                {**self._params, "group_type_index": group_type_index, **({} if  self.is_aggregating_by_groups else distinct_ids_join_params)},
             )
         )
 
@@ -93,16 +98,17 @@ class RelatedActorsQuery:
     def _take_first(self, rows: List) -> List:
         return [row[0] for row in rows]
 
+
+    def _distinct_ids_join(self):
+        pdi_query, pdi_query_params = get_team_distinct_ids_query(self.team.pk)
+        return f"JOIN ({pdi_query}) {self.DISTINCT_ID_TABLE_ALIAS} on e.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id", pdi_query_params
+
     @property
     def _filter_clause(self):
         if self.is_aggregating_by_groups:
             return f"$group_{self.group_type_index} = %(id)s"
         else:
             return f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id = %(id)s"
-
-    @property
-    def _distinct_ids_join(self):
-        return f"JOIN ({get_team_distinct_ids_query(self.team_id)}) {self.DISTINCT_ID_TABLE_ALIAS} on e.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id"
 
     @cached_property
     def _params(self):

--- a/ee/clickhouse/queries/test/test_person_distinct_id_query.py
+++ b/ee/clickhouse/queries/test/test_person_distinct_id_query.py
@@ -1,5 +1,10 @@
 from posthog.queries import person_distinct_id_query
-
+from clickhouse_driver.util.escape import escape_params
 
 def test_person_distinct_id_query(db, snapshot):
-    assert person_distinct_id_query.get_team_distinct_ids_query(2) == snapshot
+    
+    pdi_query, pdi_query_params = person_distinct_id_query.get_team_distinct_ids_query(2)
+    escaped_params = escape_params(pdi_query_params)
+    sql = pdi_query % escaped_params
+    
+    assert sql == snapshot

--- a/posthog/clickhouse/client/__init__.py
+++ b/posthog/clickhouse/client/__init__.py
@@ -1,9 +1,8 @@
-from posthog.clickhouse.client.execute import query_with_columns, substitute_params, sync_execute
+from posthog.clickhouse.client.execute import query_with_columns, sync_execute
 from posthog.clickhouse.client.execute_async import execute_with_progress
 
 __all__ = [
     "sync_execute",
     "query_with_columns",
-    "substitute_params",
     "execute_with_progress",
 ]

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 import sqlparse
 from clickhouse_driver import Client as SyncClient
-from clickhouse_driver.util.escape import escape_params
 from django.conf import settings as app_settings
 from statshog.defaults.django import statsd
 
@@ -73,6 +72,7 @@ def sync_execute(
         start_time = perf_counter()
 
         prepared_sql, prepared_args, tags = _prepare_query(client=client, query=query, args=args, workload=workload)
+
         settings = {**default_settings(), **(settings or {}), "log_comment": json.dumps(tags, separators=(",", ":"))}
         try:
             result = client.execute(

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -165,8 +165,7 @@ def _prepare_query(client: SyncClient, query: str, args: QueryArgs, workload: Wo
     else:
         # Else perform the substitution so we can perform operations on the raw
         # non-templated SQL
-        escaped_params = escape_params(args)
-        rendered_sql = query % escaped_params
+        rendered_sql = client.substitute_params(query, args)
         prepared_args = None
 
     formatted_sql = sqlparse.format(rendered_sql, strip_comments=True)

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -92,7 +92,7 @@ def get_entity_cohort_subquery(
         ) and count == 0  # = 0 means all people who never performed the event
 
         count_operator = get_count_operator(count_operator)
-        pdi_query = get_team_distinct_ids_query(cohort.team_id)
+        pdi_query, pdi_query_params = get_team_distinct_ids_query(cohort.team_id)
         extract_person = GET_PERSON_ID_BY_ENTITY_COUNT_SQL.format(
             entity_query=entity_query,
             date_query=date_query,
@@ -100,7 +100,7 @@ def get_entity_cohort_subquery(
             count_condition="" if is_negation else f"HAVING count(*) {count_operator} %(count)s",
         )
 
-        params: Dict[str, Union[str, int]] = {"count": int(count), **entity_params, **date_params}
+        params: Dict[str, Union[str, int]] = {"count": int(count), **entity_params, **date_params, **pdi_query_params}
 
         return f"{'NOT' if is_negation else ''} {custom_match_field} IN ({extract_person})", params
     else:

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -209,16 +209,18 @@ def parse_prop_clauses(
             else:
                 # Subquery filter here always should be blank as it's the first
                 filter_query = filter_query.replace(property_operator, "", 1)
+                pdi_query, pdi_query_params = get_team_distinct_ids_query(team_id)
                 final.append(
                     " {property_operator} {table_name}distinct_id IN ({filter_query})".format(
                         filter_query=GET_DISTINCT_IDS_BY_PROPERTY_SQL.format(
-                            filters=filter_query, GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id)
+                            filters=filter_query, GET_TEAM_PERSON_DISTINCT_IDS=pdi_query
                         ),
                         table_name=table_formatted,
                         property_operator=property_operator,
                     )
                 )
-                params.update(filter_params)
+                params = { **params, **filter_params, **pdi_query_params}
+                
         elif prop.type == "person" and person_properties_mode == PersonPropertiesMode.DIRECT:
             # this setting is used to generate the PersonQuery SQL.
             # When using direct mode, there should only be person properties in the entire
@@ -300,15 +302,17 @@ def parse_prop_clauses(
             method = format_static_cohort_query if prop.type == "static-cohort" else format_precalculated_cohort_query
             filter_query, filter_params = method(cohort_id, idx, prepend=prepend)  # type: ignore
             filter_query = f"""{person_id_joined_alias if not person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS else 'person_id'} IN ({filter_query})"""
-
+            
             if has_person_id_joined or person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS:
                 final.append(f"{property_operator} {filter_query}")
             else:
+                pdi_query, pdi_query_params = get_team_distinct_ids_query(team_id)
                 # :TODO: (performance) Avoid subqueries whenever possible, use joins instead
                 subquery = GET_DISTINCT_IDS_BY_PERSON_ID_FILTER.format(
                     filters=filter_query, GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id)
                 )
                 final.append(f"{property_operator} {table_formatted}distinct_id IN ({subquery})")
+                params.update(pdi_query_params)
             params.update(filter_params)
         elif prop.type == "session":
             filter_query, filter_params = get_session_property_filter_statement(prop, idx, prepend)

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -219,8 +219,8 @@ def parse_prop_clauses(
                         property_operator=property_operator,
                     )
                 )
-                params = { **params, **filter_params, **pdi_query_params}
-                
+                params = {**params, **filter_params, **pdi_query_params}
+
         elif prop.type == "person" and person_properties_mode == PersonPropertiesMode.DIRECT:
             # this setting is used to generate the PersonQuery SQL.
             # When using direct mode, there should only be person properties in the entire
@@ -302,14 +302,14 @@ def parse_prop_clauses(
             method = format_static_cohort_query if prop.type == "static-cohort" else format_precalculated_cohort_query
             filter_query, filter_params = method(cohort_id, idx, prepend=prepend)  # type: ignore
             filter_query = f"""{person_id_joined_alias if not person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS else 'person_id'} IN ({filter_query})"""
-            
+
             if has_person_id_joined or person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS:
                 final.append(f"{property_operator} {filter_query}")
             else:
                 pdi_query, pdi_query_params = get_team_distinct_ids_query(team_id)
                 # :TODO: (performance) Avoid subqueries whenever possible, use joins instead
                 subquery = GET_DISTINCT_IDS_BY_PERSON_ID_FILTER.format(
-                    filters=filter_query, GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id)
+                    filters=filter_query, GET_TEAM_PERSON_DISTINCT_IDS=pdi_query
                 )
                 final.append(f"{property_operator} {table_formatted}distinct_id IN ({subquery})")
                 params.update(pdi_query_params)

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -88,20 +88,26 @@ def get_breakdown_prop_values(
             filter, team.pk, column_optimizer=column_optimizer, entity=entity if not use_all_funnel_entities else None
         )
         pdi_query_params = {}
-        
+
         if person_query.is_used:
             person_subquery, person_join_params = person_query.get_query()
             pdi_query, pdi_query_params = get_team_distinct_ids_query(team.pk)
 
-            person_join_clauses = f"""
-                INNER JOIN ({pdi_query}) AS pdi ON e.distinct_id = pdi.distinct_id
+            person_join_clauses = (
+                """
+                INNER JOIN ({}) AS pdi ON e.distinct_id = pdi.distinct_id
+            """.format(
+                    pdi_query
+                )
+                + f"""
                 INNER JOIN ({person_subquery}) person ON pdi.person_id = person.id
             """
+            )
         elif entity.math in (WEEKLY_ACTIVE, MONTHLY_ACTIVE) or column_optimizer.is_using_cohort_propertes:
             person_join_clauses = f"""
                 INNER JOIN ({pdi_query}) AS pdi ON e.distinct_id = pdi.distinct_id
             """
-        
+
         person_join_params.update(pdi_query_params)
 
         groups_join_clause, groups_join_params = GroupsJoinQuery(filter, team.pk, column_optimizer).get_join_query()

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -100,10 +100,13 @@ class EventQuery(metaclass=ABCMeta):
         if self._should_join_distinct_ids:
             pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
 
-            return f"""
-            INNER JOIN ({pdi_query}) AS {self.DISTINCT_ID_TABLE_ALIAS}
+            return (
+                "INNER JOIN ({})".format(pdi_query)
+                + f""" AS {self.DISTINCT_ID_TABLE_ALIAS}
             ON {self.EVENT_TABLE_ALIAS}.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id
-            """, pdi_query_params
+            """,
+                pdi_query_params,
+            )
         else:
             return "", {}
 

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -96,14 +96,16 @@ class EventQuery(metaclass=ABCMeta):
     def _determine_should_join_distinct_ids(self) -> None:
         pass
 
-    def _get_distinct_id_query(self) -> str:
+    def _get_distinct_id_query(self) -> Tuple[str, Dict[str, Any]]:
         if self._should_join_distinct_ids:
+            pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
+
             return f"""
-            INNER JOIN ({get_team_distinct_ids_query(self._team_id)}) AS {self.DISTINCT_ID_TABLE_ALIAS}
+            INNER JOIN ({pdi_query}) AS {self.DISTINCT_ID_TABLE_ALIAS}
             ON {self.EVENT_TABLE_ALIAS}.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id
-            """
+            """, pdi_query_params
         else:
-            return ""
+            return "", {}
 
     def _determine_should_join_persons(self) -> None:
         if self._person_query.is_used:

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -111,10 +111,12 @@ class FunnelEventQuery(EventQuery):
         self.params.update(groups_params)
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
-
+        distinct_id_query, distinct_id_query_params = self._get_distinct_id_query()
+        self.params.update(distinct_id_query_params)
+        
         query = f"""
             SELECT {', '.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/posthog/queries/paths/paths_event_query.py
+++ b/posthog/queries/paths/paths_event_query.py
@@ -105,10 +105,12 @@ class PathEventQuery(EventQuery):
         self.params.update(groups_params)
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
-
+        distinct_id_query, distinct_id_query_params = self._get_distinct_id_query()
+        self.params.update(distinct_id_query_params)
+        
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             {funnel_paths_join}

--- a/posthog/queries/person_distinct_id_query.py
+++ b/posthog/queries/person_distinct_id_query.py
@@ -1,7 +1,7 @@
+from typing import Any, Dict, Tuple
+
 from posthog.models.person.sql import GET_TEAM_PERSON_DISTINCT_IDS
-from typing import Tuple, Dict, Any
 
 
 def get_team_distinct_ids_query(team_id: int) -> Tuple[str, Dict[str, Any]]:
-
     return GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team_id}

--- a/posthog/queries/person_distinct_id_query.py
+++ b/posthog/queries/person_distinct_id_query.py
@@ -1,7 +1,7 @@
 from posthog.models.person.sql import GET_TEAM_PERSON_DISTINCT_IDS
+from typing import Tuple, Dict, Any
 
 
-def get_team_distinct_ids_query(team_id: int) -> str:
-    from posthog.client import substitute_params
+def get_team_distinct_ids_query(team_id: int) -> Tuple[str, Dict[str, Any]]:
 
-    return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team_id})
+    return GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team_id}

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -277,13 +277,15 @@ class PersonQuery:
             )
 
             distinct_id_param = f"distinct_id_{prepend}"
+            pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
+
             distinct_id_clause = f"""
             id IN (
-                SELECT person_id FROM ({get_team_distinct_ids_query(self._team_id)}) where distinct_id = %({distinct_id_param})s
+                SELECT person_id FROM ({pdi_query}) where distinct_id = %({distinct_id_param})s
             )
             """
 
-            params.update({distinct_id_param: self._filter.search})
+            params.update({distinct_id_param: self._filter.search, **pdi_query_params})
 
             return f"AND (({search_clause}) OR ({distinct_id_clause}))", params
 
@@ -294,12 +296,14 @@ class PersonQuery:
             return "", {}
 
         if self._filter.distinct_id:
+            pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
+
             distinct_id_clause = f"""
             AND id IN (
-                SELECT person_id FROM ({get_team_distinct_ids_query(self._team_id)}) where distinct_id = %(distinct_id_filter)s
+                SELECT person_id FROM ({pdi_query}) where distinct_id = %(distinct_id_filter)s
             )
             """
-            return distinct_id_clause, {"distinct_id_filter": self._filter.distinct_id}
+            return distinct_id_clause, {"distinct_id_filter": self._filter.distinct_id, **pdi_query_params}
         return "", {}
 
     def _get_email_clause(self) -> Tuple[str, Dict]:

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -279,11 +279,13 @@ class PersonQuery:
             distinct_id_param = f"distinct_id_{prepend}"
             pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
 
-            distinct_id_clause = f"""
+            distinct_id_clause = """
             id IN (
                 SELECT person_id FROM ({pdi_query}) where distinct_id = %({distinct_id_param})s
             )
-            """
+            """.format(
+                pdi_query=pdi_query, distinct_id_param=distinct_id_param
+            )
 
             params.update({distinct_id_param: self._filter.search, **pdi_query_params})
 
@@ -298,11 +300,13 @@ class PersonQuery:
         if self._filter.distinct_id:
             pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
 
-            distinct_id_clause = f"""
+            distinct_id_clause = """
             AND id IN (
                 SELECT person_id FROM ({pdi_query}) where distinct_id = %(distinct_id_filter)s
             )
-            """
+            """.format(
+                pdi_query=pdi_query
+            )
             return distinct_id_clause, {"distinct_id_filter": self._filter.distinct_id, **pdi_query_params}
         return "", {}
 

--- a/posthog/queries/retention/event_query.py
+++ b/posthog/queries/retention/event_query.py
@@ -143,10 +143,12 @@ class RetentionEventsQuery(EventQuery):
         self.params.update(groups_params)
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
-
+        distinct_id_query, distinct_id_query_params = self._get_distinct_id_query()
+        self.params.update(distinct_id_query_params)
+        
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -3,7 +3,6 @@ from urllib.parse import urlencode
 
 import pytz
 
-from posthog.client import substitute_params
 from posthog.constants import RETENTION_FIRST_TIME, RetentionQueryType
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.team import Team
@@ -175,6 +174,4 @@ def build_target_event_query(
         using_person_on_events=using_person_on_events,
     ).get_query()
 
-    query = substitute_params(target_event_query_templated, target_event_params)
-
-    return query
+    return target_event_query_templated, target_event_params

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -32,12 +32,15 @@ class Retention:
         self, filter: RetentionFilter, team: Team
     ) -> Dict[CohortKey, Dict[str, Any]]:
 
-        actor_query = build_actor_activity_query(filter=filter, team=team, retention_events_query=self.event_query)
+        actor_query, actor_query_params = build_actor_activity_query(
+            filter=filter, team=team, retention_events_query=self.event_query
+        )
         result = insight_sync_execute(
             RETENTION_BREAKDOWN_SQL.format(actor_query=actor_query),
             settings={"timeout_before_checking_execution_speed": 60},
             filter=filter,
             query_type="retention_by_breakdown_values",
+            **actor_query_params,
         )
 
         result_dict = {
@@ -150,9 +153,7 @@ def build_returning_event_query(
         using_person_on_events=using_person_on_events,
     ).get_query()
 
-    query = substitute_params(returning_event_query_templated, returning_event_params)
-
-    return query
+    return returning_event_query_templated, returning_event_params
 
 
 def build_target_event_query(

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -226,14 +226,16 @@ class SessionRecordingList(EventQuery):
 
         if person_query:
             return (
-                f"""
+                """
                     JOIN (
                     {pdi_query}
                     ) as pdi
                     ON pdi.distinct_id = session_recordings.distinct_id
                     {person_query}
-                """,
-                { **person_query_params, **pdi_query_params },
+                """.format(
+                    pdi_query=pdi_query, person_query=person_query
+                ),
+                {**person_query_params, **pdi_query_params},
             )
         return person_query, person_query_params
 

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -222,17 +222,18 @@ class SessionRecordingList(EventQuery):
 
     def _get_recording_person_query(self) -> Tuple[str, Dict]:
         person_query, person_query_params = self._get_person_query()
-        person_distinct_id_query = get_team_distinct_ids_query(self._team_id)
+        pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
+
         if person_query:
             return (
                 f"""
                     JOIN (
-                    {person_distinct_id_query}
+                    {pdi_query}
                     ) as pdi
                     ON pdi.distinct_id = session_recordings.distinct_id
                     {person_query}
                 """,
-                person_query_params,
+                { **person_query_params, **pdi_query_params },
             )
         return person_query, person_query_params
 

--- a/posthog/queries/stickiness/stickiness_event_query.py
+++ b/posthog/queries/stickiness/stickiness_event_query.py
@@ -44,13 +44,15 @@ class StickinessEventsQuery(EventQuery):
         self.params.update(groups_params)
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
-
+        distinct_id_query, distinct_id_query_params = self._get_distinct_id_query()
+        self.params.update(distinct_id_query_params)
+        
         query = f"""
             SELECT
                 {self.aggregation_target()} AS aggregation_target,
                 countDistinct({get_trunc_func_ch(self._filter.interval)}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s))) as num_intervals
             FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -281,7 +281,7 @@ class TrendsBreakdown:
                 conditions = BREAKDOWN_ACTIVE_USER_CONDITIONS_SQL.format(
                     **breakdown_filter_params, **active_user_format_params
                 )
-                pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
+                pdi_query, pdi_query_params = get_team_distinct_ids_query(self.team_id)
 
                 inner_sql = BREAKDOWN_ACTIVE_USER_INNER_SQL.format(
                     breakdown_filter=breakdown_filter,
@@ -596,7 +596,7 @@ class TrendsBreakdown:
         params = {}
 
         person_query = PersonQuery(self.filter, self.team_id, self.column_optimizer, entity=self.entity)
-        pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
+        pdi_query, pdi_query_params = get_team_distinct_ids_query(self.team_id)
 
         event_join = EVENT_JOIN_PERSON_SQL.format(GET_TEAM_PERSON_DISTINCT_IDS=pdi_query)
         params.update(pdi_query_params)

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -213,7 +213,7 @@ class TrendsBreakdown:
                 conditions = BREAKDOWN_ACTIVE_USER_CONDITIONS_SQL.format(
                     **breakdown_filter_params, **active_user_format_params
                 )
-                pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
+                pdi_query, pdi_query_params = get_team_distinct_ids_query(self.team_id)
 
                 content_sql = BREAKDOWN_ACTIVE_USER_AGGREGATE_SQL.format(
                     breakdown_filter=breakdown_filter,
@@ -592,15 +592,13 @@ class TrendsBreakdown:
     def _person_join_condition(self) -> Tuple[str, Dict]:
         if self.using_person_on_events:
             return "", {}
-        
+
         params = {}
 
         person_query = PersonQuery(self.filter, self.team_id, self.column_optimizer, entity=self.entity)
         pdi_query, pdi_query_params = get_team_distinct_ids_query(self._team_id)
 
-        event_join = EVENT_JOIN_PERSON_SQL.format(
-            GET_TEAM_PERSON_DISTINCT_IDS=pdi_query
-        )
+        event_join = EVENT_JOIN_PERSON_SQL.format(GET_TEAM_PERSON_DISTINCT_IDS=pdi_query)
         params.update(pdi_query_params)
         if person_query.is_used:
             query, person_query_params = person_query.get_query()
@@ -610,7 +608,7 @@ class TrendsBreakdown:
             INNER JOIN ({query}) person
             ON person.id = {self.DISTINCT_ID_TABLE_ALIAS}.person_id
             """,
-                { **params, **pdi_query_params },
+                {**params, **pdi_query_params},
             )
         elif (
             self.entity.math in [UNIQUE_USERS, WEEKLY_ACTIVE, MONTHLY_ACTIVE]

--- a/posthog/queries/trends/trends_event_query_base.py
+++ b/posthog/queries/trends/trends_event_query_base.py
@@ -50,9 +50,12 @@ class TrendsEventQueryBase(EventQuery):
         session_query, session_params = self._get_sessions_query()
         self.params.update(session_params)
 
+        distinct_id_query, distinct_id_query_params = self._get_distinct_id_query()
+        self.params.update(distinct_id_query_params)
+        
         query = f"""
             FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             {session_query}


### PR DESCRIPTION
Best practice here should be to parse the params only once, thus let's pass all params to the execute call rather than intermediately substitute them 