### PR TITLE
fix: Matching events filter

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -448,7 +448,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                         const isMatchingEvent = !!matchingEvents.find((x) => x.uuid === String(event.id))
 
-                        if (showOnlyMatching && tab === SessionRecordingPlayerTab.EVENTS) {
+                        if (matchingEvents.length && showOnlyMatching && tab === SessionRecordingPlayerTab.EVENTS) {
                             // Special case - overrides the others
                             include = include && isMatchingEvent
                         }

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -165,6 +165,13 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             },
         ],
 
+        showMatchingEventsFilter: [
+            (s) => [s.matchingEvents, s.tab],
+            (matchingEvents, tab): boolean => {
+                return tab === SessionRecordingPlayerTab.EVENTS && matchingEvents.length > 0
+            },
+        ],
+
         consoleLogs: [
             (s) => [s.sessionPlayerData],
             (sessionPlayerData): RecordingConsoleLogV2[] => {
@@ -221,6 +228,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 s.miniFiltersByKey,
                 s.matchingEvents,
                 s.showOnlyMatching,
+                s.showMatchingEventsFilter,
                 s.windowIdFilter,
             ],
             (
@@ -233,6 +241,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 miniFiltersByKey,
                 matchingEvents,
                 showOnlyMatching,
+                showMatchingEventsFilter,
                 windowIdFilter
             ): InspectorListItem[] => {
                 // NOTE: Possible perf improvement here would be to have a selector to parse the items
@@ -448,7 +457,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                         const isMatchingEvent = !!matchingEvents.find((x) => x.uuid === String(event.id))
 
-                        if (matchingEvents.length && showOnlyMatching && tab === SessionRecordingPlayerTab.EVENTS) {
+                        if (showMatchingEventsFilter && showOnlyMatching) {
                             // Special case - overrides the others
                             include = include && isMatchingEvent
                         }

--- a/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorControls.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorControls.tsx
@@ -27,16 +27,11 @@ const TabToIcon = {
     [SessionRecordingPlayerTab.NETWORK]: IconGauge,
 }
 
-export function PlayerInspectorControls({
-    sessionRecordingId,
-    playerKey,
-    matching,
-}: SessionRecordingPlayerLogicProps): JSX.Element {
-    const logicProps = { sessionRecordingId, playerKey }
-    const { windowIdFilter, tab, searchQuery, syncScroll, tabsState, windowIds } = useValues(
-        playerInspectorLogic(logicProps)
+export function PlayerInspectorControls(props: SessionRecordingPlayerLogicProps): JSX.Element {
+    const { windowIdFilter, tab, searchQuery, syncScroll, tabsState, windowIds, showMatchingEventsFilter } = useValues(
+        playerInspectorLogic(props)
     )
-    const { setWindowIdFilter, setTab, setSearchQuery, setSyncScroll } = useActions(playerInspectorLogic(logicProps))
+    const { setWindowIdFilter, setTab, setSearchQuery, setSyncScroll } = useActions(playerInspectorLogic(props))
     const { showOnlyMatching, timestampMode, miniFilters } = useValues(playerSettingsLogic)
     const { setShowOnlyMatching, setTimestampMode, setMiniFilter } = useActions(playerSettingsLogic)
 
@@ -175,7 +170,7 @@ export function PlayerInspectorControls({
                     </LemonButton>
                 </div>
             </div>
-            {matching?.length && tab === SessionRecordingPlayerTab.EVENTS ? (
+            {showMatchingEventsFilter ? (
                 <div className="flex items-center">
                     <span className="flex items-center whitespace-nowrap text-xs gap-1">
                         Only events matching filters

--- a/posthog/models/session_recording/session_recording.py
+++ b/posthog/models/session_recording/session_recording.py
@@ -208,6 +208,7 @@ class SessionRecording(UUIDModel):
             recording.keypress_count = ch_recording["keypress_count"]
             recording.duration = ch_recording["duration"]
             recording.distinct_id = ch_recording["distinct_id"]
+            recording.matching_events = ch_recording["matching_events"]
             recording.set_start_url_from_urls(ch_recording["urls"])
             recordings.append(recording)
 


### PR DESCRIPTION
## Problem

If we had the show only matching enabled then it would always filter out events, even if there is no filter set.

## Changes

Fixes this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 