### PR TITLE
fix: Data management icon size

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
@@ -8,6 +8,7 @@
                 align-items: center;
                 justify-content: center;
                 width: 30px;
+                font-size: 1.5rem;
 
                 svg.taxonomy-icon {
                     flex-shrink: 0;


### PR DESCRIPTION
## Problem

The icons shrunk! Probably related to some of the overall standardisation of icon sizes

## Changes

|Before|After|
|----|----|
|<img width="306" alt="Screenshot 2023-01-19 at 11 46 49" src="https://user-images.githubusercontent.com/2536520/213422737-c4d1fb48-01d5-4375-b545-f6bd4d456a71.png">|<img width="333" alt="Screenshot 2023-01-19 at 11 46 54" src="https://user-images.githubusercontent.com/2536520/213422744-99f70769-7d0a-41a4-8a87-835933a9eac1.png">|

* Set the correct fontSize

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 