### PR TITLE
fix(naming-things): replace with_data with shallow_clone

### DIFF
--- a/ee/api/session_recording_playlist.py
+++ b/ee/api/session_recording_playlist.py
@@ -210,7 +210,9 @@ class SessionRecordingPlaylistViewSet(StructuredViewSetMixin, ForbidDestroyModel
         )
 
         filter = SessionRecordingsFilter(request=request)
-        filter = filter.with_data({SESSION_RECORDINGS_FILTER_IDS: json.dumps([x.recording_id for x in playlist_items])})
+        filter = filter.shallow_clone(
+            {SESSION_RECORDINGS_FILTER_IDS: json.dumps([x.recording_id for x in playlist_items])}
+        )
 
         return response.Response(list_recordings(filter, request, self.team))
 

--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -70,7 +70,7 @@ class ClickhouseFunnelExperimentResult:
                 experiment_end_date.astimezone(pytz.timezone(team.timezone)) if experiment_end_date else None
             )
 
-        query_filter = filter.with_data(
+        query_filter = filter.shallow_clone(
             {
                 "date_from": start_date_in_project_timezone,
                 "date_to": end_date_in_project_timezone,

--- a/ee/clickhouse/queries/experiments/secondary_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/secondary_experiment_result.py
@@ -41,7 +41,7 @@ class ClickhouseSecondaryExperimentResult:
                 experiment_end_date.astimezone(pytz.timezone(team.timezone)) if experiment_end_date else None
             )
 
-        query_filter = filter.with_data(
+        query_filter = filter.shallow_clone(
             {
                 "date_from": start_date_in_project_timezone,
                 "date_to": end_date_in_project_timezone,
@@ -56,7 +56,7 @@ class ClickhouseSecondaryExperimentResult:
 
         self.team = team
         if query_filter.insight == INSIGHT_TRENDS:
-            query_filter = query_filter.with_data({"display": TRENDS_CUMULATIVE})
+            query_filter = query_filter.shallow_clone({"display": TRENDS_CUMULATIVE})
 
         self.query_filter = query_filter
 

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -69,7 +69,7 @@ class ClickhouseTrendExperimentResult:
                 experiment_end_date.astimezone(pytz.timezone(team.timezone)) if experiment_end_date else None
             )
 
-        query_filter = filter.with_data(
+        query_filter = filter.shallow_clone(
             {
                 "display": TRENDS_CUMULATIVE,
                 "date_from": start_date_in_project_timezone,
@@ -82,7 +82,7 @@ class ClickhouseTrendExperimentResult:
             }
         )
 
-        exposure_filter = filter.with_data(
+        exposure_filter = filter.shallow_clone(
             {
                 "display": TRENDS_CUMULATIVE,
                 "date_from": experiment_start_date,

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -114,7 +114,7 @@ class FunnelCorrelation:
         self._base_uri = base_uri
 
         if self._filter.funnel_step is None:
-            self._filter = self._filter.with_data({"funnel_step": 1})
+            self._filter = self._filter.shallow_clone({"funnel_step": 1})
             # Funnel Step by default set to 1, to give us all people who entered the funnel
 
         # Used for generating the funnel persons cte
@@ -701,11 +701,11 @@ class FunnelCorrelation:
 
     def construct_event_correlation_people_url(self, success: bool, event_definition: EventDefinition) -> str:
         # NOTE: we need to convert certain params to strings. I don't think this
-        # class should need to know these details, but with_data is
+        # class should need to know these details, but shallow_clone is
         # expecting the values as they are serialized in the url
         # TODO: remove url serialization details from this class, it likely
         # belongs in the application layer, or perhaps `FunnelCorrelationPeople`
-        params = self._filter.with_data(
+        params = self._filter.shallow_clone(
             {
                 "funnel_correlation_person_converted": "true" if success else "false",
                 "funnel_correlation_person_entity": {"id": event_definition["event"], "type": "events"},
@@ -726,7 +726,7 @@ class FunnelCorrelation:
                 "text": first_element["text"],
                 "selector": build_selector(elements),
             }
-            params = self._filter.with_data(
+            params = self._filter.shallow_clone(
                 {
                     "funnel_correlation_person_converted": "true" if success else "false",
                     "funnel_correlation_person_entity": {
@@ -743,7 +743,7 @@ class FunnelCorrelation:
             return f"{self._base_uri}api/person/funnel/correlation/?{urllib.parse.urlencode(params)}"
 
         event_name, property_name, property_value = event_definition["event"].split("::")
-        params = self._filter.with_data(
+        params = self._filter.shallow_clone(
             {
                 "funnel_correlation_person_converted": "true" if success else "false",
                 "funnel_correlation_person_entity": {
@@ -763,7 +763,7 @@ class FunnelCorrelation:
         # event.event will be of the format "{property_name}::{property_value}"
         property_name, property_value = event_definition["event"].split("::")
         prop_type = "group" if self._filter.aggregation_group_type_index else "person"
-        params = self._filter.with_data(
+        params = self._filter.shallow_clone(
             {
                 "funnel_correlation_person_converted": "true" if success else "false",
                 "funnel_correlation_property_values": [

--- a/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
@@ -26,7 +26,7 @@ class FunnelCorrelationActors(ActorBaseQuery):
         self._team = team
 
         if not self._filter.correlation_person_limit:
-            self._filter = self._filter.with_data({FUNNEL_CORRELATION_PERSON_LIMIT: 100})
+            self._filter = self._filter.shallow_clone({FUNNEL_CORRELATION_PERSON_LIMIT: 100})
 
     @cached_property
     def aggregation_group_type_index(self):
@@ -141,7 +141,7 @@ class _FunnelPropertyCorrelationActors(ActorBaseQuery):
 
     def __init__(self, filter: Filter, team: Team, base_uri: str = "/") -> None:
         # Filtering on persons / groups properties can be pushed down to funnel_actors CTE
-        new_correlation_filter = filter.with_data(
+        new_correlation_filter = filter.shallow_clone(
             {
                 "properties": filter.property_groups.combine_properties(
                     PropertyOperatorType.AND, filter.correlation_property_values or []

--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -15,7 +15,7 @@ from posthog.test.test_journeys import journeys_for
 def funnel_breakdown_group_test_factory(Funnel, FunnelPerson, _create_event, _create_action, _create_person):
     class TestFunnelBreakdownGroup(APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-            person_filter = filter.with_data({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
+            person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
             _, serialized_result, _ = FunnelPerson(person_filter, self.team).get_actors()
 
             return [val["id"] for val in serialized_result]

--- a/ee/clickhouse/queries/funnels/test/test_funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_correlation.py
@@ -38,7 +38,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
     def _get_actors_for_event(self, filter: Filter, event_name: str, properties=None, success=True):
-        actor_filter = filter.with_data(
+        actor_filter = filter.shallow_clone(
             {
                 "funnel_correlation_person_entity": {"id": event_name, "type": "events", "properties": properties},
                 "funnel_correlation_person_converted": "TrUe" if success else "falSE",
@@ -49,7 +49,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         return [str(row["id"]) for row in serialized_actors]
 
     def _get_actors_for_property(self, filter: Filter, property_values: list, success=True):
-        actor_filter = filter.with_data(
+        actor_filter = filter.shallow_clone(
             {
                 "funnel_correlation_property_values": [
                     {"key": prop, "value": value, "type": type, "group_type_index": group_type_index}
@@ -137,7 +137,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(self._get_actors_for_event(filter, "negatively_related")), 0)
 
         # Now exclude positively_related
-        filter = filter.with_data({"funnel_correlation_exclude_event_names": ["positively_related"]})
+        filter = filter.shallow_clone({"funnel_correlation_exclude_event_names": ["positively_related"]})
         correlation = FunnelCorrelation(filter, self.team)
 
         result = correlation._run()[0]
@@ -355,7 +355,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(self._get_actors_for_event(filter, "negatively_related", success=False)), 1)
 
         # Now exclude all groups in positive
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {"properties": [{"key": "industry", "value": "finance", "type": "group", "group_type_index": 0}]}
         )
         result = FunnelCorrelation(filter, self.team)._run()[0]
@@ -632,7 +632,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
         # test with `$all` as property
         # _run property correlation with filter on all properties
-        filter = filter.with_data({"funnel_correlation_names": ["$all"]})
+        filter = filter.shallow_clone({"funnel_correlation_names": ["$all"]})
         correlation = FunnelCorrelation(filter, self.team)
 
         new_result = correlation._run()[0]
@@ -798,7 +798,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
             # test with `$all` as property
             # _run property correlation with filter on all properties
-            filter = filter.with_data({"funnel_correlation_names": ["$all"]})
+            filter = filter.shallow_clone({"funnel_correlation_names": ["$all"]})
             correlation = FunnelCorrelation(filter, self.team)
 
             new_result = correlation._run()[0]
@@ -903,7 +903,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         with self.assertRaises(ValidationError):
             correlation._run()
 
-        filter = filter.with_data({"funnel_correlation_type": "event_with_properties"})
+        filter = filter.shallow_clone({"funnel_correlation_type": "event_with_properties"})
         # missing "funnel_correlation_event_names": ["rick"],
         with self.assertRaises(ValidationError):
             FunnelCorrelation(filter, self.team)._run()
@@ -1037,7 +1037,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(result, expected_result)
 
         # _run property correlation with filter on all properties
-        filter = filter.with_data({"funnel_correlation_names": ["$all"]})
+        filter = filter.shallow_clone({"funnel_correlation_names": ["$all"]})
         correlation = FunnelCorrelation(filter, self.team)
 
         new_result = correlation._run()[0]
@@ -1055,7 +1055,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(new_result, new_expected_result)
 
-        filter = filter.with_data({"funnel_correlation_exclude_names": ["$browser"]})
+        filter = filter.shallow_clone({"funnel_correlation_exclude_names": ["$browser"]})
         # search for $all but exclude $browser
         correlation = FunnelCorrelation(filter, self.team)
 

--- a/ee/clickhouse/queries/funnels/test/test_funnel_correlations_persons.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_correlations_persons.py
@@ -96,7 +96,7 @@ class TestClickhouseFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
         filter, success_target_persons, failure_target_persons, person_fail, person_succ = self._setup_basic_test()
 
         # test positively_related successes
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {
                 "funnel_correlation_person_entity": {"id": "positively_related", "type": "events"},
                 "funnel_correlation_person_converted": "TrUe",
@@ -107,7 +107,7 @@ class TestClickhouseFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual([str(val["id"]) for val in serialized_actors], success_target_persons)
 
         # test negatively_related failures
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {
                 "funnel_correlation_person_entity": {"id": "negatively_related", "type": "events"},
                 "funnel_correlation_person_converted": "falsE",
@@ -119,7 +119,7 @@ class TestClickhouseFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual([str(val["id"]) for val in serialized_actors], failure_target_persons)
 
         # test positively_related failures
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {
                 "funnel_correlation_person_entity": {"id": "positively_related", "type": "events"},
                 "funnel_correlation_person_converted": "False",
@@ -130,7 +130,7 @@ class TestClickhouseFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual([str(val["id"]) for val in serialized_actors], [str(person_fail.uuid)])
 
         # test negatively_related successes
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {
                 "funnel_correlation_person_entity": {"id": "negatively_related", "type": "events"},
                 "funnel_correlation_person_converted": "trUE",
@@ -141,7 +141,7 @@ class TestClickhouseFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual([str(val["id"]) for val in serialized_actors], [str(person_succ.uuid)])
 
         # test all positively_related
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {
                 "funnel_correlation_person_entity": {"id": "positively_related", "type": "events"},
                 "funnel_correlation_person_converted": None,
@@ -154,7 +154,7 @@ class TestClickhouseFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
         )
 
         # test all negatively_related
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {
                 "funnel_correlation_person_entity": {"id": "negatively_related", "type": "events"},
                 "funnel_correlation_person_converted": None,

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -334,7 +334,9 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
         self._run_query(filter)
 
         self._run_query(
-            filter.with_data({"properties": [{"key": "tag_name", "value": [], "operator": "exact", "type": "element"}]})
+            filter.shallow_clone(
+                {"properties": [{"key": "tag_name", "value": [], "operator": "exact", "type": "element"}]}
+            )
         )
 
     def _create_groups_test_data(self):

--- a/ee/clickhouse/queries/test/test_person_query.py
+++ b/ee/clickhouse/queries/test/test_person_query.py
@@ -127,7 +127,7 @@ def test_person_query_with_extra_requested_fields(testdata, team, snapshot):
     assert person_query(team, filter) == snapshot
     assert run_query(team, filter) == {"rows": 2, "columns": 2}
 
-    filter = filter.with_data({"breakdown": "email", "breakdown_type": "person"})
+    filter = filter.shallow_clone({"breakdown": "email", "breakdown_type": "person"})
     assert person_query(team, filter) == snapshot
     assert run_query(team, filter) == {"rows": 2, "columns": 2}
 

--- a/ee/clickhouse/queries/test/test_property_optimizer.py
+++ b/ee/clickhouse/queries/test/test_property_optimizer.py
@@ -12,14 +12,14 @@ PROPERTIES_OF_ALL_TYPES = [
 ]
 
 BASE_FILTER = Filter({"events": [{"id": "$pageview", "type": "events", "order": 0}]})
-FILTER_WITH_GROUPS = BASE_FILTER.with_data({"properties": {"type": "AND", "values": PROPERTIES_OF_ALL_TYPES}})
+FILTER_WITH_GROUPS = BASE_FILTER.shallow_clone({"properties": {"type": "AND", "values": PROPERTIES_OF_ALL_TYPES}})
 TEAM_ID = 3
 
 
 class TestPersonPropertySelector(unittest.TestCase):
     def test_basic_selector(self):
 
-        filter = BASE_FILTER.with_data(
+        filter = BASE_FILTER.shallow_clone(
             {
                 "properties": {
                     "type": "OR",
@@ -34,7 +34,7 @@ class TestPersonPropertySelector(unittest.TestCase):
 
     def test_multilevel_selector(self):
 
-        filter = BASE_FILTER.with_data(
+        filter = BASE_FILTER.shallow_clone(
             {
                 "properties": {
                     "type": "AND",
@@ -62,7 +62,7 @@ class TestPersonPropertySelector(unittest.TestCase):
 
     def test_multilevel_selector_with_valid_OR_persons(self):
 
-        filter = BASE_FILTER.with_data(
+        filter = BASE_FILTER.shallow_clone(
             {
                 "properties": {
                     "type": "OR",
@@ -125,7 +125,7 @@ class TestPersonPushdown(unittest.TestCase):
         )
 
     def test_person_properties_mixed_with_event_properties(self):
-        filter = BASE_FILTER.with_data(
+        filter = BASE_FILTER.shallow_clone(
             {
                 "properties": {
                     "type": "AND",
@@ -188,7 +188,7 @@ class TestPersonPushdown(unittest.TestCase):
         )
 
     def test_person_properties_with_or_not_mixed_with_event_properties(self):
-        filter = BASE_FILTER.with_data(
+        filter = BASE_FILTER.shallow_clone(
             {
                 "properties": {
                     "type": "AND",
@@ -254,7 +254,7 @@ class TestPersonPushdown(unittest.TestCase):
         )
 
     def test_person_properties_mixed_with_event_properties_with_misdirection_using_nested_groups(self):
-        filter = BASE_FILTER.with_data(
+        filter = BASE_FILTER.shallow_clone(
             {
                 "properties": {
                     "type": "AND",

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -109,7 +109,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
             [[2, 2, 1, 2, 2, 0, 1], [2, 1, 2, 2, 0, 1], [1, 1, 1, 0, 0], [2, 2, 0, 1], [2, 0, 1], [0, 0], [1]],
         )
 
-        actor_result, _ = Retention().actors_in_period(filter.with_data({"selected_interval": 0}), self.team)
+        actor_result, _ = Retention().actors_in_period(filter.shallow_clone({"selected_interval": 0}), self.team)
         self.assertCountEqual([actor["person"]["id"] for actor in actor_result], ["org:5", "org:6"])
 
         filter = RetentionFilter(
@@ -142,7 +142,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
         )
 
-        actor_result, _ = Retention().actors_in_period(filter.with_data({"selected_interval": 0}), self.team)
+        actor_result, _ = Retention().actors_in_period(filter.shallow_clone({"selected_interval": 0}), self.team)
 
         self.assertEqual(actor_result[0]["person"]["id"], "org:5")
         self.assertEqual(actor_result[0]["appearances"], [1, 1, 1, 1, 1, 0, 0])
@@ -227,7 +227,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
                 [[2, 2, 1, 2, 2, 0, 1], [2, 1, 2, 2, 0, 1], [1, 1, 1, 0, 0], [2, 2, 0, 1], [2, 0, 1], [0, 0], [1]],
             )
 
-            actor_result, _ = Retention().actors_in_period(filter.with_data({"selected_interval": 0}), self.team)
+            actor_result, _ = Retention().actors_in_period(filter.shallow_clone({"selected_interval": 0}), self.team)
 
             self.assertCountEqual([actor["person"]["id"] for actor in actor_result], ["org:5", "org:6"])
 
@@ -266,7 +266,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
         )
 
         with override_instance_config("PERSON_ON_EVENTS_ENABLED", True):
-            actor_result, _ = Retention().actors_in_period(filter.with_data({"selected_interval": 0}), self.team)
+            actor_result, _ = Retention().actors_in_period(filter.shallow_clone({"selected_interval": 0}), self.team)
 
             self.assertTrue(actor_result[0]["person"]["id"] == "org:5")
             self.assertEqual(actor_result[0]["appearances"], [1, 1, 1, 1, 1, 0, 0])

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -266,7 +266,7 @@ class ClickhouseExperimentsViewSet(StructuredViewSetMixin, viewsets.ModelViewSet
     @action(methods=["GET"], detail=False)
     def requires_flag_implementation(self, request: Request, *args: Any, **kwargs: Any) -> Response:
 
-        filter = Filter(request=request, team=self.team).with_data({"date_from": "-7d", "date_to": ""})
+        filter = Filter(request=request, team=self.team).shallow_clone({"date_from": "-7d", "date_to": ""})
 
         warning = requires_flag_warning(filter, self.team)
 

--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -25,7 +25,7 @@ class EnterprisePersonViewSet(PersonViewSet):
     ) -> Dict[str, Tuple[List, Optional[str], Optional[str], int]]:
         filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS}, team=self.team)
         if not filter.correlation_person_limit:
-            filter = filter.with_data({FUNNEL_CORRELATION_PERSON_LIMIT: 100})
+            filter = filter.shallow_clone({FUNNEL_CORRELATION_PERSON_LIMIT: 100})
         base_uri = request.build_absolute_uri("/")
         actors, serialized_actors, raw_count = FunnelCorrelationActors(
             filter=filter, team=self.team, base_uri=base_uri

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -190,7 +190,7 @@ class ActionViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestro
         team = self.team
         filter = Filter(request=request, team=self.team)
         if not filter.limit:
-            filter = filter.with_data({LIMIT: 100})
+            filter = filter.shallow_clone({LIMIT: 100})
 
         entity = get_target_entity(filter)
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -213,7 +213,7 @@ class CohortViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         is_csv_request = self.request.accepted_renderer.format == "csv" or request.GET.get("is_csv_export")
         if is_csv_request and not filter.limit:
-            filter = filter.with_data({LIMIT: CSV_EXPORT_LIMIT, OFFSET: 0})
+            filter = filter.shallow_clone({LIMIT: CSV_EXPORT_LIMIT, OFFSET: 0})
         elif not filter.limit:
             filter = filter.with_data({LIMIT: 100})
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -215,7 +215,7 @@ class CohortViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         if is_csv_request and not filter.limit:
             filter = filter.shallow_clone({LIMIT: CSV_EXPORT_LIMIT, OFFSET: 0})
         elif not filter.limit:
-            filter = filter.with_data({LIMIT: 100})
+            filter = filter.shallow_clone({LIMIT: 100})
 
         query, params = PersonQuery(filter, team.pk, cohort=cohort).get_query(paginate=True)
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -867,7 +867,7 @@ Using the correct cache and enriching the response with dashboard specific confi
 
         #  backwards compatibility
         if filter.path_type:
-            filter = filter.with_data({PATHS_INCLUDE_EVENT_TYPES: [filter.path_type]})
+            filter = filter.shallow_clone({PATHS_INCLUDE_EVENT_TYPES: [filter.path_type]})
         resp = self.paths_query_class(filter=filter, team=team, funnel_filter=funnel_filter).run()
 
         return {"result": resp, "timezone": team.timezone}

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -192,9 +192,9 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
         is_csv_request = self.request.accepted_renderer.format == "csv"
         if is_csv_request:
-            filter = filter.with_data({LIMIT: CSV_EXPORT_LIMIT, OFFSET: 0})
+            filter = filter.shallow_clone({LIMIT: CSV_EXPORT_LIMIT, OFFSET: 0})
         elif not filter.limit:
-            filter = filter.with_data({LIMIT: DEFAULT_PAGE_LIMIT})
+            filter = filter.shallow_clone({LIMIT: DEFAULT_PAGE_LIMIT})
 
         query, params = PersonQuery(filter, team.pk).get_query(paginate=True)
 
@@ -637,7 +637,7 @@ T = TypeVar("T", Filter, PathFilter, RetentionFilter, StickinessFilter)
 
 def prepare_actor_query_filter(filter: T) -> T:
     if not filter.limit:
-        filter = filter.with_data({LIMIT: DEFAULT_PAGE_LIMIT})
+        filter = filter.shallow_clone({LIMIT: DEFAULT_PAGE_LIMIT})
 
     search = getattr(filter, "search", None)
     if not search:
@@ -677,7 +677,7 @@ def prepare_actor_query_filter(filter: T) -> T:
         else new_group
     )
 
-    return filter.with_data({"properties": prop_group, "search": None})
+    return filter.shallow_clone({"properties": prop_group, "search": None})
 
 
 class LegacyPersonViewSet(PersonViewSet):

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -217,7 +217,7 @@ def list_recordings(filter: SessionRecordingsFilter, request: request.Request, t
         recordings = recordings + list(persisted_recordings)
 
         remaining_session_ids = list(set(all_session_ids) - {x.session_id for x in persisted_recordings})
-        filter = filter.with_data({SESSION_RECORDINGS_FILTER_IDS: json.dumps(remaining_session_ids)})
+        filter = filter.shallow_clone({SESSION_RECORDINGS_FILTER_IDS: json.dumps(remaining_session_ids)})
 
     if (all_session_ids and filter.session_ids) or not all_session_ids:
         # Only go to clickhouse if we still have remaining specified IDs or we are not specifying IDs

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -46,7 +46,7 @@ class BaseFilter(BaseParamMixin, HogQLParamMixin):
         return json.dumps(self.to_dict(), default=lambda o: o.__dict__, sort_keys=True, indent=4)
 
     def shallow_clone(self, overrides: Dict[str, Any]):
-        "Allow making copy of filter whilst preserving the class"
+        "Clone the filter's data while sharing the HogQL context"
         return type(self)(data={**self._data, **overrides}, **{**self.kwargs, "hogql_context": self.hogql_context})
 
     def query_tags(self) -> Dict[str, Any]:

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -45,7 +45,7 @@ class BaseFilter(BaseParamMixin, HogQLParamMixin):
     def toJSON(self):
         return json.dumps(self.to_dict(), default=lambda o: o.__dict__, sort_keys=True, indent=4)
 
-    def with_data(self, overrides: Dict[str, Any]):
+    def shallow_clone(self, overrides: Dict[str, Any]):
         "Allow making copy of filter whilst preserving the class"
         return type(self)(data={**self._data, **overrides}, **{**self.kwargs, "hogql_context": self.hogql_context})
 

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -24,7 +24,7 @@ class SimplifyFilterMixin:
             return self
 
         # :TRICKY: Make a copy to avoid caching issues
-        result: Any = self.with_data({"is_simplified": True})  # type: ignore
+        result: Any = self.shallow_clone({"is_simplified": True})  # type: ignore
 
         if getattr(result, "filter_test_accounts", False):
             new_group = {"type": "AND", "values": team.test_account_filters}
@@ -33,7 +33,7 @@ class SimplifyFilterMixin:
                 if result.property_groups.to_dict()
                 else new_group
             )
-            result = result.with_data({"properties": prop_group, "filter_test_accounts": False})
+            result = result.shallow_clone({"properties": prop_group, "filter_test_accounts": False})
 
         updated_entities = {}
         if hasattr(result, "entities_to_dict"):
@@ -53,7 +53,7 @@ class SimplifyFilterMixin:
             new_group = {"type": "AND", "values": new_group_props}
             prop_group = {"type": "AND", "values": [new_group, prop_group]} if prop_group else new_group
 
-        return result.with_data({**updated_entities, "properties": prop_group})
+        return result.shallow_clone({**updated_entities, "properties": prop_group})
 
     def _simplify_entity(
         self, team: "Team", entity_type: Literal["events", "actions", "exclusions"], entity_params: Dict, **kwargs

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -29,7 +29,7 @@ def determine_compared_filter(filter: F) -> F:
         filter.interval,
     )
 
-    return filter.with_data({"date_from": date_from.isoformat(), "date_to": date_to.isoformat()})
+    return filter.shallow_clone({"date_from": date_from.isoformat(), "date_to": date_to.isoformat()})
 
 
 def convert_to_comparison(trend_entities: List[Dict[str, Any]], filter, label: str) -> List[Dict[str, Any]]:

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -223,7 +223,7 @@ class FOSSCohortQuery(EventQuery):
             return property_group
 
         new_props = _unwrap(filter.property_groups)
-        return filter.with_data({"properties": new_props.to_dict()})
+        return filter.shallow_clone({"properties": new_props.to_dict()})
 
     # Implemented in /ee
     def get_query(self) -> Tuple[str, Dict[str, Any]]:

--- a/posthog/queries/funnels/test/breakdown_cases.py
+++ b/posthog/queries/funnels/test/breakdown_cases.py
@@ -26,7 +26,7 @@ class FunnelStepResult:
 def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_action, _create_person):
     class TestFunnelBreakdown(APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-            person_filter = filter.with_data({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
+            person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
             _, serialized_result, _ = FunnelPerson(person_filter, self.team).get_actors()
 
             return [val["id"] for val in serialized_result]

--- a/posthog/queries/funnels/test/conversion_time_cases.py
+++ b/posthog/queries/funnels/test/conversion_time_cases.py
@@ -9,7 +9,7 @@ from posthog.test.test_journeys import journeys_for
 def funnel_conversion_time_test_factory(Funnel, FunnelPerson, _create_event, _create_person):
     class TestFunnelConversionTime(APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-            person_filter = filter.with_data({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
+            person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
             _, serialized_result, _ = FunnelPerson(person_filter, self.team).get_actors()
 
             return [val["id"] for val in serialized_result]
@@ -152,7 +152,7 @@ def funnel_conversion_time_test_factory(Funnel, FunnelPerson, _create_event, _cr
                 [people["stopped_after_signup1"].uuid, people["stopped_after_signup3"].uuid],
             )
 
-            filter = filter.with_data({"funnel_window_interval": 5, "funnel_window_interval_unit": "minute"})
+            filter = filter.shallow_clone({"funnel_window_interval": 5, "funnel_window_interval_unit": "minute"})
 
             funnel = Funnel(filter, self.team)
             result4 = funnel.run()

--- a/posthog/queries/funnels/test/test_funnel.py
+++ b/posthog/queries/funnels/test/test_funnel.py
@@ -45,7 +45,7 @@ class TestFunnelConversionTime(ClickhouseTestMixin, funnel_conversion_time_test_
 def funnel_test_factory(Funnel, event_factory, person_factory):
     class TestGetFunnel(ClickhouseTestMixin, APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-            person_filter = filter.with_data({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
+            person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
             _, serialized_result, _ = ClickhouseFunnelActors(person_filter, self.team).get_actors()
 
             return [val["id"] for val in serialized_result]
@@ -799,7 +799,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 1), [person1.uuid, person2.uuid])
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 1, "funnel_to_step": 2}]}
             )
             funnel = Funnel(filter, self.team)
@@ -813,7 +813,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 1), [person2.uuid, person3.uuid])
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 2, "funnel_to_step": 3}]}
             )
             funnel = Funnel(filter, self.team)
@@ -827,7 +827,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 1), [person3.uuid])
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 3, "funnel_to_step": 4}]}
             )
             funnel = Funnel(filter, self.team)
@@ -842,7 +842,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 1), [])
 
             #  bigger step window
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 1, "funnel_to_step": 3}]}
             )
             funnel = Funnel(filter, self.team)
@@ -1596,17 +1596,17 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             filter = Filter(data=filters)
             self.assertRaises(ValidationError, lambda: Funnel(filter, self.team))
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 1, "funnel_to_step": 2}]}
             )
             self.assertRaises(ValidationError, lambda: Funnel(filter, self.team))
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 2, "funnel_to_step": 1}]}
             )
             self.assertRaises(ValidationError, lambda: Funnel(filter, self.team))
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 2}]}
             )
             self.assertRaises(ValidationError, lambda: Funnel(filter, self.team))
@@ -1857,7 +1857,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 1), [person4.uuid])
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {
                     "exclusions": [
                         {"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1},
@@ -1876,7 +1876,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 1), [person4.uuid])
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {
                     "exclusions": [
                         {"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1},
@@ -1895,7 +1895,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 1), [person4.uuid])
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {
                     "exclusions": [
                         {"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 4},

--- a/posthog/queries/funnels/test/test_funnel_persons.py
+++ b/posthog/queries/funnels/test/test_funnel_persons.py
@@ -234,10 +234,10 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         ]
 
         for funnel_step, custom_steps, expected_count in parameters:
-            filter = base_filter.with_data({"funnel_step": funnel_step})
+            filter = base_filter.shallow_clone({"funnel_step": funnel_step})
             _, results, _ = ClickhouseFunnelActors(filter, self.team).get_actors()
 
-            new_filter = base_filter.with_data({"funnel_custom_steps": custom_steps})
+            new_filter = base_filter.shallow_clone({"funnel_custom_steps": custom_steps})
             _, new_results, _ = ClickhouseFunnelActors(new_filter, self.team).get_actors()
 
             self.assertEqual(new_results, results)
@@ -268,7 +268,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         ]
 
         for custom_steps, expected_count in parameters:
-            new_filter = base_filter.with_data({"funnel_custom_steps": custom_steps})
+            new_filter = base_filter.shallow_clone({"funnel_custom_steps": custom_steps})
             _, new_results, _ = ClickhouseFunnelActors(new_filter, self.team).get_actors()
 
             self.assertEqual(len(new_results), expected_count)
@@ -315,13 +315,13 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual([val["id"] for val in results], [person1.uuid, person2.uuid])
 
         _, results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": "Chrome"}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": "Chrome"}), self.team
         ).get_actors()
 
         self.assertCountEqual([val["id"] for val in results], [person1.uuid])
 
         _, results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": "Safari"}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": "Safari"}), self.team
         ).get_actors()
 
         self.assertCountEqual([val["id"] for val in results], [person2.uuid])
@@ -346,13 +346,13 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual([val["id"] for val in results], [person1.uuid, person2.uuid])
 
         _, results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": ["Chrome", "95"]}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": ["Chrome", "95"]}), self.team
         ).get_actors()
 
         self.assertCountEqual([val["id"] for val in results], [person1.uuid])
 
         _, results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": ["Safari", "14"]}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": ["Safari", "14"]}), self.team
         ).get_actors()
         self.assertCountEqual([val["id"] for val in results], [person2.uuid])
 
@@ -377,24 +377,24 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual([val["id"] for val in results], [person1.uuid, person2.uuid])
 
         _, results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": "EE"}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": "EE"}), self.team
         ).get_actors()
         self.assertCountEqual([val["id"] for val in results], [person2.uuid])
 
         # Check custom_steps give same answers for breakdowns
         _, custom_step_results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": "EE", "funnel_custom_steps": [1, 2, 3]}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": "EE", "funnel_custom_steps": [1, 2, 3]}), self.team
         ).get_actors()
         self.assertEqual(results, custom_step_results)
 
         _, results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": "PL"}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": "PL"}), self.team
         ).get_actors()
         self.assertCountEqual([val["id"] for val in results], [person1.uuid])
 
         # Check custom_steps give same answers for breakdowns
         _, custom_step_results, _ = ClickhouseFunnelActors(
-            filter.with_data({"funnel_step_breakdown": "PL", "funnel_custom_steps": [1, 2, 3]}), self.team
+            filter.shallow_clone({"funnel_step_breakdown": "PL", "funnel_custom_steps": [1, 2, 3]}), self.team
         ).get_actors()
         self.assertEqual(results, custom_step_results)
 

--- a/posthog/queries/funnels/test/test_funnel_strict.py
+++ b/posthog/queries/funnels/test/test_funnel_strict.py
@@ -157,7 +157,7 @@ class TestFunnelStrictSteps(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
     def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-        person_filter = filter.with_data({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
+        person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
         _, serialized_result, _ = ClickhouseFunnelStrictActors(person_filter, self.team).get_actors()
 
         return [val["id"] for val in serialized_result]

--- a/posthog/queries/funnels/test/test_funnel_trends.py
+++ b/posthog/queries/funnels/test/test_funnel_trends.py
@@ -19,7 +19,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
     def _get_actors_at_step(self, filter, entrance_period_start, drop_off):
-        person_filter = filter.with_data({"entrance_period_start": entrance_period_start, "drop_off": drop_off})
+        person_filter = filter.shallow_clone({"entrance_period_start": entrance_period_start, "drop_off": drop_off})
         funnel_query_builder = ClickhouseFunnelTrendsActors(person_filter, self.team)
         _, serialized_result, _ = funnel_query_builder.get_actors()
 

--- a/posthog/queries/funnels/test/test_funnel_unordered.py
+++ b/posthog/queries/funnels/test/test_funnel_unordered.py
@@ -548,7 +548,7 @@ class TestFunnelUnorderedStepsConversionTime(ClickhouseTestMixin, funnel_convers
 
 class TestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
     def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-        person_filter = filter.with_data({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
+        person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
         _, serialized_result, _ = ClickhouseFunnelUnorderedActors(person_filter, self.team).get_actors()
 
         return [val["id"] for val in serialized_result]
@@ -923,7 +923,7 @@ class TestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
         self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team).run())
 
         # partial windows not allowed for unordered
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {"exclusions": [{"id": "x", "type": "events", "funnel_from_step": 0, "funnel_to_step": 1}]}
         )
         self.assertRaises(ValidationError, lambda: ClickhouseFunnelUnordered(filter, self.team).run())

--- a/posthog/queries/funnels/test/test_funnel_unordered_persons.py
+++ b/posthog/queries/funnels/test/test_funnel_unordered_persons.py
@@ -59,7 +59,7 @@ class TestFunnelUnorderedStepsPersons(ClickhouseTestMixin, APIBaseTest):
         with self.assertRaises(ValueError):
             ClickhouseFunnelUnorderedActors(filter, self.team).run()
 
-        filter = filter.with_data({"funnel_step": -1})
+        filter = filter.shallow_clone({"funnel_step": -1})
         with pytest.raises(ValueError):
             _, _, _ = ClickhouseFunnelUnorderedActors(filter, self.team).run()
 

--- a/posthog/queries/paths/paths.py
+++ b/posthog/queries/paths/paths.py
@@ -59,11 +59,11 @@ class Paths:
             raise ValidationError("Cannot include all custom events and specific custom events in the same query")
 
         if not self._filter.limit:
-            self._filter = self._filter.with_data({LIMIT: 100})
+            self._filter = self._filter.shallow_clone({LIMIT: 100})
 
         if self._filter.edge_limit is None and not (self._filter.start_point and self._filter.end_point):
             # no edge restriction when both start and end points are defined
-            self._filter = self._filter.with_data({PATH_EDGE_LIMIT: EDGE_LIMIT_DEFAULT})
+            self._filter = self._filter.shallow_clone({PATH_EDGE_LIMIT: EDGE_LIMIT_DEFAULT})
 
     def run(self, *args, **kwargs):
         results = self._exec_query()

--- a/posthog/queries/properties_timeline/properties_timeline.py
+++ b/posthog/queries/properties_timeline/properties_timeline.py
@@ -84,7 +84,7 @@ class PropertiesTimeline:
     ) -> PropertiesTimelineResult:
         if filter._date_from is not None and filter._date_to is not None and filter._date_from == filter._date_to:
             # Search for `offset_time_series_date_by_interval` in the `TrendsActors` class for context on this handling
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {
                     "date_to": offset_time_series_date_by_interval(
                         cast(datetime.datetime, filter.date_from), filter=filter, team=team

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -145,7 +145,7 @@ def build_returning_event_query(
     retention_events_query=RetentionEventsQuery,
 ) -> Tuple[str, Dict[str, Any]]:
     returning_event_query_templated, returning_event_params = retention_events_query(
-        filter=filter.with_data({"breakdowns": []}),  # Avoid pulling in breakdown values from returning event query
+        filter=filter.shallow_clone({"breakdowns": []}),  # Avoid pulling in breakdown values from returning event query
         team=team,
         event_query_type=RetentionQueryType.RETURNING,
         aggregate_users_by_distinct_id=aggregate_users_by_distinct_id,

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -4783,7 +4783,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         )
         result = Trends().run(filter2, self.team)
         self.assertEqual(result[0]["count"], 2)
-        result = Trends().run(filter.with_data({"breakdown": "key"}), self.team)
+        result = Trends().run(filter.shallow_clone({"breakdown": "key"}), self.team)
         self.assertEqual(result[0]["count"], 1)
 
     @also_test_with_materialized_columns(["$some_property"])
@@ -5802,7 +5802,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response[1]["breakdown_value"], "technology")
         self.assertEqual(response[1]["count"], 1)
 
-        filter = filter.with_data(
+        filter = filter.shallow_clone(
             {"breakdown_value": "technology", "date_from": "2020-01-02T00:00:00Z", "date_to": "2020-01-03"}
         )
         entity = Entity({"id": "sign up", "name": "sign up", "type": "events", "order": 0})
@@ -5863,7 +5863,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(response[1]["breakdown_value"], "technology")
             self.assertEqual(response[1]["count"], 1)
 
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {"breakdown_value": "technology", "date_from": "2020-01-02T00:00:00Z", "date_to": "2020-01-02"}
             )
             entity = Entity({"id": "sign up", "name": "sign up", "type": "events", "order": 0})
@@ -6104,7 +6104,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(response[0]["count"], 1)
             self.assertEqual(response[0]["data"], [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
-            filter = filter.with_data({"date_from": "2020-01-02T00:00:00Z", "date_to": "2020-01-02T00:00:00Z"})
+            filter = filter.shallow_clone({"date_from": "2020-01-02T00:00:00Z", "date_to": "2020-01-02T00:00:00Z"})
             entity = Entity({"id": "sign up", "name": "sign up", "type": "events", "order": 0})
             res = self._get_trend_people(filter, entity)
 

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -91,7 +91,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
     def adjusted_filter(self, filter: Filter, team: Team) -> Tuple[Filter, Optional[Dict[str, Any]]]:
         cached_result = self.get_cached_result(filter, team)
 
-        new_filter = filter.with_data({"date_from": interval_unit(filter.interval)}) if cached_result else filter
+        new_filter = filter.shallow_clone({"date_from": interval_unit(filter.interval)}) if cached_result else filter
 
         label_to_payload = {}
         if cached_result:

--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -37,7 +37,7 @@ class TrendsActors(ActorBaseQuery):
             # This was annoying and only made it harder to reason about the API, so it's no longer how actors modal
             # URLs behave. Now we only do this handling at this level for backwards compatibility (cached results)
             # via the `date_from == date_to` check - all new requests have a "fully qualified" date range.
-            filter = filter.with_data(
+            filter = filter.shallow_clone(
                 {
                     "date_to": offset_time_series_date_by_interval(
                         cast(datetime.datetime, filter.date_from), filter=filter, team=team
@@ -55,7 +55,7 @@ class TrendsActors(ActorBaseQuery):
     def actor_query(self, limit_actors: Optional[bool] = True) -> Tuple[str, Dict]:
         if self._filter.breakdown_type == "cohort" and self._filter.breakdown_value != "all":
             cohort = Cohort.objects.get(pk=self._filter.breakdown_value, team_id=self._team.pk)
-            self._filter = self._filter.with_data(
+            self._filter = self._filter.shallow_clone(
                 {
                     "properties": self._filter.property_groups.combine_properties(
                         PropertyOperatorType.AND, [Property(key="id", value=cohort.pk, type="cohort")]
@@ -101,7 +101,7 @@ class TrendsActors(ActorBaseQuery):
                     )
                 ]
 
-            self._filter = self._filter.with_data(
+            self._filter = self._filter.shallow_clone(
                 {
                     "properties": self._filter.property_groups.combine_properties(
                         PropertyOperatorType.AND, breakdown_props


### PR DESCRIPTION
## Problem

> There's only one variable name worse than `data` and that's `data2`.

The method `filter.with_data` hides its true intent and thus makes the code [hard to parse](https://github.com/PostHog/posthog/pull/13830#discussion_r1086419645).

## Changes

Rename `filter.with_data` to `filter.shallow_clone`.

## How did you test this code?

I didn't 😊 