### PR TITLE
chore(tests): add timeout to join, satisfy Liskov substitution

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -571,8 +571,8 @@ class RaiseOnJoinThread(threading.Thread):
         except BaseException as e:
             self.exc = e
 
-    def join(self):
-        super().join()
+    def join(self, timeout=None):
+        super().join(timeout=timeout)
         if self.exc:
             raise self.exc
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -557,39 +557,38 @@ class ClickhouseTestMixin(QueryMatchingTest):
             yield queries
 
 
-class RaiseOnJoinThread(threading.Thread):
+@contextmanager
+def threadhook_context():
     """
-    By default, the thread will swallow exceptions and not raise them in the
-    main thread. This class will raise them in the main thread such that we do
-    not fail silently e.g. on failures to apply ClickHouse schemas.
+    Context manager to ensure that exceptions raised by threads are propagated
+    to the main thread.
     """
 
-    def run(self):
-        self.exc = None
-        try:
-            super().run()
-        except BaseException as e:
-            self.exc = e
+    def raise_hook(exc_type, exc_value, exc_traceback, thread):
+        raise exc_value
 
-    def join(self, timeout=None):
-        super().join(timeout=timeout)
-        if self.exc:
-            raise self.exc
+    old_hook, threading.excepthook = threading.excepthook, raise_hook
+    try:
+        yield old_hook
+    finally:
+        assert threading.excepthook is raise_hook
+        threading.excepthook = old_hook
 
 
 def run_clickhouse_statement_in_parallel(statements: List[str]):
     jobs = []
-    for item in statements:
-        thread = RaiseOnJoinThread(target=sync_execute, args=(item,))
-        jobs.append(thread)
+    with threadhook_context():
+        for item in statements:
+            thread = threading.Thread(target=sync_execute, args=(item,))
+            jobs.append(thread)
 
-    # Start the threads (i.e. calculate the random number lists)
-    for j in jobs:
-        j.start()
+        # Start the threads (i.e. calculate the random number lists)
+        for j in jobs:
+            j.start()
 
-    # Ensure all of the threads have finished
-    for j in jobs:
-        j.join()
+        # Ensure all of the threads have finished
+        for j in jobs:
+            j.join()
 
 
 class ClickhouseDestroyTablesMixin(BaseTest):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -558,10 +558,10 @@ class ClickhouseTestMixin(QueryMatchingTest):
 
 
 @contextmanager
-def threadhook_context():
+def failhard_threadhook_context():
     """
-    Context manager to ensure that exceptions raised by threads are propagated
-    to the main thread.
+    Context manager to ensure that exceptions raised by threads are treated as a
+    test failure.
     """
 
     def raise_hook(exc_type, exc_value, exc_traceback, thread):
@@ -577,7 +577,7 @@ def threadhook_context():
 
 def run_clickhouse_statement_in_parallel(statements: List[str]):
     jobs = []
-    with threadhook_context():
+    with failhard_threadhook_context():
         for item in statements:
             thread = threading.Thread(target=sync_execute, args=(item,))
             jobs.append(thread)


### PR DESCRIPTION
I'd changed this in another PR to add exception handling, but did not
make sure the overridden method had the same signature. This fixes that.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
