### PR TITLE
fix: include token in heatmap API call

### DIFF
--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -108,8 +108,12 @@ export const heatmapLogic = kea<heatmapLogicType>([
                     }
 
                     // toolbar fetch collapses queryparams but this URL has multiple with the same name
-                    const useProvidedURL = true
-                    const response = await toolbarFetch(url || defaultUrl, 'GET', undefined, useProvidedURL)
+                    const response = await toolbarFetch(
+                        url || defaultUrl,
+                        'GET',
+                        undefined,
+                        url ? 'use-as-provided' : 'only-add-token'
+                    )
 
                     if (response.status === 403) {
                         toolbarLogic.actions.authenticate()

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -372,11 +372,26 @@ export async function toolbarFetch(
     url: string,
     method: string = 'GET',
     payload?: Record<string, any>,
-    useProvidedURL?: boolean
+    /*
+     allows caller to control how the provided URL is altered before use
+     if "full" then the payload and URL are taken apart and reconstructed
+     if "only-add-token" the URL is unchanged, the payload is not used
+     but the temporary token is added to the URL
+     if "use-as-provided" then the URL is used as-is, and the payload is not used
+     this is because the heatmapLogic needs more control over how the query parameters are constructed
+    */
+    urlConstruction: 'full' | 'only-add-token' | 'use-as-provided' = 'full'
 ): Promise<Response> {
-    const { pathname, searchParams } = combineUrl(url)
-    const params = { ...searchParams, temporary_token: toolbarLogic.values.temporaryToken }
-    const fullUrl = useProvidedURL ? url : `${toolbarLogic.values.apiURL}${pathname}${encodeParams(params, '?')}`
+    let fullUrl: string
+    if (urlConstruction === 'use-as-provided') {
+        fullUrl = url
+    } else if (urlConstruction === 'only-add-token') {
+        fullUrl = `${url}&temporary_token=${toolbarLogic.values.temporaryToken}`
+    } else {
+        const { pathname, searchParams } = combineUrl(url)
+        const params = { ...searchParams, temporary_token: toolbarLogic.values.temporaryToken }
+        fullUrl = `${toolbarLogic.values.apiURL}${pathname}${encodeParams(params, '?')}`
+    }
 
     const payloadData = payload
         ? {


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/13825 we didn't spot that the URL no longer included authentication and so would only work on app.posthog.com 🤦 

Good job there are no tests on the `heatmapLogic` 🙈 

## Changes

adds the temporary token back in

## How did you test this code?

ran locally and saw the token included
