### PR TITLE
chore(feature-flag): evaluation_reasons endpoint don't use cache

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -345,7 +345,7 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
         if not distinct_id:
             raise exceptions.ValidationError(detail="distinct_id is required")
 
-        flags, reasons, _, _ = get_all_feature_flags(self.team_id, distinct_id, groups)
+        flags, reasons, _, _ = get_all_feature_flags(self.team_id, distinct_id, groups, no_cache=True)
 
         flags_with_evaluation_reasons = {}
 

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -686,9 +686,10 @@ def get_all_feature_flags(
     hash_key_override: Optional[str] = None,
     property_value_overrides: Dict[str, Union[str, int]] = {},
     group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
+    no_cache: bool = False,
 ) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict], Dict[str, object], bool]:
 
-    all_feature_flags = get_feature_flags_for_team_in_cache(team_id)
+    all_feature_flags = None if no_cache else get_feature_flags_for_team_in_cache(team_id)
     if all_feature_flags is None:
         all_feature_flags = set_feature_flags_for_team_in_cache(team_id)
 


### PR DESCRIPTION
## Problem

- context: https://posthog.slack.com/archives/C046D7C654H/p1674513390669169
- don't use cache for evaluation_reasons endpoint
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
