### PR TITLE
feat(clickhouse-queries-modal): make CH queries modal nicer to use

### DIFF
--- a/frontend/src/lib/components/CodeSnippet/index.tsx
+++ b/frontend/src/lib/components/CodeSnippet/index.tsx
@@ -16,6 +16,7 @@ import json from 'react-syntax-highlighter/dist/esm/languages/prism/json'
 import yaml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml'
 import markup from 'react-syntax-highlighter/dist/esm/languages/prism/markup'
 import http from 'react-syntax-highlighter/dist/esm/languages/prism/http'
+import sql from 'react-syntax-highlighter/dist/esm/languages/prism/sql'
 import { copyToClipboard } from 'lib/utils'
 import { Popconfirm } from 'antd'
 import { PopconfirmProps } from 'antd/lib/popconfirm'
@@ -43,6 +44,7 @@ export enum Language {
     XML = 'xml',
     HTTP = 'http',
     Markup = 'markup',
+    SQL = 'sql',
 }
 
 SyntaxHighlighter.registerLanguage(Language.Bash, bash)
@@ -63,6 +65,7 @@ SyntaxHighlighter.registerLanguage(Language.HTML, markup)
 SyntaxHighlighter.registerLanguage(Language.XML, markup)
 SyntaxHighlighter.registerLanguage(Language.Markup, markup)
 SyntaxHighlighter.registerLanguage(Language.HTTP, http)
+SyntaxHighlighter.registerLanguage(Language.SQL, sql)
 
 export interface Action {
     icon: React.ReactElement

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -4,6 +4,7 @@ import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from '../LemonButton'
 import { LemonTable } from '../LemonTable'
+import { CodeSnippet, Language } from '../CodeSnippet'
 
 interface Query {
     timestamp: number
@@ -32,16 +33,16 @@ function QueryCol({ item }: { item: Query }): JSX.Element {
     const has5lines = nthChar(item.query, '\n', 5)
     if (has5lines === -1) {
         return (
-            <pre className="code" style={{ maxWidth: 600, fontSize: 10, padding: 10 }}>
+            <CodeSnippet language={Language.SQL} copyDescription="Copy query" style={{ maxWidth: 600, fontSize: 12 }}>
                 {item.query}
-            </pre>
+            </CodeSnippet>
         )
     }
     return (
         <>
-            <pre className="code" style={{ maxWidth: 600, fontSize: 10, padding: 10 }}>
+            <CodeSnippet language={Language.SQL} copyDescription="Copy query" style={{ maxWidth: 600, fontSize: 12 }}>
                 {expanded ? item.query : item.query.slice(0, has5lines)}
-            </pre>
+            </CodeSnippet>
             <LemonButton size="small" onClick={() => setExpanded(!expanded)}>
                 {expanded ? 'Show less' : 'Show more'}
             </LemonButton>
@@ -115,6 +116,9 @@ export async function debugCHQueries(): Promise<void> {
         title: 'ClickHouse queries recently executed for this user',
         icon: null,
         content: <ModalContent origResult={results} />,
+        closable: true,
+        maskClosable: true,
+        okText: 'Close',
     })
     setTimeout(() => document?.querySelector('.ant-modal-wrap')?.scrollTo(0, 0), 200)
 }


### PR DESCRIPTION
Very minimal quick changes:

- Add close button
- Allow closing by clicking away
- Add syntax highlighting and copying functionality

<img width="1511" alt="Screenshot 2023-01-25 at 12 12 17" src="https://user-images.githubusercontent.com/38760734/214600582-d3763c05-617e-42ad-8146-af9109280027.png">
