### PR TITLE
fix: calculate info window position

### DIFF
--- a/frontend/src/toolbar/elements/InfoWindow.tsx
+++ b/frontend/src/toolbar/elements/InfoWindow.tsx
@@ -24,7 +24,7 @@ export function InfoWindow(): JSX.Element | null {
     const { rect } = activeMeta
 
     const windowWidth = Math.min(document.body.clientWidth, window.innerWidth)
-    const windowHeight = Math.min(document.body.clientHeight, window.innerHeight)
+    const windowHeight = Math.max(document.body.clientHeight, window.innerHeight)
 
     let left = rect.left + window.pageXOffset + (rect.width > 300 ? (rect.width - 300) / 2 : 0)
     let width = 300

--- a/frontend/src/toolbar/elements/InfoWindow.tsx
+++ b/frontend/src/toolbar/elements/InfoWindow.tsx
@@ -23,8 +23,8 @@ export function InfoWindow(): JSX.Element | null {
             : null
     const { rect } = activeMeta
 
-    const windowWidth = Math.min(document.documentElement.clientWidth, window.innerWidth)
-    const windowHeight = Math.min(document.documentElement.clientHeight, window.innerHeight)
+    const windowWidth = Math.min(document.body.clientWidth, window.innerWidth)
+    const windowHeight = Math.min(document.body.clientHeight, window.innerHeight)
 
     let left = rect.left + window.pageXOffset + (rect.width > 300 ? (rect.width - 300) / 2 : 0)
     let width = 300


### PR DESCRIPTION
## Problem

#13924 was almost right... If document.body.clientHeight is 8000 and document.documentElementHeight is 800 we want the larger. Except that PR has Math.min not Math.max.

## Changes

math.max

## How did you test this code?

running it locally and seeing the toolbar worked the same