### PR TITLE
feat: Add screen name info to recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -204,6 +204,14 @@ export function PlayerMeta(props: SessionRecordingPlayerLogicProps): JSX.Element
                                 </span>
                             </span>
                         )}
+                        {lastPageviewEvent?.properties?.['$screen_name'] && (
+                            <span className="flex items-center gap-2 truncate">
+                                <span>·</span>
+                                <span className="flex items-center gap-1 truncate">
+                                    {lastPageviewEvent?.properties['$screen_name']}
+                                </span>
+                            </span>
+                        )}
                     </>
                 )}
                 <div className={clsx('flex-1', isSmallPlayer ? 'min-w-4' : 'min-w-20')} />

--- a/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemEvent.tsx
@@ -27,6 +27,9 @@ export function ItemEvent({ item, expanded, setExpanded }: ItemEventProps): JSX.
                             {item.data.properties.$pathname || item.data.properties.$current_url}
                         </span>
                     ) : null}
+                    {item.data.event === '$screen' ? (
+                        <span className="text-muted-alt">{item.data.properties.$screen_name}</span>
+                    ) : null}
                 </div>
             </LemonButton>
 

--- a/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
@@ -81,7 +81,10 @@ export const playerMetaLogic = kea<playerMetaLogicType>({
                 // Go through the events in reverse to find thelatest pageview
                 for (let i = events.length - 1; i >= 0; i--) {
                     const event = events[i]
-                    if (event.event === '$pageview' && (event.playerTime ?? 0) < playerTimeClosestSecond) {
+                    if (
+                        (event.event === '$screen' || event.event === '$pageview') &&
+                        (event.playerTime ?? 0) < playerTimeClosestSecond
+                    ) {
                         return event
                     }
                 }


### PR DESCRIPTION
## Problem

We already show the path for a Pageview but with Mobile recordings incoming we should also show Screen name

## Changes

* Adds muted screen name to the events list like for Pageviews
* Adds the Screen name to the Meta area

|Before|After|
|----|----|
|<img width="1300" alt="Screenshot 2023-01-26 at 09 23 07" src="https://user-images.githubusercontent.com/2536520/214788817-24a38f44-42da-49e0-8968-68da3ead0935.png">|<img width="1335" alt="Screenshot 2023-01-26 at 09 20 27" src="https://user-images.githubusercontent.com/2536520/214788418-6b021a09-d93b-472a-a45e-2152ccd9762e.png">|





👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 