### PR TITLE
chore: file down the sharp edges on dashboard templates

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."properties" as "properties",
                                  e."$group_0" as "$group_0",
+                                 e."properties" as "properties",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -607,7 +607,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     ? JSON.stringify(
                           {
                               template_name: dashboard.name,
-                              description: dashboard.description,
+                              dashboard_description: dashboard.description,
                               dashboard_filters: dashboard.filters,
                               tags: dashboard.tags || [],
                               tiles: dashboard.tiles.map((tile) => {

--- a/posthog/api/dashboards/dashboard_templates.py
+++ b/posthog/api/dashboards/dashboard_templates.py
@@ -69,7 +69,7 @@ class DashboardTemplateViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
 
         return response.Response(annotated_templates)
 
-    @cache_for(timedelta(seconds=5))
+    @cache_for(timedelta(seconds=1))
     def _load_repository_listing(self) -> List[Dict]:
         """
         The repository in GitHub will change infrequently,

--- a/posthog/api/dashboards/dashboard_templates.py
+++ b/posthog/api/dashboards/dashboard_templates.py
@@ -34,7 +34,9 @@ class DashboardTemplateSerializer(serializers.Serializer):
             raise ValidationError(f"Could not load template from GitHub. {e}")
 
         if "template_name" not in template or template["template_name"] != validated_data["name"]:
-            raise ValidationError(detail="The requested URL does not match the requested template.")
+            raise ValidationError(
+                detail=f'The requested template "{validated_data["name"]}" does not match the requested template URL which loaded the template "{template["template_name"]}"'
+            )
 
         return DashboardTemplate.objects.create(team_id=validated_data["team_id"], **template)
 


### PR DESCRIPTION
## Problem

Now I'm finally putting the pieces of dashboard templates together some are in metric and some imperial and so they don't quite match up

## Changes

* clearer error message that would have helped me
* a test for that validation
* shorten the caching it's not super helpful and is annoying when testing to see if things are working
* correct a field name in exported templates

## How did you test this code?

running it locally and seeing it work