### PR TITLE
feat: more warnings on common test account filter mistakes

### DIFF
--- a/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/project/Settings/TestAccountFiltersConfig.tsx
@@ -11,7 +11,8 @@ import { AlertMessage } from 'lib/components/AlertMessage'
 export function TestAccountFiltersConfig(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { reportTestAccountFiltersUpdated } = useActions(eventUsageLogic)
-    const { currentTeam, currentTeamLoading, testAccountFilterWarningLabels } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading, testAccountFilterWarningLabels, testAccountFilterFrequentMistakes } =
+        useValues(teamLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const handleChange = (filters: AnyPropertyFilter[]): void => {
@@ -34,6 +35,18 @@ export function TestAccountFiltersConfig(): JSX.Element {
                             {testAccountFilterWarningLabels.map((l, i) => (
                                 <li key={i} className="ml-4">
                                     {l}
+                                </li>
+                            ))}
+                        </ul>
+                    </AlertMessage>
+                )}
+                {!!testAccountFilterFrequentMistakes && testAccountFilterFrequentMistakes.length > 0 && (
+                    <AlertMessage type="warning" className="m-2">
+                        <p>Your filter contains a setting that is likely to exclude or include unexpected users.</p>
+                        <ul className="list-disc">
+                            {testAccountFilterFrequentMistakes.map(({ key, type, fix }, i) => (
+                                <li key={i} className="ml-4">
+                                    {key} is a {type} property, but {fix}.
                                 </li>
                             ))}
                         </ul>

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -23,7 +23,7 @@ const parseUpdatedAttributeName = (attr: string | null): string => {
     return attr ? identifierToHuman(attr) : 'Project'
 }
 
-interface FrequentMistakeAdvice {
+export interface FrequentMistakeAdvice {
     key: string
     type: 'event' | 'person'
     fix: string

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -23,6 +23,12 @@ const parseUpdatedAttributeName = (attr: string | null): string => {
     return attr ? identifierToHuman(attr) : 'Project'
 }
 
+interface FrequentMistakeAdvice {
+    key: string
+    type: 'event' | 'person'
+    fix: string
+}
+
 export const teamLogic = kea<teamLogicType>([
     path(['scenes', 'teamLogic']),
     connect({
@@ -170,6 +176,26 @@ export const teamLogic = kea<teamLogicType>([
                         return filter.key
                     }
                 })
+            },
+        ],
+        testAccountFilterFrequentMistakes: [
+            (selectors) => [selectors.currentTeam],
+            (currentTeam): FrequentMistakeAdvice[] => {
+                if (!currentTeam) {
+                    return []
+                }
+                const frequentMistakes: FrequentMistakeAdvice[] = []
+
+                for (const filter of currentTeam.test_account_filters) {
+                    if (filter.key === 'email' && filter.type === 'event') {
+                        frequentMistakes.push({
+                            key: 'email',
+                            type: 'event',
+                            fix: 'it is more common to filter email by person properties, not event properties',
+                        })
+                    }
+                }
+                return frequentMistakes
             },
         ],
     }),


### PR DESCRIPTION
## Problem

More than once, while creating internal/test filters, we've seen people select email an event property when they should select email a person property

## Changes

Warns them when they do that

![Screenshot 2023-01-20 at 14 47 27](https://user-images.githubusercontent.com/984817/213727326-1a798bce-b9a2-4b9e-828f-fd63bdc45c47.png)

## How did you test this code?

running it locally and 👀 