### PR TITLE
feat: Allow setting EVENT_PARTITION_KEYS_TO_OVERRIDE dynamically

### DIFF
--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -2,7 +2,6 @@ import json
 from typing import Any
 from unittest.mock import patch
 
-from django.core.cache import cache
 from django.http.request import HttpRequest
 from django.test.client import Client
 from kafka.errors import NoBrokersAvailable
@@ -21,10 +20,6 @@ class TestCaptureAPI(APIBaseTest):
     def setUp(self):
         super().setUp()
         self.client = Client(enforce_csrf_checks=True)
-
-    def tearDown(self):
-        super().tearDown()
-        cache.clear()
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_produce_to_kafka(self, kafka_produce):

--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -11,7 +11,7 @@ from rest_framework import status
 
 import posthog.settings as settings
 from posthog.api.utils import get_event_ingestion_context
-from posthog.models.instance_setting import InstanceSetting
+from posthog.models.instance_setting import set_instance_setting
 from posthog.settings.data_stores import KAFKA_EVENTS_PLUGIN_INGESTION
 from posthog.test.base import APIBaseTest
 
@@ -25,7 +25,7 @@ class TestCaptureAPI(APIBaseTest):
         super().setUp()
         self.client = Client()
         self.partition_key = f"{self.team.pk}:id1"
-        self.database_override_key = settings.CONSTANCE_DATABASE_PREFIX + "EVENT_PARTITION_KEYS_TO_OVERRIDE"
+        self.database_override_key = "EVENT_PARTITION_KEYS_TO_OVERRIDE"
 
     def tearDown(self):
         super().tearDown()
@@ -254,12 +254,9 @@ class TestCaptureAPI(APIBaseTest):
         should cause us to pass None as the key when producing to Kafka, leading to
         random partitioning.
         """
-        # Setting up an override via EVENT_PARTITION_KEYS_TO_OVERRIDE should cause us to pass None
-        # as the key when producing to Kafka, leading to random partitioning
         distinct_id = "id-override1"
         override_key = f"{self.team.pk}:{distinct_id}"
-        InstanceSetting.objects.create(key=self.database_override_key, raw_value=f'["{override_key}"]')
-
+        set_instance_setting(self.database_override_key, [override_key])
         patched = {"EVENT_PARTITION_KEYS_TO_OVERRIDE": ("any_value", "a help str", str)}
 
         with patch.dict(settings.CONSTANCE_CONFIG, patched, clear=True):
@@ -277,6 +274,44 @@ class TestCaptureAPI(APIBaseTest):
                     "api_key": self.team.api_token,
                 },
             )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        kafka_produce_call = kafka_produce.call_args_list[0].kwargs
+        self.assertEqual(kafka_produce_call["key"], None)
+
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_partition_key_with_cache_failure(self, kafka_produce):
+        """Test event is captured with an overriden partition key via default value.
+
+        In the event of an exception in the cache we should fallback to the setting's
+        default value for "EVENT_PARTITION_KEYS_TO_OVERRIDE".
+        """
+        distinct_id = "id-override1"
+        override_key = f"{self.team.pk}:{distinct_id}"
+        set_instance_setting(self.database_override_key, [override_key])
+        patched = {"EVENT_PARTITION_KEYS_TO_OVERRIDE": (f'["{self.team.pk}:{distinct_id}"]', "a help str", str)}
+
+        with patch.dict(settings.CONSTANCE_CONFIG, patched, clear=True):
+            with patch("posthog.models.instance_setting.cache") as mock_cache:
+                mock_cache.get.side_effect = Exception("Terrible cache error")
+
+                response = self.client.post(
+                    "/capture/",
+                    {
+                        "data": json.dumps(
+                            [
+                                {
+                                    "event": "event1",
+                                    "properties": {"distinct_id": distinct_id, "token": self.team.api_token},
+                                }
+                            ]
+                        ),
+                        "api_key": self.team.api_token,
+                    },
+                )
+
+                mock_cache.get.assert_called_once_with("EVENT_PARTITION_KEYS_TO_OVERRIDE")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -427,6 +427,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
         candidate_partition_key = f"{team_id}:{distinct_id}"
 
         keys_to_override = get_instance_setting("EVENT_PARTITION_KEYS_TO_OVERRIDE")
+
         if candidate_partition_key not in keys_to_override:
             kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -30,6 +30,7 @@ from posthog.kafka_client.client import KafkaProducer
 from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE, KAFKA_SESSION_RECORDING_EVENTS
 from posthog.logging.timing import timed
 from posthog.models.feature_flag import get_all_feature_flags
+from posthog.models.instance_setting import get_instance_setting
 from posthog.models.utils import UUIDT
 from posthog.session_recordings.session_recording_helpers import preprocess_session_recording_events_for_clickhouse
 from posthog.settings import KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
@@ -425,7 +426,8 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
     else:
         candidate_partition_key = f"{team_id}:{distinct_id}"
 
-        if candidate_partition_key not in settings.EVENT_PARTITION_KEYS_TO_OVERRIDE:
+        keys_to_override = get_instance_setting("EVENT_PARTITION_KEYS_TO_OVERRIDE")
+        if candidate_partition_key not in keys_to_override:
             kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
 
     return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, patch
 
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
+from django.core.cache import cache
 from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
@@ -158,6 +159,10 @@ class TestLoginAPI(APIBaseTest):
 
 class TestPasswordResetAPI(APIBaseTest):
     CONFIG_AUTO_LOGIN = False
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
 
     # Password reset request
 

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -29,15 +29,10 @@ from posthog.api.capture import get_distinct_id
 from posthog.api.test.mock_sentry import mock_sentry_context_for_tagging
 from posthog.kafka_client.topics import KAFKA_SESSION_RECORDING_EVENTS
 from posthog.models.feature_flag import FeatureFlag
-from posthog.models.instance_setting import InstanceSetting
+from posthog.models.instance_setting import set_instance_setting
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.utils import generate_random_token_personal
-from posthog.settings import (
-    CONSTANCE_CONFIG,
-    CONSTANCE_DATABASE_PREFIX,
-    DATA_UPLOAD_MAX_MEMORY_SIZE,
-    KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC,
-)
+from posthog.settings import CONSTANCE_CONFIG, DATA_UPLOAD_MAX_MEMORY_SIZE, KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
 from posthog.test.base import BaseTest
 
 
@@ -203,9 +198,8 @@ class TestCapture(BaseTest):
         """
         distinct_id = "999"
         expected_key = f"{self.team.pk}:{distinct_id}"
-        key = CONSTANCE_DATABASE_PREFIX + "EVENT_PARTITION_KEYS_TO_OVERRIDE"
-
-        InstanceSetting.objects.create(key=key, raw_value=f'["{expected_key}"]')
+        key = "EVENT_PARTITION_KEYS_TO_OVERRIDE"
+        set_instance_setting(key, [expected_key])
         # Assume no cache for this test
         cache.clear()
 
@@ -255,9 +249,8 @@ class TestCapture(BaseTest):
         """
         distinct_id = "999"
         expected_key = f"{self.team.pk}:{distinct_id}"
-        key = CONSTANCE_DATABASE_PREFIX + "EVENT_PARTITION_KEYS_TO_OVERRIDE"
-
-        InstanceSetting.objects.create(key=key, raw_value=f'["{expected_key}"]')
+        key = "EVENT_PARTITION_KEYS_TO_OVERRIDE"
+        set_instance_setting(key, [expected_key])
         # Assume no cache for this test
         cache.clear()
 
@@ -305,8 +298,8 @@ class TestCapture(BaseTest):
         """
         distinct_id = "999"
         expected_key = f"{self.team.pk}:{distinct_id}"
-        key = CONSTANCE_DATABASE_PREFIX + "EVENT_PARTITION_KEYS_TO_OVERRIDE"
-        InstanceSetting.objects.create(key=key, raw_value=f'["{expected_key}"]')
+        key = "EVENT_PARTITION_KEYS_TO_OVERRIDE"
+        set_instance_setting(key, [expected_key])
         # Assume no caching for this test
         cache.clear()
 

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, call, patch
 from urllib.parse import quote
 
 import lzstring
+from django.core.cache import cache
 from django.db import Error as DjangoDatabaseError
 from django.db import connection
 from django.test.client import Client
@@ -203,7 +204,11 @@ class TestCapture(BaseTest):
         distinct_id = "999"
         expected_key = f"{self.team.pk}:{distinct_id}"
         key = CONSTANCE_DATABASE_PREFIX + "EVENT_PARTITION_KEYS_TO_OVERRIDE"
+
         InstanceSetting.objects.create(key=key, raw_value=f'["{expected_key}"]')
+        # Assume no cache for this test
+        cache.clear()
+
         data = {
             "event": "$autocapture",
             "properties": {
@@ -251,7 +256,11 @@ class TestCapture(BaseTest):
         distinct_id = "999"
         expected_key = f"{self.team.pk}:{distinct_id}"
         key = CONSTANCE_DATABASE_PREFIX + "EVENT_PARTITION_KEYS_TO_OVERRIDE"
+
         InstanceSetting.objects.create(key=key, raw_value=f'["{expected_key}"]')
+        # Assume no cache for this test
+        cache.clear()
+
         data = {
             "event": "$autocapture",
             "properties": {
@@ -298,6 +307,9 @@ class TestCapture(BaseTest):
         expected_key = f"{self.team.pk}:{distinct_id}"
         key = CONSTANCE_DATABASE_PREFIX + "EVENT_PARTITION_KEYS_TO_OVERRIDE"
         InstanceSetting.objects.create(key=key, raw_value=f'["{expected_key}"]')
+        # Assume no caching for this test
+        cache.clear()
+
         data = {
             "event": "$autocapture",
             "properties": {

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -175,7 +175,7 @@ class TestCapture(BaseTest):
                 ],
             },
         }
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost")
         self.assertEqual(response.get("access-control-allow-origin"), "https://localhost")
         self.assertDictContainsSubset(

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -75,6 +75,7 @@ class TestCapture(BaseTest):
 
     def setUp(self):
         super().setUp()
+        cache.clear()
         # it is really important to know that /capture is CSRF exempt. Enforce checking in the client
         self.client = Client(enforce_csrf_checks=True)
         self.database_override_key = "EVENT_PARTITION_KEYS_TO_OVERRIDE"

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -2,6 +2,7 @@ from typing import cast
 from unittest.mock import patch
 
 import pytest
+from django.core.cache import cache
 from django.utils import timezone
 from rest_framework import status
 
@@ -13,6 +14,10 @@ from posthog.version import VERSION
 
 class TestPreflight(APIBaseTest, QueryMatchingTest):
     maxDiff = 2000
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
 
     def instance_preferences(self, **kwargs):
         return {"debug_queries": False, "disable_paid_fs": False, **kwargs}

--- a/posthog/models/instance_setting.py
+++ b/posthog/models/instance_setting.py
@@ -69,7 +69,6 @@ def get_instance_settings(keys: List[str]) -> Any:
 def set_instance_setting(key: str, value: Any):
     raw_value = json.dumps(value)
     InstanceSetting.objects.update_or_create(key=CONSTANCE_DATABASE_PREFIX + key, defaults={"raw_value": raw_value})
-    cache.set(key, raw_value)
 
 
 @contextmanager

--- a/posthog/models/instance_setting.py
+++ b/posthog/models/instance_setting.py
@@ -23,6 +23,14 @@ class InstanceSetting(models.Model):
     def value(self):
         return json.loads(self.raw_value)
 
+    def delete(self, *args, **kwargs):
+        cache.delete(self.key.replace(CONSTANCE_DATABASE_PREFIX, ""))
+        super().delete(*args, **kwargs)
+
+    def save(self, *args, **kwargs):
+        cache.set(self.key.replace(CONSTANCE_DATABASE_PREFIX, ""), self.raw_value)
+        super().save(*args, **kwargs)
+
 
 def get_instance_setting(key: str) -> Any:
     assert key in CONSTANCE_CONFIG, f"Unknown dynamic setting: {repr(key)}"

--- a/posthog/models/instance_setting.py
+++ b/posthog/models/instance_setting.py
@@ -24,12 +24,12 @@ class InstanceSetting(models.Model):
         return json.loads(self.raw_value)
 
     def delete(self, *args, **kwargs):
-        cache.delete(self.key.replace(CONSTANCE_DATABASE_PREFIX, ""))
         super().delete(*args, **kwargs)
+        cache.delete(self.key.replace(CONSTANCE_DATABASE_PREFIX, ""))
 
     def save(self, *args, **kwargs):
-        cache.set(self.key.replace(CONSTANCE_DATABASE_PREFIX, ""), self.raw_value)
         super().save(*args, **kwargs)
+        cache.set(self.key.replace(CONSTANCE_DATABASE_PREFIX, ""), self.raw_value)
 
 
 def get_instance_setting(key: str) -> Any:

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -171,7 +171,12 @@ CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,
-        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            # In seconds:
+            "SOCKET_CONNECT_TIMEOUT": 5,
+            "SOCKET_TIMEOUT": 5,
+        },
         "KEY_PREFIX": "posthog",
     }
 }

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -172,7 +172,7 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,
         "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "CLIENT_CLASS": "django_redis.client.HerdClient",
             # In seconds:
             "SOCKET_CONNECT_TIMEOUT": 5,
             "SOCKET_TIMEOUT": 5,

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -123,6 +123,13 @@ CONSTANCE_CONFIG = {
         "Reply address to which email clients should send responses.",
         str,
     ),
+    "EVENT_PARTITION_KEYS_TO_OVERRIDE": (
+        get_from_env("EVENT_PARTITION_KEYS_TO_OVERRIDE", default=""),
+        "A list of <team_id:distinct_id> pairs (in the format 2:myLovelyId) that we should use"
+        "random partitioning for when producing events to the Kafka topic consumed by the plugin server"
+        "This is a measure to handle hot partitions in ad-hoc cases.",
+        str,
+    ),
     "ASYNC_MIGRATIONS_OPT_OUT_EMAILS": (
         get_from_env("ASYNC_MIGRATIONS_OPT_OUT_EMAILS", False, type_cast=str_to_bool),
         "Used to disable emails from async migrations service",
@@ -195,6 +202,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "EMAIL_USE_SSL",
     "EMAIL_DEFAULT_FROM",
     "EMAIL_REPLY_TO",
+    "EVENT_PARTITION_KEYS_TO_OVERRIDE",
     "ASYNC_MIGRATIONS_OPT_OUT_EMAILS",
     "PERSON_ON_EVENTS_ENABLED",
     "GROUPS_ON_EVENTS_ENABLED",

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -1,4 +1,6 @@
-from posthog.settings.utils import get_from_env, str_to_bool
+import os
+
+from posthog.settings.utils import get_from_env, get_list, str_to_bool
 
 CONSTANCE_DATABASE_PREFIX = "constance:posthog:"
 
@@ -124,11 +126,11 @@ CONSTANCE_CONFIG = {
         str,
     ),
     "EVENT_PARTITION_KEYS_TO_OVERRIDE": (
-        get_from_env("EVENT_PARTITION_KEYS_TO_OVERRIDE", default=""),
+        get_list(os.getenv("EVENT_PARTITION_KEYS_TO_OVERRIDE", "")),
         "A list of <team_id:distinct_id> pairs (in the format 2:myLovelyId) that we should use"
         "random partitioning for when producing events to the Kafka topic consumed by the plugin server"
         "This is a measure to handle hot partitions in ad-hoc cases.",
-        str,
+        list,
     ),
     "ASYNC_MIGRATIONS_OPT_OUT_EMAILS": (
         get_from_env("ASYNC_MIGRATIONS_OPT_OUT_EMAILS", False, type_cast=str_to_bool),

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -7,12 +7,6 @@ INGESTION_LAG_METRIC_TEAM_IDS = get_list(os.getenv("INGESTION_LAG_METRIC_TEAM_ID
 # KEEP IN SYNC WITH plugin-server/src/config/config.ts
 BUFFER_CONVERSION_SECONDS = get_from_env("BUFFER_CONVERSION_SECONDS", default=60, type_cast=int)
 
-
-# A list of <team_id:distinct_id> pairs (in the format 2:myLovelyId) that we should use
-# random partitioning for when producing events to the Kafka topic consumed by the plugin server.
-# This is a measure to handle hot partitions in ad-hoc cases.
-EVENT_PARTITION_KEYS_TO_OVERRIDE = get_list(os.getenv("EVENT_PARTITION_KEYS_TO_OVERRIDE", ""))
-
 LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS = get_list(os.getenv("LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS", ""))
 
 # Keep in sync with plugin-server

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 import sqlparse
 from django.apps import apps
+from django.core.cache import cache
 from django.db import connection, connections
 from django.db.migrations.executor import MigrationExecutor
 from django.test import TestCase, TransactionTestCase
@@ -167,6 +168,10 @@ class BaseTest(TestMixin, ErrorResponsesMixin, TestCase):
     Read more: https://docs.djangoproject.com/en/3.1/topics/testing/tools/#testcase
     """
 
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
     def is_cloud(self, value: bool):
         TEST_clear_cloud_cache()
         return self.settings(MULTI_TENANCY=value)
@@ -191,6 +196,8 @@ class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
 
     def setUp(self):
         super().setUp()
+
+        cache.clear()
 
         # Clear the cached "is_cloud" setting so that it's recalculated for each test
         TEST_clear_cloud_cache()

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 import pytest
 import sqlparse
 from django.apps import apps
-from django.core.cache import cache
 from django.db import connection, connections
 from django.db.migrations.executor import MigrationExecutor
 from django.test import TestCase, TransactionTestCase
@@ -168,10 +167,6 @@ class BaseTest(TestMixin, ErrorResponsesMixin, TestCase):
     Read more: https://docs.djangoproject.com/en/3.1/topics/testing/tools/#testcase
     """
 
-    def setUp(self):
-        super().setUp()
-        cache.clear()
-
     def is_cloud(self, value: bool):
         TEST_clear_cloud_cache()
         return self.settings(MULTI_TENANCY=value)
@@ -196,8 +191,6 @@ class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
 
     def setUp(self):
         super().setUp()
-
-        cache.clear()
 
         # Clear the cached "is_cloud" setting so that it's recalculated for each test
         TEST_clear_cloud_cache()

--- a/posthog/test/test_instance_setting_model.py
+++ b/posthog/test/test_instance_setting_model.py
@@ -99,10 +99,10 @@ def test_get_instance_setting_sets_cache(db, cache, raw_value):
     key = "my_key"
     patched = {key: ("default_value", "a help str", str)}
 
-    InstanceSetting.objects.create(key=settings.CONSTANCE_DATABASE_PREFIX + key, raw_value=raw_value)
-
     with patch.dict(settings.CONSTANCE_CONFIG, patched, clear=True):
         assert cache.get(key) is None
+
+        InstanceSetting.objects.create(key=settings.CONSTANCE_DATABASE_PREFIX + key, raw_value=raw_value)
 
         first_value = get_instance_setting(key)
         assert first_value == json.loads(raw_value)


### PR DESCRIPTION
## Problem

Problem: Overriding hot partition keys

From time to time, we see clients go crazy with events (usually big snapshots).
These events can cause an increase in a single partition in Kafka as we have assigned partition keys by `(team_id, distinct_id)` pairs. Whenever we detect this hot partition issue, we set a key override so that the misbehaving `(team_id, distinct_id)` pair is evenly distributed instead of going to a single partition.

The problem is that the override is set as an environment variable that has to trigger a re-deployment every time it's updated. This not only requires some overhead work, but also further slows down our application recovery during an incident as all worker pods reset.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Solution: Override keys with a dynamic setting

Our Django application supports dynamic settings. Let's add a key to our dynamic settings to set the override key dynamically via the admin UI. The code that uses the setting now needs to reference the `InstanceSettings` model instead:
+ The current environment value can be used as default after JSON formatting.
+ RISK: Our dynamic settings are currently not cached. We should use Redis cache to avoid hitting the database on every request.
  + Solution: Caching was implemented when fetching values to minimize db hits.
+ RISK: How will the endpoint behave if the cache is down? What if cache is slow?
  + Solution: Error handling will default to configured value in the event cache raises an exception.
+ RISK: How will the endpoint behave if the database is down?
  + Solution: On query errors, we default to the environment configuration value, which would be the same behavior as currently.

A few tests seem to depend on state from previous tests to pass, as enabling dynamic cache settings breaks them. They are as follows:

```
posthog/api/test/test_authentication.py::TestPasswordResetAPI::test_cant_reset_if_email_is_not_configured
posthog/api/test/test_preflight.py::TestPreflight::test_demo
posthog/api/test/test_preflight.py::TestPreflight::test_preflight_request
posthog/api/test/test_preflight.py::TestPreflight::test_preflight_request_unauthenticated
posthog/api/test/test_preflight.py::TestPreflight::test_preflight_request_with_object_storage_available
```

Running the tests in isolation one by one makes them pass, so it's clear they are failing due to some uncleaned state in the cache. This can be resolved by disabling cache on test setup, as I've done in my latest [commit](https://github.com/PostHog/posthog/pull/13891/commits/c6af8941fd7e0e090a9555d32db633d42457181d). This could potentially require a more in-depth review.

On a related note, Django is considering adding cache resets to it's `TestCase`: https://code.djangoproject.com/ticket/11505.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests initially added in `ee/api/test/test_capture.py` have been moved over to `posthog/api/test/test_capture.py`.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
