### PR TITLE
feat: Link to Insights from a recording event

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -9,12 +9,14 @@ import {
     AnyPropertyFilter,
     BehavioralCohortType,
     BehavioralEventType,
+    ChartDisplayType,
     CohortCriteriaGroupFilter,
     CohortType,
     DateMappingOption,
     EventType,
     FilterLogicalOperator,
     GroupActorType,
+    InsightType,
     IntervalType,
     PropertyFilter,
     PropertyFilterValue,
@@ -23,6 +25,7 @@ import {
     PropertyOperator,
     PropertyType,
     TimeUnitType,
+    TrendsFilterType,
 } from '~/types'
 import * as Sentry from '@sentry/react'
 import equal from 'fast-deep-equal'
@@ -41,6 +44,7 @@ import { IconCopy } from './components/icons'
 import { lemonToast } from './components/lemonToast'
 import { BehavioralFilterKey } from 'scenes/cohorts/CohortFilters/types'
 import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
+import { urls } from 'scenes/urls'
 
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects
@@ -1572,4 +1576,49 @@ export function downloadFile(file: File): void {
         URL.revokeObjectURL(link.href)
         link?.parentNode?.removeChild(link)
     }, 0)
+}
+
+export function insightUrlForEvent(event: EventType): string | undefined {
+    let insightParams: Partial<TrendsFilterType> | undefined
+    if (event.event === '$pageview') {
+        insightParams = {
+            insight: InsightType.TRENDS,
+            interval: 'day',
+            display: ChartDisplayType.ActionsLineGraph,
+            actions: [],
+            events: [
+                {
+                    id: '$pageview',
+                    name: '$pageview',
+                    type: 'events',
+                    order: 0,
+                    properties: [
+                        {
+                            key: '$current_url',
+                            value: event.properties.$current_url,
+                            type: 'event',
+                        },
+                    ],
+                },
+            ],
+        }
+    } else if (event.event !== '$autocapture') {
+        insightParams = {
+            insight: InsightType.TRENDS,
+            interval: 'day',
+            display: ChartDisplayType.ActionsLineGraph,
+            actions: [],
+            events: [
+                {
+                    id: event.event,
+                    name: event.event,
+                    type: 'events',
+                    order: 0,
+                    properties: [],
+                },
+            ],
+        }
+    }
+
+    return insightParams ? urls.insightNew(insightParams) : undefined
 }

--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -1,4 +1,4 @@
-import { ChartDisplayType, EventType, InsightType, TrendsFilterType } from '~/types'
+import { EventType } from '~/types'
 import { More } from 'lib/components/LemonButton/More'
 import { LemonButton } from 'lib/components/LemonButton'
 import { createActionFromEvent } from 'scenes/events/createActionFromEvent'
@@ -8,6 +8,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { IconPlayCircle } from 'lib/components/icons'
 import { useActions } from 'kea'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
+import { insightUrlForEvent } from 'lib/utils'
 
 interface EventActionProps {
     event: EventType
@@ -15,47 +16,7 @@ interface EventActionProps {
 
 export function EventRowActions({ event }: EventActionProps): JSX.Element {
     const { openSessionPlayer } = useActions(sessionPlayerModalLogic)
-
-    let insightParams: Partial<TrendsFilterType> | undefined
-    if (event.event === '$pageview') {
-        insightParams = {
-            insight: InsightType.TRENDS,
-            interval: 'day',
-            display: ChartDisplayType.ActionsLineGraph,
-            actions: [],
-            events: [
-                {
-                    id: '$pageview',
-                    name: '$pageview',
-                    type: 'events',
-                    order: 0,
-                    properties: [
-                        {
-                            key: '$current_url',
-                            value: event.properties.$current_url,
-                            type: 'event',
-                        },
-                    ],
-                },
-            ],
-        }
-    } else if (event.event !== '$autocapture') {
-        insightParams = {
-            insight: InsightType.TRENDS,
-            interval: 'day',
-            display: ChartDisplayType.ActionsLineGraph,
-            actions: [],
-            events: [
-                {
-                    id: event.event,
-                    name: event.event,
-                    type: 'events',
-                    order: 0,
-                    properties: [],
-                },
-            ],
-        }
-    }
+    const insightUrl = insightUrlForEvent(event)
 
     return (
         <More
@@ -98,13 +59,8 @@ export function EventRowActions({ event }: EventActionProps): JSX.Element {
                             View recording
                         </LemonButton>
                     )}
-                    {insightParams && (
-                        <LemonButton
-                            status="stealth"
-                            to={urls.insightNew(insightParams)}
-                            fullWidth
-                            data-attr="events-table-usage"
-                        >
+                    {insightUrl && (
+                        <LemonButton to={insightUrl} status="stealth" fullWidth data-attr="events-table-usage">
                             Try out in Insights
                         </LemonButton>
                     )}

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -4,21 +4,13 @@ import { EventDetails } from 'scenes/events/EventDetails'
 import { Link } from 'lib/components/Link'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
-import { autoCaptureEventToDescription } from 'lib/utils'
+import { autoCaptureEventToDescription, insightUrlForEvent } from 'lib/utils'
 import './EventsTable.scss'
 import { eventsTableLogic } from './eventsTableLogic'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
 import { TZLabel } from 'lib/components/TZLabel'
 import { keyMapping, PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import {
-    ActionType,
-    AnyPropertyFilter,
-    ChartDisplayType,
-    ColumnChoice,
-    EventsTableRowItem,
-    InsightType,
-    TrendsFilterType,
-} from '~/types'
+import { ActionType, AnyPropertyFilter, ColumnChoice, EventsTableRowItem } from '~/types'
 import { LemonEventName } from 'scenes/actions/EventName'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { Tooltip } from 'lib/components/Tooltip'
@@ -337,46 +329,7 @@ export function EventsTable({
                         return { props: { colSpan: 0 } }
                     }
 
-                    let insightParams: Partial<TrendsFilterType> | undefined
-                    if (event.event === '$pageview') {
-                        insightParams = {
-                            insight: InsightType.TRENDS,
-                            interval: 'day',
-                            display: ChartDisplayType.ActionsLineGraph,
-                            actions: [],
-                            events: [
-                                {
-                                    id: '$pageview',
-                                    name: '$pageview',
-                                    type: 'events',
-                                    order: 0,
-                                    properties: [
-                                        {
-                                            key: '$current_url',
-                                            value: event.properties.$current_url,
-                                            type: 'event',
-                                        },
-                                    ],
-                                },
-                            ],
-                        }
-                    } else if (event.event !== '$autocapture') {
-                        insightParams = {
-                            insight: InsightType.TRENDS,
-                            interval: 'day',
-                            display: ChartDisplayType.ActionsLineGraph,
-                            actions: [],
-                            events: [
-                                {
-                                    id: event.event,
-                                    name: event.event,
-                                    type: 'events',
-                                    order: 0,
-                                    properties: [],
-                                },
-                            ],
-                        }
-                    }
+                    const insightUrl = insightUrlForEvent(event)
 
                     return (
                         <More
@@ -415,10 +368,10 @@ export function EventsTable({
                                             View recording
                                         </LemonButton>
                                     )}
-                                    {insightParams && (
+                                    {insightUrl && (
                                         <LemonButton
+                                            to={insightUrl}
                                             status="stealth"
-                                            to={urls.insightNew(insightParams)}
                                             fullWidth
                                             data-attr="events-table-usage"
                                         >

--- a/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemEvent.tsx
@@ -1,6 +1,7 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
+import { IconOpenInNew } from 'lib/components/icons'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { capitalizeFirstLetter, autoCaptureEventToDescription } from 'lib/utils'
+import { capitalizeFirstLetter, autoCaptureEventToDescription, insightUrlForEvent } from 'lib/utils'
 import { InspectorListItemEvent } from '../../playerInspectorLogic'
 import { SimpleKeyValueList } from './SimpleKeyValueList'
 
@@ -11,6 +12,7 @@ export interface ItemEventProps {
 }
 
 export function ItemEvent({ item, expanded, setExpanded }: ItemEventProps): JSX.Element {
+    const insightUrl = insightUrlForEvent(item.data)
     return (
         <div>
             <LemonButton noPadding onClick={() => setExpanded(!expanded)} status={'primary-alt'} fullWidth>
@@ -32,6 +34,24 @@ export function ItemEvent({ item, expanded, setExpanded }: ItemEventProps): JSX.
 
             {expanded && (
                 <div className="p-2 text-xs border-t">
+                    {insightUrl ? (
+                        <>
+                            <div className="flex justify-end">
+                                <LemonButton
+                                    size="small"
+                                    type="secondary"
+                                    sideIcon={<IconOpenInNew />}
+                                    data-attr="recordings-event-to-insights"
+                                    to={insightUrl}
+                                    targetBlank
+                                >
+                                    Try out in Insights
+                                </LemonButton>
+                            </div>
+                            <LemonDivider dashed />
+                        </>
+                    ) : null}
+
                     <SimpleKeyValueList item={item.data.properties} />
                 </div>
             )}


### PR DESCRIPTION
## Problem

When looking at a recording sometimes you think "I wonder about the metrics for this event in the recoding" but jumping out to Insights isn't easy

## Changes

* Now it's just a click of a button!
* (Also refactors this into a helper util)

![2023-01-26 16 05 54](https://user-images.githubusercontent.com/2536520/214871442-af6bb174-3e1e-42a8-a088-956a2749756c.gif)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 