### PR TITLE
fix(admin): Remove unused fields from the Team admin page

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -43,6 +43,16 @@ class PluginAdmin(admin.ModelAdmin):
 class TeamAdmin(admin.ModelAdmin):
     list_display = ("id", "name", "organization_link", "organization_id")
     search_fields = ("name", "organization__id", "organization__name")
+    readonly_fields = ["primary_dashboard", "test_account_filters"]
+    exclude = [
+        "event_names",
+        "event_names_with_usage",
+        "plugins_opt_in",
+        "event_properties",
+        "event_properties_with_usage",
+        "event_properties_numerical",
+        "session_recording_retention_period_days",
+    ]
 
     def organization_link(self, team: Team):
         return format_html(


### PR DESCRIPTION
## Problem

We couldn't save any fields on a team because some disused fields were required but empty
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Hide those fields from the admin page.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Go to a team in django admin and try to change the api token
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
