### PR TITLE
chore(clickhouse): update from 22.3 to 22.8

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -201,7 +201,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.8.14']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:22.3']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:22.8']
                 segment: ['FOSS', 'EE']
                 person-on-events: [false, true]
                 # :NOTE: Keep concurrency and groups in sync

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -24,7 +24,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:22.3}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:22.8}
         restart: on-failure
         depends_on:
             - kafka


### PR DESCRIPTION
We're updated both in production and [in the Helm
chart](https://github.com/PostHog/charts-clickhouse/pull/663) so I guess
we also want to update here as well?

The thing that brought my here was wanting to use [`EMPTY
AS`](https://github.com/ClickHouse/ClickHouse/pull/38272)

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
