### PR TITLE
Publish playwright to github pages

### DIFF
--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -6,6 +6,9 @@ on:
         branches:
             - master
 
+permissions:
+    pages: write
+
 jobs:
     playwright:
         name: Visual Regression Tests

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -6,6 +6,11 @@ on:
         branches:
             - master
 
+permissions:
+    id-token: write
+    contents: read
+    pages: write
+
 jobs:
     playwright:
         name: Visual Regression Tests

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -9,6 +9,7 @@ on:
 permissions:
     id-token: write
     pages: write
+    contents: read
 
 jobs:
     playwright:
@@ -17,57 +18,46 @@ jobs:
         container:
             image: mcr.microsoft.com/playwright:v1.28.1-focal
         steps:
-            # - uses: actions/checkout@v3
+            - uses: actions/checkout@v3
 
-            # - name: Install pnpm
-            #   uses: pnpm/action-setup@v2
-            #   with:
-            #       version: 7.x.x
+            - name: Install pnpm
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 7.x.x
 
-            # - name: Set up Node.js
-            #   uses: actions/setup-node@v3
-            #   with:
-            #       node-version: 18
-            #       cache: pnpm
+            - name: Set up Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+                  cache: pnpm
 
-            # - name: Install package.json dependencies with pnpm
-            #   run: pnpm install --frozen-lockfile
+            - name: Install package.json dependencies with pnpm
+              run: pnpm install --frozen-lockfile
 
-            # - name: Install CI utilities with pnpm
-            #   run: pnpm install concurrently http-server wait-on
+            - name: Install CI utilities with pnpm
+              run: pnpm install concurrently http-server wait-on
 
-            # - name: Build Storybook
-            #   run: pnpm build-storybook --quiet
+            - name: Build Storybook
+              run: pnpm build-storybook --quiet
 
-            # - name: Serve Storybook and run tests
-            #   run: |
-            #       pnpm exec concurrently -k -s first -n "SRVR,TEST" -c "magenta,blue" \
-            #         "pnpm exec http-server storybook-static --port 6006" \
-            #         "pnpm exec wait-on http://127.0.0.1:6006 --timeout 60 && pnpm exec playwright test"
-
-            # - name: Upload Playwright report
-            #   uses: actions/upload-artifact@v3
-            #   if: always()
-            #   with:
-            #       name: playwright-report
-            #       path: |
-            #           playwright-report/
-            #           test-results/
-            #       retention-days: 7
+            - name: Serve Storybook and run tests
+              run: |
+                  pnpm exec concurrently -k -s first -n "SRVR,TEST" -c "magenta,blue" \
+                    "pnpm exec http-server storybook-static --port 6006" \
+                    "pnpm exec wait-on http://127.0.0.1:6006 --timeout 60 && pnpm exec playwright test"
 
             - name: Setup Pages
               if: always()
               uses: actions/configure-pages@v2
-
-            - name: add example file
-              run: echo "Hello World" > example.txt
 
             - name: Upload artifact
               if: always()
               uses: actions/upload-pages-artifact@v1
               with:
                   # Upload entire coverage folder
-                  path: ./
+                  path: |
+                      playwright-report/
+                      test-results/
 
             - name: Deploy to GitHub Pages
               if: always()

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -50,3 +50,21 @@ jobs:
                       playwright-report/
                       test-results/
                   retention-days: 7
+
+            - name: Setup Pages
+              if: always()
+              uses: actions/configure-pages@v2
+
+            - name: Upload artifact
+              if: always()
+              uses: actions/upload-pages-artifact@v1
+              with:
+                  # Upload entire coverage folder
+                  path: |
+                      playwright-report/
+                      test-results/
+
+            - name: Deploy to GitHub Pages
+              if: always()
+              id: deployment
+              uses: actions/deploy-pages@v1

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -66,8 +66,7 @@ jobs:
               uses: actions/upload-pages-artifact@v1
               with:
                   # Upload entire coverage folder
-                  path: |
-                      example.txt
+                  path: ./
 
             - name: Deploy to GitHub Pages
               if: always()

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -6,11 +6,6 @@ on:
         branches:
             - master
 
-permissions:
-    id-token: write
-    pages: write
-    contents: read
-
 jobs:
     playwright:
         name: Visual Regression Tests
@@ -46,20 +41,64 @@ jobs:
                     "pnpm exec http-server storybook-static --port 6006" \
                     "pnpm exec wait-on http://127.0.0.1:6006 --timeout 60 && pnpm exec playwright test"
 
-            - name: Setup Pages
+            - name: Upload Playwright report
+              uses: actions/upload-artifact@v3
               if: always()
-              uses: actions/configure-pages@v2
-
-            - name: Upload artifact
-              if: always()
-              uses: actions/upload-pages-artifact@v1
               with:
-                  # Upload entire coverage folder
+                  name: playwright-report
                   path: |
                       playwright-report/
                       test-results/
+                  retention-days: 7
 
-            - name: Deploy to GitHub Pages
-              if: always()
-              id: deployment
-              uses: actions/deploy-pages@v1
+    publish_report:
+        name: Publish HTML Report
+        # using always() is not ideal here, because it would also run if the workflow was cancelled
+        if: "success() || needs.playwright.result == 'failure'"
+        needs: [playwright]
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        env:
+            # Unique URL path for each workflow run attempt
+            HTML_REPORT_URL_PATH: reports/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
+        steps:
+            - name: Checkout GitHub Pages Branch
+              uses: actions/checkout@v2
+              with:
+                  ref: gh-pages
+            - name: Set Git User
+              # see: https://github.com/actions/checkout/issues/13#issuecomment-724415212
+              run: |
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            - name: Download zipped HTML report
+              uses: actions/download-artifact@v2
+              with:
+                  name: playwright-report
+                  path: ${{ env.HTML_REPORT_URL_PATH }}
+            - name: Push HTML Report
+              timeout-minutes: 3
+              # commit report, then try push-rebase-loop until it's able to merge the HTML report to the gh-pages branch
+              # this is necessary when this job is running at least twice at the same time (e.g. through two pushes at the same time)
+              run: |
+                  git add .
+                  git commit -m "workflow: add HTML report for run-id ${{ github.run_id }} (attempt:  ${{ github.run_attempt }})"
+
+                  while true; do
+                    git pull --rebase
+                    if [ $? -ne 0 ]; then
+                      echo "Failed to rebase. Please review manually."
+                      exit 1
+                    fi
+
+                    git push
+                    if [ $? -eq 0 ]; then
+                      echo "Successfully pushed HTML report to repo."
+                      exit 0
+                    fi
+                  done
+            - name: Output Report URL as Worfklow Annotation
+              run: |
+                  FULL_HTML_REPORT_URL=https://ysfaran.github.io/playwright-gh-actions-gh-pages/$HTML_REPORT_URL_PATH
+
+                  echo "::notice title=📋 Published Playwright Test Report::$FULL_HTML_REPORT_URL"

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -7,6 +7,7 @@ on:
             - master
 
 permissions:
+    id-token: write
     pages: write
 
 jobs:

--- a/.github/workflows/ci-e2e-vrt.yml
+++ b/.github/workflows/ci-e2e-vrt.yml
@@ -13,47 +13,50 @@ jobs:
         container:
             image: mcr.microsoft.com/playwright:v1.28.1-focal
         steps:
-            - uses: actions/checkout@v3
+            # - uses: actions/checkout@v3
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@v2
-              with:
-                  version: 7.x.x
+            # - name: Install pnpm
+            #   uses: pnpm/action-setup@v2
+            #   with:
+            #       version: 7.x.x
 
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-                  cache: pnpm
+            # - name: Set up Node.js
+            #   uses: actions/setup-node@v3
+            #   with:
+            #       node-version: 18
+            #       cache: pnpm
 
-            - name: Install package.json dependencies with pnpm
-              run: pnpm install --frozen-lockfile
+            # - name: Install package.json dependencies with pnpm
+            #   run: pnpm install --frozen-lockfile
 
-            - name: Install CI utilities with pnpm
-              run: pnpm install concurrently http-server wait-on
+            # - name: Install CI utilities with pnpm
+            #   run: pnpm install concurrently http-server wait-on
 
-            - name: Build Storybook
-              run: pnpm build-storybook --quiet
+            # - name: Build Storybook
+            #   run: pnpm build-storybook --quiet
 
-            - name: Serve Storybook and run tests
-              run: |
-                  pnpm exec concurrently -k -s first -n "SRVR,TEST" -c "magenta,blue" \
-                    "pnpm exec http-server storybook-static --port 6006" \
-                    "pnpm exec wait-on http://127.0.0.1:6006 --timeout 60 && pnpm exec playwright test"
+            # - name: Serve Storybook and run tests
+            #   run: |
+            #       pnpm exec concurrently -k -s first -n "SRVR,TEST" -c "magenta,blue" \
+            #         "pnpm exec http-server storybook-static --port 6006" \
+            #         "pnpm exec wait-on http://127.0.0.1:6006 --timeout 60 && pnpm exec playwright test"
 
-            - name: Upload Playwright report
-              uses: actions/upload-artifact@v3
-              if: always()
-              with:
-                  name: playwright-report
-                  path: |
-                      playwright-report/
-                      test-results/
-                  retention-days: 7
+            # - name: Upload Playwright report
+            #   uses: actions/upload-artifact@v3
+            #   if: always()
+            #   with:
+            #       name: playwright-report
+            #       path: |
+            #           playwright-report/
+            #           test-results/
+            #       retention-days: 7
 
             - name: Setup Pages
               if: always()
               uses: actions/configure-pages@v2
+
+            - name: add example file
+              run: echo "Hello World" > example.txt
 
             - name: Upload artifact
               if: always()
@@ -61,8 +64,7 @@ jobs:
               with:
                   # Upload entire coverage folder
                   path: |
-                      playwright-report/
-                      test-results/
+                      example.txt
 
             - name: Deploy to GitHub Pages
               if: always()

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -238,3 +238,55 @@ jobs:
                   if-no-files-found: warn
                   retention-days: 1
                   path: 'plugin-server/coverage'
+
+    publish-coverage:
+        name: Publish HTML Report
+        # using always() is not ideal here, because it would also run if the workflow was cancelled
+        if: "success() || needs.functional-tests.result == 'failure'"
+        needs: [functional-tests]
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        env:
+            # Unique URL path for each workflow run attempt
+            HTML_REPORT_URL_PATH: plugin-server/functional-tests/coverage/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
+        steps:
+            - name: Checkout GitHub Pages Branch
+              uses: actions/checkout@v2
+              with:
+                  ref: gh-pages
+            - name: Set Git User
+              # see: https://github.com/actions/checkout/issues/13#issuecomment-724415212
+              run: |
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            - name: Download zipped HTML report
+              uses: actions/download-artifact@v2
+              with:
+                  name: functional-coverage
+                  path: ${{ env.HTML_REPORT_URL_PATH }}
+            - name: Push HTML Report
+              timeout-minutes: 3
+              # commit report, then try push-rebase-loop until it's able to merge the HTML report to the gh-pages branch
+              # this is necessary when this job is running at least twice at the same time (e.g. through two pushes at the same time)
+              run: |
+                  git add .
+                  git commit -m "workflow: add HTML report for run-id ${{ github.run_id }} (attempt:  ${{ github.run_attempt }})"
+
+                  while true; do
+                    git pull --rebase
+                    if [ $? -ne 0 ]; then
+                      echo "Failed to rebase. Please review manually."
+                      exit 1
+                    fi
+
+                    git push
+                    if [ $? -eq 0 ]; then
+                      echo "Successfully pushed HTML report to repo."
+                      exit 0
+                    fi
+                  done
+            - name: Output Report URL as Worfklow Annotation
+              run: |
+                  FULL_HTML_REPORT_URL=https://posthog.github.io/$HTML_REPORT_URL_PATH
+
+                  echo "::notice title=📋 Published Coverage Test Report::$FULL_HTML_REPORT_URL"

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -169,9 +169,6 @@ jobs:
             - name: Code check out
               uses: actions/checkout@v3
 
-            - name: Setup Pages
-              uses: actions/configure-pages@v2
-
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker compose -f docker-compose.dev.yml down
@@ -233,14 +230,11 @@ jobs:
                   cd plugin-server
                   ./bin/ci_functional_tests.sh
 
-            - name: Upload artifact
+            - name: Upload coverage report
+              uses: actions/upload-artifact@v3
               if: always()
-              uses: actions/upload-pages-artifact@v1
               with:
-                  # Upload entire coverage folder
+                  name: functional-coverage
+                  if-no-files-found: warn
+                  retention-days: 1
                   path: 'plugin-server/coverage'
-
-            - name: Deploy to GitHub Pages
-              if: always()
-              id: deployment
-              uses: actions/deploy-pages@v1

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -169,6 +169,9 @@ jobs:
             - name: Code check out
               uses: actions/checkout@v3
 
+            - name: Setup Pages
+              uses: actions/configure-pages@v2
+
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker compose -f docker-compose.dev.yml down
@@ -230,65 +233,14 @@ jobs:
                   cd plugin-server
                   ./bin/ci_functional_tests.sh
 
-            - name: Upload coverage report
-              uses: actions/upload-artifact@v3
+            - name: Upload artifact
               if: always()
+              uses: actions/upload-pages-artifact@v1
               with:
-                  name: functional-coverage
-                  if-no-files-found: warn
-                  retention-days: 1
+                  # Upload entire coverage folder
                   path: 'plugin-server/coverage'
 
-    publish-coverage:
-        # Publishes coverage reports to GitHub Pages. This is largely ripped from
-        # https://ysfaran.github.io/blog/2022/09/02/playwright-gh-action-gh-pages/
-        name: Publish Coverage HTML Report
-        # using always() is not ideal here, because it would also run if the workflow was cancelled
-        if: "success() || needs.functional-tests.result == 'failure'"
-        needs: [functional-tests]
-        runs-on: ubuntu-latest
-        continue-on-error: true
-        env:
-            # Unique URL path for each workflow run attempt
-            HTML_REPORT_URL_PATH: plugin-server/functional-tests/coverage/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
-        steps:
-            - name: Checkout GitHub Pages Branch
-              uses: actions/checkout@v2
-              with:
-                  ref: gh-pages
-            - name: Set Git User
-              # see: https://github.com/actions/checkout/issues/13#issuecomment-724415212
-              run: |
-                  git config --global user.name "github-actions[bot]"
-                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            - name: Download zipped HTML report
-              uses: actions/download-artifact@v2
-              with:
-                  name: functional-coverage
-                  path: ${{ env.HTML_REPORT_URL_PATH }}
-            - name: Push HTML Report
-              timeout-minutes: 3
-              # commit report, then try push-rebase-loop until it's able to merge the HTML report to the gh-pages branch
-              # this is necessary when this job is running at least twice at the same time (e.g. through two pushes at the same time)
-              run: |
-                  git add .
-                  git commit -m "workflow: add HTML report for run-id ${{ github.run_id }} (attempt:  ${{ github.run_attempt }})"
-
-                  while true; do
-                    git pull --rebase
-                    if [ $? -ne 0 ]; then
-                      echo "Failed to rebase. Please review manually."
-                      exit 1
-                    fi
-
-                    git push
-                    if [ $? -eq 0 ]; then
-                      echo "Successfully pushed HTML report to repo."
-                      exit 0
-                    fi
-                  done
-            - name: Output Report URL as Worfklow Annotation
-              run: |
-                  FULL_HTML_REPORT_URL=https://posthog.github.io/$HTML_REPORT_URL_PATH
-
-                  echo "::notice title=📋 Published Coverage Test Report::$FULL_HTML_REPORT_URL"
+            - name: Deploy to GitHub Pages
+              if: always()
+              id: deployment
+              uses: actions/deploy-pages@v1

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -240,7 +240,9 @@ jobs:
                   path: 'plugin-server/coverage'
 
     publish-coverage:
-        name: Publish HTML Report
+        # Publishes coverage reports to GitHub Pages. This is largely ripped from
+        # https://ysfaran.github.io/blog/2022/09/02/playwright-gh-action-gh-pages/
+        name: Publish Coverage HTML Report
         # using always() is not ideal here, because it would also run if the workflow was cancelled
         if: "success() || needs.functional-tests.result == 'failure'"
         needs: [functional-tests]


### PR DESCRIPTION
Uses GitHub Pages to publish the test coverage report for the
plugin-server functional tests. I was originally going to do this for
Playwright as the output from the failures here was super obvious what
the problem was when it was failing, but I've also wanted to do this for
coverage and it doesn't tread on too many toes.

Very much a wip, it's based on https://ysfaran.github.io/blog/2022/09/02/playwright-gh-action-gh-pages/

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
