### PR TITLE
fix: exclude some selectors from matching

### DIFF
--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -34,7 +34,7 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
     return finder(element, {
         attr: (name) => dataAttributes.some((dataAttribute) => wildcardMatch(dataAttribute)(name)),
         className: (name) => !name.startsWith('is-'),
-        idName: (name) => !name.startsWith('root'),
+        idName: (name) => name !== 'root',
         tagName: (name) => !TAGS_TO_IGNORE.includes(name),
         seedMinLength: 5, // include several selectors e.g. prefer .project-homepage > .project-header > .project-title over .project-title
     })

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -33,8 +33,6 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
 
     return finder(element, {
         attr: (name) => dataAttributes.some((dataAttribute) => wildcardMatch(dataAttribute)(name)),
-        className: (name) => !name.startsWith('is-'),
-        idName: (name) => name !== 'root',
         tagName: (name) => !TAGS_TO_IGNORE.includes(name),
         seedMinLength: 5, // include several selectors e.g. prefer .project-homepage > .project-header > .project-title over .project-title
     })

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -33,6 +33,9 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
 
     return finder(element, {
         attr: (name) => dataAttributes.some((dataAttribute) => wildcardMatch(dataAttribute)(name)),
+        className: (name) => !name.startsWith('is-'),
+        idName: (name) => !name.startsWith('root'),
+        tagName: (name) => !TAGS_TO_IGNORE.includes(name),
         seedMinLength: 5, // include several selectors e.g. prefer .project-homepage > .project-header > .project-title over .project-title
     })
 }


### PR DESCRIPTION
## Problem

toolbar css selectors now seek a longer unique match so you don't get matches like `.w-full` because that's the only instance right now on the page.

But that also means you get things like `#root > blah` or `blah .is-active`

## Changes

* uses the existing `TAGS_TO_IGNORE` list to ignore those tags

|before|after|
|-|-|
|![Screenshot 2023-01-27 at 10 46 48](https://user-images.githubusercontent.com/984817/215068172-46cb9c95-1908-4efe-bbae-cc41d45f48fe.png)|![Screenshot 2023-01-27 at 10 47 20](https://user-images.githubusercontent.com/984817/215068194-0f49b15f-d89e-4799-b405-11c742a878d8.png)|

Ideally we'd exclude the leading tag if the remaining selector is also unique, but one step at a time

## How did you test this code?

running it locally