### PR TITLE
feat: Moved Tooltip to top level and added descriptions to expanded area

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemPerformanceEvent.tsx
@@ -7,7 +7,6 @@ import { SimpleKeyValueList } from './SimpleKeyValueList'
 import { Tooltip } from 'lib/components/Tooltip'
 import { Fragment } from 'react'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
-import { IconInfo } from 'lib/components/icons'
 
 export interface ItemPerformanceEvent {
     item: PerformanceEvent
@@ -158,30 +157,27 @@ export function ItemPerformanceEvent({
                                 {performanceSummaryCards.map(({ label, description, key, scoreBenchmarks }, index) => (
                                     <Fragment key={key}>
                                         {index !== 0 && <LemonDivider vertical dashed />}
-                                        <div className="flex-1 p-2 text-center">
-                                            <div className="text-sm">
-                                                {label}
-                                                <Tooltip isDefaultTooltip title={description}>
-                                                    <IconInfo className="text-xl text-muted" />
-                                                </Tooltip>
+                                        <Tooltip isDefaultTooltip title={description}>
+                                            <div className="flex-1 p-2 text-center">
+                                                <div className="text-sm">{label}</div>
+                                                <div className="text-lg font-semibold">
+                                                    {item?.[key] === undefined ? (
+                                                        '-'
+                                                    ) : (
+                                                        <span
+                                                            className={clsx({
+                                                                'text-danger-dark': item[key] >= scoreBenchmarks[1],
+                                                                'text-warning-dark':
+                                                                    item[key] >= scoreBenchmarks[0] &&
+                                                                    item[key] < scoreBenchmarks[1],
+                                                            })}
+                                                        >
+                                                            {humanFriendlyMilliseconds(item[key])}
+                                                        </span>
+                                                    )}
+                                                </div>
                                             </div>
-                                            <div className="text-lg font-semibold">
-                                                {item?.[key] === undefined ? (
-                                                    '-'
-                                                ) : (
-                                                    <span
-                                                        className={clsx({
-                                                            'text-danger-dark': item[key] >= scoreBenchmarks[1],
-                                                            'text-warning-dark':
-                                                                item[key] >= scoreBenchmarks[0] &&
-                                                                item[key] < scoreBenchmarks[1],
-                                                        })}
-                                                    >
-                                                        {humanFriendlyMilliseconds(item[key])}
-                                                    </span>
-                                                )}
-                                            </div>
-                                        </div>
+                                        </Tooltip>
                                     </Fragment>
                                 ))}
                             </div>
@@ -211,23 +207,54 @@ export function ItemPerformanceEvent({
                     <CodeSnippet language={Language.Markup} wrap copyDescription="performance event name">
                         {item.name}
                     </CodeSnippet>
-                    <p>
-                        Request started at <b>{humanFriendlyMilliseconds(item.start_time || item.fetch_start)}</b> and
-                        took <b>{humanFriendlyMilliseconds(item.duration)}</b>
-                        {item.decoded_body_size ? (
-                            <>
-                                {' '}
-                                to load <b>{humanizeBytes(item.decoded_body_size)}</b> of data
-                            </>
-                        ) : null}
-                        {compressionPercentage && item.encoded_body_size ? (
-                            <>
-                                , compressed to <b>{humanizeBytes(item.encoded_body_size)}</b> saving{' '}
-                                <b>{compressionPercentage.toFixed(1)}%</b>
-                            </>
-                        ) : null}
-                        .
-                    </p>
+
+                    {item.entry_type === 'navigation' ? (
+                        <>
+                            {performanceSummaryCards.map(({ label, description, key, scoreBenchmarks }) => (
+                                <div key={key}>
+                                    <div className="flex gap-2 font-semibold my-1">
+                                        <span>{label}</span>
+                                        <span>
+                                            {item?.[key] === undefined ? (
+                                                '-'
+                                            ) : (
+                                                <span
+                                                    className={clsx({
+                                                        'text-danger-dark': item[key] >= scoreBenchmarks[1],
+                                                        'text-warning-dark':
+                                                            item[key] >= scoreBenchmarks[0] &&
+                                                            item[key] < scoreBenchmarks[1],
+                                                    })}
+                                                >
+                                                    {humanFriendlyMilliseconds(item[key])}
+                                                </span>
+                                            )}
+                                        </span>
+                                    </div>
+
+                                    <p>{description}</p>
+                                </div>
+                            ))}
+                        </>
+                    ) : (
+                        <p>
+                            Request started at <b>{humanFriendlyMilliseconds(item.start_time || item.fetch_start)}</b>{' '}
+                            and took <b>{humanFriendlyMilliseconds(item.duration)}</b>
+                            {item.decoded_body_size ? (
+                                <>
+                                    {' '}
+                                    to load <b>{humanizeBytes(item.decoded_body_size)}</b> of data
+                                </>
+                            ) : null}
+                            {compressionPercentage && item.encoded_body_size ? (
+                                <>
+                                    , compressed to <b>{humanizeBytes(item.encoded_body_size)}</b> saving{' '}
+                                    <b>{compressionPercentage.toFixed(1)}%</b>
+                                </>
+                            ) : null}
+                            .
+                        </p>
+                    )}
 
                     <LemonDivider dashed />
                     <SimpleKeyValueList item={sanitizedProps} />


### PR DESCRIPTION
## Problem

We want to give people quick hints about what the key network info means but the use of an Info icon in this case both looks off and is tricky to trigger.

## Changes

* Make the Tooltip based on hovering over the metric overall
* Add the expanded descriptions to the expanded state

|Before|After|
|----|----|
|<img width="626" alt="Screenshot 2023-01-20 at 10 03 16" src="https://user-images.githubusercontent.com/2536520/213656930-7a1d577c-4ef8-42c0-9fc7-b5eb49d663ab.png">|<img width="590" alt="Screenshot 2023-01-20 at 10 02 56" src="https://user-images.githubusercontent.com/2536520/213656927-d8046cd0-6839-47be-aaf2-b904a3970e8c.png">|
|<img width="660" alt="Screenshot 2023-01-20 at 10 03 00" src="https://user-images.githubusercontent.com/2536520/213656932-94915661-4428-4584-879e-77b66755fcd1.png">|<img width="651" alt="Screenshot 2023-01-20 at 10 03 21" src="https://user-images.githubusercontent.com/2536520/213656928-66541af1-6819-4148-a1a3-501d31b36a7d.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
