### PR TITLE
fix: Refactor person merging do less within a transaction

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -569,7 +569,7 @@ export class PersonState {
             }
 
             failedAttempts++
-            if (failedAttempts === MAX_FAILED_PERSON_MERGE_ATTEMPTS) {
+            if (failedAttempts >= MAX_FAILED_PERSON_MERGE_ATTEMPTS) {
                 throw error // Very much not OK, failed repeatedly so rethrowing the error
             }
 

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -4,7 +4,7 @@ import equal from 'fast-deep-equal'
 import { StatsD } from 'hot-shots'
 import { ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
-import { DatabaseError, PoolClient } from 'pg'
+import { PoolClient } from 'pg'
 
 import { Person, PropertyUpdateOperation } from '../../types'
 import { DB } from '../../utils/db/db'
@@ -564,10 +564,6 @@ export class PersonState {
             // :KLUDGE: Avoid unneeded fetches in updateProperties()
             this.personContainer = this.personContainer.with(mergedPerson)
         } catch (error) {
-            if (!(error instanceof DatabaseError)) {
-                throw error // Very much not OK, this is some completely unexpected error
-            }
-
             failedAttempts++
             if (failedAttempts >= MAX_FAILED_PERSON_MERGE_ATTEMPTS) {
                 throw error // Very much not OK, failed repeatedly so rethrowing the error

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -365,7 +365,7 @@ export class PersonState {
         )
     }
 
-    private async aliasDeprecated(
+    public async aliasDeprecated(
         previousDistinctId: string,
         distinctId: string,
         teamId: number,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
If we hit retries before we would still send the kafka messages. Plus we would do all this inside the postgres transaction, which we shouldn't.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
