### PR TITLE
fix: more gracefully handle when related feature flag value is undefined

### DIFF
--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -74,7 +74,9 @@ export function RelatedFeatureFlags({ distinctId, groups }: Props): JSX.Element 
             render: function Render(_, featureFlag: RelatedFeatureFlag) {
                 return (
                     <div style={{ wordBreak: 'break-word' }}>
-                        {featureFlag.active ? capitalizeFirstLetter(featureFlag.value.toString()) : '--'}
+                        {featureFlag.active && featureFlag.value
+                            ? capitalizeFirstLetter(featureFlag.value.toString())
+                            : '--'}
                     </div>
                 )
             },

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -21,7 +21,7 @@ export interface FeatureFlagEvaluationType {
 
 export interface RelatedFeatureFlagResponse {
     [key: string]: {
-        value: boolean | string
+        value: boolean | string | undefined
         evaluation: FeatureFlagEvaluationType
     }
 }

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -21,7 +21,7 @@ export interface FeatureFlagEvaluationType {
 
 export interface RelatedFeatureFlagResponse {
     [key: string]: {
-        value: boolean | string | undefined
+        value: boolean | string
         evaluation: FeatureFlagEvaluationType
     }
 }


### PR DESCRIPTION
## Problem

Described in #13885 

## Changes

- Checks whether the feature flag value is defined before calling toString()

## How did you test this code?

I didn't, but hope it should be simple enough to YOLO 🙈 
