### PR TITLE
fix: only show installed templates as available

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.test.ts
@@ -1,0 +1,76 @@
+import { expectLogic } from 'kea-test-utils'
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { dashboardTemplatesLogic } from './dashboardTemplatesLogic'
+
+describe('dashboardTemplatesLogic', () => {
+    let logic: ReturnType<typeof dashboardTemplatesLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                'api/projects/@current/dashboard_templates/repository/': [
+                    {
+                        name: 'Product analytics',
+                        url: 'https://raw.githubusercontent.com/PostHog/templates-repository/8e3cc02518644c9b6e458b2fc6eb4504e3957f07/dashboards/posthog-product-analytics.json',
+                        description: 'The OG PostHog product analytics dashboard template',
+                        verified: true,
+                        maintainer: 'official',
+                        installed: true,
+                    },
+                    {
+                        name: 'Website traffic',
+                        url: 'https://raw.githubusercontent.com/PostHog/templates-repository/7916bed2463112a6354078065db1892eda51fd17/dashboards/posthog-website-traffic.json',
+                        description: 'The website analytics dashboard that PostHog uses',
+                        verified: true,
+                        maintainer: 'official',
+                        installed: false,
+                    },
+                ],
+            },
+        })
+        initKeaTests()
+        logic = dashboardTemplatesLogic()
+        logic.mount()
+    })
+
+    it('loads templates on mount', async () => {
+        await expectLogic(logic)
+            .toDispatchActions(['loadRepository', 'loadRepositorySuccess'])
+            .toMatchValues({
+                repository: {
+                    'https://raw.githubusercontent.com/PostHog/templates-repository/7916bed2463112a6354078065db1892eda51fd17/dashboards/posthog-website-traffic.json':
+                        {
+                            description: 'The website analytics dashboard that PostHog uses',
+                            installed: false,
+                            maintainer: 'official',
+                            name: 'Website traffic',
+                            url: 'https://raw.githubusercontent.com/PostHog/templates-repository/7916bed2463112a6354078065db1892eda51fd17/dashboards/posthog-website-traffic.json',
+                            verified: true,
+                        },
+                    'https://raw.githubusercontent.com/PostHog/templates-repository/8e3cc02518644c9b6e458b2fc6eb4504e3957f07/dashboards/posthog-product-analytics.json':
+                        {
+                            description: 'The OG PostHog product analytics dashboard template',
+                            installed: true,
+                            maintainer: 'official',
+                            name: 'Product analytics',
+                            url: 'https://raw.githubusercontent.com/PostHog/templates-repository/8e3cc02518644c9b6e458b2fc6eb4504e3957f07/dashboards/posthog-product-analytics.json',
+                            verified: true,
+                        },
+                },
+            })
+    })
+    it('only shows installed templates as available for use', async () => {
+        await expectLogic(logic)
+            .toDispatchActions(['loadRepository', 'loadRepositorySuccess'])
+            .toMatchValues({
+                templatesList: [
+                    {
+                        'data-attr': 'dashboard-select-Product-analytics',
+                        label: 'Product analytics',
+                        value: 'Product analytics',
+                    },
+                ],
+            })
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
@@ -13,7 +13,7 @@ export const dashboardTemplatesLogic = kea<dashboardTemplatesLogicType>([
             {} as Record<string, DashboardTemplatesRepositoryEntry>,
             {
                 loadRepository: async () => {
-                    const results = await api.get('api/projects/@current/dashboard_templates/repository')
+                    const results = await api.get('/api/projects/@current/dashboard_templates/repository')
                     const repository: Record<string, DashboardTemplatesRepositoryEntry> = {}
                     for (const template of results as DashboardTemplatesRepositoryEntry[]) {
                         if (template.url) {
@@ -38,11 +38,13 @@ export const dashboardTemplatesLogic = kea<dashboardTemplatesLogicType>([
             [] as LemonSelectOption<string>[],
             {
                 loadRepositorySuccess: (_, { repository }) => {
-                    return Object.values(repository).map((entry) => ({
-                        value: entry.name,
-                        label: entry.name,
-                        'data-attr': `dashboard-select-${entry.name.replace(' ', '-')}`,
-                    }))
+                    return Object.values(repository)
+                        .filter((r) => !!r.installed)
+                        .map((entry) => ({
+                            value: entry.name,
+                            label: entry.name,
+                            'data-attr': `dashboard-select-${entry.name.replace(' ', '-')}`,
+                        }))
                 },
             },
         ],


### PR DESCRIPTION
## Problem

Dashboard templates isn't released yet. When the flag is turned on it shows any template as available to use for creating a dashboard not only the installed ones

## Changes

Only shows the installed ones

## How did you test this code?

added developer tests and ran it locally