### PR TITLE
fix(trends): ensure formula + breakdown works correctly for all series

### DIFF
--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -26,13 +26,13 @@ class TrendsFormula:
             queries.append(sql)
             params = {**params, **entity_params}
 
-        breakdown_values_list = ""
+        breakdown_value = ""
         if filter.breakdown_type == "cohort":
             breakdown_values_list = ", ".join(f"sub_{letter}.breakdown_value" for letter in letters)
+            breakdown_value = ", arrayFilter(x -> x != 0, [{}])[1]".format(breakdown_values_list)
         else:
             breakdown_values_list = ", ".join(trim_quotes_expr(f"sub_{letter}.breakdown_value") for letter in letters)
-
-        breakdown_value = ", arrayFilter(x -> notEmpty(x), [{}])[1]".format(breakdown_values_list)
+            breakdown_value = ", arrayFilter(x -> notEmpty(x), [{}])[1]".format(breakdown_values_list)
 
         is_aggregate = filter.display in NON_TIME_SERIES_DISPLAY_TYPES
 

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -20,7 +20,7 @@ class TrendsFormula:
         queries = []
         params: Dict[str, Any] = {}
         for idx, entity in enumerate(filter.entities):
-            query_type, sql, entity_params, _ = self._get_sql_for_entity(filter, team, entity)  # type: ignore
+            _, sql, entity_params, _ = self._get_sql_for_entity(filter, team, entity)  # type: ignore
             sql = sql.replace("%(", f"%({idx}_")
             entity_params = {f"{idx}_{key}": value for key, value in entity_params.items()}
             queries.append(sql)
@@ -28,11 +28,11 @@ class TrendsFormula:
 
         breakdown_value = ""
         if filter.breakdown_type == "cohort":
-            breakdown_values_list = ", ".join(f"sub_{letter}.breakdown_value" for letter in letters)
-            breakdown_value = ", arrayFilter(x -> x != 0, [{}])[1]".format(breakdown_values_list)
+            breakdown_columns = ", ".join(f"sub_{letter}.breakdown_value" for letter in letters)
+            breakdown_value = ", arrayFilter(x -> x != 0, [{}])[1]".format(breakdown_columns)
         else:
-            breakdown_values_list = ", ".join(trim_quotes_expr(f"sub_{letter}.breakdown_value") for letter in letters)
-            breakdown_value = ", arrayFilter(x -> notEmpty(x), [{}])[1]".format(breakdown_values_list)
+            breakdown_columns = ", ".join(trim_quotes_expr(f"sub_{letter}.breakdown_value") for letter in letters)
+            breakdown_value = ", arrayFilter(x -> notEmpty(x), [{}])[1]".format(breakdown_columns)
 
         is_aggregate = filter.display in NON_TIME_SERIES_DISPLAY_TYPES
 

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -26,11 +26,14 @@ class TrendsFormula:
             queries.append(sql)
             params = {**params, **entity_params}
 
-        breakdown_value = (
-            ", sub_A.breakdown_value"
-            if filter.breakdown_type == "cohort"
-            else f", {trim_quotes_expr('sub_A.breakdown_value')}"
-        )
+        breakdown_values_list = ""
+        if filter.breakdown_type == "cohort":
+            breakdown_values_list = ", ".join(f"sub_{letter}.breakdown_value" for letter in letters)
+        else:
+            breakdown_values_list = ", ".join(trim_quotes_expr(f"sub_{letter}.breakdown_value") for letter in letters)
+
+        breakdown_value = ", arrayFilter(x -> notEmpty(x), [{}])[1]".format(breakdown_values_list)
+
         is_aggregate = filter.display in NON_TIME_SERIES_DISPLAY_TYPES
 
         sql = """SELECT

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -126,6 +126,152 @@
      ORDER BY breakdown_value) as sub_B ON sub_A.breakdown_value = sub_B.breakdown_value
   '
 ---
+# name: TestFormula.test_breakdown_cohort
+  '
+  SELECT sub_A.date,
+         arrayMap((A, B) -> A + B, arrayResize(sub_A.data, max_length, 0), arrayResize(sub_B.data, max_length, 0)) ,
+         arrayFilter(x -> x != 0, [sub_A.breakdown_value, sub_B.breakdown_value])[1] ,
+         arrayMax([length(sub_A.data), length(sub_B.data)]) as max_length
+  FROM
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) as data,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT [993, 0] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               value as breakdown_value
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        993 as value
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)
+                 WHERE person_id IN
+                     (SELECT id
+                      FROM person
+                      WHERE team_id = 2
+                        AND id IN
+                          (SELECT id
+                           FROM person
+                           WHERE team_id = 2
+                             AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', '')))) )
+                      GROUP BY id
+                      HAVING max(is_deleted) = 0
+                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))))
+                 UNION ALL SELECT DISTINCT distinct_id,
+                                           0 as value
+                 FROM events all_events
+                 WHERE team_id = 2
+                   AND toDateTime(all_events.timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+                   AND toDateTime(all_events.timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') ) ep ON e.distinct_id = ep.distinct_id
+              where team_id = 2
+                AND event = 'session start'
+                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_A
+  FULL OUTER JOIN
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) as data,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT [993, 0] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               value as breakdown_value
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        993 as value
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)
+                 WHERE person_id IN
+                     (SELECT id
+                      FROM person
+                      WHERE team_id = 2
+                        AND id IN
+                          (SELECT id
+                           FROM person
+                           WHERE team_id = 2
+                             AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', '')))) )
+                      GROUP BY id
+                      HAVING max(is_deleted) = 0
+                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))))
+                 UNION ALL SELECT DISTINCT distinct_id,
+                                           0 as value
+                 FROM events all_events
+                 WHERE team_id = 2
+                   AND toDateTime(all_events.timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+                   AND toDateTime(all_events.timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') ) ep ON e.distinct_id = ep.distinct_id
+              where team_id = 2
+                AND event = 'session start'
+                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_B ON sub_A.breakdown_value = sub_B.breakdown_value
+  '
+---
 # name: TestFormula.test_breakdown_with_different_breakdown_values_per_series
   '
   

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -377,7 +377,7 @@
               CROSS JOIN
                 (SELECT breakdown_value
                  FROM
-                   (SELECT ['London', 'Belo Horizonte'] as breakdown_value) ARRAY
+                   (SELECT ['London', 'Belo Horizonte', ''] as breakdown_value) ARRAY
                  JOIN breakdown_value) as sec
               ORDER BY breakdown_value,
                        day_start
@@ -389,7 +389,7 @@
                 AND event = 'session end'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
                 AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-                AND replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') in (['London', 'Belo Horizonte'])
+                AND replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') in (['London', 'Belo Horizonte', ''])
               GROUP BY day_start,
                        breakdown_value))
         GROUP BY day_start,

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -153,7 +153,7 @@
               CROSS JOIN
                 (SELECT breakdown_value
                  FROM
-                   (SELECT [993, 0] as breakdown_value) ARRAY
+                   (SELECT [36, 0] as breakdown_value) ARRAY
                  JOIN breakdown_value) as sec
               ORDER BY breakdown_value,
                        day_start
@@ -163,7 +163,7 @@
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
-                        993 as value
+                        36 as value
                  FROM
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
@@ -222,7 +222,7 @@
               CROSS JOIN
                 (SELECT breakdown_value
                  FROM
-                   (SELECT [993, 0] as breakdown_value) ARRAY
+                   (SELECT [36, 0] as breakdown_value) ARRAY
                  JOIN breakdown_value) as sec
               ORDER BY breakdown_value,
                        day_start
@@ -232,7 +232,7 @@
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
-                        993 as value
+                        36 as value
                  FROM
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -1,3 +1,259 @@
+# name: TestFormula.test_breakdown
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') AS value,
+            sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event = 'session start'
+       AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFormula.test_breakdown.1
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') AS value,
+            avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event = 'session start'
+       AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFormula.test_breakdown.2
+  '
+  SELECT sub_A.date,
+         arrayMap((A, B) -> A - B, arrayResize(sub_A.data, max_length, 0), arrayResize(sub_B.data, max_length, 0)) ,
+         arrayFilter(x -> notEmpty(x), [replaceRegexpAll(sub_A.breakdown_value, '^"|"$', ''), replaceRegexpAll(sub_B.breakdown_value, '^"|"$', '')])[1] ,
+         arrayMax([length(sub_A.data), length(sub_B.data)]) as max_length
+  FROM
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) as data,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT ['London', 'Paris'] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') as breakdown_value
+              FROM events e
+              WHERE e.team_id = 2
+                AND event = 'session start'
+                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+                AND replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') in (['London', 'Paris'])
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_A
+  FULL OUTER JOIN
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) as data,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT ['London', 'Paris'] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') as breakdown_value
+              FROM events e
+              WHERE e.team_id = 2
+                AND event = 'session start'
+                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+                AND replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') in (['London', 'Paris'])
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_B ON sub_A.breakdown_value = sub_B.breakdown_value
+  '
+---
+# name: TestFormula.test_breakdown_with_different_breakdown_values_per_series
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') AS value,
+            sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event = 'session start'
+       AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFormula.test_breakdown_with_different_breakdown_values_per_series.1
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') AS value,
+            sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event = 'session end'
+       AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+       AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFormula.test_breakdown_with_different_breakdown_values_per_series.2
+  '
+  SELECT sub_A.date,
+         arrayMap((A, B) -> A + B, arrayResize(sub_A.data, max_length, 0), arrayResize(sub_B.data, max_length, 0)) ,
+         arrayFilter(x -> notEmpty(x), [replaceRegexpAll(sub_A.breakdown_value, '^"|"$', ''), replaceRegexpAll(sub_B.breakdown_value, '^"|"$', '')])[1] ,
+         arrayMax([length(sub_A.data), length(sub_B.data)]) as max_length
+  FROM
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) as data,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT ['London', 'Paris'] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') as breakdown_value
+              FROM events e
+              WHERE e.team_id = 2
+                AND event = 'session start'
+                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+                AND replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') in (['London', 'Paris'])
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_A
+  FULL OUTER JOIN
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) as data,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT ['London', 'Belo Horizonte'] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') as breakdown_value
+              FROM events e
+              WHERE e.team_id = 2
+                AND event = 'session end'
+                AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+                AND replaceRegexpAll(JSONExtractRaw(properties, 'location'), '^"|"$', '') in (['London', 'Belo Horizonte'])
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_B ON sub_A.breakdown_value = sub_B.breakdown_value
+  '
+---
 # name: TestFormula.test_formula_with_unique_sessions
   '
   SELECT sub_A.date,

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -80,6 +80,18 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
                 },
             )
 
+            _create_event(
+                team=self.team,
+                event="session end",
+                distinct_id="blabla",
+                properties={
+                    "session duration": 400,
+                    "location": "",
+                    "$session_id": "1",
+                    "$group_0": "org:5",
+                },
+            )
+
     def _run(self, extra: Dict = {}, run_at: Optional[str] = None):
         with freeze_time(run_at or "2020-01-04T13:01:01Z"):
             action_response = Trends().run(
@@ -179,9 +191,7 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     def test_breakdown_with_different_breakdown_values_per_series(self):
-        # Regression test to ensure we actually get data for "Belo Horizonte" below
-        # We previously had a bug where if series B,C,D, etc. had a value not present
-        # in series A, we'd just default to an empty string
+
         response = self._run(
             {
                 "events": [
@@ -197,8 +207,16 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response[0]["label"], "London")
         self.assertEqual(response[1]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 500.0, 0.0, 0.0])
         self.assertEqual(response[1]["label"], "Paris")
+
+        # Regression test to ensure we actually get data for "Belo Horizonte" below
+        # We previously had a bug where if series B,C,D, etc. had a value not present
+        # in series A, we'd just default to an empty string
         self.assertEqual(response[2]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 500.0, 0.0])
         self.assertEqual(response[2]["label"], "Belo Horizonte")
+
+        # regression test for empty string values
+        self.assertEqual(response[2]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 400.0, 0.0])
+        self.assertEqual(response[2]["label"], "")
 
     def test_breakdown_counts_of_different_events_one_without_events(self):
         with freeze_time("2020-01-04T13:01:01Z"):

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -274,6 +274,7 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
+    @snapshot_clickhouse_queries
     def test_breakdown_cohort(self):
         cohort = Cohort.objects.create(
             team=self.team,

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -208,15 +208,15 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response[1]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 500.0, 0.0, 0.0])
         self.assertEqual(response[1]["label"], "Paris")
 
+        # regression test for empty string values
+        self.assertEqual(response[2]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 400.0, 0.0])
+        self.assertEqual(response[2]["label"], "")
+
         # Regression test to ensure we actually get data for "Belo Horizonte" below
         # We previously had a bug where if series B,C,D, etc. had a value not present
         # in series A, we'd just default to an empty string
-        self.assertEqual(response[2]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 500.0, 0.0])
-        self.assertEqual(response[2]["label"], "Belo Horizonte")
-
-        # regression test for empty string values
-        self.assertEqual(response[3]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 400.0, 0.0])
-        self.assertEqual(response[3]["label"], "")
+        self.assertEqual(response[3]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 500.0, 0.0])
+        self.assertEqual(response[3]["label"], "Belo Horizonte")
 
     def test_breakdown_counts_of_different_events_one_without_events(self):
         with freeze_time("2020-01-04T13:01:01Z"):

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -215,8 +215,8 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response[2]["label"], "Belo Horizonte")
 
         # regression test for empty string values
-        self.assertEqual(response[2]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 400.0, 0.0])
-        self.assertEqual(response[2]["label"], "")
+        self.assertEqual(response[3]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 400.0, 0.0])
+        self.assertEqual(response[3]["label"], "")
 
     def test_breakdown_counts_of_different_events_one_without_events(self):
         with freeze_time("2020-01-04T13:01:01Z"):


### PR DESCRIPTION
## Problem

Resolves https://github.com/PostHog/posthog/issues/7125

## Changes

Our previous query assumed both series would always have the same values, and thus defaulted to using only `subA.breakddown_value`, which was leading to a bunch of "empty string" series. We now ensure we use values from all series.


## How did you test this code?

Added a test
