### PR TITLE
fix(navigation): Fix blurry UI on mobile Safari

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.scss
+++ b/frontend/src/layout/navigation/SideBar/SideBar.scss
@@ -35,8 +35,7 @@
 .SideBar__overlay {
     z-index: var(--z-mobile-nav-overlay);
     transition: background-color var(--modal-transition-time) ease-out,
-        backdrop-filter var(--modal-transition-time) ease-out,
-        -webkit-backdrop-filter var(--modal-transition-time) ease-out;
+        backdrop-filter var(--modal-transition-time) ease-out;
     opacity: 1;
     position: absolute;
     height: 100%;
@@ -44,12 +43,10 @@
 
     background-color: var(--modal-backdrop-color);
     backdrop-filter: blur(var(--modal-backdrop-blur));
-    -webkit-backdrop-filter: blur(var(--modal-backdrop-blur));
 
     .SideBar--hidden & {
         background-color: transparent;
         backdrop-filter: blur(0px);
-        -webkit-backdrop-filter: blur(var(--modal-backdrop-blur));
         pointer-events: none;
     }
     @include screen($lg) {

--- a/frontend/src/lib/components/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/components/LemonModal/LemonModal.scss
@@ -6,8 +6,7 @@
     bottom: 0;
 
     transition: background-color var(--modal-transition-time) ease-out,
-        backdrop-filter var(--modal-transition-time) ease-out,
-        -webkit-backdrop-filter var(--modal-transition-time) ease-out;
+        backdrop-filter var(--modal-transition-time) ease-out;
     z-index: var(--z-modal);
 
     display: flex;
@@ -21,13 +20,11 @@
     &.ReactModal__Overlay--after-open {
         background-color: var(--modal-backdrop-color);
         backdrop-filter: blur(var(--modal-backdrop-blur));
-        -webkit-backdrop-filter: blur(var(--modal-backdrop-blur));
     }
 
     &.ReactModal__Overlay--before-close {
         background-color: transparent;
         backdrop-filter: blur(0px);
-        -webkit-backdrop-filter: blur(var(--modal-backdrop-blur));
     }
 }
 

--- a/frontend/src/scenes/session-recordings/player/PlayerUpNext.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerUpNext.scss
@@ -35,7 +35,6 @@
     box-shadow: var(--shadow-elevation);
     background-color: rgba(255, 255, 255, 0.75);
     backdrop-filter: blur(5px);
-    -webkit-backdrop-filter: blur(10px);
     font-weight: 600;
     cursor: pointer;
     overflow: hidden;


### PR DESCRIPTION
## Problem

We've been manually specifying the `-webkit-backdrop-filter` CSS property alongside `backdrop-filter`, but it's an easy way to break things on Safari, since you won't notice the two properties getting out of sync on any other browser. We should be fully relying on autoprefixer for this anyway. And now indeed we did run into diverging values impacting the user experience – after deploying https://github.com/PostHog/posthog/pull/13764 (which copied already-desynchronized styling from `LemonModal`) iOS users have been seeing blurry UI (since all iOS browsers have to use Safari's WebKit engine – see ZEN-1509).

## Changes

Fixes the issue by removing hand-rolled `-webkit-backdrop-filter`.
