### PR TITLE
chore: remove caching from loading github templates

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."$group_0" as "$group_0",
                                  e."properties" as "properties",
+                                 e."$group_0" as "$group_0",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."properties" as "properties",
                                  e."$group_0" as "$group_0",
+                                 e."properties" as "properties",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/posthog/api/dashboards/dashboard_templates.py
+++ b/posthog/api/dashboards/dashboard_templates.py
@@ -1,5 +1,4 @@
 import json
-from datetime import timedelta
 from typing import Dict, List
 
 import requests
@@ -10,7 +9,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 
 from posthog.api.routing import StructuredViewSetMixin
-from posthog.cache_utils import cache_for
+from posthog.logging.timing import timed
 from posthog.models.dashboard_templates import DashboardTemplate
 from posthog.permissions import ProjectMembershipNecessaryPermissions
 
@@ -54,6 +53,7 @@ class DashboardTemplateViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
         serializer.save(team_id=self.team_id)
         return response.Response(data="", status=status.HTTP_200_OK)
 
+    @timed("dashboard_templates.api_repository_load")
     @action(methods=["GET"], detail=False)
     def repository(self, request: request.Request, **kwargs) -> response.Response:
         loaded_templates = self._load_repository_listing()
@@ -69,12 +69,8 @@ class DashboardTemplateViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
 
         return response.Response(annotated_templates)
 
-    @cache_for(timedelta(seconds=1))
-    def _load_repository_listing(self) -> List[Dict]:
-        """
-        The repository in GitHub will change infrequently,
-        there is no point loading it over-the-wire on every request
-        """
+    @staticmethod
+    def _load_repository_listing() -> List[Dict]:
         url = "https://raw.githubusercontent.com/PostHog/templates-repository/main/dashboards/dashboards.json"
         loaded_templates: List[Dict] = json.loads(requests.get(url).text)
         return loaded_templates


### PR DESCRIPTION
## Problem

The call is really fast so the cache is likely not that helpful and the cache is annoying when updating and changing things

## Changes

removes the cache and adds a statsd timer instead

## How did you test this code?

👀 