### PR TITLE
refactor(recordings): remove session code from event pipeline

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -124,9 +124,11 @@ export const fetchPostgresPersons = async (pgClient: Pool, teamId: number) => {
     return rows
 }
 
-export const fetchSessionRecordingsEvents = async (clickHouseClient: ClickHouse, teamId: number) => {
+export const fetchSessionRecordingsEvents = async (clickHouseClient: ClickHouse, teamId: number, uuid?: string) => {
     const queryResult = (await clickHouseClient.querying(
-        `SELECT * FROM session_recording_events WHERE team_id = ${teamId} ORDER BY timestamp ASC`
+        `SELECT * FROM session_recording_events WHERE team_id = ${teamId} ${
+            uuid ? ` AND uuid = '${uuid}'` : ''
+        } ORDER BY timestamp ASC`
     )) as unknown as ClickHouse.ObjectQueryResult<RawSessionRecordingEvent>
     return queryResult.data.map((event) => {
         return {
@@ -174,7 +176,8 @@ export const createTeam = async (
     pgClient: Pool,
     organizationId: string,
     slack_incoming_webhook?: string,
-    token?: string
+    token?: string,
+    sessionRecordingOptIn = true
 ) => {
     const team = await insertRow(pgClient, 'posthog_team', {
         organization_id: organizationId,
@@ -191,7 +194,7 @@ export const createTeam = async (
         completed_snippet_onboarding: true,
         ingested_event: true,
         uuid: new UUIDT().toString(),
-        session_recording_opt_in: true,
+        session_recording_opt_in: sessionRecordingOptIn,
         plugins_opt_in: false,
         opt_out_capture: false,
         is_demo: false,

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -225,7 +225,7 @@ test.concurrent(`recording events not ingested to ClickHouse if team is opted ou
 
     // NOTE: we're assuming that we have a single partition for the Kafka topic,
     // and that the consumer produces messages in the order they are consumed.
-    const events = await fetchSessionRecordingsEvents(clickHouseClient, teamOptedInOut, uuidOptedOut)
+    const events = await fetchSessionRecordingsEvents(clickHouseClient, teamOptedOutId, uuidOptedOut)
     expect(events.length).toBe(0)
 })
 

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -84,6 +84,10 @@ test.concurrent(
         // pushing to `session_recording_events`. There will still be session
         // recording events in the `events_plugin_ingestion` topic for a while
         // so we need to still handle these events with the current consumer.
+        // TODO: we push recording events that we get from
+        // `events_plugin_ingestion` to `session_recording_events`. We should be
+        // able to remove this push and this test once we know there are no more
+        // recording events in `events_plugin_ingestion`.
         const teamId = await createTeam(postgres, organizationId)
         const distinctId = new UUIDT().toString()
         const uuid = new UUIDT().toString()
@@ -126,7 +130,11 @@ test.concurrent(
                 $session_id: '1234abc',
                 $snapshot_data: 'yes way',
             },
-            token
+            token,
+            new Date(),
+            new Date(),
+            new Date(),
+            'session_recording_events'
         )
 
         await waitForExpect(async () => {
@@ -203,6 +211,10 @@ test.concurrent(
         // `$performance_event` events in the `events_plugin_ingestion` topic
         // for a while so we need to still handle these events with the current
         // consumer.
+        // TODO: we push recording events that we get from
+        // `events_plugin_ingestion` to `session_recording_events`. We should be
+        // able to remove this push and this test once we know there are no more
+        // recording events in `events_plugin_ingestion`.
         const teamId = await createTeam(postgres, organizationId)
         const distinctId = new UUIDT().toString()
         const uuid = new UUIDT().toString()

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -177,7 +177,7 @@ test.concurrent(`recording events not ingested to ClickHouse if team is opted ou
     // for the team that is opted in was ingested and the recording for the team
     // that is opted out was not ingested.
     const tokenOptedOut = uuidv4()
-    const teamOptedInOut = await createTeam(postgres, organizationId, undefined, tokenOptedOut, false)
+    const teamOptedOutId = await createTeam(postgres, organizationId, undefined, tokenOptedOut, false)
     const uuidOptedOut = new UUIDT().toString()
 
     await capture(

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -225,6 +225,8 @@ test.concurrent(`recording events not ingested to ClickHouse if team is opted ou
 
     // NOTE: we're assuming that we have a single partition for the Kafka topic,
     // and that the consumer produces messages in the order they are consumed.
+    // TODO: add some side-effect we can assert on rather than relying on the
+    // partitioning / ordering setup e.g. an ingestion warning.
     const events = await fetchSessionRecordingsEvents(clickHouseClient, teamOptedOutId, uuidOptedOut)
     expect(events.length).toBe(0)
 })

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { KAFKA_SESSION_RECORDING_EVENTS } from 'config/kafka-topics'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
+import { KAFKA_SESSION_RECORDING_EVENTS } from '../../../config/kafka-topics'
 import { Hub, PipelineEvent, WorkerMethods } from '../../../types'
 import { formPipelineEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -70,7 +70,6 @@ export async function ingestEvent(
             team_id: event.team_id.toString(),
         })
         // we've confirmed team_id exists so can assert event as PluginEvent
-
         await workerMethods.runEventPipeline(event as PluginEvent)
     } else {
         server.statsd?.increment('kafka_queue_ingest_event_hit', {

--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -123,7 +123,7 @@ export const eachBatch =
                 })
                 .observe(message.value.length)
 
-            if (!messagePayload.team_id && !event.token) {
+            if (messagePayload.team_id == null && !messagePayload.token) {
                 status.warn('⚠️', 'invalid_message', {
                     reason: 'no_token',
                     partition: batch.partition,
@@ -137,7 +137,8 @@ export const eachBatch =
 
             try {
                 teamId =
-                    messagePayload.team_id ?? (event.token ? (await teamManager.getTeamByToken(event.token))?.id : null)
+                    messagePayload.team_id ??
+                    (messagePayload.token ? (await teamManager.getTeamByToken(messagePayload.token))?.id : null)
 
                 if (!teamId) {
                     status.warn('⚠️', 'invalid_message', {

--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -4,7 +4,7 @@ import { EachBatchPayload, Kafka } from 'kafkajs'
 import { exponentialBuckets, Histogram } from 'prom-client'
 
 import { KAFKA_SESSION_RECORDING_EVENTS, KAFKA_SESSION_RECORDING_EVENTS_DLQ } from '../../config/kafka-topics'
-import { PipelineEvent, RawEventMessage } from '../../types'
+import { PipelineEvent, RawEventMessage, Team } from '../../types'
 import { DependencyUnavailableError } from '../../utils/db/error'
 import { KafkaProducerWrapper } from '../../utils/db/kafka-producer-wrapper'
 import { status } from '../../utils/status'
@@ -133,14 +133,16 @@ export const eachBatch =
                 continue
             }
 
-            let teamId: number | null = null
+            let team: Team | null = null
 
             try {
-                teamId =
-                    messagePayload.team_id ??
-                    (messagePayload.token ? (await teamManager.getTeamByToken(messagePayload.token))?.id : null)
+                if (messagePayload.team_id != null) {
+                    team = await teamManager.fetchTeam(messagePayload.team_id)
+                } else if (messagePayload.token) {
+                    team = await teamManager.getTeamByToken(messagePayload.token)
+                }
 
-                if (!teamId) {
+                if (team == null) {
                     status.warn('⚠️', 'invalid_message', {
                         reason: 'team_not_found',
                         partition: batch.partition,
@@ -150,26 +152,28 @@ export const eachBatch =
                     continue
                 }
 
-                if (event.event === '$snapshot') {
-                    await createSessionRecordingEvent(
-                        messagePayload.uuid,
-                        teamId,
-                        messagePayload.distinct_id,
-                        parseEventTimestamp(event as PluginEvent),
-                        event.ip,
-                        event.properties || {},
-                        producer
-                    )
-                } else if (event.event === '$performance_event') {
-                    await createPerformanceEvent(
-                        messagePayload.uuid,
-                        teamId,
-                        messagePayload.distinct_id,
-                        event.properties || {},
-                        event.ip,
-                        parseEventTimestamp(event as PluginEvent),
-                        producer
-                    )
+                if (team.session_recording_opt_in) {
+                    if (event.event === '$snapshot') {
+                        await createSessionRecordingEvent(
+                            messagePayload.uuid,
+                            team.id,
+                            messagePayload.distinct_id,
+                            parseEventTimestamp(event as PluginEvent),
+                            event.ip,
+                            event.properties || {},
+                            producer
+                        )
+                    } else if (event.event === '$performance_event') {
+                        await createPerformanceEvent(
+                            messagePayload.uuid,
+                            team.id,
+                            messagePayload.distinct_id,
+                            event.properties || {},
+                            event.ip,
+                            parseEventTimestamp(event as PluginEvent),
+                            producer
+                        )
+                    }
                 }
             } catch (error) {
                 status.error('⚠️', 'processing_error', {

--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -135,24 +135,41 @@ export const eachBatch =
 
             let teamId: number | null = null
 
-            teamId =
-                messagePayload.team_id ?? (event.token ? (await teamManager.getTeamByToken(event.token))?.id : null)
-
-            if (!teamId) {
-                status.warn('⚠️', 'invalid_message', {
-                    reason: 'team_not_found',
-                    partition: batch.partition,
-                    offset: message.offset,
-                })
-                await producer.queueMessage({ topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ, messages: [message] })
-                continue
-            }
-
             try {
-                await processEvent(
-                    { ...event, team_id: teamId, distinct_id: messagePayload.distinct_id, uuid: messagePayload.uuid },
-                    producer
-                )
+                teamId =
+                    messagePayload.team_id ?? (event.token ? (await teamManager.getTeamByToken(event.token))?.id : null)
+
+                if (!teamId) {
+                    status.warn('⚠️', 'invalid_message', {
+                        reason: 'team_not_found',
+                        partition: batch.partition,
+                        offset: message.offset,
+                    })
+                    await producer.queueMessage({ topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ, messages: [message] })
+                    continue
+                }
+
+                if (event.event === '$snapshot') {
+                    await createSessionRecordingEvent(
+                        messagePayload.uuid,
+                        teamId,
+                        messagePayload.distinct_id,
+                        parseEventTimestamp(event as PluginEvent),
+                        event.ip,
+                        event.properties || {},
+                        producer
+                    )
+                } else if (event.event === '$performance_event') {
+                    await createPerformanceEvent(
+                        messagePayload.uuid,
+                        teamId,
+                        messagePayload.distinct_id,
+                        event.properties || {},
+                        event.ip,
+                        parseEventTimestamp(event as PluginEvent),
+                        producer
+                    )
+                }
             } catch (error) {
                 status.error('⚠️', 'processing_error', {
                     eventId: event.uuid,
@@ -215,30 +232,6 @@ export const eachBatch =
 
         status.debug('✅', 'Processed batch', { size: batch.messages.length })
     }
-
-export const processEvent = async (event: PluginEvent, producer: KafkaProducerWrapper) => {
-    if (event.event === '$snapshot') {
-        await createSessionRecordingEvent(
-            event.uuid,
-            event.team_id,
-            event.distinct_id,
-            parseEventTimestamp(event),
-            event.ip,
-            event.properties || {},
-            producer
-        )
-    } else if (event.event === '$performance_event') {
-        await createPerformanceEvent(
-            event.uuid,
-            event.team_id,
-            event.distinct_id,
-            event.properties || {},
-            event.ip,
-            parseEventTimestamp(event),
-            producer
-        )
-    }
-}
 
 const consumerBatchSize = new Histogram({
     name: 'consumed_batch_size',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -496,6 +496,9 @@ export interface RawEventMessage extends BaseEventMessage {
     sent_at: string
     /** JSON-encoded number. */
     kafka_offset: string
+    /** Messages may have a token instead of a team_id, to be used e.g. to
+     * resolve to a team_id */
+    token?: string
 }
 
 /** Usable event message. */

--- a/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/2-emitToBufferStep.ts
@@ -20,10 +20,6 @@ export async function emitToBufferStep(
 
     const personContainer = new LazyPersonContainer(event.team_id, event.distinct_id, runner.hub)
 
-    if (['$snapshot', '$performance_event'].includes(event.event)) {
-        return runner.nextStep('processPersonsStep', event, personContainer)
-    }
-
     if (
         process.env.DELAY_ALL_EVENTS_FOR_TEAMS === '*' ||
         process.env.DELAY_ALL_EVENTS_FOR_TEAMS?.split(',').includes(event.team_id.toString())

--- a/plugin-server/src/worker/ingestion/event-pipeline/3-pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/3-pluginsProcessEventStep.ts
@@ -12,17 +12,13 @@ export async function pluginsProcessEventStep(
 ): Promise<StepResult> {
     let processedEvent: PluginEvent | null = event
 
-    // run processEvent on all events that are not meta-events like $snapshot or $performance_event
-    // NOTE: These are technically filtered out in step 2, but we still need to check here just to be sure
-    if (!['$snapshot', '$performance_event'].includes(event.event)) {
-        processedEvent = await runInstrumentedFunction({
-            server: runner.hub,
-            event,
-            func: (event) => runProcessEvent(runner.hub, event),
-            statsKey: 'kafka_queue.single_event',
-            timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
-        })
-    }
+    processedEvent = await runInstrumentedFunction({
+        server: runner.hub,
+        event,
+        func: (event) => runProcessEvent(runner.hub, event),
+        statsKey: 'kafka_queue.single_event',
+        timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
+    })
 
     if (processedEvent) {
         return runner.nextStep('processPersonsStep', processedEvent, personContainer)

--- a/plugin-server/src/worker/ingestion/event-pipeline/3-pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/3-pluginsProcessEventStep.ts
@@ -10,9 +10,7 @@ export async function pluginsProcessEventStep(
     event: PluginEvent,
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
-    let processedEvent: PluginEvent | null = event
-
-    processedEvent = await runInstrumentedFunction({
+    const processedEvent = await runInstrumentedFunction({
         server: runner.hub,
         event,
         func: (event) => runProcessEvent(runner.hub, event),

--- a/plugin-server/src/worker/ingestion/event-pipeline/4-processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/4-processPersonsStep.ts
@@ -16,12 +16,6 @@ export async function processPersonsStep(
 ): Promise<StepResult> {
     const event = normalizeEvent(pluginEvent)
 
-    // TODO: Have the snapshot events pipeline be completely separate
-    // from all other events
-    if (['$snapshot', '$performance_event'].includes(event.event)) {
-        return runner.nextStep('prepareEventStep', event, personContainer)
-    }
-
     const timestamp = parseEventTimestamp(event)
 
     if (runner.onlyUpdatePersonIdAssociations) {

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-prepareEventStep.ts
@@ -1,6 +1,5 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { PostIngestionEvent } from '../../../types'
 import { LazyPersonContainer } from '../lazy-person-container'
 import { parseEventTimestamp } from '../timestamps'
 import { captureIngestionWarning } from '../utils'
@@ -29,10 +28,8 @@ export async function prepareEventStep(
 
     await runner.hub.siteUrlManager.updateIngestionSiteUrl(site_url)
 
-    if (preIngestionEvent && !['$snapshot', '$performance_event'].includes(event.event)) {
+    if (preIngestionEvent) {
         return runner.nextStep('createEventStep', preIngestionEvent, personContainer)
-    } else if (preIngestionEvent && preIngestionEvent.event === '$snapshot') {
-        return runner.nextStep('runAsyncHandlersStep', preIngestionEvent as PostIngestionEvent, personContainer)
     } else {
         return null
     }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -235,36 +235,6 @@ export class EventsProcessor {
         return preIngestionEvent
     }
 
-    private async createSessionRecordingEvent(
-        uuid: string,
-        team_id: number,
-        distinct_id: string,
-        timestamp: DateTime,
-        ip: string | null,
-        properties: Properties
-    ): Promise<PostIngestionEvent> {
-        return await createSessionRecordingEvent(
-            uuid,
-            team_id,
-            distinct_id,
-            timestamp,
-            ip,
-            properties,
-            this.kafkaProducer
-        )
-    }
-
-    private async createPerformanceEvent(
-        uuid: string,
-        team_id: number,
-        distinct_id: string,
-        timestamp: DateTime,
-        ip: string | null,
-        properties: Properties
-    ): Promise<PostIngestionEvent> {
-        return await createPerformanceEvent(uuid, team_id, distinct_id, properties, ip, timestamp, this.kafkaProducer)
-    }
-
     private async upsertGroup(teamId: number, properties: Properties, timestamp: DateTime): Promise<void> {
         if (!properties['$group_type'] || !properties['$group_key']) {
             return

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -20,15 +20,15 @@ import {
     PluginsServerConfig,
     PropertyDefinitionTypeEnum,
     PropertyUpdateOperation,
-    RawPerformanceEvent,
     Team,
 } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
+import { KafkaProducerWrapper } from '../../src/utils/db/kafka-producer-wrapper'
 import { personInitialAndUTMProperties } from '../../src/utils/db/utils'
 import { posthog } from '../../src/utils/posthog'
 import { UUIDT } from '../../src/utils/utils'
 import { EventPipelineRunner } from '../../src/worker/ingestion/event-pipeline/runner'
-import { EventsProcessor } from '../../src/worker/ingestion/process-event'
+import { createPerformanceEvent, EventsProcessor } from '../../src/worker/ingestion/process-event'
 import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { resetKafka } from '../helpers/kafka'
 import { createUserTeamAndOrganization, getFirstTeam, getTeams, resetTestDatabase } from '../helpers/sql'
@@ -1118,75 +1118,59 @@ test('capture first team event', async () => {
 })
 
 test('performance event stored as performance_event', async () => {
-    await eventsProcessor.processEvent(
-        'some-id',
-        '',
-        {
-            event: '$performance_event',
-            properties: {
-                // Taken from a real event from the JS
-                '0': 'resource',
-                '1': 1671723295836,
-                '2': 'http://localhost:8000/api/projects/1/session_recordings',
-                '3': 10737.89999999106,
-                '4': 0,
-                '5': 0,
-                '6': 0,
-                '7': 10737.89999999106,
-                '8': 10737.89999999106,
-                '9': 10737.89999999106,
-                '10': 10737.89999999106,
-                '11': 0,
-                '12': 10737.89999999106,
-                '13': 10745.09999999404,
-                '14': 11121.70000000298,
-                '15': 11122.20000000298,
-                '16': 73374,
-                '17': 1767,
-                '18': 'fetch',
-                '19': 'http/1.1',
-                '20': 'non-blocking',
-                '22': 2067,
-                '39': 384.30000001192093,
-                '40': 1671723306573,
-                token: 'phc_234',
-                $session_id: '1853a793ad26c1-0eea05631cbeff-17525635-384000-1853a793ad31dd2',
-                $window_id: '1853a793ad424a5-017f7473b057f1-17525635-384000-1853a793ad524dc',
-                distinct_id: '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
-                $current_url: 'http://localhost:8000/recordings/recent',
-            },
-        } as any as PluginEvent,
-        team.id,
-        now,
-        new UUIDT().toString()
-    )
-
-    const fetchPerformanceEvents = async (): Promise<RawPerformanceEvent[]> => {
-        return (await hub.db.clickhouseQuery<RawPerformanceEvent>(`SELECT * FROM performance_events`)).data
+    const producer = {
+        queueSingleJsonMessage: jest.fn(),
     }
 
-    await delayUntilEventIngested(() => fetchPerformanceEvents())
+    await createPerformanceEvent(
+        'some-id',
+        team.id,
+        '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
+        {
+            // Taken from a real event from the JS
+            '0': 'resource',
+            '1': 1671723295836,
+            '2': 'http://localhost:8000/api/projects/1/session_recordings',
+            '3': 10737.89999999106,
+            '4': 0,
+            '5': 0,
+            '6': 0,
+            '7': 10737.89999999106,
+            '8': 10737.89999999106,
+            '9': 10737.89999999106,
+            '10': 10737.89999999106,
+            '11': 0,
+            '12': 10737.89999999106,
+            '13': 10745.09999999404,
+            '14': 11121.70000000298,
+            '15': 11122.20000000298,
+            '16': 73374,
+            '17': 1767,
+            '18': 'fetch',
+            '19': 'http/1.1',
+            '20': 'non-blocking',
+            '22': 2067,
+            '39': 384.30000001192093,
+            '40': 1671723306573,
+            token: 'phc_234',
+            $session_id: '1853a793ad26c1-0eea05631cbeff-17525635-384000-1853a793ad31dd2',
+            $window_id: '1853a793ad424a5-017f7473b057f1-17525635-384000-1853a793ad524dc',
+            distinct_id: '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
+            $current_url: 'http://localhost:8000/recordings/recent',
+        },
+        '',
+        now,
+        producer as any as KafkaProducerWrapper
+    )
 
-    const events = await hub.db.fetchEvents()
-    expect(events.length).toEqual(0)
+    const [_topic, _uuid, data] = producer.queueSingleJsonMessage.mock.calls[0]
 
-    const sessionRecordingEvents = await fetchPerformanceEvents()
-    expect(sessionRecordingEvents.length).toBe(1)
-
-    const [event] = sessionRecordingEvents
-
-    expect(event).toEqual({
-        _offset: expect.any(Number),
-        _partition: 0,
-        _timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}[\d\s:]+/),
+    expect(data).toEqual({
         connect_end: 10737.89999999106,
         connect_start: 10737.89999999106,
         current_url: 'http://localhost:8000/recordings/recent',
         decoded_body_size: 73374,
-        distinct_id: 'some-id',
-        dom_complete: 0,
-        dom_content_loaded_event: 0,
-        dom_interactive: 0,
+        distinct_id: '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
         domain_lookup_end: 10737.89999999106,
         domain_lookup_start: 10737.89999999106,
         duration: 384.30000001192093,
@@ -1194,38 +1178,23 @@ test('performance event stored as performance_event', async () => {
         entry_type: 'resource',
         fetch_start: 10737.89999999106,
         initiator_type: 'fetch',
-        largest_contentful_paint_element: '',
-        largest_contentful_paint_id: '',
-        largest_contentful_paint_load_time: 0,
-        largest_contentful_paint_render_time: 0,
-        largest_contentful_paint_size: 0,
-        largest_contentful_paint_url: '',
-        load_event_end: 0,
-        load_event_start: 0,
         name: 'http://localhost:8000/api/projects/1/session_recordings',
-        navigation_type: '',
         next_hop_protocol: 'http/1.1',
-        pageview_id: '',
-        redirect_count: 0,
+        pageview_id: undefined,
         redirect_end: 0,
         redirect_start: 0,
         render_blocking_status: 'non-blocking',
         request_start: 10745.09999999404,
         response_end: 11122.20000000298,
         response_start: 11121.70000000298,
-        response_status: 0,
         secure_connection_start: 0,
         session_id: '1853a793ad26c1-0eea05631cbeff-17525635-384000-1853a793ad31dd2',
         start_time: 10737.89999999106,
         team_id: 2,
-        time_origin: '2022-12-22 15:34:55.836',
-        timestamp: '2022-12-22 15:35:06.573',
+        time_origin: 1671723295836,
+        timestamp: 1671723306573,
         transfer_size: 2067,
-        unload_event_end: 0,
-        unload_event_start: 0,
-        uuid: expect.stringMatching(
-            /^[0-9a-fA-F-]{36}$/ // a uuid
-        ),
+        uuid: 'some-id',
         window_id: '1853a793ad424a5-017f7473b057f1-17525635-384000-1853a793ad524dc',
         worker_start: 0,
     })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -108,164 +108,154 @@ describe('emitToBufferStep()', () => {
         expect(runner.hub.graphileWorker.enqueue).not.toHaveBeenCalled()
     })
 
-    it('calls `processPersonsStep` for $snapshot events', async () => {
-        const event = { ...pluginEvent, event: '$snapshot' }
+    describe('shouldSendEventToBuffer()', () => {
+        beforeEach(() => {
+            jest.spyOn(DateTime, 'now').mockReturnValue(now)
+        })
 
-        const response = await emitToBufferStep(runner, event, () => true)
+        it('returns false for an existing non-anonymous person', () => {
+            const result = shouldSendEventToBuffer(runner.hub, pluginEvent, existingPerson, 2)
+            expect(result).toEqual(false)
+        })
 
-        expect(response).toEqual(['processPersonsStep', event, expect.any(LazyPersonContainer)])
-        expect(runner.hub.db.fetchPerson).not.toHaveBeenCalled()
-        expect(runner.hub.graphileWorker.enqueue).not.toHaveBeenCalled()
-    })
-})
+        it('returns false for recently created person', () => {
+            const person = {
+                ...existingPerson,
+                created_at: now.minus({ seconds: 5 }),
+            }
 
-describe('shouldSendEventToBuffer()', () => {
-    beforeEach(() => {
-        jest.spyOn(DateTime, 'now').mockReturnValue(now)
-    })
+            const result = shouldSendEventToBuffer(runner.hub, pluginEvent, person, 2)
+            expect(result).toEqual(false)
+        })
 
-    it('returns false for an existing non-anonymous person', () => {
-        const result = shouldSendEventToBuffer(runner.hub, pluginEvent, existingPerson, 2)
-        expect(result).toEqual(false)
-    })
+        it('returns false for anonymous person', () => {
+            const anonEvent = {
+                ...pluginEvent,
+                distinctId: '$some_device_id',
+                properties: { $device_id: '$some_device_id' },
+            }
 
-    it('returns false for recently created person', () => {
-        const person = {
-            ...existingPerson,
-            created_at: now.minus({ seconds: 5 }),
-        }
+            const result = shouldSendEventToBuffer(runner.hub, anonEvent, existingPerson, 2)
+            expect(result).toEqual(false)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, pluginEvent, person, 2)
-        expect(result).toEqual(false)
-    })
+        it('returns false for recently created anonymous person', () => {
+            const person = {
+                ...existingPerson,
+                created_at: now.minus({ seconds: 5 }),
+            }
 
-    it('returns false for anonymous person', () => {
-        const anonEvent = {
-            ...pluginEvent,
-            distinctId: '$some_device_id',
-            properties: { $device_id: '$some_device_id' },
-        }
+            const result = shouldSendEventToBuffer(runner.hub, anonEvent, person, 2)
+            expect(result).toEqual(false)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, anonEvent, existingPerson, 2)
-        expect(result).toEqual(false)
-    })
+        it('returns true for non-existing person', () => {
+            const result = shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 2)
+            expect(result).toEqual(true)
+        })
 
-    it('returns false for recently created anonymous person', () => {
-        const person = {
-            ...existingPerson,
-            created_at: now.minus({ seconds: 5 }),
-        }
+        it('returns false for $groupidentify events', () => {
+            const event = {
+                ...pluginEvent,
+                event: '$groupidentify',
+            }
 
-        const result = shouldSendEventToBuffer(runner.hub, anonEvent, person, 2)
-        expect(result).toEqual(false)
-    })
+            const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+            expect(result).toEqual(false)
+        })
 
-    it('returns true for non-existing person', () => {
-        const result = shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 2)
-        expect(result).toEqual(true)
-    })
+        it('returns false for merging $identify events for non-existing users', () => {
+            const event = {
+                ...pluginEvent,
+                event: '$identify',
+                properties: { $anon_distinct_id: 'some-id' },
+            }
 
-    it('returns false for $groupidentify events', () => {
-        const event = {
-            ...pluginEvent,
-            event: '$groupidentify',
-        }
+            const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+            expect(result).toEqual(false)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
-        expect(result).toEqual(false)
-    })
+        it('returns false for merging $identify events for new users', () => {
+            const event = {
+                ...pluginEvent,
+                event: '$identify',
+                properties: { $anon_distinct_id: 'some-id' },
+            }
+            const person = {
+                ...existingPerson,
+                created_at: now.minus({ seconds: 5 }),
+            }
 
-    it('returns false for merging $identify events for non-existing users', () => {
-        const event = {
-            ...pluginEvent,
-            event: '$identify',
-            properties: { $anon_distinct_id: 'some-id' },
-        }
+            const result = shouldSendEventToBuffer(runner.hub, event, person, 2)
+            expect(result).toEqual(false)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
-        expect(result).toEqual(false)
-    })
+        it('returns true for non merging $identify events', () => {
+            const event = {
+                ...pluginEvent,
+                event: '$identify',
+            }
 
-    it('returns false for merging $identify events for new users', () => {
-        const event = {
-            ...pluginEvent,
-            event: '$identify',
-            properties: { $anon_distinct_id: 'some-id' },
-        }
-        const person = {
-            ...existingPerson,
-            created_at: now.minus({ seconds: 5 }),
-        }
+            const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+            expect(result).toEqual(true)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, event, person, 2)
-        expect(result).toEqual(false)
-    })
+        it('returns true for non merging $create_alias events', () => {
+            const event = {
+                ...pluginEvent,
+                event: '$create_alias',
+            }
 
-    it('returns true for non merging $identify events', () => {
-        const event = {
-            ...pluginEvent,
-            event: '$identify',
-        }
+            const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+            expect(result).toEqual(true)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
-        expect(result).toEqual(true)
-    })
+        it('returns false for merging $create_alias events', () => {
+            const event = {
+                ...pluginEvent,
+                event: '$create_alias',
+                properties: { alias: 'some-id' },
+            }
 
-    it('returns true for non merging $create_alias events', () => {
-        const event = {
-            ...pluginEvent,
-            event: '$create_alias',
-        }
+            const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
+            expect(result).toEqual(false)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
-        expect(result).toEqual(true)
-    })
+        it('returns false for events from mobile libraries', () => {
+            const eventIos = {
+                ...pluginEvent,
+                event: 'some_event',
+                properties: { $lib: 'posthog-ios' },
+            }
+            const eventAndroid = {
+                ...pluginEvent,
+                event: 'some_event',
+                properties: { $lib: 'posthog-android' },
+            }
 
-    it('returns false for merging $create_alias events', () => {
-        const event = {
-            ...pluginEvent,
-            event: '$create_alias',
-            properties: { alias: 'some-id' },
-        }
+            expect(shouldSendEventToBuffer(runner.hub, eventIos, {} as Person, 2)).toEqual(false)
+            expect(shouldSendEventToBuffer(runner.hub, eventIos, undefined, 2)).toEqual(false)
+            expect(shouldSendEventToBuffer(runner.hub, eventAndroid, undefined, 2)).toEqual(false)
+        })
 
-        const result = shouldSendEventToBuffer(runner.hub, event, undefined, 2)
-        expect(result).toEqual(false)
-    })
+        it('handles CONVERSION_BUFFER_ENABLED and conversionBufferEnabledTeams', () => {
+            runner.hub.CONVERSION_BUFFER_ENABLED = false
+            runner.hub.conversionBufferEnabledTeams = new Set([2])
 
-    it('returns false for events from mobile libraries', () => {
-        const eventIos = {
-            ...pluginEvent,
-            event: 'some_event',
-            properties: { $lib: 'posthog-ios' },
-        }
-        const eventAndroid = {
-            ...pluginEvent,
-            event: 'some_event',
-            properties: { $lib: 'posthog-android' },
-        }
+            expect(shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 2)).toEqual(true)
+            expect(shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 3)).toEqual(false)
 
-        expect(shouldSendEventToBuffer(runner.hub, eventIos, {} as Person, 2)).toEqual(false)
-        expect(shouldSendEventToBuffer(runner.hub, eventIos, undefined, 2)).toEqual(false)
-        expect(shouldSendEventToBuffer(runner.hub, eventAndroid, undefined, 2)).toEqual(false)
-    })
+            runner.hub.CONVERSION_BUFFER_ENABLED = true
+            expect(shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 3)).toEqual(true)
+        })
 
-    it('handles CONVERSION_BUFFER_ENABLED and conversionBufferEnabledTeams', () => {
-        runner.hub.CONVERSION_BUFFER_ENABLED = false
-        runner.hub.conversionBufferEnabledTeams = new Set([2])
+        it('handles teamIdsToBufferAnonymousEventsFor', () => {
+            runner.hub.MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR = 2
 
-        expect(shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 2)).toEqual(true)
-        expect(shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 3)).toEqual(false)
-
-        runner.hub.CONVERSION_BUFFER_ENABLED = true
-        expect(shouldSendEventToBuffer(runner.hub, pluginEvent, undefined, 3)).toEqual(true)
-    })
-
-    it('handles teamIdsToBufferAnonymousEventsFor', () => {
-        runner.hub.MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR = 2
-
-        expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 1)).toEqual(true)
-        expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 2)).toEqual(true)
-        expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 3)).toEqual(false)
-        expect(shouldSendEventToBuffer(runner.hub, anonEvent, {} as Person, 1)).toEqual(false)
+            expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 1)).toEqual(true)
+            expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 2)).toEqual(true)
+            expect(shouldSendEventToBuffer(runner.hub, anonEvent, undefined, 3)).toEqual(false)
+            expect(shouldSendEventToBuffer(runner.hub, anonEvent, {} as Person, 1)).toEqual(false)
+        })
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
@@ -224,24 +224,4 @@ describe('Event Pipeline integration test', () => {
 
         expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
     })
-
-    describe('$snapshot event', () => {
-        it('processing never loads person data', async () => {
-            const event: PluginEvent = {
-                event: '$snapshot',
-                properties: { $session_id: 'abcf-efg', $snapshot_data: { timestamp: 123 } },
-                timestamp: new Date().toISOString(),
-                now: new Date().toISOString(),
-                team_id: 2,
-                distinct_id: 'abc',
-                ip: null,
-                site_url: 'https://example.com',
-                uuid: new UUIDT().toString(),
-            }
-
-            await ingestEvent(event)
-
-            expect(hub.db.fetchPerson).not.toHaveBeenCalled()
-        })
-    })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
@@ -44,15 +44,6 @@ describe('pluginsProcessEventStep()', () => {
         expect(response).toEqual(['processPersonsStep', processedEvent, personContainer])
     })
 
-    it('automatically forwards `$snapshot` events', async () => {
-        const event = { ...pluginEvent, event: '$snapshot' }
-
-        const response = await pluginsProcessEventStep(runner, event, personContainer)
-
-        expect(runProcessEvent).not.toHaveBeenCalled()
-        expect(response).toEqual(['processPersonsStep', event, personContainer])
-    })
-
     it('automatically forwards `$performance_event` events', async () => {
         const event = { ...pluginEvent, event: '$performance_event' }
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
@@ -44,15 +44,6 @@ describe('pluginsProcessEventStep()', () => {
         expect(response).toEqual(['processPersonsStep', processedEvent, personContainer])
     })
 
-    it('automatically forwards `$performance_event` events', async () => {
-        const event = { ...pluginEvent, event: '$performance_event' }
-
-        const response = await pluginsProcessEventStep(runner, event, personContainer)
-
-        expect(runProcessEvent).not.toHaveBeenCalled()
-        expect(response).toEqual(['processPersonsStep', event, personContainer])
-    })
-
     it('does not forward but counts dropped events by plugins', async () => {
         jest.mocked(runProcessEvent).mockResolvedValue(null)
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
@@ -83,35 +83,4 @@ describe('prepareEventStep()', () => {
         ])
         expect(hub.db.kafkaProducer!.queueMessage).not.toHaveBeenCalled()
     })
-
-    it('produces to kafka and to `runAsyncHandlersStep` for $snapshot events', async () => {
-        const response = await prepareEventStep(runner, { ...pluginEvent, event: '$snapshot' }, personContainer)
-
-        expect(response).toEqual([
-            'runAsyncHandlersStep',
-            {
-                distinctId: 'my_id',
-                elementsList: [],
-                event: '$snapshot',
-                eventUuid: '017ef865-19da-0000-3b60-1506093bf40f',
-                ip: '127.0.0.1',
-                properties: {
-                    $ip: '127.0.0.1',
-                },
-                teamId: 2,
-                timestamp: '2020-02-23T02:15:00.000Z',
-            },
-            personContainer,
-        ])
-        expect(hub.db.kafkaProducer!.queueMessage).toHaveBeenCalled()
-    })
-
-    it('does not continue if event is ignored', async () => {
-        await hub.db.postgresQuery('UPDATE posthog_team SET session_recording_opt_in = $1', [false], 'testRecordings')
-
-        const response = await prepareEventStep(runner, { ...pluginEvent, event: '$snapshot' }, personContainer)
-
-        expect(response).toEqual(null)
-        expect(hub.db.kafkaProducer!.queueMessage).not.toHaveBeenCalled()
-    })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
@@ -50,17 +50,6 @@ describe('processPersonsStep()', () => {
         expect(jest.mocked(updatePersonState)).toHaveBeenCalled()
     })
 
-    it('forwards $snapshot events to `prepareEventStep` without creating / updating the person', async () => {
-        const snapshotEvent = {
-            ...pluginEvent,
-            event: '$snapshot',
-        }
-        const response = await processPersonsStep(runner, snapshotEvent, personContainer)
-
-        expect(response).toEqual(['prepareEventStep', snapshotEvent, personContainer])
-        expect(jest.mocked(updatePersonState)).not.toHaveBeenCalled()
-    })
-
     it('re-normalizes the event with properties set by plugins', async () => {
         const event = {
             ...pluginEvent,

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
@@ -17,10 +17,6 @@ const ingestionEvent: PostIngestionEvent = {
     properties: {},
     elementsList: testElements,
 }
-const snapshotEvent = {
-    ...ingestionEvent,
-    event: '$snapshot',
-}
 
 describe('runAsyncHandlersStep()', () => {
     let runner: any
@@ -76,21 +72,5 @@ describe('runAsyncHandlersStep()', () => {
         await expect(runAsyncHandlersStep(runner, ingestionEvent, personContainer)).rejects.toThrow(error)
 
         expect(runOnEvent).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(ingestionEvent))
-    })
-
-    describe('$snapshot events', () => {
-        it('does not do action matching or webhook firing', async () => {
-            await runAsyncHandlersStep(runner, snapshotEvent, personContainer)
-
-            expect(runner.hub.actionMatcher.match).not.toHaveBeenCalled()
-            expect(runner.hub.hookCannon.findAndFireHooks).not.toHaveBeenCalled()
-        })
-
-        it('calls only onSnapshot plugin methods', async () => {
-            await runAsyncHandlersStep(runner, snapshotEvent, personContainer)
-
-            expect(runOnSnapshot).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(snapshotEvent))
-            expect(runOnEvent).not.toHaveBeenCalled()
-        })
     })
 })

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -1050,22 +1050,6 @@ describe('vm tests', () => {
         expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=onEvent')
     })
 
-    test('onSnapshot', async () => {
-        const indexJs = `
-            async function onSnapshot (event, meta) {
-                await fetch('https://google.com/results.json?query=' + event.event)
-            }
-        `
-        await resetTestDatabase(indexJs)
-        const vm = await createReadyPluginConfigVm(hub, pluginConfig39, indexJs)
-        const event: ProcessedPluginEvent = {
-            ...defaultEvent,
-            event: '$snapshot',
-        }
-        await vm.methods.onSnapshot!(event)
-        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=$snapshot')
-    })
-
     describe('exportEvents', () => {
         beforeEach(() => {
             jest.spyOn(hub.appMetrics, 'queueMetric')


### PR DESCRIPTION
We have moved session recrodings to a separate topic and consumer. There
may be session recordings in the old topic, but we divert these to the
new logic for processing them.

1. Made a few additions to the functional tests.
2. Added recordings opt in to the new consumer code.
3. I also fixed a test that was mistakenly sending to the wrong topic.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
