### PR TITLE
feat(data-exploration): rename to "Event Explorer"

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -177,7 +177,14 @@ function Pages(): JSX.Element {
                     )}
                     <div className="SideBar__heading">Data</div>
 
-                    <PageButton icon={<IconLive />} identifier={Scene.Events} to={urls.events()} />
+                    <PageButton
+                        icon={<IconLive />}
+                        identifier={Scene.Events}
+                        to={urls.events()}
+                        title={
+                            featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_LIVE_EVENTS] ? 'Event Explorer' : 'Live Events'
+                        }
+                    />
                     <PageButton
                         icon={<IconUnverifiedEvent />}
                         identifier={Scene.DataManagement}

--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -20,7 +20,10 @@ export function Events(): JSX.Element {
 
     return (
         <>
-            <PageHeader title="Live events" caption="Event history limited to the last twelve months." />
+            <PageHeader
+                title={featureDataExploration ? 'Event Explorer' : 'Live events'}
+                caption="Event history limited to the last twelve months."
+            />
             <div className="pt-4 border-t" />
             {featureDataExploration ? <EventsScene /> : <EventsTable pageKey={'EventsTable'} />}
         </>

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -14,6 +14,7 @@ import { emptySceneParams, preloadedScenes, redirects, routes, sceneConfiguratio
 import { organizationLogic } from './organizationLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { appContextLogic } from './appContextLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 /** Mapping of some scenes that aren't directly accessible from the sidebar to ones that are - for the sidebar. */
 const sceneNavAlias: Partial<Record<Scene, Scene>> = {
@@ -121,8 +122,14 @@ export const sceneLogic = kea<sceneLogicType>({
     },
     selectors: {
         sceneConfig: [
-            (s) => [s.scene],
-            (scene: Scene): SceneConfig | null => {
+            (s) => [s.scene, s.featureFlags],
+            (scene: Scene, featureFlags): SceneConfig | null => {
+                if (scene === Scene.Events && featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_LIVE_EVENTS]) {
+                    return {
+                        ...sceneConfigurations[scene],
+                        name: 'Event Explorer',
+                    }
+                }
                 return sceneConfigurations[scene] || null
             },
         ],


### PR DESCRIPTION
## Problem

The title "Live events" doesn't cover nearly half the features of the data exploration table. There are two options:

1. Separate into a) "Live events" or "Real time events" and b) "Data explorer" views
2. Rename this one view into something that covers both cases

## Changes

A totally non-controversial change to rename the "Live events" scene to the "Event Explorer" scene, **only when the data exploration flag is enabled**.

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/53387/214024894-64f7dcf7-b1bc-4ee5-8f6d-bc4dc6e842a6.png">

- "Event Explorer" title case not "Event explorer" sentence case because of all the way the capitalisation is done in the sidebar ("Project settings" being the lone sentence case entry)
- I capitalised the page title as well because it just looked odd when inconsistent with the others
- Why "Event Explorer", not "Data Explorer" or "Universal search" --> It's still good to use the word "Event" to direct users to the right page.
- The nice surprise now is when you open the page: "ah, I can make it update in near real time". If we ever get a true "real time" view, we can make a new scene :)

## How did you test this code?

Made the change, assumed everyone is on board and there will be no long discussion.