### PR TITLE
feat(hogql): add "learn more" link

### DIFF
--- a/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
+++ b/frontend/src/queries/QueryEditor/InlineHogQLEditor.tsx
@@ -38,6 +38,11 @@ export function InlineHogQLEditor({ value, onChange }: InlineHogQLEditorProps): 
             >
                 {value ? 'Update HogQL expression' : 'Add HogQL expression'}
             </LemonButton>
+            <div className="text-right">
+                <a href="https://github.com/PostHog/meta/issues/86" target={'_blank'}>
+                    Learn more about HogQL
+                </a>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a link "Learn more about HogQL" that takes to this page: https://github.com/PostHog/meta/issues/86

<img width="1005" alt="image" src="https://user-images.githubusercontent.com/53387/214518661-13766642-0c3b-475c-bad7-945f9675436a.png">

There's [an issue](https://github.com/PostHog/posthog.com/issues/5146) out about making a nicer page to link to.

## How did you test this code?

The link showed up and worked locally in the browser.