### PR TITLE
feat: Person and Group property definitions API, frontend and docs

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."$group_0" as "$group_0",
                                  e."properties" as "properties",
+                                 e."$group_0" as "$group_0",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."properties" as "properties",
                                  e."$group_0" as "$group_0",
+                                 e."properties" as "properties",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -274,8 +274,17 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         name: 'Person properties',
                         searchPlaceholder: 'person properties',
                         type: TaxonomicFilterGroupType.PersonProperties,
-                        logic: personPropertiesModel,
-                        value: 'personProperties',
+                        logic: featureFlags[FEATURE_FLAGS.PERSON_GROUPS_PROPERTY_DEFINITIONS]
+                            ? undefined
+                            : personPropertiesModel,
+                        value: featureFlags[FEATURE_FLAGS.PERSON_GROUPS_PROPERTY_DEFINITIONS]
+                            ? undefined
+                            : 'personProperties',
+                        endpoint: featureFlags[FEATURE_FLAGS.PERSON_GROUPS_PROPERTY_DEFINITIONS]
+                            ? combineUrl(`api/projects/${teamId}/property_definitions`, {
+                                  type: 'person',
+                              }).url
+                            : undefined,
                         getName: (personProperty: PersonProperty) => personProperty.name,
                         getValue: (personProperty: PersonProperty) => personProperty.name,
                         ...propertyTaxonomicGroupProps(true),
@@ -458,14 +467,24 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                 })),
         ],
         groupAnalyticsTaxonomicGroups: [
-            (s) => [s.groupTypes, s.currentTeamId, s.aggregationLabel],
-            (groupTypes, teamId, aggregationLabel): TaxonomicFilterGroup[] =>
+            (s) => [s.groupTypes, s.currentTeamId, s.aggregationLabel, s.featureFlags],
+            (groupTypes, teamId, aggregationLabel, featureFlags): TaxonomicFilterGroup[] =>
                 groupTypes.map((type) => ({
                     name: `${capitalizeFirstLetter(aggregationLabel(type.group_type_index).singular)} properties`,
                     searchPlaceholder: `${aggregationLabel(type.group_type_index).singular} properties`,
                     type: `${TaxonomicFilterGroupType.GroupsPrefix}_${type.group_type_index}` as unknown as TaxonomicFilterGroupType,
-                    logic: groupPropertiesModel,
-                    value: `groupProperties_${type.group_type_index}`,
+                    logic: featureFlags[FEATURE_FLAGS.PERSON_GROUPS_PROPERTY_DEFINITIONS]
+                        ? undefined
+                        : groupPropertiesModel,
+                    value: featureFlags[FEATURE_FLAGS.PERSON_GROUPS_PROPERTY_DEFINITIONS]
+                        ? undefined
+                        : `groupProperties_${type.group_type_index}`,
+                    endpoint: featureFlags[FEATURE_FLAGS.PERSON_GROUPS_PROPERTY_DEFINITIONS]
+                        ? combineUrl(`api/projects/${teamId}/property_definitions`, {
+                              type: 'group',
+                              group_type_index: type.group_type_index,
+                          }).url
+                        : undefined,
                     valuesEndpoint: (key) =>
                         `api/projects/${teamId}/groups/property_values/?${toParams({
                             key,

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -142,6 +142,7 @@ export const FEATURE_FLAGS = {
     DATA_EXPLORATION_INSIGHTS: 'data-exploration-insights', // owner @thmsobrmlr
     RECORDING_DEBUGGING: 'recording-debugging', // owner #team-session-recordings
     FF_JSON_PAYLOADS: 'ff-json-payloads', // owner @EDsCODE
+    PERSON_GROUPS_PROPERTY_DEFINITIONS: 'person-groups-property-definitions', // owner: @macobo
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -5,8 +5,10 @@ from typing import Any, Dict, List, Optional, Type
 from django.db import connection
 from django.db.models import Prefetch
 from rest_framework import mixins, permissions, serializers, viewsets
+from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import LimitOffsetPagination
 
+from posthog.api.documentation import extend_schema
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.constants import GROUP_TYPES_LIMIT, AvailableFeature
@@ -14,6 +16,73 @@ from posthog.exceptions import EnterpriseFeatureException
 from posthog.filters import TermSearchFilterBackend, term_search_filter_sql
 from posthog.models import PropertyDefinition, TaggedItem
 from posthog.permissions import OrganizationMemberPermissions, TeamMemberAccessPermission
+
+
+class PropertyDefinitionQuerySerializer(serializers.Serializer):
+    search = serializers.CharField(
+        help_text="Searches properties by name",
+        required=False,
+        allow_blank=True,
+    )
+
+    type = serializers.ChoiceField(
+        choices=["event", "person", "group"],
+        help_text="What property definitions to return",
+        default="event",
+    )
+    group_type_index = serializers.IntegerField(
+        help_text="What group type is the property for. Only should be set if `type=group`",
+        required=False,
+    )
+
+    properties = serializers.CharField(
+        help_text="Comma-separated list of properties to filter",
+        required=False,
+    )
+    is_numerical = serializers.BooleanField(
+        help_text="Whether to return only (or excluding) numerical property definitions",
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    # :TODO: Move this under `type`
+    is_feature_flag = serializers.BooleanField(
+        help_text="Whether to return only (or excluding) feature flag properties",
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    event_names = serializers.CharField(
+        help_text="If sent, response value will have `is_seen_on_filtered_events` populated. JSON-encoded",
+        required=False,
+    )
+    filter_by_event_names = serializers.BooleanField(
+        help_text="Whether to return only properties for events in `event_names`",
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    excluded_properties = serializers.CharField(
+        help_text="JSON-encoded list of excluded properties",
+        required=False,
+    )
+
+    def validate(self, attrs):
+        type_ = attrs.get("type", "event")
+
+        if type_ == "group" and attrs.get("group_type_index") is None:
+            raise ValidationError("`group_type_index` must be set for `group` type")
+
+        if type_ != "group" and attrs.get("group_type_index") is not None:
+            raise ValidationError("`group_type_index` can only set for `group` type")
+
+        if attrs.get("group_type_index") and not (0 <= attrs.get("group_type_index") < GROUP_TYPES_LIMIT):
+            raise ValidationError("Invalid value for `group_type_index`")
+
+        if type_ != "event" and attrs.get("event_names"):
+            raise ValidationError("`event_names` can only be set for `event` type")
+
+        return super().validate(attrs)
 
 
 @dataclasses.dataclass
@@ -29,6 +98,9 @@ class QueryContext:
     limit: int
     offset: int
 
+    type: PropertyDefinition.Type = PropertyDefinition.Type.EVENT
+
+    group_type_index_filter: str = ""
     name_filter: str = ""
     numerical_filter: str = ""
     search_query: str = ""
@@ -57,31 +129,44 @@ class QueryContext:
             return self
 
     def with_is_numerical_flag(self, is_numerical: Optional[str]) -> "QueryContext":
-        if is_numerical == "true":
+        if is_numerical:
             return dataclasses.replace(
                 self, numerical_filter="AND is_numerical = true AND name NOT IN ('distinct_id', 'timestamp')"
             )
         else:
             return self
 
-    def with_feature_flags(self, is_feature_flag: Optional[str]) -> "QueryContext":
-        if is_feature_flag == "true":
+    def with_feature_flags(self, is_feature_flag: Optional[bool]) -> "QueryContext":
+        if is_feature_flag is None:
+            return self
+        elif is_feature_flag:
             return dataclasses.replace(
                 self,
                 is_feature_flag_filter="AND (name LIKE %(is_feature_flag_like)s)",
                 params={**self.params, "is_feature_flag_like": "$feature/%"},
             )
-        elif is_feature_flag == "false":
+        elif not is_feature_flag:
             return dataclasses.replace(
                 self,
                 is_feature_flag_filter="AND (name NOT LIKE %(is_feature_flag_like)s)",
                 params={**self.params, "is_feature_flag_like": "$feature/%"},
             )
-        else:
-            return self
+
+    def with_type_filter(self, type: str, group_type_index: Optional[int]):
+        if type == "event":
+            return dataclasses.replace(self, type=PropertyDefinition.Type.EVENT)
+        elif type == "person":
+            return dataclasses.replace(self, type=PropertyDefinition.Type.PERSON)
+        elif type == "group":
+            return dataclasses.replace(
+                self,
+                type=PropertyDefinition.Type.GROUP,
+                group_type_index_filter="AND group_type_index = %(group_type_index)s",
+                params={**self.params, "group_type_index": group_type_index},
+            )
 
     def with_event_property_filter(
-        self, event_names: Optional[str], filter_by_event_names: Optional[str]
+        self, event_names: Optional[str], filter_by_event_names: Optional[bool]
     ) -> "QueryContext":
         event_property_filter = ""
         event_name_filter = ""
@@ -99,15 +184,13 @@ class QueryContext:
             event_property_field = (
                 f"case when {self.posthog_eventproperty_table_join_alias}.id is null then false else true end"
             )
-
-            if filter_by_event_names == "true":
-                event_property_filter = f"AND {event_property_field} = true"
-
-        if is_filtering_by_event_names:
             event_name_join_filter = " AND event in %(event_names)s"
             qualified_event_name_join_filter = (
                 f" AND {self.posthog_eventproperty_table_join_alias}.event in %(event_names)s"
             )
+
+            if filter_by_event_names:
+                event_property_filter = f"AND {event_property_field} = true"
 
         return dataclasses.replace(
             self,
@@ -140,9 +223,11 @@ class QueryContext:
             FROM {self.table}
             {self._join_on_event_property()}
             WHERE posthog_propertydefinition.team_id = {self.team_id}
-              AND type = {PropertyDefinition.Type.EVENT}
+              AND type = {self.type}
               AND posthog_propertydefinition.name NOT IN %(excluded_properties)s
-             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter} {self.event_name_filter}
+             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
+             {self.event_name_filter}
+             {self.group_type_index_filter}
             ORDER BY is_seen_on_filtered_events DESC, posthog_propertydefinition.query_usage_30_day DESC NULLS LAST, posthog_propertydefinition.name ASC
             LIMIT {self.limit} OFFSET {self.offset}
             """
@@ -155,9 +240,11 @@ class QueryContext:
             FROM {self.table}
             {self._join_on_event_property()}
             WHERE posthog_propertydefinition.team_id = {self.team_id}
-              AND type = {PropertyDefinition.Type.EVENT}
+              AND type = {self.type}
               AND posthog_propertydefinition.name NOT IN %(excluded_properties)s
-             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter} {self.event_name_filter}
+             {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
+             {self.event_name_filter}
+             {self.group_type_index_filter}
             """
 
         return query
@@ -273,7 +360,7 @@ class PropertyDefinitionViewSet(
     pagination_class = NotCountingLimitOffsetPaginator
 
     def get_queryset(self):
-        queryset = PropertyDefinition.objects.filter(type=PropertyDefinition.Type.EVENT)
+        queryset = PropertyDefinition.objects
 
         property_definition_fields = ", ".join(
             [f'posthog_propertydefinition."{f.column}"' for f in PropertyDefinition._meta.get_fields() if hasattr(f, "column")]  # type: ignore
@@ -304,8 +391,10 @@ class PropertyDefinitionViewSet(
         limit = self.paginator.get_limit(self.request)  # type: ignore
         offset = self.paginator.get_offset(self.request)  # type: ignore
 
-        search = self.request.GET.get("search", None)
-        search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)
+        query = PropertyDefinitionQuerySerializer(data=self.request.query_params)
+        query.is_valid(raise_exception=True)
+
+        search_query, search_kwargs = term_search_filter_sql(self.search_fields, query.validated_data.get("search"))
 
         query_context = (
             QueryContext(
@@ -319,15 +408,16 @@ class PropertyDefinitionViewSet(
                 limit=limit,
                 offset=offset,
             )
-            .with_properties_to_filter(self.request.GET.get("properties", None))
-            .with_is_numerical_flag(self.request.GET.get("is_numerical", None))
-            .with_feature_flags(self.request.GET.get("is_feature_flag"))
+            .with_type_filter(query.validated_data.get("type"), query.validated_data.get("group_type_index"))
+            .with_properties_to_filter(query.validated_data.get("properties"))
+            .with_is_numerical_flag(query.validated_data.get("is_numerical"))
+            .with_feature_flags(query.validated_data.get("is_feature_flag"))
             .with_event_property_filter(
-                event_names=self.request.GET.get("event_names", None),
-                filter_by_event_names=self.request.GET.get("filter_by_event_names", None),
+                event_names=query.validated_data.get("event_names"),
+                filter_by_event_names=query.validated_data.get("filter_by_event_names"),
             )
             .with_search(search_query, search_kwargs)
-            .with_excluded_properties(self.request.GET.get("excluded_properties", None))
+            .with_excluded_properties(query.validated_data.get("excluded_properties"))
         )
 
         with connection.cursor() as cursor:
@@ -368,3 +458,7 @@ class PropertyDefinitionViewSet(
                 new_enterprise_property.save()
                 return new_enterprise_property
         return PropertyDefinition.objects.get(id=id)
+
+    @extend_schema(parameters=[PropertyDefinitionQuerySerializer])
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)


### PR DESCRIPTION
## Problem

Related: https://github.com/PostHog/posthog/issues/13767, https://github.com/PostHog/posthog/pull/13809, https://github.com/PostHog/posthog/pull/13816

## Changes

- Add docs for property definitions API parameters
- Add `type` and `group_type_index` parameters
- Add new FE code under a feature flag

## How did you test this code?

- Unit tests
- Tested FE locally creating the feature flag
