### PR TITLE
chore(person-merges): Add ClickHouse person_overrides_dict

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."$group_0" as "$group_0",
                                  e."properties" as "properties",
+                                 e."$group_0" as "$group_0",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."properties" as "properties",
                                  e."$group_0" as "$group_0",
+                                 e."properties" as "properties",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/posthog/clickhouse/migrations/0039_person_overrides_dict.py
+++ b/posthog/clickhouse/migrations/0039_person_overrides_dict.py
@@ -1,0 +1,7 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.models.person_overrides.sql import PERSON_OVERRIDES_CREATE_DICTIONARY_SQL
+
+operations = [
+    migrations.RunSQL(PERSON_OVERRIDES_CREATE_DICTIONARY_SQL),
+]

--- a/posthog/clickhouse/schema.py
+++ b/posthog/clickhouse/schema.py
@@ -23,6 +23,7 @@ from posthog.models.performance.sql import (
 from posthog.models.person.sql import *
 from posthog.models.person_overrides.sql import (
     KAFKA_PERSON_OVERRIDES_TABLE_SQL,
+    PERSON_OVERRIDES_CREATE_DICTIONARY_SQL,
     PERSON_OVERRIDES_CREATE_MATERIALIZED_VIEW_SQL,
     PERSON_OVERRIDES_CREATE_TABLE_SQL,
 )
@@ -89,6 +90,8 @@ CREATE_TABLE_QUERIES = (
     + CREATE_KAFKA_TABLE_QUERIES
     + CREATE_MV_TABLE_QUERIES
 )
+
+CREATE_DICTIONARY_QUERIES = (PERSON_OVERRIDES_CREATE_DICTIONARY_SQL,)
 
 build_query = lambda query: query if isinstance(query, str) else query()
 get_table_name = lambda query: re.findall(r"[\.\s]`?([a-z0-9_]+)`?\s+ON CLUSTER", build_query(query))[0]

--- a/posthog/clickhouse/test/test_person_overrides.py
+++ b/posthog/clickhouse/test/test_person_overrides.py
@@ -1,7 +1,8 @@
 import json
 from datetime import datetime, timedelta
 from time import sleep
-from uuid import uuid4
+from typing import TypedDict
+from uuid import UUID, uuid4
 
 import pytest
 import pytz
@@ -89,6 +90,18 @@ def test_can_insert_person_overrides():
         sync_execute(DROP_PERSON_OVERRIDES_CREATE_MATERIALIZED_VIEW_SQL)
 
 
+class PersonOverrideValues(TypedDict):
+    """A dict of values that may be inserted into person_overrides."""
+
+    team_id: int
+    old_person_id: UUID
+    override_person_id: UUID
+    merged_at: datetime
+    oldest_event: datetime
+    created_at: datetime
+    version: int
+
+
 @pytest.mark.django_db
 def test_person_overrides_dict():
     """Test behavior of person_overrides_dict with multiple versions of same key.
@@ -98,7 +111,7 @@ def test_person_overrides_dict():
     sync_execute(PERSON_OVERRIDES_CREATE_TABLE_SQL)
     sync_execute(PERSON_OVERRIDES_CREATE_DICTIONARY_SQL)
 
-    values = {
+    values: PersonOverrideValues = {
         "team_id": 1,
         "old_person_id": uuid4(),
         "override_person_id": uuid4(),
@@ -133,7 +146,7 @@ def test_person_overrides_dict():
     assert len(results) == 1
     assert results[0][0] == values["override_person_id"]
 
-    values["version"] += 1
+    values["version"] = 2
     values["override_person_id"] = uuid4()
 
     sync_execute(

--- a/posthog/clickhouse/test/test_person_overrides.py
+++ b/posthog/clickhouse/test/test_person_overrides.py
@@ -121,26 +121,10 @@ def test_person_overrides_dict():
         "version": 1,
     }
 
-    sync_execute(
-        """
-        INSERT INTO person_overrides (*)
-        VALUES (
-            {team_id},
-            '{old_person_id}',
-            '{override_person_id}',
-            '{merged_at:%Y-%m-%d %H:%M:%S}',
-            '{oldest_event:%Y-%m-%d %H:%M:%S}',
-            '{created_at:%Y-%m-%d %H:%M:%S}',
-            {version}
-        )
-        """.format(
-            **values
-        )
-    )
-
+    sync_execute("INSERT INTO person_overrides (*) VALUES", [values])
     sync_execute("SYSTEM RELOAD DICTIONARY person_overrides_dict")
     results = sync_execute(
-        "SELECT dictGet(person_overrides_dict, 'override_person_id', ({team_id}, '{old_person_id}'))".format(**values)
+        "SELECT dictGet(person_overrides_dict, 'override_person_id', (%(team_id)s, %(old_person_id)s))", values
     )
 
     assert len(results) == 1
@@ -149,26 +133,10 @@ def test_person_overrides_dict():
     values["version"] = 2
     values["override_person_id"] = uuid4()
 
-    sync_execute(
-        """
-        INSERT INTO person_overrides (*)
-        VALUES (
-            {team_id},
-            '{old_person_id}',
-            '{override_person_id}',
-            '{merged_at:%Y-%m-%d %H:%M:%S}',
-            '{oldest_event:%Y-%m-%d %H:%M:%S}',
-            '{created_at:%Y-%m-%d %H:%M:%S}',
-            {version}
-        )
-        """.format(
-            **values
-        )
-    )
-
+    sync_execute("INSERT INTO person_overrides (*) VALUES", [values])
     sync_execute("SYSTEM RELOAD DICTIONARY person_overrides_dict")
     new_results = sync_execute(
-        "SELECT dictGet(person_overrides_dict, 'override_person_id', ({team_id}, '{old_person_id}'))".format(**values)
+        "SELECT dictGet(person_overrides_dict, 'override_person_id', (%(team_id)s, %(old_person_id)s))", values
     )
 
     assert len(new_results) == 1

--- a/posthog/management/commands/setup_test_environment.py
+++ b/posthog/management/commands/setup_test_environment.py
@@ -3,6 +3,7 @@ from django.test.runner import DiscoverRunner as TestRunner
 from infi.clickhouse_orm import Database
 
 from posthog.clickhouse.schema import (
+    CREATE_DICTIONARY_QUERIES,
     CREATE_DISTRIBUTED_TABLE_QUERIES,
     CREATE_KAFKA_TABLE_QUERIES,
     CREATE_MERGETREE_TABLE_QUERIES,
@@ -53,6 +54,7 @@ class Command(BaseCommand):
         create_clickhouse_schema_in_parallel(CREATE_KAFKA_TABLE_QUERIES)
         create_clickhouse_schema_in_parallel(CREATE_DISTRIBUTED_TABLE_QUERIES)
         create_clickhouse_schema_in_parallel(CREATE_MV_TABLE_QUERIES)
+        create_clickhouse_schema_in_parallel(CREATE_DICTIONARY_QUERIES)
 
 
 def create_clickhouse_schema_in_parallel(queries):

--- a/posthog/models/person_overrides/sql.py
+++ b/posthog/models/person_overrides/sql.py
@@ -146,8 +146,7 @@ GET_LATEST_PERSON_OVERRIDE_ID_SQL = f"""
 SELECT
     team_id,
     old_person_id,
-    override_person_id,
-    version
+    override_person_id
 FROM
     `{CLICKHOUSE_DATABASE}`.`person_overrides` AS overrides
 JOIN (
@@ -175,11 +174,7 @@ PERSON_OVERRIDES_CREATE_DICTIONARY_SQL = f"""
         override_person_id UUID
     )
     PRIMARY KEY team_id, old_person_id
-    SOURCE(CLICKHOUSE(
-        TABLE 'person_overrides'
-        DB '{CLICKHOUSE_DATABASE}'
-        QUERY '{GET_LATEST_PERSON_OVERRIDE_ID_SQL}'
-    ))
+    SOURCE(CLICKHOUSE(QUERY '{GET_LATEST_PERSON_OVERRIDE_ID_SQL}'))
     LAYOUT(COMPLEX_KEY_HASHED(PREALLOCATE 1))
 
     -- The LIFETIME setting indicates to ClickHouse to automatically update this dictionary

--- a/posthog/models/person_overrides/sql.py
+++ b/posthog/models/person_overrides/sql.py
@@ -146,23 +146,12 @@ GET_LATEST_PERSON_OVERRIDE_ID_SQL = f"""
 SELECT
     team_id,
     old_person_id,
-    override_person_id
+    argMax(override_person_id, version)
 FROM
     `{CLICKHOUSE_DATABASE}`.`person_overrides` AS overrides
-JOIN (
-    SELECT
-        team_id,
-        old_person_id,
-        max(version) AS max_version
-    FROM `{CLICKHOUSE_DATABASE}`.`person_overrides`
-    GROUP BY
-        team_id,
-        old_person_id
-) AS latest
-ON
-    latest.team_id = overrides.team_id
-    AND latest.old_person_id = overrides.old_person_id
-    AND latest.max_version = overrides.version
+GROUP BY
+    team_id,
+    old_person_id
 """
 
 # ClickHouse dictionaries allow us to JOIN events with their new override_person_ids (if any).

--- a/posthog/models/person_overrides/sql.py
+++ b/posthog/models/person_overrides/sql.py
@@ -182,10 +182,10 @@ PERSON_OVERRIDES_CREATE_DICTIONARY_SQL = f"""
     ))
     LAYOUT(COMPLEX_KEY_HASHED(PREALLOCATE 1))
 
-    -- The LIFETIME setting indicates to ClickHouse not to automatically update this dictionary
-    -- as we'll want to control when override_person_ids in `person_overrides` are squashed back
-    -- into the events table.
-    LIFETIME(MIN 0 MAX 0)
+    -- The LIFETIME setting indicates to ClickHouse to automatically update this dictionary
+    -- when not set to 0. When using a time range ClickHouse will pick a uniformly random time in
+    -- the range. We are setting an initial update time range of 5 to 10 seconds.
+    LIFETIME(MIN 5 MAX 10)
 """
 
 DROP_PERSON_OVERRIDES_CREATE_DICTIONARY_SQL = f"""


### PR DESCRIPTION
## Problem

Creates a ClickHouse dictionary `person_overrides_dict` to close #13910 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a `CREATE DICTIONARY` query to create a `person_overrides_dict` over the `person_overrides` table added on #13753:
* Dictionary selects `override_person_id` for each `(team_id, old_person_id)` pair.
* Dictionary is refreshed every 5 to 10 seconds (initial values, subject to change).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test for basic dictionary behavior:
* Dictionaries should always favor newer versions.
* Any other behavior we should test?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
