### PR TITLE
feat: remove `items` from dashboard API

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -288,7 +288,6 @@ describe('dashboardLogic', () => {
             }).toFinishAllListeners()
 
             expect(api.update).toHaveBeenCalledWith(`api/projects/${MOCK_TEAM_ID}/dashboards/5`, {
-                no_items_field: true,
                 tiles: [
                     {
                         id: 0,
@@ -314,7 +313,6 @@ describe('dashboardLogic', () => {
             }).toFinishAllListeners()
 
             expect(api.update).toHaveBeenCalledWith(`api/projects/${MOCK_TEAM_ID}/dashboards/5`, {
-                no_items_field: true,
                 tiles: [
                     {
                         id: 1,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -230,7 +230,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     try {
                         return await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                             filters: values.filters,
-                            no_items_field: true,
                         })
                     } catch (e) {
                         lemonToast.error('Could not update dashboardFilters: ' + e)
@@ -245,7 +244,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                     await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                         tiles: [{ id: tileId, color }],
-                        no_items_field: true,
                     })
                     const matchingTile = values.tiles.find((tile) => tile.id === tileId)
                     if (matchingTile) {
@@ -257,7 +255,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     try {
                         await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                             tiles: [{ id: tile.id, deleted: true }],
-                            no_items_field: true,
                         })
                         dashboardsModel.actions.tileRemovedFromDashboard({
                             tile: tile,
@@ -282,7 +279,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         }
                         return await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                             tiles: [newTile],
-                            no_items_field: true,
                         } as Partial<InsightModel>)
                     } catch (e) {
                         lemonToast.error('Could not duplicate tile: ' + e)
@@ -302,7 +298,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             {
                                 tile,
                                 toDashboard,
-                                no_items_field: true,
                             }
                         )
                     }
@@ -645,7 +640,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return (refresh?: boolean) =>
                     `api/projects/${teamLogic.values.currentTeamId}/dashboards/${id}/?${toParams({
                         refresh,
-                        no_items_field: true,
                     })}`
             },
         ],
@@ -861,7 +855,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 tiles: layoutsToUpdate,
-                no_items_field: true,
             })
         },
         moveToDashboardSuccess: ({ payload }) => {

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -5,7 +5,6 @@ import structlog
 from django.db.models import Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
-from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
@@ -19,14 +18,13 @@ from posthog.api.insight import InsightSerializer, InsightViewSet
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
-from posthog.constants import INSIGHT_TRENDS, AvailableFeature
+from posthog.constants import AvailableFeature
 from posthog.event_usage import report_user_action
 from posthog.helpers import create_dashboard_from_template
 from posthog.models import Dashboard, DashboardTile, Insight, Team, Text
 from posthog.models.team.team import get_available_features_for_team
 from posthog.models.user import User
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.utils import should_ignore_dashboard_items_field
 
 logger = structlog.get_logger(__name__)
 
@@ -73,7 +71,6 @@ class DashboardTileSerializer(serializers.ModelSerializer):
 
 
 class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
-    items = serializers.SerializerMethodField()
     tiles = serializers.SerializerMethodField()
     created_by = UserBasicSerializer(read_only=True)
     use_template = serializers.CharField(write_only=True, allow_blank=True, required=False)
@@ -88,7 +85,6 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
             "id",
             "name",
             "description",
-            "items",
             "pinned",
             "created_at",
             "created_by",
@@ -320,39 +316,6 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
             serialized_tiles.append(tile_data)
 
         return serialized_tiles
-
-    @extend_schema(deprecated=True, description="items is deprecated, use tiles instead")
-    def get_items(self, dashboard: Dashboard):
-        if self.context["view"].action == "list" or should_ignore_dashboard_items_field(self.context["request"]):
-            return None
-
-        # used by insight serializer to load insight filters in correct context
-        self.context.update({"dashboard": dashboard})
-
-        insights = []
-        for tile in dashboard.tiles.all():
-            self.context.update({"dashboard_tile": tile})
-            if tile.insight:
-                insight = tile.insight
-                layouts = tile.layouts
-                # workaround because DashboardTiles layouts were migrated as stringified JSON :/
-                if isinstance(layouts, str):
-                    layouts = json.loads(layouts)
-
-                color = tile.color
-
-                # Make sure all items have an insight set
-                if not insight.filters.get("insight"):
-                    insight.filters["insight"] = INSIGHT_TRENDS
-                    insight.save(update_fields=["filters"])
-
-                self.context.update({"filters_hash": tile.filters_hash})
-                insight_data = InsightSerializer(insight, many=False, context=self.context).data
-                insight_data["layouts"] = layouts
-                insight_data["color"] = color
-                insights.append(insight_data)
-
-        return insights
 
     def get_effective_privilege_level(self, dashboard: Dashboard) -> Dashboard.PrivilegeLevel:
         return dashboard.get_effective_privilege_level(self.context["request"].user.id)

--- a/posthog/api/test/dashboards/__init__.py
+++ b/posthog/api/test/dashboards/__init__.py
@@ -71,10 +71,6 @@ class DashboardAPI:
         if team_id is None:
             team_id = self.team.id
 
-        if query_params is None:
-            # default to no items field
-            query_params = {"no_items_field": True}
-
         response = self.client.get(f"/api/projects/{team_id}/dashboards/{dashboard_id}", query_params)
         self.assertEqual(response.status_code, expected_status)
 

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -931,17 +931,3 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         dashboard_two_json = self.dashboard_api.get_dashboard(dashboard_two_id)
         expected_dashboards_on_insight = dashboard_two_json["tiles"][0]["insight"]["dashboards"]
         assert expected_dashboards_on_insight == [dashboard_two_id]
-
-    def test_dashboard_items_deprecation(self) -> None:
-        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "items deprecation"})
-        self.dashboard_api.create_insight({"dashboards": [dashboard_id]})
-
-        default_dashboard_json = self.dashboard_api.get_dashboard(dashboard_id, query_params={})
-
-        assert len(default_dashboard_json["tiles"]) == 1
-        assert len(default_dashboard_json["items"]) == 1
-
-        no_items_dashboard_json = self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": True})
-
-        assert len(no_items_dashboard_json["tiles"]) == 1
-        assert no_items_dashboard_json["items"] is None

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -962,10 +962,6 @@ def should_refresh(request: Request) -> bool:
     return _request_has_key_set("refresh", request)
 
 
-def should_ignore_dashboard_items_field(request: Request) -> bool:
-    return _request_has_key_set("no_items_field", request)
-
-
 def _request_has_key_set(key: str, request: Request) -> bool:
     query_param = request.query_params.get(key)
     data_value = request.data.get(key)


### PR DESCRIPTION
Previous release started defaulting to not including dashboard items. Now its time to remove this deadish code forever

Should mention in release notes that the API endpoint has changed.