### PR TITLE
chore(tests): raise on clickhouse errors

### DIFF
--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -24,7 +24,7 @@ BASE_APP_METRICS_COLUMNS = """
 
 APP_METRICS_DATA_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE sharded_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE TABLE IF NOT EXISTS sharded_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     {BASE_APP_METRICS_COLUMNS}
     {KAFKA_COLUMNS_WITH_PARTITION}
@@ -38,7 +38,7 @@ ORDER BY (team_id, plugin_config_id, job_id, category, toStartOfHour(timestamp),
 
 DISTRIBUTED_APP_METRICS_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE TABLE IF NOT EXISTS app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     {BASE_APP_METRICS_COLUMNS}
     {KAFKA_COLUMNS_WITH_PARTITION}
@@ -49,7 +49,7 @@ ENGINE={Distributed(data_table="sharded_app_metrics", sharding_key="rand()")}
 
 KAFKA_APP_METRICS_TABLE_SQL = (
     lambda: f"""
-CREATE TABLE kafka_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE TABLE IF NOT EXISTS kafka_app_metrics ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 (
     team_id Int64,
     timestamp DateTime64(6, 'UTC'),
@@ -69,7 +69,7 @@ ENGINE={kafka_engine(topic=KAFKA_APP_METRICS)}
 
 APP_METRICS_MV_TABLE_SQL = (
     lambda: f"""
-CREATE MATERIALIZED VIEW app_metrics_mv ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
+CREATE MATERIALIZED VIEW IF NOT EXISTS app_metrics_mv ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'
 TO {settings.CLICKHOUSE_DATABASE}.sharded_app_metrics
 AS SELECT
 team_id,


### PR DESCRIPTION
Previously we were silently failing on some mutations in tests, which
makes it tricky to debug. This change raises on any errors from threads
used to execute the mutations.

As a result, it highlighted that we try to create app_metric tables over
and again, so I've made them all `IF NOT EXISTS` to avoid errors.

This was highlighed when I was trying to test the table mutations in https://github.com/PostHog/posthog/pull/13753

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
