### PR TITLE
fix(query-performance): Speed up permissioning in API

### DIFF
--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -67,8 +67,7 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer):
 
         modified_user_permissions = UserPermissions(
             user=validated_data["user"],
-            organization=self.context["view"].organization,
-            current_team=self.context["view"].team,
+            team=self.context["view"].team,
         )
         if modified_user_permissions.current_team.effective_membership_level is None:
             raise exceptions.ValidationError("Cannot add collaborators that have no access to the project.")

--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -67,10 +67,10 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer):
 
         modified_user_permissions = UserPermissions(
             user=validated_data["user"],
-            team=self.context["view"].team,
             organization=self.context["view"].organization,
+            current_team=self.context["view"].team,
         )
-        if modified_user_permissions.team.effective_membership_level is None:
+        if modified_user_permissions.effective_membership_level is None:
             raise exceptions.ValidationError("Cannot add collaborators that have no access to the project.")
         if modified_user_permissions.dashboard(dashboard).can_restrict:
             raise exceptions.ValidationError(

--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -8,8 +8,9 @@ from rest_framework.request import Request
 from ee.models.dashboard_privilege import DashboardPrivilege
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.models import Dashboard, Team, User
+from posthog.models import Dashboard, User
 from posthog.permissions import TeamMemberAccessPermission
+from posthog.user_permissions import UserPermissions
 
 
 class CanEditDashboardCollaborator(BasePermission):
@@ -22,7 +23,8 @@ class CanEditDashboardCollaborator(BasePermission):
             dashboard: Dashboard = Dashboard.objects.get(id=view.parents_query_dict["dashboard_id"])
         except Dashboard.DoesNotExist:
             raise exceptions.NotFound("Dashboard not found.")
-        return dashboard.can_user_edit(cast(User, request.user).id)
+
+        return view.user_permissions.dashboard(dashboard).can_edit
 
 
 class DashboardCollaboratorSerializer(serializers.ModelSerializer):
@@ -46,7 +48,8 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, Any]:
         dashboard: Dashboard = self.context["dashboard"]
-        if dashboard.effective_restriction_level <= Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT:
+        dashboard_permissions = self.context["view"].user_permissions.dashboard(dashboard)
+        if dashboard_permissions.effective_restriction_level <= Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT:
             raise exceptions.ValidationError("Cannot add collaborators to a dashboard on the lowest restriction level.")
         attrs = super().validate(attrs)
         level = attrs.get("level")
@@ -61,9 +64,15 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer):
             validated_data["user"] = User.objects.filter(is_active=True).get(uuid=user_uuid)
         except User.DoesNotExist:
             raise serializers.ValidationError("User does not exist.")
-        if cast(Team, dashboard.team).get_effective_membership_level(validated_data["user"].id) is None:
+
+        modified_user_permissions = UserPermissions(
+            user=validated_data["user"],
+            team=self.context["view"].team,
+            organization=self.context["view"].organization,
+        )
+        if modified_user_permissions.team.effective_membership_level is None:
             raise exceptions.ValidationError("Cannot add collaborators that have no access to the project.")
-        if dashboard.can_user_restrict(validated_data["user"].id):
+        if modified_user_permissions.dashboard(dashboard).can_restrict:
             raise exceptions.ValidationError(
                 "Cannot add collaborators that already have inherent access (the dashboard owner or a project admins)."
             )
@@ -99,7 +108,10 @@ class DashboardCollaboratorViewSet(
 
     def perform_destroy(self, instance) -> None:
         dashboard = cast(Dashboard, instance.dashboard)
-        if dashboard.effective_restriction_level <= Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT:
+        if (
+            self.user_permissions.dashboard(dashboard).effective_restriction_level
+            <= Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+        ):
             raise exceptions.ValidationError(
                 "Cannot remove collaborators from a dashboard on the lowest restriction level."
             )

--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -70,7 +70,7 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer):
             organization=self.context["view"].organization,
             current_team=self.context["view"].team,
         )
-        if modified_user_permissions.effective_membership_level is None:
+        if modified_user_permissions.current_team.effective_membership_level is None:
             raise exceptions.ValidationError("Cannot add collaborators that have no access to the project.")
         if modified_user_permissions.dashboard(dashboard).can_restrict:
             raise exceptions.ValidationError(

--- a/ee/api/explicit_team_member.py
+++ b/ee/api/explicit_team_member.py
@@ -60,7 +60,7 @@ class ExplicitTeamMemberSerializer(serializers.ModelSerializer):
         requesting_user: User = self.context["request"].user
         membership_being_accessed = cast(Optional[ExplicitTeamMembership], self.instance)
         try:
-            requesting_level = self.context["team"].get_effective_membership_level(requesting_user.id)
+            requesting_level = self.context["view"].user_permissions.team(team).effective_membership_level
         except OrganizationMembership.DoesNotExist:
             # Requesting user does not belong to the project's organization, so we spoof a 404 for enhanced security
             raise exceptions.NotFound("Project not found.")

--- a/ee/api/explicit_team_member.py
+++ b/ee/api/explicit_team_member.py
@@ -12,9 +12,10 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.permissions import TeamMemberStrictManagementPermission
+from posthog.user_permissions import UserPermissionsSerializerMixin
 
 
-class ExplicitTeamMemberSerializer(serializers.ModelSerializer):
+class ExplicitTeamMemberSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin):
     user = UserBasicSerializer(source="parent_membership.user", read_only=True)
     parent_level = serializers.IntegerField(source="parent_membership.level", read_only=True)
 
@@ -60,7 +61,7 @@ class ExplicitTeamMemberSerializer(serializers.ModelSerializer):
         requesting_user: User = self.context["request"].user
         membership_being_accessed = cast(Optional[ExplicitTeamMembership], self.instance)
         try:
-            requesting_level = self.context["view"].user_permissions.team(team).effective_membership_level
+            requesting_level = self.user_permissions.team(team).effective_membership_level
         except OrganizationMembership.DoesNotExist:
             # Requesting user does not belong to the project's organization, so we spoof a 404 for enhanced security
             raise exceptions.NotFound("Project not found.")

--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -437,13 +437,13 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         Team.objects.create(organization=self.organization, name="Other", access_control=True)
 
         # The other team should not be returned as it's restricted for the logged-in user
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(7):
             projects_response = self.client.get(f"/api/projects/")
 
         # 9 (above) + 2 below:
         # Used for `metadata`.`taxonomy_set_events_count`: SELECT COUNT(*) FROM "ee_enterpriseeventdefinition" WHERE ...
         #  Used for `metadata`.`taxonomy_set_properties_count`: SELECT COUNT(*) FROM "ee_enterprisepropertydefinition" WHERE ...
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             current_org_response = self.client.get(f"/api/organizations/{self.organization.id}/")
 
         self.assertEqual(projects_response.status_code, HTTP_200_OK)
@@ -461,7 +461,6 @@ class TestProjectEnterpriseAPI(APILicensedTest):
                     "is_demo": False,
                     "timezone": "UTC",
                     "access_control": False,
-                    "effective_membership_level": int(OrganizationMembership.Level.MEMBER),
                 }
             ],
         )
@@ -480,7 +479,6 @@ class TestProjectEnterpriseAPI(APILicensedTest):
                     "is_demo": False,
                     "timezone": "UTC",
                     "access_control": False,
-                    "effective_membership_level": int(OrganizationMembership.Level.MEMBER),
                 }
             ],
         )

--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from rest_framework.decorators import action
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -11,7 +11,7 @@ from ee.clickhouse.queries.retention import ClickhouseRetention
 from ee.clickhouse.queries.stickiness import ClickhouseStickiness
 from posthog.api.insight import InsightViewSet
 from posthog.decorators import cached_function
-from posthog.models import Insight, User
+from posthog.models import Insight
 from posthog.models.dashboard import Dashboard
 from posthog.models.filters import Filter
 
@@ -23,7 +23,7 @@ class CanEditInsight(BasePermission):
         if request.method in SAFE_METHODS:
             return True
 
-        return insight.get_effective_privilege_level(cast(User, request.user).id) == Dashboard.PrivilegeLevel.CAN_EDIT
+        return view.user_permissions.insight(insight).effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
 
 
 class ClickhouseInsightsViewSet(InsightViewSet):

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."$group_0" as "$group_0",
                                  e."properties" as "properties",
+                                 e."$group_0" as "$group_0",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."properties" as "properties",
                                  e."$group_0" as "$group_0",
+                                 e."properties" as "properties",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -109,7 +109,6 @@ function OtherProjectButton({ team }: { team: TeamBasicType }): JSX.Element {
             title={`Switch to project ${team.name}`}
             status="stealth"
             fullWidth
-            disabled={!team.effective_membership_level}
         >
             <ProjectName team={team} />
         </LemonButtonWithSideAction>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -268,8 +268,6 @@ export interface TeamBasicType {
     timezone: string
     /** Whether the project is private. */
     access_control: boolean
-    /** Effective access level of the user in this specific team. Null if user has no access. */
-    effective_membership_level: OrganizationMembershipLevel | null
 }
 
 export interface CorrelationConfigType {
@@ -297,6 +295,10 @@ export interface TeamType extends TeamBasicType {
     has_group_types: boolean
     primary_dashboard: number // Dashboard shown on the project homepage
     live_events_columns: string[] | null // Custom columns shown on the Live Events page
+
+    /** Effective access level of the user in this specific team. Null if user has no access. */
+    effective_membership_level: OrganizationMembershipLevel | null
+
     /** Used to exclude person properties from correlation analysis results.
      *
      * For example can be used to exclude properties that have trivial causation.

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -248,6 +248,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
         if "request" in self.context:
             report_user_action(user, "dashboard updated", instance.get_analytics_metadata())
 
+        self.user_permissions.reset_insights_dashboard_cached_results()
         return instance
 
     @staticmethod

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -71,12 +71,8 @@ class DashboardTileSerializer(serializers.ModelSerializer):
         return representation
 
 
-<<<<<<< HEAD
-class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
-=======
 class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer, UserPermissionsSerializerMixin):
     items = serializers.SerializerMethodField()
->>>>>>> f6418e269a... Handle shared dashboards slightly better
     tiles = serializers.SerializerMethodField()
     created_by = UserBasicSerializer(read_only=True)
     use_template = serializers.CharField(write_only=True, allow_blank=True, required=False)

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -308,7 +308,10 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
 
         serialized_tiles = []
 
-        for tile in DashboardTile.dashboard_queryset(dashboard.tiles):
+        tiles = DashboardTile.dashboard_queryset(dashboard.tiles)
+        self.context["view"].user_permissions.set_preloaded_dashboard_tiles(tiles)
+
+        for tile in tiles:
             self.context.update({"dashboard_tile": tile})
 
             if isinstance(tile.layouts, str):

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -318,7 +318,14 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
 
         return serialized_tiles
 
+    def get_effective_restriction_level(self, dashboard: Dashboard) -> Dashboard.RestrictionLevel:
+        if self.context.get("is_shared"):
+            return Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+        return self.context["view"].user_permissions.dashboard(dashboard).effective_restriction_level
+
     def get_effective_privilege_level(self, dashboard: Dashboard) -> Dashboard.PrivilegeLevel:
+        if self.context.get("is_shared"):
+            return Dashboard.PrivilegeLevel.CAN_VIEW
         return self.context["view"].user_permissions.dashboard(dashboard).effective_privilege_level
 
     def validate(self, data):

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -25,6 +25,7 @@ from posthog.models import Dashboard, DashboardTile, Insight, Team, Text
 from posthog.models.team.team import get_available_features_for_team
 from posthog.models.user import User
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
+from posthog.user_permissions import UserPermissionsSerializerMixin
 
 logger = structlog.get_logger(__name__)
 
@@ -70,7 +71,12 @@ class DashboardTileSerializer(serializers.ModelSerializer):
         return representation
 
 
+<<<<<<< HEAD
 class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
+=======
+class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer, UserPermissionsSerializerMixin):
+    items = serializers.SerializerMethodField()
+>>>>>>> f6418e269a... Handle shared dashboards slightly better
     tiles = serializers.SerializerMethodField()
     created_by = UserBasicSerializer(read_only=True)
     use_template = serializers.CharField(write_only=True, allow_blank=True, required=False)
@@ -215,7 +221,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
             )
 
     def update(self, instance: Dashboard, validated_data: Dict, *args: Any, **kwargs: Any) -> Dashboard:
-        can_user_restrict = self.context["view"].user_permissions.dashboard(instance).can_restrict
+        can_user_restrict = self.user_permissions.dashboard(instance).can_restrict
         if "restriction_level" in validated_data and not can_user_restrict:
             raise exceptions.PermissionDenied(
                 "Only the dashboard owner and project admins have the restriction rights required to change the dashboard's restriction level."
@@ -309,7 +315,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
         serialized_tiles = []
 
         tiles = DashboardTile.dashboard_queryset(dashboard.tiles)
-        self.context["view"].user_permissions.set_preloaded_dashboard_tiles(tiles)
+        self.user_permissions.set_preloaded_dashboard_tiles(tiles)
 
         for tile in tiles:
             self.context.update({"dashboard_tile": tile})
@@ -324,12 +330,12 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
     def get_effective_restriction_level(self, dashboard: Dashboard) -> Dashboard.RestrictionLevel:
         if self.context.get("is_shared"):
             return Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-        return self.context["view"].user_permissions.dashboard(dashboard).effective_restriction_level
+        return self.user_permissions.dashboard(dashboard).effective_restriction_level
 
     def get_effective_privilege_level(self, dashboard: Dashboard) -> Dashboard.PrivilegeLevel:
         if self.context.get("is_shared"):
             return Dashboard.PrivilegeLevel.CAN_VIEW
-        return self.context["view"].user_permissions.dashboard(dashboard).effective_privilege_level
+        return self.user_permissions.dashboard(dashboard).effective_privilege_level
 
     def validate(self, data):
         if data.get("use_dashboard", None) and data.get("use_template", None):

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -319,7 +319,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
         return serialized_tiles
 
     def get_effective_privilege_level(self, dashboard: Dashboard) -> Dashboard.PrivilegeLevel:
-        return self.context["view"].user_permissions.dashboard(dashboard).effective_priviledge_level
+        return self.context["view"].user_permissions.dashboard(dashboard).effective_privilege_level
 
     def validate(self, data):
         if data.get("use_dashboard", None) and data.get("use_template", None):

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -72,7 +72,6 @@ class DashboardTileSerializer(serializers.ModelSerializer):
 
 
 class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer, UserPermissionsSerializerMixin):
-    items = serializers.SerializerMethodField()
     tiles = serializers.SerializerMethodField()
     created_by = UserBasicSerializer(read_only=True)
     use_template = serializers.CharField(write_only=True, allow_blank=True, required=False)

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -316,7 +316,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
         serialized_tiles = []
 
         tiles = DashboardTile.dashboard_queryset(dashboard.tiles)
-        self.user_permissions.set_preloaded_dashboard_tiles(tiles)
+        self.user_permissions.set_preloaded_dashboard_tiles(list(tiles))
 
         for tile in tiles:
             self.context.update({"dashboard_tile": tile})

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -401,9 +401,13 @@ class InsightSerializer(InsightBasicSerializer):
         return self.insight_result(insight).is_cached
 
     def get_effective_restriction_level(self, insight: Insight) -> Dashboard.RestrictionLevel:
+        if self.context.get("is_shared"):
+            return Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
         return self.context["view"].user_permissions.insight(insight).effective_restriction_level
 
     def get_effective_privilege_level(self, insight: Insight) -> Dashboard.PrivilegeLevel:
+        if self.context.get("is_shared"):
+            return Dashboard.PrivilegeLevel.CAN_VIEW
         return self.context["view"].user_permissions.insight(insight).effective_privilege_level
 
     def to_representation(self, instance: Insight):

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -361,13 +361,11 @@ class InsightSerializer(InsightBasicSerializer):
         ids_to_remove = [id for id in old_dashboard_ids if id not in new_dashboard_ids]
         candidate_dashboards = Dashboard.objects.filter(id__in=ids_to_add)
         dashboard: Dashboard
+        user_permissions = self.context["view"].user_permissions
         for dashboard in candidate_dashboards:
             # does this user have permission on dashboards to add... if they are restricted
             # it will mean this dashboard becomes restricted because of the patch
-            if (
-                dashboard.get_effective_privilege_level(self.context["request"].user.id)
-                == Dashboard.PrivilegeLevel.CAN_VIEW
-            ):
+            if user_permissions.dashboard(dashboard).effective_privilege_level == Dashboard.PrivilegeLevel.CAN_VIEW:
                 raise PermissionDenied(f"You don't have permission to add insights to dashboard: {dashboard.id}")
 
             if dashboard.team != instance.team:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -309,6 +309,8 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
 
         self._log_insight_update(before_update, dashboards_before_change, updated_insight)
 
+        self.user_permissions.reset_insights_dashboard_cached_results()
+
         return updated_insight
 
     def _log_insight_update(self, before_update, dashboards_before_change, updated_insight):

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -181,6 +181,7 @@ class InsightSerializer(InsightBasicSerializer):
     is_cached = serializers.SerializerMethodField(read_only=True)
     created_by = UserBasicSerializer(read_only=True)
     last_modified_by = UserBasicSerializer(read_only=True)
+    effective_restriction_level = serializers.SerializerMethodField()
     effective_privilege_level = serializers.SerializerMethodField()
     timezone = serializers.SerializerMethodField(help_text="The timezone this chart is displayed in.")
     dashboards = serializers.PrimaryKeyRelatedField(
@@ -399,8 +400,11 @@ class InsightSerializer(InsightBasicSerializer):
     def get_is_cached(self, insight: Insight):
         return self.insight_result(insight).is_cached
 
+    def get_effective_restriction_level(self, insight: Insight) -> Dashboard.RestrictionLevel:
+        return self.context["view"].user_permissions.insight(insight).effective_restriction_level
+
     def get_effective_privilege_level(self, insight: Insight) -> Dashboard.PrivilegeLevel:
-        return insight.get_effective_privilege_level(self.context["request"].user.id)
+        return self.context["view"].user_permissions.insight(insight).effective_privilege_level
 
     def to_representation(self, instance: Insight):
         representation = super().to_representation(instance)

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -21,7 +21,7 @@ from posthog.permissions import (
     OrganizationMemberPermissions,
     extract_organization,
 )
-from posthog.user_permissions import UserPermissionsSerializerMixin
+from posthog.user_permissions import UserPermissions, UserPermissionsSerializerMixin
 
 
 class PremiumMultiorganizationPermissions(permissions.BasePermission):
@@ -188,3 +188,6 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             ],
             ignore_conflicts=True,
         )
+
+    def get_serializer_context(self) -> Dict[str, Any]:
+        return {**super().get_serializer_context(), "user_permissions": UserPermissions(cast(User, self.request.user))}

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -21,6 +21,7 @@ from posthog.permissions import (
     OrganizationMemberPermissions,
     extract_organization,
 )
+from posthog.user_permissions import UserPermissionsSerializerMixin
 
 
 class PremiumMultiorganizationPermissions(permissions.BasePermission):
@@ -59,7 +60,7 @@ class OrganizationPermissionsWithDelete(OrganizationAdminWritePermissions):
         )
 
 
-class OrganizationSerializer(serializers.ModelSerializer):
+class OrganizationSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin):
     membership_level = serializers.SerializerMethodField()
     teams = serializers.SerializerMethodField()
     metadata = serializers.SerializerMethodField()
@@ -106,18 +107,15 @@ class OrganizationSerializer(serializers.ModelSerializer):
         return organization
 
     def get_membership_level(self, organization: Organization) -> Optional[OrganizationMembership.Level]:
-        membership = OrganizationMembership.objects.filter(
-            organization=organization,
-            user=self.context["request"].user,
-        ).first()
+        membership = self.user_permissions.organization_memberships.get(organization.pk)
         return membership.level if membership is not None else None
 
     def get_teams(self, instance: Organization) -> List[Dict[str, Any]]:
         teams = cast(
             List[Dict[str, Any]], TeamBasicSerializer(instance.teams.all(), context=self.context, many=True).data
         )
-        visible_teams = [team for team in teams if team["effective_membership_level"] is not None]
-        return visible_teams
+        visible_team_ids = set(self.user_permissions.team_ids_visible_for_user)
+        return [team for team in teams if team["id"] in visible_team_ids]
 
     def get_metadata(self, instance: Organization) -> Dict[str, Union[str, int, object]]:
         output = {

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -168,7 +168,7 @@ class StructuredViewSetMixin(_GenericViewSet):
 
     @cached_property
     def user_permissions(self) -> "UserPermissions":
-        assert not self.request.user.is_anonymous
+        # assert not self.request.user.is_anonymous
 
         return UserPermissions(user=self.request.user, team=self.team, organization=self.organization)
 

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -170,7 +170,7 @@ class StructuredViewSetMixin(_GenericViewSet):
     def user_permissions(self) -> "UserPermissions":
         # assert not self.request.user.is_anonymous
 
-        return UserPermissions(user=self.request.user, team=self.team, organization=self.organization)
+        return UserPermissions(user=self.request.user, team=self.team)
 
     # Stdout tracing to see what legacy endpoints (non-project-nested) are still requested by the frontend
     # TODO: Delete below when no legacy endpoints are used anymore

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -168,9 +168,7 @@ class StructuredViewSetMixin(_GenericViewSet):
 
     @cached_property
     def user_permissions(self) -> "UserPermissions":
-        # assert not self.request.user.is_anonymous
-
-        return UserPermissions(user=self.request.user, team=self.team)
+        return UserPermissions(user=cast(User, self.request.user), team=self.team)
 
     # Stdout tracing to see what legacy endpoints (non-project-nested) are still requested by the frontend
     # TODO: Delete below when no legacy endpoints are used anymore

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -13,6 +13,7 @@ from posthog.auth import JwtAuthentication, PersonalAPIKeyAuthentication
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.models.user import User
+from posthog.user_permissions import UserPermissions
 
 if TYPE_CHECKING:
     _GenericViewSet = GenericViewSet
@@ -164,6 +165,12 @@ class StructuredViewSetMixin(_GenericViewSet):
                 raise AuthenticationFailed()
 
         return team_found
+
+    @cached_property
+    def user_permissions(self) -> "UserPermissions":
+        assert not self.request.user.is_anonymous
+
+        return UserPermissions(user=self.request.user, team=self.team, organization=self.organization)
 
     # Stdout tracing to see what legacy endpoints (non-project-nested) are still requested by the frontend
     # TODO: Delete below when no legacy endpoints are used anymore

--- a/posthog/api/shared.py
+++ b/posthog/api/shared.py
@@ -41,7 +41,7 @@ class TeamBasicSerializer(serializers.ModelSerializer):
         )
 
     def get_effective_membership_level(self, team: Team) -> Optional[OrganizationMembership.Level]:
-        return team.get_effective_membership_level(self.context["request"].user.id)
+        return self.context["view"].user_permissions.team(team).effective_membership_level
 
 
 class OrganizationBasicSerializer(serializers.ModelSerializer):

--- a/posthog/api/shared.py
+++ b/posthog/api/shared.py
@@ -22,8 +22,6 @@ class TeamBasicSerializer(serializers.ModelSerializer):
     Also used for nested serializers.
     """
 
-    effective_membership_level = serializers.SerializerMethodField(read_only=True)
-
     class Meta:
         model = Team
         fields = (
@@ -37,11 +35,7 @@ class TeamBasicSerializer(serializers.ModelSerializer):
             "is_demo",
             "timezone",
             "access_control",
-            "effective_membership_level",
         )
-
-    def get_effective_membership_level(self, team: Team) -> Optional[OrganizationMembership.Level]:
-        return self.context["view"].user_permissions.team(team).effective_membership_level
 
 
 class OrganizationBasicSerializer(serializers.ModelSerializer):

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -16,6 +16,7 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset, asset_for_token, get_content_response
 from posthog.models.insight import Insight
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
+from posthog.user_permissions import UserPermissions
 from posthog.utils import render_template
 
 
@@ -155,7 +156,12 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
             raise NotFound()
 
         embedded = "embedded" in request.GET or "/embedded/" in request.path
-        context = {"view": self, "request": request, "is_shared": True}
+        context = {
+            "view": self,
+            "request": request,
+            "user_permissions": UserPermissions(request.user, resource.team),
+            "is_shared": True,
+        }
         exported_data: Dict[str, Any] = {"type": "embed" if embedded else "scene"}
 
         if asset:

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -15,6 +15,7 @@ from posthog.models import SharingConfiguration
 from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset, asset_for_token, get_content_response
 from posthog.models.insight import Insight
+from posthog.models.user import User
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.user_permissions import UserPermissions
 from posthog.utils import render_template
@@ -159,7 +160,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
         context = {
             "view": self,
             "request": request,
-            "user_permissions": UserPermissions(request.user, resource.team),
+            "user_permissions": UserPermissions(cast(User, request.user), resource.team),
             "is_shared": True,
         }
         exported_data: Dict[str, Any] = {"type": "embed" if embedded else "scene"}

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -155,7 +155,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
             raise NotFound()
 
         embedded = "embedded" in request.GET or "/embedded/" in request.path
-        context = {"view": self, "request": request}
+        context = {"view": self, "request": request, "is_shared": True}
         exported_data: Dict[str, Any] = {"type": "embed" if embedded else "scene"}
 
         if asset:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -323,4 +323,5 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
 
     @cached_property
     def user_permissions(self):
-        return UserPermissions(cast(User, self.request.user))
+        team = self.get_object() if self.action == "reset_token" else None
+        return UserPermissions(cast(User, self.request.user), team)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -323,6 +323,4 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
 
     @cached_property
     def user_permissions(self):
-        return UserPermissions(
-            cast(User, self.request.user), team=self.team, organization=getattr(self.request.user, "organization", None)
-        )
+        return UserPermissions(cast(User, self.request.user), team=self.team)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -26,7 +26,7 @@ from posthog.permissions import (
     TeamMemberStrictManagementPermission,
 )
 from posthog.tasks.demo_create_data import create_data_for_demo_team
-from posthog.user_permissions import UserPermissions
+from posthog.user_permissions import UserPermissions, UserPermissionsSerializerMixin
 
 
 class PremiumMultiprojectPermissions(permissions.BasePermission):
@@ -88,7 +88,7 @@ class CachingTeamSerializer(serializers.ModelSerializer):
         ]
 
 
-class TeamSerializer(serializers.ModelSerializer):
+class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin):
     effective_membership_level = serializers.SerializerMethodField()
     has_group_types = serializers.SerializerMethodField()
     groups_on_events_querying_enabled = serializers.SerializerMethodField()
@@ -144,7 +144,7 @@ class TeamSerializer(serializers.ModelSerializer):
         )
 
     def get_effective_membership_level(self, team: Team) -> Optional[OrganizationMembership.Level]:
-        return self.context["view"].user_permissions.team(team).effective_membership_level
+        return self.user_permissions.team(team).effective_membership_level
 
     def get_has_group_types(self, team: Team) -> bool:
         return GroupTypeMapping.objects.filter(team=team).exists()

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -26,6 +26,7 @@ from posthog.permissions import (
     TeamMemberStrictManagementPermission,
 )
 from posthog.tasks.demo_create_data import create_data_for_demo_team
+from posthog.user_permissions import UserPermissions
 
 
 class PremiumMultiprojectPermissions(permissions.BasePermission):
@@ -143,7 +144,7 @@ class TeamSerializer(serializers.ModelSerializer):
         )
 
     def get_effective_membership_level(self, team: Team) -> Optional[OrganizationMembership.Level]:
-        return team.get_effective_membership_level(self.context["request"].user.id)
+        return self.context["view"].user_permissions.team(team).effective_membership_level
 
     def get_has_group_types(self, team: Team) -> bool:
         return GroupTypeMapping.objects.filter(team=team).exists()
@@ -218,13 +219,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
 
     def get_queryset(self):
         # This is actually what ensures that a user cannot read/update a project for which they don't have permission
-        visible_teams_ids = [
-            team.id
-            for team in super()
-            .get_queryset()
-            .filter(organization__in=cast(User, self.request.user).organizations.all())
-            if team.get_effective_membership_level(self.request.user.id) is not None
-        ]
+        visible_teams_ids = UserPermissions(cast(User, self.request.user)).team_ids_visible_for_user
         return super().get_queryset().filter(id__in=visible_teams_ids)
 
     def get_serializer_class(self) -> Type[serializers.BaseSerializer]:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -323,4 +323,4 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
 
     @cached_property
     def user_permissions(self):
-        return UserPermissions(cast(User, self.request.user), team=self.team)
+        return UserPermissions(cast(User, self.request.user))

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Any, Dict, List, Optional, Type, cast
 
 from django.core.cache import cache
@@ -319,3 +320,9 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         team = self.get_object()
         cache_key = f"is_generating_demo_data_{team.pk}"
         return response.Response({"is_generating_demo_data": cache.get(cache_key) == "True"})
+
+    @cached_property
+    def user_permissions(self):
+        return UserPermissions(
+            cast(User, self.request.user), team=self.team, organization=getattr(self.request.user, "organization", None)
+        )

--- a/posthog/api/test/__snapshots__/test_action.ambr
+++ b/posthog/api/test/__snapshots__/test_action.ambr
@@ -170,9 +170,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.14
@@ -310,9 +308,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.3
@@ -469,9 +465,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_actions-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/actions/%3F%24'*/
   '
 ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.8

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -122,9 +122,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
@@ -352,9 +350,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.3
@@ -454,9 +450,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.7

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -92,41 +92,10 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
-  '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
@@ -134,7 +103,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -145,7 +114,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -156,7 +125,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -182,7 +151,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -201,6 +170,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
@@ -313,41 +298,10 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_web_app_queries.3
-  '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_web_app_queries.4
   '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
@@ -355,7 +309,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_web_app_queries.5
+# name: TestDecide.test_web_app_queries.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -366,7 +320,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_web_app_queries.6
+# name: TestDecide.test_web_app_queries.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -377,7 +331,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_web_app_queries.7
+# name: TestDecide.test_web_app_queries.6
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -401,6 +355,22 @@
   FROM "posthog_user"
   WHERE "posthog_user"."id" = 2
   LIMIT 21
+  '
+---
+# name: TestDecide.test_web_app_queries.7
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_web_app_queries.8

--- a/posthog/api/test/__snapshots__/test_element.ambr
+++ b/posthog/api/test/__snapshots__/test_element.ambr
@@ -92,8 +92,6 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='element-stats',route='api/element/stats/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='element-stats',route='api/element/stats/%3F%24'*/
   '
 ---

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -289,17 +289,7 @@
 ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.18
   '
-  SELECT "posthog_dashboardtile"."id",
-         "posthog_dashboardtile"."dashboard_id",
-         "posthog_dashboardtile"."insight_id",
-         "posthog_dashboardtile"."text_id",
-         "posthog_dashboardtile"."layouts",
-         "posthog_dashboardtile"."color",
-         "posthog_dashboardtile"."filters_hash",
-         "posthog_dashboardtile"."last_refresh",
-         "posthog_dashboardtile"."refreshing",
-         "posthog_dashboardtile"."refresh_attempt",
-         "posthog_dashboardtile"."deleted"
+  SELECT "posthog_dashboardtile"."dashboard_id"
   FROM "posthog_dashboardtile"
   INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT ("posthog_dashboardtile"."deleted"
@@ -327,8 +317,12 @@
          "posthog_dashboard"."share_token",
          "posthog_dashboard"."is_shared"
   FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."id" IN (1,
+                                          2,
+                                          3,
+                                          4,
+                                          5 /* ... */)) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.2
@@ -355,186 +349,10 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.20
-  '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestInsight.test_listing_insights_does_not_nplus1.21
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestInsight.test_listing_insights_does_not_nplus1.22
-  '
-  SELECT "posthog_dashboardtile"."id",
-         "posthog_dashboardtile"."dashboard_id",
-         "posthog_dashboardtile"."insight_id",
-         "posthog_dashboardtile"."text_id",
-         "posthog_dashboardtile"."layouts",
-         "posthog_dashboardtile"."color",
-         "posthog_dashboardtile"."filters_hash",
-         "posthog_dashboardtile"."last_refresh",
-         "posthog_dashboardtile"."refreshing",
-         "posthog_dashboardtile"."refresh_attempt",
-         "posthog_dashboardtile"."deleted"
-  FROM "posthog_dashboardtile"
-  INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
-  WHERE (NOT ("posthog_dashboardtile"."deleted"
-              AND "posthog_dashboardtile"."deleted" IS NOT NULL)
-         AND NOT ("posthog_dashboard"."deleted")
-         AND "posthog_dashboardtile"."insight_id" = 2) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestInsight.test_listing_insights_does_not_nplus1.23
-  '
-  SELECT "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared"
-  FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestInsight.test_listing_insights_does_not_nplus1.24
-  '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestInsight.test_listing_insights_does_not_nplus1.25
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestInsight.test_listing_insights_does_not_nplus1.26
   '
   SELECT "posthog_tag"."name"
   FROM "posthog_taggeditem"
@@ -542,14 +360,14 @@
   WHERE "posthog_taggeditem"."insight_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestInsight.test_listing_insights_does_not_nplus1.27
+# name: TestInsight.test_listing_insights_does_not_nplus1.21
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_dashboarditem"
   WHERE NOT ("posthog_dashboarditem"."deleted")
   '
 ---
-# name: TestInsight.test_listing_insights_does_not_nplus1.28
+# name: TestInsight.test_listing_insights_does_not_nplus1.22
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -575,7 +393,7 @@
   LIMIT 21 /**/
   '
 ---
-# name: TestInsight.test_listing_insights_does_not_nplus1.29
+# name: TestInsight.test_listing_insights_does_not_nplus1.23
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -612,6 +430,280 @@
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
+# name: TestInsight.test_listing_insights_does_not_nplus1.24
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestInsight.test_listing_insights_does_not_nplus1.25
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestInsight.test_listing_insights_does_not_nplus1.26
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboarditem"
+  WHERE (NOT ("posthog_dashboarditem"."deleted")
+         AND "posthog_dashboarditem"."team_id" = 2) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestInsight.test_listing_insights_does_not_nplus1.27
+  '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config",
+         T4."id",
+         T4."password",
+         T4."last_login",
+         T4."first_name",
+         T4."last_name",
+         T4."is_staff",
+         T4."is_active",
+         T4."date_joined",
+         T4."uuid",
+         T4."current_organization_id",
+         T4."current_team_id",
+         T4."email",
+         T4."temporary_token",
+         T4."distinct_id",
+         T4."email_opt_in",
+         T4."partial_notification_settings",
+         T4."anonymize_data",
+         T4."toolbar_mode",
+         T4."events_column_config"
+  FROM "posthog_dashboarditem"
+  INNER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_dashboarditem"."created_by_id" = "posthog_user"."id")
+  LEFT OUTER JOIN "posthog_user" T4 ON ("posthog_dashboarditem"."last_modified_by_id" = T4."id")
+  WHERE (NOT ("posthog_dashboarditem"."deleted")
+         AND "posthog_dashboarditem"."team_id" = 2)
+  ORDER BY "posthog_dashboarditem"."order" ASC
+  LIMIT 100 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestInsight.test_listing_insights_does_not_nplus1.28
+  '
+  SELECT "posthog_taggeditem"."id",
+         "posthog_taggeditem"."tag_id",
+         "posthog_taggeditem"."dashboard_id",
+         "posthog_taggeditem"."insight_id",
+         "posthog_taggeditem"."event_definition_id",
+         "posthog_taggeditem"."property_definition_id",
+         "posthog_taggeditem"."action_id",
+         "posthog_taggeditem"."feature_flag_id",
+         "posthog_tag"."id",
+         "posthog_tag"."name",
+         "posthog_tag"."team_id"
+  FROM "posthog_taggeditem"
+  INNER JOIN "posthog_tag" ON ("posthog_taggeditem"."tag_id" = "posthog_tag"."id")
+  WHERE "posthog_taggeditem"."insight_id" IN (1,
+                                              2,
+                                              3,
+                                              4,
+                                              5 /* ... */) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestInsight.test_listing_insights_does_not_nplus1.29
+  '
+  SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
+         "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_dashboard"
+  INNER JOIN "posthog_dashboardtile" ON ("posthog_dashboard"."id" = "posthog_dashboardtile"."dashboard_id")
+  INNER JOIN "posthog_team" ON ("posthog_dashboard"."team_id" = "posthog_team"."id")
+  INNER JOIN "posthog_organization" ON ("posthog_team"."organization_id" = "posthog_organization"."id")
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboardtile"."insight_id" IN (1,
+                                                      2,
+                                                      3,
+                                                      4,
+                                                      5 /* ... */)) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
 # name: TestInsight.test_listing_insights_does_not_nplus1.3
   '
   SELECT "posthog_dashboard"."id",
@@ -638,12 +730,70 @@
 ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.30
   '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
+  SELECT "posthog_dashboardtile"."id",
+         "posthog_dashboardtile"."dashboard_id",
+         "posthog_dashboardtile"."insight_id",
+         "posthog_dashboardtile"."text_id",
+         "posthog_dashboardtile"."layouts",
+         "posthog_dashboardtile"."color",
+         "posthog_dashboardtile"."filters_hash",
+         "posthog_dashboardtile"."last_refresh",
+         "posthog_dashboardtile"."refreshing",
+         "posthog_dashboardtile"."refresh_attempt",
+         "posthog_dashboardtile"."deleted",
+         "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
          "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -658,32 +808,36 @@
          "posthog_organization"."setup_section_2_completed",
          "posthog_organization"."personalization",
          "posthog_organization"."domain_whitelist"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  FROM "posthog_dashboardtile"
+  INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
+  INNER JOIN "posthog_team" ON ("posthog_dashboard"."team_id" = "posthog_team"."id")
+  INNER JOIN "posthog_organization" ON ("posthog_team"."organization_id" = "posthog_organization"."id")
+  WHERE (NOT ("posthog_dashboardtile"."deleted"
+              AND "posthog_dashboardtile"."deleted" IS NOT NULL)
+         AND NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboardtile"."insight_id" IN (1,
+                                                      2,
+                                                      3,
+                                                      4,
+                                                      5 /* ... */)) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.31
   '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  SELECT "posthog_taggeditem"."id",
+         "posthog_taggeditem"."tag_id",
+         "posthog_taggeditem"."dashboard_id",
+         "posthog_taggeditem"."insight_id",
+         "posthog_taggeditem"."event_definition_id",
+         "posthog_taggeditem"."property_definition_id",
+         "posthog_taggeditem"."action_id",
+         "posthog_taggeditem"."feature_flag_id"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."insight_id" IN (1,
+                                              2,
+                                              3,
+                                              4,
+                                              5 /* ... */) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
 # name: TestInsight.test_listing_insights_does_not_nplus1.32

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -283,9 +283,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.2
@@ -312,9 +310,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.20
@@ -541,9 +537,7 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.3
@@ -802,8 +796,6 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -63,17 +63,7 @@
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.10
   '
-  SELECT "posthog_dashboardtile"."id",
-         "posthog_dashboardtile"."dashboard_id",
-         "posthog_dashboardtile"."insight_id",
-         "posthog_dashboardtile"."text_id",
-         "posthog_dashboardtile"."layouts",
-         "posthog_dashboardtile"."color",
-         "posthog_dashboardtile"."filters_hash",
-         "posthog_dashboardtile"."last_refresh",
-         "posthog_dashboardtile"."refreshing",
-         "posthog_dashboardtile"."refresh_attempt",
-         "posthog_dashboardtile"."deleted"
+  SELECT "posthog_dashboardtile"."dashboard_id"
   FROM "posthog_dashboardtile"
   INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT ("posthog_dashboardtile"."deleted"
@@ -101,185 +91,15 @@
          "posthog_dashboard"."share_token",
          "posthog_dashboard"."is_shared"
   FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."id" IN (1,
+                                          2,
+                                          3,
+                                          4,
+                                          5 /* ... */)) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.12
-  '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.13
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.14
-  '
-  SELECT "posthog_dashboardtile"."id",
-         "posthog_dashboardtile"."dashboard_id",
-         "posthog_dashboardtile"."insight_id",
-         "posthog_dashboardtile"."text_id",
-         "posthog_dashboardtile"."layouts",
-         "posthog_dashboardtile"."color",
-         "posthog_dashboardtile"."filters_hash",
-         "posthog_dashboardtile"."last_refresh",
-         "posthog_dashboardtile"."refreshing",
-         "posthog_dashboardtile"."refresh_attempt",
-         "posthog_dashboardtile"."deleted"
-  FROM "posthog_dashboardtile"
-  INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
-  WHERE (NOT ("posthog_dashboardtile"."deleted"
-              AND "posthog_dashboardtile"."deleted" IS NOT NULL)
-         AND NOT ("posthog_dashboard"."deleted")
-         AND "posthog_dashboardtile"."insight_id" = 2) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.15
-  '
-  SELECT "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared"
-  FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.16
-  '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.17
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.18
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -305,7 +125,7 @@
   LIMIT 21 /**/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.19
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.13
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -342,65 +162,19 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.2
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.14
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
          "posthog_organizationmembership"."user_id",
          "posthog_organizationmembership"."level",
          "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
+         "posthog_organizationmembership"."updated_at"
   FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.20
-  '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.21
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.15
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -421,7 +195,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.22
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.16
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -519,7 +293,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.23
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.17
   '
   SELECT "posthog_sharingconfiguration"."id",
          "posthog_sharingconfiguration"."team_id",
@@ -536,7 +310,7 @@
                                                           5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.24
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.18
   '
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -667,6 +441,9 @@
   WHERE (NOT ("posthog_dashboardtile"."deleted"
               AND "posthog_dashboardtile"."deleted" IS NOT NULL)
          AND NOT ("posthog_dashboard"."deleted")
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboardtile"."deleted"
+                  AND "posthog_dashboardtile"."deleted" IS NOT NULL)
          AND (NOT "posthog_dashboarditem"."deleted"
               OR "posthog_dashboardtile"."insight_id" IS NULL)
          AND "posthog_dashboardtile"."dashboard_id" = 2
@@ -678,7 +455,7 @@
   ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.25
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.19
   '
   SELECT "posthog_insightcachingstate"."id",
          "posthog_insightcachingstate"."team_id",
@@ -699,7 +476,19 @@
                                                               5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.26
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.2
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at"
+  FROM "posthog_organizationmembership"
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.20
   '
   SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
          "posthog_dashboard"."id",
@@ -788,7 +577,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.27
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.21
   '
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -813,7 +602,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.28
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.22
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -837,6 +626,337 @@
                                      3,
                                      4,
                                      5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.23
+  '
+  SELECT "posthog_dashboardtile"."id",
+         "posthog_dashboardtile"."dashboard_id",
+         "posthog_dashboardtile"."insight_id",
+         "posthog_dashboardtile"."text_id",
+         "posthog_dashboardtile"."layouts",
+         "posthog_dashboardtile"."color",
+         "posthog_dashboardtile"."filters_hash",
+         "posthog_dashboardtile"."last_refresh",
+         "posthog_dashboardtile"."refreshing",
+         "posthog_dashboardtile"."refresh_attempt",
+         "posthog_dashboardtile"."deleted",
+         "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config",
+         T6."id",
+         T6."password",
+         T6."last_login",
+         T6."first_name",
+         T6."last_name",
+         T6."is_staff",
+         T6."is_active",
+         T6."date_joined",
+         T6."uuid",
+         T6."current_organization_id",
+         T6."current_team_id",
+         T6."email",
+         T6."temporary_token",
+         T6."distinct_id",
+         T6."email_opt_in",
+         T6."partial_notification_settings",
+         T6."anonymize_data",
+         T6."toolbar_mode",
+         T6."events_column_config",
+         "posthog_text"."id",
+         "posthog_text"."body",
+         "posthog_text"."created_by_id",
+         "posthog_text"."last_modified_at",
+         "posthog_text"."last_modified_by_id",
+         "posthog_text"."team_id"
+  FROM "posthog_dashboardtile"
+  INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_dashboardtile"."insight_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_team" ON ("posthog_dashboarditem"."team_id" = "posthog_team"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_dashboarditem"."created_by_id" = "posthog_user"."id")
+  LEFT OUTER JOIN "posthog_user" T6 ON ("posthog_dashboarditem"."last_modified_by_id" = T6."id")
+  LEFT OUTER JOIN "posthog_text" ON ("posthog_dashboardtile"."text_id" = "posthog_text"."id")
+  WHERE (NOT ("posthog_dashboardtile"."deleted"
+              AND "posthog_dashboardtile"."deleted" IS NOT NULL)
+         AND NOT ("posthog_dashboard"."deleted")
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboardtile"."deleted"
+                  AND "posthog_dashboardtile"."deleted" IS NOT NULL)
+         AND (NOT "posthog_dashboarditem"."deleted"
+              OR "posthog_dashboardtile"."insight_id" IS NULL)
+         AND "posthog_dashboardtile"."dashboard_id" = 2
+         AND "posthog_dashboardtile"."dashboard_id" = 2
+         AND (NOT "posthog_dashboarditem"."deleted"
+              OR "posthog_dashboardtile"."insight_id" IS NULL))
+  ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.24
+  '
+  SELECT "posthog_insightcachingstate"."id",
+         "posthog_insightcachingstate"."team_id",
+         "posthog_insightcachingstate"."insight_id",
+         "posthog_insightcachingstate"."dashboard_tile_id",
+         "posthog_insightcachingstate"."cache_key",
+         "posthog_insightcachingstate"."target_cache_age_seconds",
+         "posthog_insightcachingstate"."last_refresh",
+         "posthog_insightcachingstate"."last_refresh_queued_at",
+         "posthog_insightcachingstate"."refresh_attempt",
+         "posthog_insightcachingstate"."created_at",
+         "posthog_insightcachingstate"."updated_at"
+  FROM "posthog_insightcachingstate"
+  WHERE "posthog_insightcachingstate"."dashboard_tile_id" IN (1,
+                                                              2,
+                                                              3,
+                                                              4,
+                                                              5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.25
+  '
+  SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
+         "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
+         "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_dashboard"
+  INNER JOIN "posthog_dashboardtile" ON ("posthog_dashboard"."id" = "posthog_dashboardtile"."dashboard_id")
+  INNER JOIN "posthog_team" ON ("posthog_dashboard"."team_id" = "posthog_team"."id")
+  INNER JOIN "posthog_organization" ON ("posthog_team"."organization_id" = "posthog_organization"."id")
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."id" IN
+           (SELECT U0."dashboard_id"
+            FROM "posthog_dashboardtile" U0
+            INNER JOIN "posthog_dashboard" U1 ON (U0."dashboard_id" = U1."id")
+            WHERE (NOT (U0."deleted"
+                        AND U0."deleted" IS NOT NULL)
+                   AND NOT (U1."deleted")))
+         AND "posthog_dashboardtile"."insight_id" IN (1,
+                                                      2,
+                                                      3,
+                                                      4,
+                                                      5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.26
+  '
+  SELECT "posthog_dashboardtile"."id",
+         "posthog_dashboardtile"."dashboard_id",
+         "posthog_dashboardtile"."insight_id",
+         "posthog_dashboardtile"."text_id",
+         "posthog_dashboardtile"."layouts",
+         "posthog_dashboardtile"."color",
+         "posthog_dashboardtile"."filters_hash",
+         "posthog_dashboardtile"."last_refresh",
+         "posthog_dashboardtile"."refreshing",
+         "posthog_dashboardtile"."refresh_attempt",
+         "posthog_dashboardtile"."deleted"
+  FROM "posthog_dashboardtile"
+  INNER JOIN "posthog_dashboard" ON ("posthog_dashboardtile"."dashboard_id" = "posthog_dashboard"."id")
+  WHERE (NOT ("posthog_dashboardtile"."deleted"
+              AND "posthog_dashboardtile"."deleted" IS NOT NULL)
+         AND NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboardtile"."insight_id" IN (1,
+                                                      2,
+                                                      3,
+                                                      4,
+                                                      5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.27
+  '
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared"
+  FROM "posthog_dashboard"
+  WHERE "posthog_dashboard"."id" IN (1,
+                                     2,
+                                     3,
+                                     4,
+                                     5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.28
+  '
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared"
+  FROM "posthog_dashboard"
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."id" IN (1,
+                                          2,
+                                          3,
+                                          4,
+                                          5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.29
@@ -981,25 +1101,22 @@
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.3
   '
-  SELECT "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared"
-  FROM "posthog_dashboard"
-  WHERE (NOT ("posthog_dashboard"."deleted")
-         AND "posthog_dashboard"."id" = 2)
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
@@ -1231,6 +1348,30 @@
 ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.4
   '
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared"
+  FROM "posthog_dashboard"
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."id" = 2)
+  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.5
+  '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
          "posthog_team"."organization_id",
@@ -1266,7 +1407,7 @@
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.5
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.6
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -1293,7 +1434,7 @@
                                           5 /* ... */)) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.6
+# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.7
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1334,27 +1475,6 @@
          "posthog_team"."event_properties_numerical"
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
-# name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.7
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21 /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -158,19 +158,19 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             }
 
             with self.assertNumQueries(10):
-                self.dashboard_api.get_dashboard(dashboard_id)
+                self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
             self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
-            with self.assertNumQueries(20):
-                self.dashboard_api.get_dashboard(dashboard_id)
+            with self.assertNumQueries(19):
+                self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
             self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
-            with self.assertNumQueries(20):
-                self.dashboard_api.get_dashboard(dashboard_id)
+            with self.assertNumQueries(19):
+                self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
             self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
-            with self.assertNumQueries(20):
-                self.dashboard_api.get_dashboard(dashboard_id)
+            with self.assertNumQueries(19):
+                self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
     @snapshot_postgres_queries
     def test_listing_dashboards_is_not_nplus1(self) -> None:

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -339,7 +339,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(Insight.objects.count(), i + 1)
 
             with capture_db_queries() as capture_query_context:
-                response = self.client.get(f"/api/projects/{self.team.id}/insights")
+                response = self.client.get(f"/api/projects/{self.team.id}/insights?basic=true")
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 self.assertEqual(len(response.json()["results"]), i + 1)
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -28,6 +28,7 @@ from posthog.models.organization import Organization
 from posthog.models.user import NOTIFICATION_DEFAULTS, Notifications
 from posthog.tasks import user_identify
 from posthog.tasks.email import send_email_change_emails
+from posthog.user_permissions import UserPermissions
 from posthog.utils import get_js_url
 
 
@@ -226,6 +227,9 @@ class UserViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.Lis
         if not self.request.user.is_staff:
             queryset = queryset.filter(id=self.request.user.id)
         return queryset
+
+    def get_serializer_context(self):
+        return {**super().get_serializer_context(), "user_permissions": UserPermissions(cast(User, self.request.user))}
 
 
 @authenticate_secondarily

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -20,6 +20,7 @@ from posthog.clickhouse.client.execute import clickhouse_query_counter
 from posthog.clickhouse.query_tagging import QueryCounter, reset_query_tags, tag_queries
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Team, User
 from posthog.settings.statsd import STATSD_HOST
+from posthog.user_permissions import UserPermissions
 
 from .auth import PersonalAPIKeyAuthentication
 
@@ -162,7 +163,10 @@ class AutoProjectMiddleware:
             actual_item = target_queryset.only("team").select_related("team").first()
             if actual_item is not None:
                 actual_item_team: Team = actual_item.team
-                if actual_item_team.get_effective_membership_level(user.id) is not None:
+                user_permissions = UserPermissions(user)
+                # :KLUDGE: This is more inefficient than needed, doing several expensive lookups
+                #   However this should be a rare operation!
+                if user_permissions.team(actual_item_team).effective_membership_level is not None:
                     user.current_team = actual_item_team
                     user.current_organization_id = actual_item_team.organization_id
                     user.save()

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -107,7 +107,7 @@ class DashboardTile(models.Model):
                 "insight__last_modified_by",
                 "insight__team",
             )
-            .exclude(dashboard__deleted=True)
+            .exclude(dashboard__deleted=True, deleted=True)
             .filter(Q(insight__deleted=False) | Q(insight__isnull=True))
             .order_by("insight__order")
         )

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -140,32 +140,6 @@ class Insight(models.Model):
             return self.filters
 
     @property
-    def effective_restriction_level(self) -> Dashboard.RestrictionLevel:
-        dashboard_tiles = list(self.dashboard_tiles.all())
-        if not dashboard_tiles:
-            return Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-
-        restrictions = [t.dashboard.effective_restriction_level for t in dashboard_tiles]
-        restriction_set_to_only_collaborators = next(
-            (x for x in restrictions if x == Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT), None
-        )
-        if restriction_set_to_only_collaborators:
-            return Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
-        else:
-            return Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-
-    def get_effective_privilege_level(self, user_id: int) -> Dashboard.PrivilegeLevel:
-        dashboard_tiles = list(self.dashboard_tiles.all())
-        if not dashboard_tiles:
-            return Dashboard.PrivilegeLevel.CAN_EDIT
-
-        edit_permissions = [t.dashboard.can_user_edit(user_id) for t in dashboard_tiles]
-        if any(edit_permissions):
-            return Dashboard.PrivilegeLevel.CAN_EDIT
-        else:
-            return Dashboard.PrivilegeLevel.CAN_VIEW
-
-    @property
     def url(self):
         return absolute_uri(f"/insights/{self.short_id}")
 

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -1,7 +1,7 @@
 import json
 import re
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import Any, List, Optional
 
 import posthoganalytics
 import pytz
@@ -14,7 +14,6 @@ from sentry_sdk import capture_exception
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import is_cloud
-from posthog.constants import AvailableFeature
 from posthog.helpers.dashboard_templates import create_dashboard_from_template
 from posthog.models.dashboard import Dashboard
 from posthog.models.filters.filter import Filter
@@ -25,9 +24,6 @@ from posthog.models.team.util import actor_on_events_ready
 from posthog.models.utils import UUIDClassicModel, generate_random_token_project, sane_repr
 from posthog.settings.utils import get_list
 from posthog.utils import GenericEmails
-
-if TYPE_CHECKING:
-    from posthog.models.organization import OrganizationMembership
 
 TIMEZONES = [(tz, tz) for tz in pytz.common_timezones]
 
@@ -194,52 +190,6 @@ class Team(UUIDClassicModel):
     def delete(self, *args, **kwargs):
         super().delete(*args, **kwargs)
         set_team_in_cache(self.api_token, None)
-
-    def get_effective_membership_level_for_parent_membership(
-        self, requesting_parent_membership: "OrganizationMembership"
-    ) -> Optional["OrganizationMembership.Level"]:
-        if (
-            not requesting_parent_membership.organization.is_feature_available(
-                AvailableFeature.PROJECT_BASED_PERMISSIONING
-            )
-            or not self.access_control
-        ):
-            return requesting_parent_membership.level
-        from posthog.models.organization import OrganizationMembership
-
-        try:
-            from ee.models import ExplicitTeamMembership
-        except ImportError:
-            # Only organizations admins and above get implicit project membership
-            if requesting_parent_membership.level < OrganizationMembership.Level.ADMIN:
-                return None
-            return requesting_parent_membership.level
-        else:
-            try:
-                return (
-                    requesting_parent_membership.explicit_team_memberships.only("parent_membership", "level")
-                    .get(team=self)
-                    .effective_level
-                )
-            except ExplicitTeamMembership.DoesNotExist:
-                # Only organizations admins and above get implicit project membership
-                if requesting_parent_membership.level < OrganizationMembership.Level.ADMIN:
-                    return None
-                return requesting_parent_membership.level
-
-    def get_effective_membership_level(self, user_id: int) -> Optional["OrganizationMembership.Level"]:
-        """Return an effective membership level.
-        None returned if the user has no explicit membership and organization access is too low for implicit membership.
-        """
-        from posthog.models.organization import OrganizationMembership
-
-        try:
-            requesting_parent_membership: OrganizationMembership = OrganizationMembership.objects.select_related(
-                "organization"
-            ).get(organization_id=self.organization_id, user_id=user_id)
-        except OrganizationMembership.DoesNotExist:
-            return None
-        return self.get_effective_membership_level_for_parent_membership(requesting_parent_membership)
 
     @property
     def person_on_events_querying_enabled(self) -> bool:

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -168,10 +168,10 @@ class TeamMemberAccessPermission(BasePermission):
 
     def has_permission(self, request, view) -> bool:
         try:
-            team = view.team
+            view.team
         except Team.DoesNotExist:
             return True  # This will be handled as a 404 in the viewset
-        requesting_level = team.get_effective_membership_level(request.user.id)
+        requesting_level = view.user_permissions.current_team.effective_membership_level
         return requesting_level is not None
 
 
@@ -192,7 +192,7 @@ class TeamMemberLightManagementPermission(BasePermission):
                 team = view.team
         except Team.DoesNotExist:
             return True  # This will be handled as a 404 in the viewset
-        requesting_level = team.get_effective_membership_level(request.user.id)
+        requesting_level = view.user_permissions.team(team).effective_membership_level
         if requesting_level is None:
             return False
         minimum_level = (
@@ -210,8 +210,7 @@ class TeamMemberStrictManagementPermission(BasePermission):
     message = "You don't have sufficient permissions in the project."
 
     def has_permission(self, request, view) -> bool:
-        team = view.team
-        requesting_level = team.get_effective_membership_level(request.user.id)
+        requesting_level = view.user_permissions.current_team.effective_membership_level
         if requesting_level is None:
             return False
         minimum_level = (

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -153,7 +153,7 @@
               CROSS JOIN
                 (SELECT breakdown_value
                  FROM
-                   (SELECT [36, 0] as breakdown_value) ARRAY
+                   (SELECT [34, 0] as breakdown_value) ARRAY
                  JOIN breakdown_value) as sec
               ORDER BY breakdown_value,
                        day_start
@@ -163,7 +163,7 @@
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
-                        36 as value
+                        34 as value
                  FROM
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
@@ -222,7 +222,7 @@
               CROSS JOIN
                 (SELECT breakdown_value
                  FROM
-                   (SELECT [36, 0] as breakdown_value) ARRAY
+                   (SELECT [34, 0] as breakdown_value) ARRAY
                  JOIN breakdown_value) as sec
               ORDER BY breakdown_value,
                        day_start
@@ -232,7 +232,7 @@
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
-                        36 as value
+                        34 as value
                  FROM
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -11,6 +11,7 @@ from posthog.celery import app
 from posthog.cloud_utils import is_cloud
 from posthog.email import EmailMessage, is_email_available
 from posthog.models import Organization, OrganizationInvite, OrganizationMembership, Plugin, PluginConfig, Team, User
+from posthog.user_permissions import UserPermissions
 
 logger = structlog.get_logger(__name__)
 
@@ -87,7 +88,7 @@ def send_fatal_plugin_error(
 ) -> None:
     if not is_email_available(with_absolute_urls=True):
         return
-    plugin_config: PluginConfig = PluginConfig.objects.select_related("plugin", "team").get(id=plugin_config_id)
+    plugin_config: PluginConfig = PluginConfig.objects.prefetch_related("plugin", "team").get(id=plugin_config_id)
     plugin: Plugin = plugin_config.plugin
     team: Team = plugin_config.team
     campaign_key: str = f"plugin_disabled_email_plugin_config_{plugin_config_id}_updated_at_{plugin_config_updated_at}"
@@ -97,17 +98,22 @@ def send_fatal_plugin_error(
         template_name="fatal_plugin_error",
         template_context={"plugin": plugin, "team": team, "error": error, "is_system_error": is_system_error},
     )
-
-    memberships_to_email = [
-        membership
-        for membership in OrganizationMembership.objects.select_related("user", "organization").filter(
-            organization_id=team.organization_id
-        )
+    memberships_to_email = []
+    memberships = OrganizationMembership.objects.prefetch_related("user", "organization").filter(
+        organization_id=team.organization_id
+    )
+    for membership in memberships:
+        if not membership.user.notification_settings["plugin_disabled"]:
+            continue
+        team_permissions = UserPermissions(membership.user).team(team)
         # Only send the email to users who have access to the affected project
         # Those without access have `effective_membership_level` of `None`
-        if team.get_effective_membership_level_for_parent_membership(membership) is not None
-        and membership.user.notification_settings["plugin_disabled"]
-    ]
+        if (
+            team_permissions.effective_membership_level_for_parent_membership(membership.organization, membership)
+            is not None
+        ):
+            memberships_to_email.append(membership)
+
     if memberships_to_email:
         for membership in memberships_to_email:
             message.add_recipient(email=membership.user.email, name=membership.user.first_name)

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -92,7 +92,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.base_app_num_queries = 42
+        cls.base_app_num_queries = 39
         if settings.MULTI_TENANCY:
             cls.base_app_num_queries += 2
         # Create another team that the user does have access to

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -14,10 +14,9 @@ from posthog.user_permissions import UserPermissions
 class WithPermissionsBase:
     user: User
     team: Team
-    organization: Organization
 
     def permissions(self):
-        return UserPermissions(user=self.user, team=self.team, organization=self.organization)
+        return UserPermissions(user=self.user, team=self.team)
 
 
 class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
@@ -41,8 +40,9 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
     def test_team_effective_membership_level_does_not_belong(self):
         self.organization_membership.delete()
 
+        permissions = UserPermissions(user=self.user)
         with self.assertNumQueries(1):
-            assert self.permissions().current_team.effective_membership_level is None
+            assert permissions.team(self.team).effective_membership_level is None
 
     def test_team_effective_membership_level_with_explicit_membership_returns_current_level(self):
         self.team.access_control = True

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -1,8 +1,6 @@
-
 from ee.models.explicit_team_membership import ExplicitTeamMembership
 from posthog.constants import AvailableFeature
-from posthog.models.organization import Organization, OrganizationMembership
-from posthog.models.user import User
+from posthog.models.organization import OrganizationMembership
 from posthog.test.base import BaseTest
 from posthog.user_permissions import UserPermissions
 
@@ -16,28 +14,26 @@ class TestUserPermissions(BaseTest):
         self.organization.save()
 
     def permissions(self, **kwargs):
-        options = {
-            "user": self.user,
-            "team": self.team,
-            "organization": self.team.organization,
-            **kwargs
-        }
+        options = {"user": self.user, "team": self.team, "organization": self.organization, **kwargs}
 
         return UserPermissions(**options)
 
     def test_team_effective_membership_level(self):
-        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.MEMBER
+        with self.assertNumQueries(1):
+            assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.MEMBER
 
     def test_team_effective_membership_level_updated(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
+        with self.assertNumQueries(1):
+            assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
 
     def test_team_effective_membership_level_does_not_belong(self):
         self.organization_membership.delete()
 
-        assert self.permissions().team_effective_membership_level is None
+        with self.assertNumQueries(1):
+            assert self.permissions().team_effective_membership_level is None
 
     def test_team_effective_membership_level_with_explicit_membership_returns_current_level(self):
         self.team.access_control = True
@@ -45,7 +41,17 @@ class TestUserPermissions(BaseTest):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
+        with self.assertNumQueries(2):
+            assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    def test_team_effective_membership_level_with_member(self):
+        self.team.access_control = True
+        self.team.save()
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        with self.assertNumQueries(2):
+            assert self.permissions().team_effective_membership_level is None
 
     def test_team_effective_membership_level_with_explicit_membership_returns_explicit_membership(self):
         self.team.access_control = True
@@ -57,5 +63,5 @@ class TestUserPermissions(BaseTest):
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
-        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
-
+        with self.assertNumQueries(2):
+            assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -2,23 +2,27 @@ from ee.models.dashboard_privilege import DashboardPrivilege
 from ee.models.explicit_team_membership import ExplicitTeamMembership
 from posthog.constants import AvailableFeature
 from posthog.models.dashboard import Dashboard
+from posthog.models.dashboard_tile import DashboardTile
+from posthog.models.insight import Insight
 from posthog.models.organization import OrganizationMembership
 from posthog.test.base import BaseTest
 from posthog.user_permissions import UserPermissions
 
 
-class TestUserTeamPermissions(BaseTest):
+class WithPermissionsBase:
+    def permissions(self, **kwargs):
+        options = {"user": self.user, "team": self.team, "organization": self.organization, **kwargs}
+
+        return UserPermissions(**options)  # type: ignore
+
+
+class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
     def setUp(self):
         super().setUp()
         self.organization.available_features = [
             AvailableFeature.PROJECT_BASED_PERMISSIONING,
             AvailableFeature.DASHBOARD_PERMISSIONING,
         ]
-
-    def permissions(self, **kwargs):
-        options = {"user": self.user, "team": self.team, "organization": self.organization, **kwargs}
-
-        return UserPermissions(**options)  # type: ignore
 
     def test_team_effective_membership_level(self):
         with self.assertNumQueries(1):
@@ -69,17 +73,12 @@ class TestUserTeamPermissions(BaseTest):
             assert self.permissions().team.effective_membership_level == OrganizationMembership.Level.ADMIN
 
 
-class TestUserDashboardPermissions(BaseTest):
+class TestUserDashboardPermissions(BaseTest, WithPermissionsBase):
     def setUp(self):
         super().setUp()
         self.organization.available_features = [AvailableFeature.DASHBOARD_PERMISSIONING]
         self.organization.save()
         self.dashboard = Dashboard.objects.create(team=self.team)
-
-    def permissions(self, **kwargs):
-        options = {"user": self.user, "team": self.team, "organization": self.organization, **kwargs}
-
-        return UserPermissions(**options)  # type: ignore
 
     def dashboard_permissions(self):
         return self.permissions().dashboard(self.dashboard)
@@ -176,3 +175,85 @@ class TestUserDashboardPermissions(BaseTest):
         )
 
         assert self.dashboard_permissions().can_edit
+
+
+class TestUserInsightPermissions(BaseTest, WithPermissionsBase):
+    def setUp(self):
+        super().setUp()
+        self.organization.available_features = [AvailableFeature.DASHBOARD_PERMISSIONING]
+        self.organization.save()
+
+        self.dashboard1 = Dashboard.objects.create(
+            team=self.team, restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+        )
+        self.dashboard2 = Dashboard.objects.create(team=self.team)
+        self.insight = Insight.objects.create(team=self.team)
+        self.tile1 = DashboardTile.objects.create(dashboard=self.dashboard1, insight=self.insight)
+        self.tile2 = DashboardTile.objects.create(dashboard=self.dashboard2, insight=self.insight)
+
+    def insight_permissions(self):
+        return self.permissions().insight(self.insight)
+
+    def test_effective_restriction_level_limited(self):
+        assert (
+            self.insight_permissions().effective_restriction_level
+            == Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT
+        )
+
+    def test_effective_restriction_level_all_allow(self):
+        Dashboard.objects.all().update(restriction_level=Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT)
+
+        assert (
+            self.insight_permissions().effective_restriction_level
+            == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+        )
+
+    def test_effective_restriction_level_with_no_dashboards(self):
+        DashboardTile.objects.all().delete()
+
+        assert (
+            self.insight_permissions().effective_restriction_level
+            == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+        )
+
+    def test_effective_restriction_level_with_no_permissioning(self):
+        self.organization.available_features = []
+        self.organization.save()
+
+        assert (
+            self.insight_permissions().effective_restriction_level
+            == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+        )
+
+    def test_effective_privilege_level_all_limited(self):
+        Dashboard.objects.all().update(restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT)
+
+        assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_VIEW
+
+    def test_effective_privilege_level_some_limited(self):
+        assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
+
+    def test_effective_privilege_level_all_limited_as_collaborator(self):
+        Dashboard.objects.all().update(restriction_level=Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT)
+        self.dashboard1.created_by = self.user
+        self.dashboard1.save()
+
+        assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
+
+    def test_effective_privilege_level_with_no_dashboards(self):
+        DashboardTile.objects.all().delete()
+
+        assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
+
+    def test_efficiency(self):
+        insights = []
+        for _ in range(10):
+            insight = Insight.objects.create(team=self.team)
+            DashboardTile.objects.create(dashboard=self.dashboard1, insight=insight)
+            insights.append(insight)
+
+        user_permissions = self.permissions()
+        with self.assertNumQueries(90):
+            for insight in insights:
+                assert user_permissions.insight(insight).effective_restriction_level is not None
+                assert user_permissions.insight(insight).effective_privilege_level is not None

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -25,6 +25,7 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         self.organization.available_features = [
             AvailableFeature.PROJECT_BASED_PERMISSIONING,
         ]
+        self.organization.save()
 
     def test_team_effective_membership_level(self):
         with self.assertNumQueries(1):
@@ -325,7 +326,7 @@ class TestUserPermissionsEfficiency(BaseTest, WithPermissionsBase):
             models.append((organization, membership, team))
 
         user_permissions = UserPermissions(user)
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             assert len(user_permissions.team_ids_visible_for_user) == 10
 
             for _, _, team in models:

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -246,14 +246,16 @@ class TestUserInsightPermissions(BaseTest, WithPermissionsBase):
         assert self.insight_permissions().effective_privilege_level == Dashboard.PrivilegeLevel.CAN_EDIT
 
     def test_efficiency(self):
-        insights = []
+        insights, tiles = [], []
         for _ in range(10):
             insight = Insight.objects.create(team=self.team)
-            DashboardTile.objects.create(dashboard=self.dashboard1, insight=insight)
+            tile = DashboardTile.objects.create(dashboard=self.dashboard1, insight=insight)
             insights.append(insight)
+            tiles.append(tile)
 
         user_permissions = self.permissions()
-        with self.assertNumQueries(90):
+        user_permissions.set_preloaded_dashboard_tiles(tiles)
+        with self.assertNumQueries(5):
             for insight in insights:
                 assert user_permissions.insight(insight).effective_restriction_level is not None
                 assert user_permissions.insight(insight).effective_privilege_level is not None

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -1,0 +1,61 @@
+
+from ee.models.explicit_team_membership import ExplicitTeamMembership
+from posthog.constants import AvailableFeature
+from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.user import User
+from posthog.test.base import BaseTest
+from posthog.user_permissions import UserPermissions
+
+
+class TestUserPermissions(BaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.organization.available_features = [AvailableFeature.PROJECT_BASED_PERMISSIONING]
+        self.organization.save()
+
+    def permissions(self, **kwargs):
+        options = {
+            "user": self.user,
+            "team": self.team,
+            "organization": self.team.organization,
+            **kwargs
+        }
+
+        return UserPermissions(**options)
+
+    def test_team_effective_membership_level(self):
+        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.MEMBER
+
+    def test_team_effective_membership_level_updated(self):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    def test_team_effective_membership_level_does_not_belong(self):
+        self.organization_membership.delete()
+
+        assert self.permissions().team_effective_membership_level is None
+
+    def test_team_effective_membership_level_with_explicit_membership_returns_current_level(self):
+        self.team.access_control = True
+        self.team.save()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    def test_team_effective_membership_level_with_explicit_membership_returns_explicit_membership(self):
+        self.team.access_control = True
+        self.team.save()
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        ExplicitTeamMembership.objects.create(
+            team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
+        )
+
+        assert self.permissions().team_effective_membership_level == OrganizationMembership.Level.ADMIN
+

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -101,7 +101,7 @@ class UserDashboardPermissions:
         self.dashboard = dashboard
 
     @cached_property
-    def restriction_level(self) -> Dashboard.RestrictionLevel:
+    def effective_restriction_level(self) -> Dashboard.RestrictionLevel:
         return (
             self.dashboard.restriction_level
             if self.p.organization_instance.is_feature_available(AvailableFeature.DASHBOARD_PERMISSIONING)
@@ -126,7 +126,7 @@ class UserDashboardPermissions:
     def effective_privilege_level(self) -> Dashboard.PrivilegeLevel:
         if (
             # Checks can be skipped if the dashboard in on the lowest restriction level
-            self.dashboard.effective_restriction_level == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+            self.effective_restriction_level == Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
             # Users with restriction rights can do anything
             or self.can_restrict
         ):
@@ -138,7 +138,7 @@ class UserDashboardPermissions:
 
     @cached_property
     def can_edit(self) -> bool:
-        if self.dashboard.effective_restriction_level < Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT:
+        if self.effective_restriction_level < Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT:
             return True
         return self.effective_privilege_level >= Dashboard.PrivilegeLevel.CAN_EDIT
 
@@ -153,7 +153,7 @@ class UserInsightPermissions:
         if len(self.insight_dashboards) == 0:
             return Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
 
-        return max(self.p.dashboard(dashboard).restriction_level for dashboard in self.insight_dashboards)
+        return max(self.p.dashboard(dashboard).effective_restriction_level for dashboard in self.insight_dashboards)
 
     @cached_property
     def effective_privilege_level(self) -> Dashboard.PrivilegeLevel:

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -1,0 +1,15 @@
+from functools import cached_property
+from typing import Optional
+from posthog.models import User, Team, Organization, OrganizationMembership
+
+class UserPermissions:
+    def __init__(self, user: User, team: Team, organization: Organization):
+        self.user = user
+        self.team = team
+        self.organization = organization
+
+    @cached_property
+    def team_effective_membership_level(self) -> Optional[OrganizationMembership.Level]:
+        return self.team.get_effective_membership_level(self.user.pk)
+
+

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -1,33 +1,55 @@
 from functools import cached_property
-from typing import Optional
+from typing import Dict, Optional
 
 from posthog.constants import AvailableFeature
-from posthog.models import Organization, OrganizationMembership, Team, User
+from posthog.models import Dashboard, Organization, OrganizationMembership, Team, User
 
 
 class UserPermissions:
     def __init__(self, user: User, team: Team, organization: Organization):
-        self.user = user
-        self.team = team
-        self.organization = organization
+        self.user_instance = user
+        self.team_instance = team
+        self.organization_instance = organization
+
+        self._dashboard_permissions: Dict[int, UserDashboardPermissions] = {}
 
     @cached_property
-    def team_effective_membership_level(self) -> Optional["OrganizationMembership.Level"]:
+    def team(self) -> "UserTeamPermissions":
+        return UserTeamPermissions(self)
+
+    def dashboard(self, dashboard: Dashboard) -> "UserDashboardPermissions":
+        if dashboard.pk not in self._dashboard_permissions:
+            self._dashboard_permissions[dashboard.pk] = UserDashboardPermissions(self, dashboard)
+        return self._dashboard_permissions[dashboard.pk]
+
+    @cached_property
+    def organization_membership(self) -> Optional[OrganizationMembership]:
+        return OrganizationMembership.objects.filter(
+            organization=self.organization_instance, user=self.user_instance
+        ).first()
+
+
+class UserTeamPermissions:
+    def __init__(self, user_permissions: "UserPermissions"):
+        self.p = user_permissions
+
+    @cached_property
+    def effective_membership_level(self) -> Optional["OrganizationMembership.Level"]:
         """Return an effective membership level.
         None returned if the user has no explicit membership and organization access is too low for implicit membership.
         """
 
-        return self.team_effective_membership_level_for_parent_membership(self._organization_membership)
+        return self.effective_membership_level_for_parent_membership(self.p.organization_membership)
 
-    def team_effective_membership_level_for_parent_membership(
+    def effective_membership_level_for_parent_membership(
         self, organization_membership: Optional["OrganizationMembership"]
     ) -> Optional["OrganizationMembership.Level"]:
         if organization_membership is None:
             return None
 
         if (
-            not self.organization.is_feature_available(AvailableFeature.PROJECT_BASED_PERMISSIONING)
-            or not self.team.access_control
+            not self.p.organization_instance.is_feature_available(AvailableFeature.PROJECT_BASED_PERMISSIONING)
+            or not self.p.team_instance.access_control
         ):
             return organization_membership.level
 
@@ -41,6 +63,24 @@ class UserPermissions:
                 return None
             return organization_membership.level
 
+
+class UserDashboardPermissions:
+    def __init__(self, user_permissions: "UserPermissions", dashboard: Dashboard):
+        self.p = user_permissions
+        self.dashboard = dashboard
+
     @cached_property
-    def _organization_membership(self) -> Optional[OrganizationMembership]:
-        return OrganizationMembership.objects.filter(organization=self.organization, user=self.user).first()
+    def restriction_level(self) -> Dashboard.RestrictionLevel:
+        return self.dashboard.effective_restriction_level
+
+    @cached_property
+    def can_restrict(self) -> bool:
+        return self.dashboard.can_user_restrict(self.p.user_instance.pk)
+
+    @cached_property
+    def effective_privilege_level(self) -> Dashboard.PrivilegeLevel:
+        return self.dashboard.get_effective_privilege_level(self.p.user_instance.pk)
+
+    @cached_property
+    def can_edit(self) -> bool:
+        return self.dashboard.can_user_edit(self.p.user_instance.pk)

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -257,6 +257,8 @@ class UserPermissionsSerializerMixin:
     Mixin for getting easy access to UserPermissions within a mixin
     """
 
+    context: Any
+
     @cached_property
     def user_permissions(self) -> UserPermissions:
         if "user_permissions" in self.context:

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -52,7 +52,7 @@ class UserPermissions:
         self._tiles = tiles
 
     @cached_property
-    def preloaded_dashboards(self) -> Optional[List[Dashboard]]:
+    def preloaded_insight_dashboards(self) -> Optional[List[Dashboard]]:
         if self._tiles is None:
             return None
 
@@ -168,8 +168,8 @@ class UserInsightPermissions:
     @cached_property
     def insight_dashboards(self):
         # If we're in dashboard(s) and have sped up lookups
-        if self.p.preloaded_dashboards is not None:
-            return self.p.preloaded_dashboards
+        if self.p.preloaded_insight_dashboards is not None:
+            return self.p.preloaded_insight_dashboards
 
         dashboard_ids = set(
             DashboardTile.objects.filter(insight=self.insight.pk).values_list("dashboard_id", flat=True)

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -123,6 +123,13 @@ class UserPermissions:
         dashboard_ids = set(tile.dashboard_id for tile in self._tiles)
         return list(Dashboard.objects.filter(pk__in=dashboard_ids))
 
+    def reset_insights_dashboard_cached_results(self):
+        """
+        Resets cached results for insights/dashboards. Useful for update methods.
+        """
+        self._dashboard_permissions = {}
+        self._insight_permissions = {}
+
 
 class UserTeamPermissions:
     def __init__(self, user_permissions: "UserPermissions", team: Team):

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -242,3 +242,15 @@ class UserInsightPermissions:
             DashboardTile.objects.filter(insight=self.insight.pk).values_list("dashboard_id", flat=True)
         )
         return list(Dashboard.objects.filter(pk__in=dashboard_ids))
+
+
+class UserPermissionsSerializerMixin:
+    """
+    Mixin for getting easy access to UserPermissions within a mixin
+    """
+
+    @cached_property
+    def user_permissions(self) -> UserPermissions:
+        if "user_permissions" in self.context:
+            return self.context["user_permissions"]
+        return self.context["view"].user_permissions

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -1,6 +1,9 @@
 from functools import cached_property
 from typing import Optional
-from posthog.models import User, Team, Organization, OrganizationMembership
+
+from posthog.constants import AvailableFeature
+from posthog.models import Organization, OrganizationMembership, Team, User
+
 
 class UserPermissions:
     def __init__(self, user: User, team: Team, organization: Organization):
@@ -9,7 +12,48 @@ class UserPermissions:
         self.organization = organization
 
     @cached_property
-    def team_effective_membership_level(self) -> Optional[OrganizationMembership.Level]:
-        return self.team.get_effective_membership_level(self.user.pk)
+    def team_effective_membership_level(self) -> Optional["OrganizationMembership.Level"]:
+        """Return an effective membership level.
+        None returned if the user has no explicit membership and organization access is too low for implicit membership.
+        """
+        from posthog.models.organization import OrganizationMembership
 
+        try:
+            requesting_parent_membership: OrganizationMembership = OrganizationMembership.objects.select_related(
+                "organization"
+            ).get(organization_id=self.organization.pk, user_id=self.user.pk)
+        except OrganizationMembership.DoesNotExist:
+            return None
+        return self.get_effective_membership_level_for_parent_membership(requesting_parent_membership)
 
+    def get_effective_membership_level_for_parent_membership(
+        self, requesting_parent_membership: "OrganizationMembership"
+    ) -> Optional["OrganizationMembership.Level"]:
+        if (
+            not requesting_parent_membership.organization.is_feature_available(
+                AvailableFeature.PROJECT_BASED_PERMISSIONING
+            )
+            or not self.team.access_control
+        ):
+            return requesting_parent_membership.level
+        from posthog.models.organization import OrganizationMembership
+
+        try:
+            from ee.models import ExplicitTeamMembership
+        except ImportError:
+            # Only organizations admins and above get implicit project membership
+            if requesting_parent_membership.level < OrganizationMembership.Level.ADMIN:
+                return None
+            return requesting_parent_membership.level
+        else:
+            try:
+                return (
+                    requesting_parent_membership.explicit_team_memberships.only("parent_membership", "level")
+                    .get(team=self.team)
+                    .effective_level
+                )
+            except ExplicitTeamMembership.DoesNotExist:
+                # Only organizations admins and above get implicit project membership
+                if requesting_parent_membership.level < OrganizationMembership.Level.ADMIN:
+                    return None
+                return requesting_parent_membership.level

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -345,7 +345,7 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
         if request.user.pk:
             user = cast(User, request.user)
-            user_permissions = UserPermissions(user)
+            user_permissions = UserPermissions(user=user, team=user.team)
             user_serialized = UserSerializer(
                 request.user, context={"request": request, "user_permissions": user_permissions}, many=False
             )

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -331,6 +331,7 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     if not request.GET.get("no-preloaded-app-context"):
         from posthog.api.team import TeamSerializer
         from posthog.api.user import User, UserSerializer
+        from posthog.user_permissions import UserPermissions
         from posthog.views import preflight_check
 
         posthog_app_context = {
@@ -343,14 +344,19 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
         }
 
         if request.user.pk:
-            user_serialized = UserSerializer(request.user, context={"request": request}, many=False)
+            user = cast(User, request.user)
+            user_permissions = UserPermissions(user)
+            user_serialized = UserSerializer(
+                request.user, context={"request": request, "user_permissions": user_permissions}, many=False
+            )
             posthog_app_context["current_user"] = user_serialized.data
             posthog_distinct_id = user_serialized.data.get("distinct_id")
-            team = cast(User, request.user).team
-            if team:
-                team_serialized = TeamSerializer(team, context={"request": request}, many=False)
+            if user.team:
+                team_serialized = TeamSerializer(
+                    user.team, context={"request": request, "user_permissions": user_permissions}, many=False
+                )
                 posthog_app_context["current_team"] = team_serialized.data
-                posthog_app_context["frontend_apps"] = get_frontend_apps(team.pk)
+                posthog_app_context["frontend_apps"] = get_frontend_apps(user.team.pk)
 
     context["posthog_app_context"] = json.dumps(posthog_app_context, default=json_uuid_convert)
 


### PR DESCRIPTION
## Problem

Dashboards load for a long time. Other endpoints suffer from similar overhead.

Loading a dashboard with 10 insights was doing upwards of 90 queries total for calculating insight permissions
Moving business logic out of models has both performance and maintainability benefits

Re-creating https://github.com/PostHog/posthog/pull/13566