### PR TITLE
feat: Increased size of modal for recordings

### DIFF
--- a/frontend/src/lib/components/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/components/LemonModal/LemonModal.scss
@@ -31,8 +31,9 @@
 .LemonModal {
     position: relative;
     max-width: 90%;
-    min-width: 30rem;
-    width: min-content;
+    width: fit-content;
+    min-width: min(30rem, 100%);
+    max-height: 90%;
     margin: 1rem auto;
     border-radius: var(--radius);
     background-color: #fff;
@@ -41,7 +42,6 @@
     transition: opacity var(--modal-transition-time) ease-out, transform var(--modal-transition-time) ease-out;
     display: flex;
     flex-direction: column;
-    max-height: 90%;
 
     // Transition properties
     will-change: transform;
@@ -108,6 +108,7 @@
 
 .LemonModal__footer {
     display: flex;
+    flex-wrap: wrap;
     justify-content: flex-end;
     gap: 0.5rem;
     border-top: 1px solid var(--border);

--- a/frontend/src/lib/components/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/components/LemonModal/LemonModal.scss
@@ -30,7 +30,7 @@
 
 .LemonModal {
     position: relative;
-    max-width: 80%;
+    max-width: 90%;
     min-width: 30rem;
     width: min-content;
     margin: 1rem auto;

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.scss
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.scss
@@ -56,7 +56,7 @@
 
     .SessionRecordingPlayer__inspector {
         border-top: 1px solid var(--border);
-        min-height: calc(100vh - 4rem);
+        min-height: 50rem;
     }
 
     &--widescreen {
@@ -72,12 +72,20 @@
             flex: 1;
             border-left: 1px solid var(--border);
             border-top: none;
+            min-height: auto;
         }
 
         .SessionRecordingPlayer__body {
             // Rough aproximation of the parent elements
             height: calc(100vh - 20rem);
             min-height: calc(100vh - 20rem);
+        }
+
+        .LemonModal & {
+            .SessionRecordingPlayer__body {
+                height: calc(90vh - 15rem);
+                min-height: auto;
+            }
         }
     }
 }

--- a/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
+++ b/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
@@ -17,7 +17,7 @@ export function SessionPlayerModal(): JSX.Element | null {
             onClose={closeSessionPlayer}
             simple
             title={''}
-            width={880}
+            width={1600}
             fullScreen={isFullScreen}
             closable={!isFullScreen}
         >


### PR DESCRIPTION
## Problem

We often have enough real-estate to show the widescreen version of the recording in a modal, but we don't...

## Changes

* Expand the width of the recording modal
* Set the height of the player to a more sensible height so there is less double-scrolling in the modal

![2023-01-19 10 26 27](https://user-images.githubusercontent.com/2536520/213405843-7cb34e86-39fa-449c-b07c-0954b629e302.gif)



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 