### PR TITLE
fix: Show "pressed" for touch autocapture

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -693,6 +693,10 @@ export function autoCaptureEventToDescription(
         if (event.properties.$event_type === 'submit') {
             return 'submitted'
         }
+
+        if (event.properties.$event_type === 'touch') {
+            return 'pressed'
+        }
         return 'interacted with'
     }
 


### PR DESCRIPTION
## Problem

Noticed whilst working on RN autocapture that we don't display it properly

## Changes

Adds "pressed" instead of "interacted with".

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't....