### PR TITLE
feat(query-tags): add tag for number of entitities

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."$group_0" as "$group_0",
                                  e."properties" as "properties",
+                                 e."$group_0" as "$group_0",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."properties" as "properties",
                                  e."$group_0" as "$group_0",
+                                 e."properties" as "properties",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -434,6 +434,10 @@ class EntitiesMixin(BaseParamMixin):
             entity.index = index
         return processed_entities
 
+    @include_query_tags
+    def query_tags_entities(self):
+        return {"number_of_entities": len(self.entities)}
+
     @cached_property
     def actions(self) -> List[Entity]:
         return [entity for entity in self.entities if entity.type == TREND_FILTER_TYPE_ACTIONS]


### PR DESCRIPTION
This will be helpful in correlating the number of series / entities in a graph with query performance