### PR TITLE
fix: info window needs two positions

### DIFF
--- a/frontend/src/toolbar/elements/InfoWindow.tsx
+++ b/frontend/src/toolbar/elements/InfoWindow.tsx
@@ -24,7 +24,8 @@ export function InfoWindow(): JSX.Element | null {
     const { rect } = activeMeta
 
     const windowWidth = Math.min(document.body.clientWidth, window.innerWidth)
-    const windowHeight = Math.max(document.body.clientHeight, window.innerHeight)
+    const positioningHeight = document.body.clientHeight
+    const windowHeight = window.innerHeight
 
     let left = rect.left + window.pageXOffset + (rect.width > 300 ? (rect.width - 300) / 2 : 0)
     let width = 300
@@ -46,7 +47,7 @@ export function InfoWindow(): JSX.Element | null {
 
     if (spaceAbove > spaceBelow) {
         top = undefined
-        bottom = windowHeight - rect.top + 10 - window.pageYOffset
+        bottom = positioningHeight - rect.top + 10 - window.pageYOffset
         maxHeight = spaceAbove
     } else {
         maxHeight = spaceBelow


### PR DESCRIPTION
## Problem

#13926 half fixes our customers problem. Now the window doesn't (apparently) disappear but because we are correctly using the very long body height we are not able to determine that the highlighted element is in the bottom half of the visible area (because we're not checking against the visible area). So the info window never moves above the highlighted element (at least until it is potentially out of the viewport so the user won't know)

## Changes

Use the body height for positioning and the viewport height for deciding where on the screen the element is

## How did you test this code?

👁️ and 🧠 