### PR TITLE
fix: Recording buffer calculation

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -79,8 +79,8 @@ describe('sessionRecordingDataLogic', () => {
                 person: recordingMetaJson.person,
                 metadata: parseMetadataResponse(recordingMetaJson),
                 bufferedTo: {
-                    time: 44579,
-                    windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                    time: 167777,
+                    windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                 },
                 next: undefined,
                 snapshotsByWindowId: recordingSnapshotsJson.snapshot_data_by_window_id,
@@ -439,8 +439,8 @@ describe('sessionRecordingDataLogic', () => {
                         person: recordingMetaJson.person,
                         metadata: parseMetadataResponse(recordingMetaJson),
                         bufferedTo: {
-                            time: 44579,
-                            windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                            time: 167777,
+                            windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                         },
                         next: undefined,
                         snapshotsByWindowId: recordingSnapshotsJson.snapshot_data_by_window_id,
@@ -485,8 +485,8 @@ describe('sessionRecordingDataLogic', () => {
                     person: recordingMetaJson.person,
                     metadata: parseMetadataResponse(recordingMetaJson),
                     bufferedTo: {
-                        time: 44579,
-                        windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                        time: 167777,
+                        windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                     },
                     snapshotsByWindowId: {
                         '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f': snapsWindow1,
@@ -505,8 +505,8 @@ describe('sessionRecordingDataLogic', () => {
                         person: recordingMetaJson.person,
                         metadata: parseMetadataResponse(recordingMetaJson),
                         bufferedTo: {
-                            time: 44579,
-                            windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                            time: 167777,
+                            windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                         },
                         snapshotsByWindowId: {
                             '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f': [
@@ -566,8 +566,8 @@ describe('sessionRecordingDataLogic', () => {
                     person: recordingMetaJson.person,
                     metadata: parseMetadataResponse(recordingMetaJson),
                     bufferedTo: {
-                        time: 44579,
-                        windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                        time: 167777,
+                        windowId: '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                     },
                     snapshotsByWindowId: {
                         '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f': snapsWindow1,

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -87,23 +87,23 @@ const calculateBufferedTo = (
 ): PlayerPosition | null => {
     let bufferedTo: PlayerPosition | null = null
     // If we don't have metadata or snapshots yet, then we can't calculate the bufferedTo.
-    if (segments && snapshotsByWindowId && startAndEndTimesByWindowId) {
-        for (const segment of segments) {
-            const lastEventForWindowId = (snapshotsByWindowId[segment.windowId] ?? []).slice(-1).pop()
+    if (!segments || !snapshotsByWindowId || !startAndEndTimesByWindowId) {
+        return bufferedTo
+    }
 
-            if (lastEventForWindowId && lastEventForWindowId.timestamp >= segment.startTimeEpochMs) {
-                // If we've buffered past the start of the segment, see how far.
-                const windowStartTime = startAndEndTimesByWindowId[segment.windowId].startTimeEpochMs
-                bufferedTo = {
-                    windowId: segment.windowId,
-                    time: Math.min(lastEventForWindowId.timestamp - windowStartTime, segment.endPlayerPosition.time),
-                }
-            } else {
-                // If we haven't buffered past the start of the segment, then return our current bufferedTo.
-                return bufferedTo
+    for (const segment of segments) {
+        const lastEventForWindowId = (snapshotsByWindowId[segment.windowId] ?? []).slice(-1).pop()
+
+        if (lastEventForWindowId && lastEventForWindowId.timestamp >= segment.startTimeEpochMs) {
+            // If we've buffered past the start of the segment, see how far.
+            const windowStartTime = startAndEndTimesByWindowId[segment.windowId].startTimeEpochMs
+            bufferedTo = {
+                windowId: segment.windowId,
+                time: Math.min(lastEventForWindowId.timestamp - windowStartTime, segment.endPlayerPosition.time),
             }
         }
     }
+
     return bufferedTo
 }
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -374,6 +374,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
         loadRecordingSnapshotsFailure: () => {
             if (Object.keys(values.sessionPlayerData.snapshotsByWindowId).length === 0) {
+                console.error('PostHog Recording Playback Error: No snapshots loaded')
                 actions.setErrorPlayerState(true)
             }
         },
@@ -453,6 +454,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             ) {
                 values.player?.replayer?.pause()
                 actions.endBuffer()
+                console.error("Error: Player tried to seek to a position that hasn't loaded yet")
                 actions.setErrorPlayerState(true)
             }
 
@@ -583,6 +585,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             ) {
                 values.player?.replayer?.pause()
                 actions.endBuffer()
+                console.error('PostHog Recording Playback Error: Tried to access snapshot that is not loaded yet')
                 actions.setErrorPlayerState(true)
             }
 


### PR DESCRIPTION
## Problem

Customer reported an issue where the buffering would stop half way through. This seems to be somehow related to the fact that when swapping between windows, the calculated window of the segment is slightly bigger than that of the snapshot.

## Changes

* Instead of returning, we continue to loop until we find the latest point buffered to

NOTE: There is probably a different issue to be investigated as to why these numbers off. I added some console.errors so it is easier to know which error is the reason for a buffering issue next time.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
