### PR TITLE
feat: Use TZlabel for absolute time in recordings

### DIFF
--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -33,6 +33,7 @@ interface TZLabelRawProps {
     formatDate?: string
     formatTime?: string
     showPopover?: boolean
+    noStyles?: boolean
     className?: string
 }
 
@@ -43,6 +44,7 @@ function TZLabelRaw({
     formatDate,
     formatTime,
     showPopover = true,
+    noStyles = false,
     className,
 }: TZLabelRawProps): JSX.Element {
     usePeriodicRerender(1000)
@@ -56,7 +58,7 @@ function TZLabelRaw({
     const { reportTimezoneComponentViewed } = useActions(eventUsageLogic)
 
     const innerContent = (
-        <span className={clsx('tz-label', showPopover && 'tz-label--hoverable', className)}>
+        <span className={!noStyles ? clsx('tz-label', showPopover && 'tz-label--hoverable', className) : className}>
             {formatDate || formatTime
                 ? humanFriendlyDetailedTime(parsedTime, formatDate, formatTime)
                 : parsedTime.fromNow()}

--- a/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/PlayerInspectorList.tsx
@@ -25,6 +25,7 @@ import { LemonSkeleton } from 'lib/components/LemonSkeleton'
 import { userLogic } from 'scenes/userLogic'
 import { PayGatePage } from 'lib/components/PayGatePage/PayGatePage'
 import { IconWindow } from '../../icons'
+import { TZLabel } from '@posthog/apps-common'
 
 const typeToIconAndDescription = {
     [SessionRecordingPlayerTab.ALL]: {
@@ -184,7 +185,7 @@ function PlayerInspectorListItem({
                 >
                     <span className="p-1 text-xs">
                         {timestampMode === 'absolute' ? (
-                            <>{item.timestamp.format('DD MMM HH:mm:ss')}</>
+                            <TZLabel time={item.timestamp} formatDate="DD, MMM" formatTime="hh:mm:ss" noStyles />
                         ) : (
                             <>
                                 {item.timeInRecording < 0 ? (


### PR DESCRIPTION
## Problem

We weren't using the helpful TZLabel for the recording timestamp button

## Changes

* Adds it with a property to remove the styling of the component

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
👀 