### PR TITLE
fix: calculate info window position

### DIFF
--- a/frontend/src/toolbar/elements/InfoWindow.tsx
+++ b/frontend/src/toolbar/elements/InfoWindow.tsx
@@ -23,8 +23,8 @@ export function InfoWindow(): JSX.Element | null {
             : null
     const { rect } = activeMeta
 
-    const windowWidth = Math.min(document.documentElement.clientWidth, window.innerWidth)
-    const windowHeight = Math.min(document.documentElement.clientHeight, window.innerHeight)
+    const windowWidth = Math.min(document.body.clientWidth, window.innerWidth)
+    const windowHeight = Math.min(document.body.clientHeight, window.innerHeight)
 
     let left = rect.left + window.pageXOffset + (rect.width > 300 ? (rect.width - 300) / 2 : 0)
     let width = 300


### PR DESCRIPTION
## Problem

A client has `position:relative` set on the body of their site. If the toolbar needs to draw a window e.g. on a highlighted heatmap element then it can if the highighted element is in the top half of the page and not if it is in the bottom half

In that case we use 

```
const windowHeight = Math.min(document.documentElement.clientHeight, window.innerHeight)
bottom = windowHeight - rect.top + 10 - window.pageYOffset
``` 

to determine the bottom of the `InfoWindow`

Normally (I think) `document.documentElement.clientHeight` is what the InfoWindow is positioned relative to

## Changes

Uses `document.body.clientHeight instead. 

In the usual case it returns the same value as `document.documentElement` and in this case it returns the desired position

## How did you test this code?

* Manually calculating and replacing values on the customer site and seeing it work
* running this locally and seeing it work