### PR TITLE
feat(data-exploration): HogQL refactor, events list filters

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -3,7 +3,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { allOperatorsMapping, alphabet, capitalizeFirstLetter, formatPropertyLabel } from 'lib/utils'
 import { LocalFilter, toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
-import { BreakdownFilter } from 'scenes/insights/filters/BreakdownFilter'
+import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { humanizePathsEventTypes } from 'scenes/insights/utils'
 import { apiValueToMathType, MathCategory, MathDefinition, mathsLogic } from 'scenes/trends/mathsLogic'
 import { urls } from 'scenes/urls'
@@ -288,7 +288,7 @@ export function BreakdownSummary({ filters }: { filters: Partial<FilterType> }):
     return (
         <div>
             <h5>Breakdown by</h5>
-            <BreakdownFilter
+            <TaxonomicBreakdownFilter
                 filters={filters}
                 useMultiBreakdown={
                     isFunnelsFilter(filters) && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -20,7 +20,7 @@ import {
 import { PropertyFilterInternalProps } from 'lib/components/PropertyFilters/types'
 import clsx from 'clsx'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { AnyPropertyFilter, FilterLogicalOperator } from '~/types'
+import { AnyPropertyFilter, FilterLogicalOperator, PropertyFilterType } from '~/types'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { LemonButtonWithPopup } from '@posthog/lemon-ui'
 
@@ -51,7 +51,10 @@ export function TaxonomicPropertyFilter({
         value
     ) => {
         selectItem(taxonomicGroup, value)
-        if (taxonomicGroup.type === TaxonomicFilterGroupType.Cohorts) {
+        if (
+            taxonomicGroup.type === TaxonomicFilterGroupType.Cohorts ||
+            taxonomicGroup.type === TaxonomicFilterGroupType.HogQLExpression
+        ) {
             onComplete?.()
         }
     }
@@ -68,8 +71,16 @@ export function TaxonomicPropertyFilter({
     })
     const { filter, dropdownOpen, selectedCohortName, activeTaxonomicGroup } = useValues(logic)
     const { openDropdown, closeDropdown, selectItem } = useActions(logic)
-    const showInitialSearchInline = !disablePopover && ((!filter?.type && !filter?.key) || filter?.type === 'cohort')
-    const showOperatorValueSelect = filter?.type && filter?.key && filter?.type !== 'cohort'
+    const showInitialSearchInline =
+        !disablePopover &&
+        ((!filter?.type && !filter?.key) ||
+            filter?.type === PropertyFilterType.Cohort ||
+            filter?.type === PropertyFilterType.HogQL)
+    const showOperatorValueSelect =
+        filter?.type &&
+        filter?.key &&
+        filter?.type !== PropertyFilterType.Cohort &&
+        filter?.type !== PropertyFilterType.HogQL
 
     const { propertyDefinitions } = useValues(propertyDefinitionsModel)
 

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -1,6 +1,13 @@
 import { kea } from 'kea'
 import { TaxonomicPropertyFilterLogicProps } from 'lib/components/PropertyFilters/types'
-import { AnyPropertyFilter, CohortPropertyFilter, PropertyOperator, PropertyType } from '~/types'
+import {
+    AnyPropertyFilter,
+    CohortPropertyFilter,
+    HogQLPropertyFilter,
+    PropertyFilterType,
+    PropertyOperator,
+    PropertyType,
+} from '~/types'
 import type { taxonomicPropertyFilterLogicType } from './taxonomicPropertyFilterLogicType'
 import { cohortsModel } from '~/models/cohortsModel'
 import { TaxonomicFilterGroup, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
@@ -82,13 +89,20 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
         selectItem: ({ taxonomicGroup, propertyKey }) => {
             const propertyType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type)
             if (propertyKey && propertyType) {
-                if (propertyType === 'cohort') {
+                if (propertyType === PropertyFilterType.Cohort) {
                     const cohortProperty: CohortPropertyFilter = {
                         key: 'id',
                         value: parseInt(String(propertyKey)),
                         type: propertyType,
                     }
                     props.propertyFilterLogic.actions.setFilter(props.filterIndex, cohortProperty)
+                } else if (propertyType === PropertyFilterType.HogQL) {
+                    const hogQLProperty: HogQLPropertyFilter = {
+                        type: propertyType,
+                        key: String(propertyKey),
+                        value: null, // must specify something to be compatible with existing types
+                    }
+                    props.propertyFilterLogic.actions.setFilter(props.filterIndex, hogQLProperty)
                 } else {
                     const propertyValueType = values.describeProperty(propertyKey)
                     const property_name_to_default_operator_override = {

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -44,10 +44,8 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
     listeners(({ actions, props, values }) => ({
         // Only send update if value is set to something
         setFilter: ({ property }) => {
-            if (props.sendAllKeyUpdates) {
+            if (props.sendAllKeyUpdates || property?.value || (property?.key && property.type === 'hogql')) {
                 actions.update()
-            } else {
-                property?.value && actions.update()
             }
         },
         remove: () => actions.update(),

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -8,6 +8,7 @@ import {
     FeaturePropertyFilter,
     FilterLogicalOperator,
     GroupPropertyFilter,
+    HogQLPropertyFilter,
     PersonPropertyFilter,
     PropertyFilter,
     PropertyFilterType,
@@ -57,7 +58,7 @@ export function isValidPropertyFilter(filter: AnyPropertyFilter): filter is Prop
     return (
         !!filter && // is not falsy
         'key' in filter && // has a "key" property
-        Object.values(filter).some((v) => !!v) // contains some properties with values
+        ((filter.type === 'hogql' && !!filter.key) || Object.values(filter).some((v) => !!v)) // contains some properties with values
     )
 }
 
@@ -89,6 +90,9 @@ export function isGroupPropertyFilter(filter?: AnyFilterLike | null): filter is 
 }
 export function isFeaturePropertyFilter(filter?: AnyFilterLike | null): filter is FeaturePropertyFilter {
     return filter?.type === PropertyFilterType.Feature
+}
+export function isHogQLPropertyFilter(filter?: AnyFilterLike | null): filter is HogQLPropertyFilter {
+    return filter?.type === PropertyFilterType.HogQL
 }
 
 export function isAnyPropertyfilter(filter?: AnyFilterLike | null): filter is AnyPropertyFilter {
@@ -148,6 +152,7 @@ const propertyFilterMapping: Partial<Record<PropertyFilterType, TaxonomicFilterG
     [PropertyFilterType.Cohort]: TaxonomicFilterGroupType.Cohorts,
     [PropertyFilterType.Element]: TaxonomicFilterGroupType.Elements,
     [PropertyFilterType.Session]: TaxonomicFilterGroupType.Sessions,
+    [PropertyFilterType.HogQL]: TaxonomicFilterGroupType.HogQLExpression,
 }
 
 export function propertyFilterTypeToTaxonomicFilterType(

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -145,13 +145,13 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             (excludedProperties) => excludedProperties ?? {},
         ],
         taxonomicGroups: [
-            (selectors) => [
-                selectors.currentTeamId,
-                selectors.groupAnalyticsTaxonomicGroups,
-                selectors.groupAnalyticsTaxonomicGroupNames,
-                selectors.eventNames,
-                selectors.excludedProperties,
-                featureFlagLogic.selectors.featureFlags,
+            (s) => [
+                s.currentTeamId,
+                s.groupAnalyticsTaxonomicGroups,
+                s.groupAnalyticsTaxonomicGroupNames,
+                s.eventNames,
+                s.excludedProperties,
+                s.featureFlags,
             ],
             (
                 teamId,
@@ -431,12 +431,17 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             (activeTab, taxonomicGroups) => taxonomicGroups.find((g) => g.type === activeTab),
         ],
         taxonomicGroupTypes: [
-            (selectors) => [(_, props) => props.taxonomicGroupTypes, selectors.taxonomicGroups],
-            (groupTypes, taxonomicGroups): TaxonomicFilterGroupType[] =>
-                groupTypes || taxonomicGroups.map((g) => g.type),
+            (s, p) => [p.taxonomicGroupTypes, s.taxonomicGroups, s.featureFlags],
+            (groupTypes, taxonomicGroups, featureFlags): TaxonomicFilterGroupType[] =>
+                (groupTypes || taxonomicGroups.map((g) => g.type)).filter((type) => {
+                    return (
+                        type !== TaxonomicFilterGroupType.HogQLExpression ||
+                        !!featureFlags[FEATURE_FLAGS.HOGQL_EXPRESSIONS]
+                    )
+                }),
         ],
         groupAnalyticsTaxonomicGroupNames: [
-            (selectors) => [selectors.groupTypes, selectors.currentTeamId, selectors.aggregationLabel],
+            (s) => [s.groupTypes, s.currentTeamId, s.aggregationLabel],
             (groupTypes, teamId, aggregationLabel): TaxonomicFilterGroup[] =>
                 groupTypes.map((type) => ({
                     name: `${capitalizeFirstLetter(aggregationLabel(type.group_type_index).plural)}`,
@@ -453,7 +458,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                 })),
         ],
         groupAnalyticsTaxonomicGroups: [
-            (selectors) => [selectors.groupTypes, selectors.currentTeamId, selectors.aggregationLabel],
+            (s) => [s.groupTypes, s.currentTeamId, s.aggregationLabel],
             (groupTypes, teamId, aggregationLabel): TaxonomicFilterGroup[] =>
                 groupTypes.map((type) => ({
                     name: `${capitalizeFirstLetter(aggregationLabel(type.group_type_index).singular)} properties`,
@@ -521,6 +526,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                     return taxonomicGroup.searchPlaceholder
                 })
                 return names
+                    .filter((a) => !!a)
                     .map(
                         (name, index) =>
                             `${index !== 0 ? (index === searchGroupTypes.length - 1 ? ' or ' : ', ') : ''}${name}`

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -32,10 +32,15 @@ import { KeyMappingInterface } from 'lib/components/PropertyKeyInfo'
 import { AlignType } from 'rc-trigger/lib/interface'
 import { dayjs } from 'lib/dayjs'
 import { getAppContext } from './utils/getAppContext'
-import { isPropertyFilterWithOperator, isValidPropertyFilter } from './components/PropertyFilters/utils'
+import {
+    isHogQLPropertyFilter,
+    isPropertyFilterWithOperator,
+    isValidPropertyFilter,
+} from './components/PropertyFilters/utils'
 import { IconCopy } from './components/icons'
 import { lemonToast } from './components/lemonToast'
 import { BehavioralFilterKey } from 'scenes/cohorts/CohortFilters/types'
+import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
 
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects
@@ -358,6 +363,9 @@ export function formatPropertyLabel(
     keyMapping: KeyMappingInterface,
     valueFormatter: (value: PropertyFilterValue | undefined) => string | string[] | null = (s) => [String(s)]
 ): string {
+    if (isHogQLPropertyFilter(item)) {
+        return extractExpressionComment(item.key)
+    }
     const { value, key, operator, type } = item
     return type === 'cohort'
         ? cohortsById[value]?.name || `ID ${value}`

--- a/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
+++ b/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
@@ -21,7 +21,9 @@ export function InlineHogQLEditor({ value, onChange }: InlineHogQLEditorProps): 
                 className="font-mono"
                 minRows={6}
                 maxRows={6}
-                placeholder={'Enter HogQL Expression...'}
+                placeholder={
+                    'Enter HogQL Expression, such as:\n- properties.$current_url\n- total()\n- sum(toInt(properties.$screen_width)) * 10\n- concat(event, " ", distinct_id)\n- ifElse(1 < 2, "small", "large")'
+                }
                 autoFocus
             />
             <LemonButton
@@ -34,7 +36,7 @@ export function InlineHogQLEditor({ value, onChange }: InlineHogQLEditorProps): 
                 disabled={!localValue}
                 center
             >
-                {value ? 'Edit HogQL expression' : 'Add HogQL expression'}
+                {value ? 'Update HogQL expression' : 'Add HogQL expression'}
             </LemonButton>
         </div>
     )

--- a/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
+++ b/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
@@ -22,7 +22,7 @@ export function InlineHogQLEditor({ value, onChange }: InlineHogQLEditorProps): 
                 minRows={6}
                 maxRows={6}
                 placeholder={
-                    'Enter HogQL Expression, such as:\n- properties.$current_url\n- total()\n- sum(toInt(properties.$screen_width)) * 10\n- concat(event, " ", distinct_id)\n- ifElse(1 < 2, "small", "large")'
+                    'Enter HogQL Expression, such as:\n- properties.$current_url\n- count()\n- sum(toInt(properties.$screen_width)) * 10\n- concat(event, " ", distinct_id)\n- ifElse(1 < 2, "small", "large")'
                 }
                 autoFocus
             />

--- a/frontend/src/queries/nodes/EventsNode/EventPropertyFilters.tsx
+++ b/frontend/src/queries/nodes/EventsNode/EventPropertyFilters.tsx
@@ -2,6 +2,7 @@ import { EventsNode, EventsQuery } from '~/queries/schema'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { AnyPropertyFilter } from '~/types'
 import { useState } from 'react'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 interface EventPropertyFiltersProps {
     query: EventsNode | EventsQuery
@@ -14,6 +15,14 @@ export function EventPropertyFilters({ query, setQuery }: EventPropertyFiltersPr
     return !query.properties || Array.isArray(query.properties) ? (
         <PropertyFilters
             propertyFilters={query.properties || []}
+            taxonomicGroupTypes={[
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.PersonProperties,
+                TaxonomicFilterGroupType.EventFeatureFlags,
+                TaxonomicFilterGroupType.Cohorts,
+                TaxonomicFilterGroupType.Elements,
+                TaxonomicFilterGroupType.HogQLExpression,
+            ]}
             onChange={(value: AnyPropertyFilter[]) => setQuery?.({ ...query, properties: value })}
             pageKey={`EventPropertyFilters.${id}`}
             style={{ marginBottom: 0, marginTop: 0 }}

--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -1,6 +1,6 @@
 import { useValues, useActions } from 'kea'
 import { QueryEditorFilterProps } from '~/types'
-import { BreakdownFilter } from 'scenes/insights/filters/BreakdownFilter'
+import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { isTrendsQuery } from '~/queries/utils'
@@ -19,5 +19,5 @@ export function Breakdown({ insightProps, query }: QueryEditorFilterProps): JSX.
     const setFilters = (breakdown: BreakdownFilterType): void => {
         updateBreakdown(breakdown)
     }
-    return <BreakdownFilter filters={filters} setFilters={setFilters} useMultiBreakdown={useMultiBreakdown} />
+    return <TaxonomicBreakdownFilter filters={filters} setFilters={setFilters} useMultiBreakdown={useMultiBreakdown} />
 }

--- a/frontend/src/scenes/insights/EditorFilters/Breakdown.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/Breakdown.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { EditorFilterProps, InsightType } from '~/types'
-import { BreakdownFilter } from 'scenes/insights/filters/BreakdownFilter'
+import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -12,5 +12,11 @@ export function Breakdown({ filters }: EditorFilterProps): JSX.Element {
     const useMultiBreakdown =
         filters.insight !== InsightType.TRENDS && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]
 
-    return <BreakdownFilter filters={filters} setFilters={setFiltersMerge} useMultiBreakdown={useMultiBreakdown} />
+    return (
+        <TaxonomicBreakdownFilter
+            filters={filters}
+            setFilters={setFiltersMerge}
+            useMultiBreakdown={useMultiBreakdown}
+        />
+    )
 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -6,9 +6,8 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { Breakdown, ChartDisplayType, FilterType, InsightType, TrendsFilterType } from '~/types'
 import { BreakdownTag } from './BreakdownTag'
 import './TaxonomicBreakdownFilter.scss'
-import { onFilterChange } from './taxonomicBreakdownFilterUtils'
+import { onFilterChange, isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
-import { isURLNormalizeable } from 'scenes/insights/filters/BreakdownFilter/index'
 
 export interface TaxonomicBreakdownFilterProps {
     filters: Partial<FilterType>
@@ -24,7 +23,7 @@ export const isCohortBreakdown = (t: number | string): t is number | string => i
 
 export const isPersonEventOrGroup = (t: number | string): t is string => typeof t === 'string' && t !== 'all'
 
-export function BreakdownFilter({
+export function TaxonomicBreakdownFilter({
     filters,
     setFilters,
     useMultiBreakdown = false,

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/index.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/index.ts
@@ -1,5 +1,0 @@
-export { BreakdownFilter } from './TaxonomicBreakdownFilter'
-
-export const isURLNormalizeable = (propertyName: string): boolean => {
-    return ['$current_url', '$pathname'].includes(propertyName)
-}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -5,8 +5,10 @@ import {
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 import { taxonomicFilterTypeToPropertyFilterType } from 'lib/components/PropertyFilters/utils'
-import { isURLNormalizeable } from 'scenes/insights/filters/BreakdownFilter/index'
 
+export const isURLNormalizeable = (propertyName: string): boolean => {
+    return ['$current_url', '$pathname'].includes(propertyName)
+}
 interface FilterChange {
     useMultiBreakdown: string | boolean | undefined
     breakdownParts: (string | number)[]

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -29,7 +29,7 @@ import {
     isStickinessFilter,
     isTrendsFilter,
 } from 'scenes/insights/sharedUtils'
-import { isURLNormalizeable } from 'scenes/insights/filters/BreakdownFilter'
+import { isURLNormalizeable } from 'scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils'
 
 export function getDefaultEvent(): Entity {
     const event = getDefaultEventName()

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -429,6 +429,7 @@ export enum PropertyFilterType {
     Cohort = 'cohort',
     Recording = 'recording',
     Group = 'group',
+    HogQL = 'hogql',
 }
 
 /** Sync with plugin-server/src/types.ts */
@@ -482,6 +483,11 @@ export interface FeaturePropertyFilter extends BasePropertyFilter {
     operator: PropertyOperator
 }
 
+export interface HogQLPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.HogQL
+    key: string
+}
+
 export type PropertyFilter =
     | EventPropertyFilter
     | PersonPropertyFilter
@@ -491,6 +497,7 @@ export type PropertyFilter =
     | RecordingDurationFilter
     | GroupPropertyFilter
     | FeaturePropertyFilter
+    | HogQLPropertyFilter
 
 export type AnyPropertyFilter =
     | Partial<EventPropertyFilter>
@@ -501,6 +508,7 @@ export type AnyPropertyFilter =
     | Partial<RecordingDurationFilter>
     | Partial<GroupPropertyFilter>
     | Partial<FeaturePropertyFilter>
+    | Partial<HogQLPropertyFilter>
 
 export type AnyFilterLike = AnyPropertyFilter | PropertyGroupFilter | PropertyGroupFilterValue
 

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -186,6 +186,266 @@
   LIMIT 10
   '
 ---
+# name: TestEvents.test_hogql_property_filter
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter.1
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter.2
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'foo'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter.3
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'foo'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter.4
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'a%sd'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter.5
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'a%sd'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter.6
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals(replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''), 'test_val2'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter.7
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         'a%sd',
+         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals(replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''), 'test_val2'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized.1
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized.2
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'foo'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized.3
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'foo'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized.4
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'a%sd'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized.5
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals('a%sd', 'a%sd'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized.6
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp > '2020-01-09 12:14:00.000000'
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals("mat_key", 'test_val2'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
+# name: TestEvents.test_hogql_property_filter_materialized.7
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT event,
+         distinct_id,
+         "mat_key",
+         'a%sd',
+         concat(event, ' ', "mat_key")
+  FROM events
+  WHERE team_id = 2
+    AND timestamp < '2020-01-10 12:14:05.000000'
+    AND (equals("mat_key", 'test_val2'))
+  ORDER BY event ASC
+  LIMIT 101
+  '
+---
 # name: TestEvents.test_select_hogql_expressions
   '
   /* user_id:0 request:_snapshot_ */

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -779,3 +779,46 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                     "results": [[2, "sign out"], [1, "sign up"]],
                 },
             )
+
+    @also_test_with_materialized_columns(["key"])
+    @snapshot_clickhouse_queries
+    def test_hogql_property_filter(self):
+        with freeze_time("2020-01-10 12:00:00"):
+            _create_person(
+                properties={"email": "tom@posthog.com"},
+                distinct_ids=["2", "some-random-uid"],
+                team=self.team,
+                immediate=True,
+            )
+            _create_event(team=self.team, event="sign up", distinct_id="2", properties={"key": "test_val1"})
+        with freeze_time("2020-01-10 12:11:00"):
+            _create_event(team=self.team, event="sign out", distinct_id="2", properties={"key": "test_val2"})
+        with freeze_time("2020-01-10 12:12:00"):
+            _create_event(team=self.team, event="sign out", distinct_id="3", properties={"key": "test_val2"})
+        with freeze_time("2020-01-10 12:13:00"):
+            _create_event(team=self.team, event="sign out", distinct_id="4", properties={"key": "test_val3"})
+        flush_persons_and_events()
+
+        with freeze_time("2020-01-10 12:14:00"):
+            select = ["event", "distinct_id", "properties.key", "'a%sd'", "concat(event, ' ', properties.key)"]
+
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?select={json.dumps(select)}").json()
+            self.assertEqual(len(response["results"]), 4)
+
+            properties = [{"type": "hogql", "key": "'a%sd' == 'foo'"}]
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/events/?select={json.dumps(select)}&properties={json.dumps(properties)}"
+            ).json()
+            self.assertEqual(len(response["results"]), 0)
+
+            properties = [{"type": "hogql", "key": "'a%sd' == 'a%sd'"}]
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/events/?select={json.dumps(select)}&properties={json.dumps(properties)}"
+            ).json()
+            self.assertEqual(len(response["results"]), 4)
+
+            properties = [{"type": "hogql", "key": "properties.key == 'test_val2'"}]
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/events/?select={json.dumps(select)}&properties={json.dumps(properties)}"
+            ).json()
+            self.assertEqual(len(response["results"]), 2)

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, List, Optional, cast
 
 from clickhouse_driver.util.escape import escape_param
 
-from posthog.models.property.util import get_property_string_expr
-
 # fields you can select from in the events query
 EVENT_FIELDS = ["id", "uuid", "event", "timestamp", "distinct_id"]
 # "person.*" fields you can select from in the events query
@@ -308,6 +306,9 @@ def translate_ast(node: ast.AST, stack: List[ast.AST], context: HogQLContext) ->
 
 
 def property_access_to_clickhouse(chain: List[str]):
+    # Circular import otherwise
+    from posthog.models.property.util import get_property_string_expr
+
     """Given a list like ['properties', '$browser'] or ['uuid'], translate to the correct ClickHouse expr."""
     if len(chain) == 2:
         if chain[0] == "properties":

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -120,9 +120,9 @@ class HogQLContext:
     """Context given to a HogQL expression parser"""
 
     # If set, will save string constants to this dict. Inlines strings into the query if None.
-    values: Optional[Dict[str, Any]] = field(default_factory=lambda: {})
+    values: Optional[Dict[str, Any]] = field(default_factory=dict)
     # List of field and property accesses found in the expression
-    attribute_list: List[List[str]] = field(default_factory=lambda: [])
+    attribute_list: List[List[str]] = field(default_factory=list)
     # Did the last calls to translate_hogql since setting this to False contain any HOGQL_AGGREGATIONS
     found_aggregation: bool = False
 

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -120,7 +120,7 @@ class HogQLContext:
     """Context given to a HogQL expression parser"""
 
     # If set, will save string constants to this dict. Inlines strings into the query if None.
-    values: Optional[Dict[str, Any]] = field(default_factory=dict)
+    values: Optional[Dict] = field(default_factory=dict)
     # List of field and property accesses found in the expression
     attribute_list: List[List[str]] = field(default_factory=list)
     # Did the last calls to translate_hogql since setting this to False contain any HOGQL_AGGREGATIONS

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -118,7 +118,7 @@ SELECT_STAR_FROM_EVENTS_FIELDS = [
 
 
 @dataclass
-class ExprParserContext:
+class HogQLContext:
     """Context given to a HogQL expression parser"""
 
     # If set, will save string constants to this list instead of inlining them
@@ -129,7 +129,7 @@ class ExprParserContext:
     is_aggregation: bool = False
 
 
-def translate_hql(hql: str, context: Optional[ExprParserContext] = None) -> str:
+def translate_hogql(hql: str, context: Optional[HogQLContext] = None) -> str:
     """Translate a HogQL expression into a Clickhouse expression."""
     if hql == "*":
         return f"tuple({','.join(SELECT_STAR_FROM_EVENTS_FIELDS)})"
@@ -146,11 +146,11 @@ def translate_hql(hql: str, context: Optional[ExprParserContext] = None) -> str:
     except SyntaxError as err:
         raise ValueError(f"SyntaxError: {err.msg}")
     if not context:
-        context = ExprParserContext()
+        context = HogQLContext()
     return translate_ast(node, [], context)
 
 
-def translate_ast(node: ast.AST, stack: List[ast.AST], context: ExprParserContext) -> str:
+def translate_ast(node: ast.AST, stack: List[ast.AST], context: HogQLContext) -> str:
     """Translate a parsed HogQL expression in the shape of a Python AST into a Clickhouse expression."""
     stack.append(node)
     if isinstance(node, ast.Module):

--- a/posthog/hogql/test/test_hogql.py
+++ b/posthog/hogql/test/test_hogql.py
@@ -1,46 +1,46 @@
 from typing import Any, Dict
 
-from posthog.hogql.expr_parser import ExprParserContext, translate_hql
+from posthog.hogql.hogql import HogQLContext, translate_hogql
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 
-class TestExprParser(APIBaseTest, ClickhouseTestMixin):
+class TestHogQLContext(APIBaseTest, ClickhouseTestMixin):
     def test_hogql_literals(self):
-        self.assertEqual(translate_hql("1 + 2"), "plus(1, 2)")
-        self.assertEqual(translate_hql("-1 + 2"), "plus(-1, 2)")
-        self.assertEqual(translate_hql("-1 - 2 / (3 + 4)"), "minus(-1, divide(2, plus(3, 4)))")
-        self.assertEqual(translate_hql("1.0 * 2.66"), "multiply(1.0, 2.66)")
-        self.assertEqual(translate_hql("1.0 % 2.66"), "modulo(1.0, 2.66)")
-        self.assertEqual(translate_hql("'string'"), "'string'")
-        self.assertEqual(translate_hql('"string"'), "'string'")
+        self.assertEqual(translate_hogql("1 + 2"), "plus(1, 2)")
+        self.assertEqual(translate_hogql("-1 + 2"), "plus(-1, 2)")
+        self.assertEqual(translate_hogql("-1 - 2 / (3 + 4)"), "minus(-1, divide(2, plus(3, 4)))")
+        self.assertEqual(translate_hogql("1.0 * 2.66"), "multiply(1.0, 2.66)")
+        self.assertEqual(translate_hogql("1.0 % 2.66"), "modulo(1.0, 2.66)")
+        self.assertEqual(translate_hogql("'string'"), "'string'")
+        self.assertEqual(translate_hogql('"string"'), "'string'")
 
     def test_hogql_fields_and_properties(self):
         self.assertEqual(
-            translate_hql("properties.bla"),
+            translate_hogql("properties.bla"),
             "replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hql("properties['bla']"),
+            translate_hogql("properties['bla']"),
             "replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hql('properties["bla"]'),
+            translate_hogql('properties["bla"]'),
             "replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hql("properties.$bla"),
+            translate_hogql("properties.$bla"),
             "replaceRegexpAll(JSONExtractRaw(properties, '$bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hql("person.properties.bla"),
+            translate_hogql("person.properties.bla"),
             "replaceRegexpAll(JSONExtractRaw(person_properties, 'bla'), '^\"|\"$', '')",
         )
-        self.assertEqual(translate_hql("uuid"), "uuid")
-        self.assertEqual(translate_hql("event"), "event")
-        self.assertEqual(translate_hql("timestamp"), "timestamp")
-        self.assertEqual(translate_hql("distinct_id"), "distinct_id")
-        self.assertEqual(translate_hql("person_id"), "person_id")
-        self.assertEqual(translate_hql("person.created_at"), "person_created_at")
+        self.assertEqual(translate_hogql("uuid"), "uuid")
+        self.assertEqual(translate_hogql("event"), "event")
+        self.assertEqual(translate_hogql("timestamp"), "timestamp")
+        self.assertEqual(translate_hogql("distinct_id"), "distinct_id")
+        self.assertEqual(translate_hogql("person_id"), "person_id")
+        self.assertEqual(translate_hogql("person.created_at"), "person_created_at")
 
     def test_hogql_materialized_fields_and_properties(self):
         try:
@@ -50,20 +50,20 @@ class TestExprParser(APIBaseTest, ClickhouseTestMixin):
             self.assertEqual(1 + 2, 3)
             return
         materialize("events", "$browser")
-        self.assertEqual(translate_hql("properties['$browser']"), '"mat_$browser"')
+        self.assertEqual(translate_hogql("properties['$browser']"), '"mat_$browser"')
 
         materialize("events", "$initial_waffle", table_column="person_properties")
-        self.assertEqual(translate_hql("person.properties['$initial_waffle']"), '"mat_pp_$initial_waffle"')
+        self.assertEqual(translate_hogql("person.properties['$initial_waffle']"), '"mat_pp_$initial_waffle"')
 
     def test_hogql_methods(self):
-        self.assertEqual(translate_hql("count()"), "count(*)")
-        self.assertEqual(translate_hql("count(event)"), "count(distinct event)")
+        self.assertEqual(translate_hogql("count()"), "count(*)")
+        self.assertEqual(translate_hogql("count(event)"), "count(distinct event)")
 
     def test_hogql_functions(self):
-        self.assertEqual(translate_hql("abs(1)"), "abs(1)")
-        self.assertEqual(translate_hql("max2(1,2)"), "max2(1, 2)")
-        self.assertEqual(translate_hql("toInt('1')"), "toInt64OrNull('1')")
-        self.assertEqual(translate_hql("toFloat('1.3')"), "toFloat64OrNull('1.3')")
+        self.assertEqual(translate_hogql("abs(1)"), "abs(1)")
+        self.assertEqual(translate_hogql("max2(1,2)"), "max2(1, 2)")
+        self.assertEqual(translate_hogql("toInt('1')"), "toInt64OrNull('1')")
+        self.assertEqual(translate_hogql("toFloat('1.3')"), "toFloat64OrNull('1.3')")
 
     def test_hogql_expr_parse_errors(self):
         self._assert_value_error("", "Module body must contain only one 'Expr'")
@@ -91,23 +91,23 @@ class TestExprParser(APIBaseTest, ClickhouseTestMixin):
         self._assert_value_error("1;2", "Module body must contain only one 'Expr'")
 
     def test_hogql_returned_properties(self):
-        context = ExprParserContext()
-        translate_hql("avg(properties.prop) + avg(uuid) + event", context)
+        context = HogQLContext()
+        translate_hogql("avg(properties.prop) + avg(uuid) + event", context)
         self.assertEqual(context.attribute_list, [["properties", "prop"], ["uuid"], ["event"]])
         self.assertEqual(context.is_aggregation, True)
 
-        context = ExprParserContext()
-        translate_hql("coalesce(event, properties.event)", context)
+        context = HogQLContext()
+        translate_hogql("coalesce(event, properties.event)", context)
         self.assertEqual(context.attribute_list, [["event"], ["properties", "event"]])
         self.assertEqual(context.is_aggregation, False)
 
-        context = ExprParserContext()
-        translate_hql("count() + sum(timestamp)", context)
+        context = HogQLContext()
+        translate_hogql("count() + sum(timestamp)", context)
         self.assertEqual(context.attribute_list, [["timestamp"]])
         self.assertEqual(context.is_aggregation, True)
 
-        context = ExprParserContext()
-        translate_hql("event + avg(event + properties.event) + avg(event + properties.event)", context)
+        context = HogQLContext()
+        translate_hogql("event + avg(event + properties.event) + avg(event + properties.event)", context)
         self.assertEqual(
             context.attribute_list, [["event"], ["event"], ["properties", "event"], ["event"], ["properties", "event"]]
         )
@@ -115,54 +115,54 @@ class TestExprParser(APIBaseTest, ClickhouseTestMixin):
 
     def test_hogql_logic(self):
         self.assertEqual(
-            translate_hql("event or timestamp"),
+            translate_hogql("event or timestamp"),
             "or(event, timestamp)",
         )
         self.assertEqual(
-            translate_hql("properties.bla and properties.bla2"),
+            translate_hogql("properties.bla and properties.bla2"),
             "and(replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', ''), replaceRegexpAll(JSONExtractRaw(properties, 'bla2'), '^\"|\"$', ''))",
         )
         self.assertEqual(
-            translate_hql("event or timestamp or true or count()"),
+            translate_hogql("event or timestamp or true or count()"),
             "or(event, timestamp, true, count(*))",
         )
         self.assertEqual(
-            translate_hql("event or not timestamp"),
+            translate_hogql("event or not timestamp"),
             "or(event, not(timestamp))",
         )
 
     def test_hogql_comparisons(self):
-        self.assertEqual(translate_hql("event == 'E'"), "equals(event, 'E')")
-        self.assertEqual(translate_hql("event != 'E'"), "notEquals(event, 'E')")
-        self.assertEqual(translate_hql("event > 'E'"), "greater(event, 'E')")
-        self.assertEqual(translate_hql("event >= 'E'"), "greaterOrEquals(event, 'E')")
-        self.assertEqual(translate_hql("event < 'E'"), "less(event, 'E')")
-        self.assertEqual(translate_hql("event <= 'E'"), "lessOrEquals(event, 'E')")
+        self.assertEqual(translate_hogql("event == 'E'"), "equals(event, 'E')")
+        self.assertEqual(translate_hogql("event != 'E'"), "notEquals(event, 'E')")
+        self.assertEqual(translate_hogql("event > 'E'"), "greater(event, 'E')")
+        self.assertEqual(translate_hogql("event >= 'E'"), "greaterOrEquals(event, 'E')")
+        self.assertEqual(translate_hogql("event < 'E'"), "less(event, 'E')")
+        self.assertEqual(translate_hogql("event <= 'E'"), "lessOrEquals(event, 'E')")
 
     def test_hogql_special_root_properties(self):
         self.assertEqual(
-            translate_hql("*"),
+            translate_hogql("*"),
             "tuple(uuid,event,properties,timestamp,team_id,distinct_id,elements_chain,created_at,person_id,person_created_at,person_properties)",
         )
         self.assertEqual(
-            translate_hql("person"),
+            translate_hogql("person"),
             "tuple(distinct_id, person_id, person_created_at, replaceRegexpAll(JSONExtractRaw(person_properties, 'name'), '^\"|\"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'email'), '^\"|\"$', ''))",
         )
         self._assert_value_error("person + 1", 'Can not use the field "person" in an expression')
 
     def test_collected_values(self):
         collected_values: Dict[str, Any] = {}
-        context = ExprParserContext(collect_values=collected_values)
-        self.assertEqual(translate_hql("event == 'E'", context), "equals(event, %(val_0)s)")
+        context = HogQLContext(collect_values=collected_values)
+        self.assertEqual(translate_hogql("event == 'E'", context), "equals(event, %(val_0)s)")
         self.assertEqual(collected_values, {"val_0": "E"})
         self.assertEqual(
-            translate_hql("coalesce(4.2, 5, 'lol', 'hoo')", context), "coalesce(4.2, 5, %(val_1)s, %(val_2)s)"
+            translate_hogql("coalesce(4.2, 5, 'lol', 'hoo')", context), "coalesce(4.2, 5, %(val_1)s, %(val_2)s)"
         )
         self.assertEqual(collected_values, {"val_0": "E", "val_1": "lol", "val_2": "hoo"})
 
     def _assert_value_error(self, expr, expected_error):
         with self.assertRaises(ValueError) as context:
-            translate_hql(expr)
+            translate_hogql(expr)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
         self.assertTrue(expected_error in str(context.exception))

--- a/posthog/hogql/test/test_hogql.py
+++ b/posthog/hogql/test/test_hogql.py
@@ -1,46 +1,50 @@
-from typing import Any, Dict
-
 from posthog.hogql.hogql import HogQLContext, translate_hogql
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 
 class TestHogQLContext(APIBaseTest, ClickhouseTestMixin):
+    # Helper to always translate HogQL with a blank context
+    def _translate(self, query: str):
+        return translate_hogql(query, HogQLContext())
+
     def test_hogql_literals(self):
-        self.assertEqual(translate_hogql("1 + 2"), "plus(1, 2)")
-        self.assertEqual(translate_hogql("-1 + 2"), "plus(-1, 2)")
-        self.assertEqual(translate_hogql("-1 - 2 / (3 + 4)"), "minus(-1, divide(2, plus(3, 4)))")
-        self.assertEqual(translate_hogql("1.0 * 2.66"), "multiply(1.0, 2.66)")
-        self.assertEqual(translate_hogql("1.0 % 2.66"), "modulo(1.0, 2.66)")
-        self.assertEqual(translate_hogql("'string'"), "'string'")
-        self.assertEqual(translate_hogql('"string"'), "'string'")
+        self.assertEqual(self._translate("1 + 2"), "plus(1, 2)")
+        self.assertEqual(self._translate("-1 + 2"), "plus(-1, 2)")
+        self.assertEqual(self._translate("-1 - 2 / (3 + 4)"), "minus(-1, divide(2, plus(3, 4)))")
+        self.assertEqual(self._translate("1.0 * 2.66"), "multiply(1.0, 2.66)")
+        self.assertEqual(self._translate("1.0 % 2.66"), "modulo(1.0, 2.66)")
+        self.assertEqual(translate_hogql("'string'", HogQLContext(values=None)), "'string'")
+        self.assertEqual(translate_hogql('"string"', HogQLContext(values=None)), "'string'")
+        self.assertEqual(self._translate("'string'"), "%(val_0)s")
+        self.assertEqual(self._translate('"string"'), "%(val_0)s")
 
     def test_hogql_fields_and_properties(self):
         self.assertEqual(
-            translate_hogql("properties.bla"),
+            self._translate("properties.bla"),
             "replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hogql("properties['bla']"),
+            self._translate("properties['bla']"),
             "replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hogql('properties["bla"]'),
+            self._translate('properties["bla"]'),
             "replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hogql("properties.$bla"),
+            self._translate("properties.$bla"),
             "replaceRegexpAll(JSONExtractRaw(properties, '$bla'), '^\"|\"$', '')",
         )
         self.assertEqual(
-            translate_hogql("person.properties.bla"),
+            self._translate("person.properties.bla"),
             "replaceRegexpAll(JSONExtractRaw(person_properties, 'bla'), '^\"|\"$', '')",
         )
-        self.assertEqual(translate_hogql("uuid"), "uuid")
-        self.assertEqual(translate_hogql("event"), "event")
-        self.assertEqual(translate_hogql("timestamp"), "timestamp")
-        self.assertEqual(translate_hogql("distinct_id"), "distinct_id")
-        self.assertEqual(translate_hogql("person_id"), "person_id")
-        self.assertEqual(translate_hogql("person.created_at"), "person_created_at")
+        self.assertEqual(self._translate("uuid"), "uuid")
+        self.assertEqual(self._translate("event"), "event")
+        self.assertEqual(self._translate("timestamp"), "timestamp")
+        self.assertEqual(self._translate("distinct_id"), "distinct_id")
+        self.assertEqual(self._translate("person_id"), "person_id")
+        self.assertEqual(self._translate("person.created_at"), "person_created_at")
 
     def test_hogql_materialized_fields_and_properties(self):
         try:
@@ -50,20 +54,21 @@ class TestHogQLContext(APIBaseTest, ClickhouseTestMixin):
             self.assertEqual(1 + 2, 3)
             return
         materialize("events", "$browser")
-        self.assertEqual(translate_hogql("properties['$browser']"), '"mat_$browser"')
+        self.assertEqual(self._translate("properties['$browser']"), '"mat_$browser"')
 
         materialize("events", "$initial_waffle", table_column="person_properties")
-        self.assertEqual(translate_hogql("person.properties['$initial_waffle']"), '"mat_pp_$initial_waffle"')
+        self.assertEqual(self._translate("person.properties['$initial_waffle']"), '"mat_pp_$initial_waffle"')
 
     def test_hogql_methods(self):
-        self.assertEqual(translate_hogql("count()"), "count(*)")
-        self.assertEqual(translate_hogql("count(event)"), "count(distinct event)")
+        self.assertEqual(self._translate("count()"), "count(*)")
+        self.assertEqual(self._translate("count(event)"), "count(distinct event)")
 
     def test_hogql_functions(self):
-        self.assertEqual(translate_hogql("abs(1)"), "abs(1)")
-        self.assertEqual(translate_hogql("max2(1,2)"), "max2(1, 2)")
-        self.assertEqual(translate_hogql("toInt('1')"), "toInt64OrNull('1')")
-        self.assertEqual(translate_hogql("toFloat('1.3')"), "toFloat64OrNull('1.3')")
+        context = HogQLContext(values=None)  # inline values
+        self.assertEqual(self._translate("abs(1)"), "abs(1)")
+        self.assertEqual(self._translate("max2(1,2)"), "max2(1, 2)")
+        self.assertEqual(translate_hogql("toInt('1')", context), "toInt64OrNull('1')")
+        self.assertEqual(translate_hogql("toFloat('1.3')", context), "toFloat64OrNull('1.3')")
 
     def test_hogql_expr_parse_errors(self):
         self._assert_value_error("", "Module body must contain only one 'Expr'")
@@ -94,75 +99,75 @@ class TestHogQLContext(APIBaseTest, ClickhouseTestMixin):
         context = HogQLContext()
         translate_hogql("avg(properties.prop) + avg(uuid) + event", context)
         self.assertEqual(context.attribute_list, [["properties", "prop"], ["uuid"], ["event"]])
-        self.assertEqual(context.is_aggregation, True)
+        self.assertEqual(context.found_aggregation, True)
 
         context = HogQLContext()
         translate_hogql("coalesce(event, properties.event)", context)
         self.assertEqual(context.attribute_list, [["event"], ["properties", "event"]])
-        self.assertEqual(context.is_aggregation, False)
+        self.assertEqual(context.found_aggregation, False)
 
         context = HogQLContext()
         translate_hogql("count() + sum(timestamp)", context)
         self.assertEqual(context.attribute_list, [["timestamp"]])
-        self.assertEqual(context.is_aggregation, True)
+        self.assertEqual(context.found_aggregation, True)
 
         context = HogQLContext()
         translate_hogql("event + avg(event + properties.event) + avg(event + properties.event)", context)
         self.assertEqual(
             context.attribute_list, [["event"], ["event"], ["properties", "event"], ["event"], ["properties", "event"]]
         )
-        self.assertEqual(context.is_aggregation, True)
+        self.assertEqual(context.found_aggregation, True)
 
     def test_hogql_logic(self):
         self.assertEqual(
-            translate_hogql("event or timestamp"),
+            self._translate("event or timestamp"),
             "or(event, timestamp)",
         )
         self.assertEqual(
-            translate_hogql("properties.bla and properties.bla2"),
+            self._translate("properties.bla and properties.bla2"),
             "and(replaceRegexpAll(JSONExtractRaw(properties, 'bla'), '^\"|\"$', ''), replaceRegexpAll(JSONExtractRaw(properties, 'bla2'), '^\"|\"$', ''))",
         )
         self.assertEqual(
-            translate_hogql("event or timestamp or true or count()"),
+            self._translate("event or timestamp or true or count()"),
             "or(event, timestamp, true, count(*))",
         )
         self.assertEqual(
-            translate_hogql("event or not timestamp"),
+            self._translate("event or not timestamp"),
             "or(event, not(timestamp))",
         )
 
     def test_hogql_comparisons(self):
-        self.assertEqual(translate_hogql("event == 'E'"), "equals(event, 'E')")
-        self.assertEqual(translate_hogql("event != 'E'"), "notEquals(event, 'E')")
-        self.assertEqual(translate_hogql("event > 'E'"), "greater(event, 'E')")
-        self.assertEqual(translate_hogql("event >= 'E'"), "greaterOrEquals(event, 'E')")
-        self.assertEqual(translate_hogql("event < 'E'"), "less(event, 'E')")
-        self.assertEqual(translate_hogql("event <= 'E'"), "lessOrEquals(event, 'E')")
+        context = HogQLContext(values=None)  # inline values
+        self.assertEqual(translate_hogql("event == 'E'", context), "equals(event, 'E')")
+        self.assertEqual(translate_hogql("event != 'E'", context), "notEquals(event, 'E')")
+        self.assertEqual(translate_hogql("event > 'E'", context), "greater(event, 'E')")
+        self.assertEqual(translate_hogql("event >= 'E'", context), "greaterOrEquals(event, 'E')")
+        self.assertEqual(translate_hogql("event < 'E'", context), "less(event, 'E')")
+        self.assertEqual(translate_hogql("event <= 'E'", context), "lessOrEquals(event, 'E')")
 
     def test_hogql_special_root_properties(self):
         self.assertEqual(
-            translate_hogql("*"),
+            self._translate("*"),
             "tuple(uuid,event,properties,timestamp,team_id,distinct_id,elements_chain,created_at,person_id,person_created_at,person_properties)",
         )
         self.assertEqual(
-            translate_hogql("person"),
+            self._translate("person"),
             "tuple(distinct_id, person_id, person_created_at, replaceRegexpAll(JSONExtractRaw(person_properties, 'name'), '^\"|\"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'email'), '^\"|\"$', ''))",
         )
         self._assert_value_error("person + 1", 'Can not use the field "person" in an expression')
 
-    def test_collected_values(self):
-        collected_values: Dict[str, Any] = {}
-        context = HogQLContext(collect_values=collected_values)
+    def test_hogql_values(self):
+        context = HogQLContext()
         self.assertEqual(translate_hogql("event == 'E'", context), "equals(event, %(val_0)s)")
-        self.assertEqual(collected_values, {"val_0": "E"})
+        self.assertEqual(context.values, {"val_0": "E"})
         self.assertEqual(
             translate_hogql("coalesce(4.2, 5, 'lol', 'hoo')", context), "coalesce(4.2, 5, %(val_1)s, %(val_2)s)"
         )
-        self.assertEqual(collected_values, {"val_0": "E", "val_1": "lol", "val_2": "hoo"})
+        self.assertEqual(context.values, {"val_0": "E", "val_1": "lol", "val_2": "hoo"})
 
     def _assert_value_error(self, expr, expected_error):
         with self.assertRaises(ValueError) as context:
-            translate_hogql(expr)
+            self._translate(expr)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
         self.assertTrue(expected_error in str(context.exception))

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -8,7 +8,7 @@ from django.utils.timezone import now
 
 from posthog.api.utils import get_pk_or_uuid
 from posthog.clickhouse.client.connection import Workload
-from posthog.hogql.expr_parser import SELECT_STAR_FROM_EVENTS_FIELDS, ExprParserContext, translate_hql
+from posthog.hogql.hogql import SELECT_STAR_FROM_EVENTS_FIELDS, HogQLContext, translate_hogql
 from posthog.models import Action, Filter, Person, Team
 from posthog.models.action.util import format_action_filter
 from posthog.models.element import chain_to_elements
@@ -146,17 +146,17 @@ def query_events_list(
         select = ["*"]
 
     for expr in select:
-        context = ExprParserContext()
+        context = HogQLContext()
         context.collect_values = collected_hogql_values
-        clickhouse_sql = translate_hql(expr, context)
+        clickhouse_sql = translate_hogql(expr, context)
         select_columns.append(clickhouse_sql)
         if not context.is_aggregation:
             group_by_columns.append(clickhouse_sql)
 
     for expr in where or []:
-        context = ExprParserContext()
+        context = HogQLContext()
         context.collect_values = collected_hogql_values
-        clickhouse_sql = translate_hql(expr, context)
+        clickhouse_sql = translate_hogql(expr, context)
         if context.is_aggregation:
             having_filters.append(clickhouse_sql)
         else:
@@ -168,9 +168,9 @@ def query_events_list(
             if fragment.startswith("-"):
                 order_direction = "DESC"
                 fragment = fragment[1:]
-            context = ExprParserContext()
+            context = HogQLContext()
             context.collect_values = collected_hogql_values
-            order_by_list.append(translate_hql(fragment, context) + " " + order_direction)
+            order_by_list.append(translate_hogql(fragment, context) + " " + order_direction)
     else:
         order_by_list.append(select_columns[0] + " ASC")
 

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -80,6 +80,7 @@ def query_events_list(
 ) -> Union[List, EventsQueryResponse]:
     # Note: This code is inefficient and problematic, see https://github.com/PostHog/posthog/issues/13485 for details.
     # To isolate its impact from rest of the queries its queries are run on different nodes as part of "offline" workloads.
+    hogql_context = HogQLContext()
 
     limit += 1
     limit_sql = "LIMIT %(limit)s"
@@ -95,7 +96,7 @@ def query_events_list(
         }
     )
     prop_filters, prop_filter_params = parse_prop_grouped_clauses(
-        team_id=team.pk, property_group=filter.property_groups, has_person_id_joined=False
+        team_id=team.pk, property_group=filter.property_groups, has_person_id_joined=False, hogql_context=hogql_context
     )
 
     if action_id:
@@ -135,7 +136,6 @@ def query_events_list(
 
     # events list v2 - hogql
 
-    hogql_context = HogQLContext()
     select_columns: List[str] = []
     group_by_columns: List[str] = []
     where_filters: List[str] = []

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -41,6 +41,7 @@ PropertyType = Literal[
     "recording",
     "behavioral",
     "session",
+    "hogql",
 ]
 
 PropertyName = str
@@ -92,6 +93,7 @@ VALIDATE_PROP_TYPES = {
     "recording": ["key", "value"],
     "behavioral": ["key", "value"],
     "session": ["key", "value"],
+    "hogql": ["key"],
 }
 
 VALIDATE_BEHAVIORAL_PROP_TYPES = {
@@ -224,6 +226,8 @@ class Property:
 
         if value is None and self.operator in ["is_set", "is_not_set"]:
             self.value = self.operator
+        elif self.type == "hogql":
+            pass  # keep value as None
         elif value is None:
             raise ValueError(f"Value must be set for property type {self.type} & operator {self.operator}")
         else:


### PR DESCRIPTION
## Problem

Bringing over a few refactors from https://github.com/PostHog/posthog/pull/13264

## Changes

- Rename `ExprParserContext` to `HogQLContext`, and `expr_parser.py` to `hogql.py`
- Add `type: 'hogql'` property filters
- Make these filters work in the events table (passed hogql context to `parse_prop_grouped_clauses`)
- Rename `BreakdownFilter` to `TaxonomicBreakdownFilter` to align with the filename
- Improve inline query editor placeholder with helpful hints

## How did you test this code?

- Wrote tests for the events endpoint
- Added filters manually in the interface