### PR TITLE
feat: simplify selectors with data attributes

### DIFF
--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -31,35 +31,22 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
         return
     }
 
-    const chosenSelector = finder(element, {
+    for (const { name, value } of Array.from(element.attributes)) {
+        if (dataAttributes.indexOf(name) === -1) {
+            continue
+        }
+
+        const selector = `[${cssEscape(name)}="${cssEscape(value)}"]`
+        if (querySelectorAllDeep(selector).length == 1) {
+            return selector
+        }
+    }
+
+    return finder(element, {
         attr: (name) => dataAttributes.some((dataAttribute) => wildcardMatch(dataAttribute)(name)),
         tagName: (name) => !TAGS_TO_IGNORE.includes(name),
         seedMinLength: 5, // include several selectors e.g. prefer .project-homepage > .project-header > .project-title over .project-title
     })
-    return simplifyDataAttributes(chosenSelector)
-}
-
-function simplifyDataAttributes(chosenSelector: string): string {
-    // if the chosen selector is a several part selector ending with a data attribute,
-    // check if the data attribute is unique by itself
-    // because the selector string has been through the "finder" library
-    // we can be confident of the format and content
-    const parts = chosenSelector.split(' ')
-    if (parts.length <= 1) {
-        return chosenSelector
-    }
-    const tail = parts[parts.length - 1]
-    return isAttribute(tail) && isUnique(tail) ? tail : chosenSelector
-}
-
-function isAttribute(candidate: string): boolean {
-    // the selector has already been parsed and sanitized so we can do a simple check
-    return candidate.startsWith('[') && candidate.endsWith(']')
-}
-
-function isUnique(selector: string): boolean {
-    const elements = querySelectorAllDeep(selector)
-    return elements.length === 1
 }
 
 export function elementToActionStep(element: HTMLElement, dataAttributes: string[]): ActionStepType {

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -31,11 +31,35 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
         return
     }
 
-    return finder(element, {
+    const chosenSelector = finder(element, {
         attr: (name) => dataAttributes.some((dataAttribute) => wildcardMatch(dataAttribute)(name)),
         tagName: (name) => !TAGS_TO_IGNORE.includes(name),
         seedMinLength: 5, // include several selectors e.g. prefer .project-homepage > .project-header > .project-title over .project-title
     })
+    return simplifyDataAttributes(chosenSelector)
+}
+
+function simplifyDataAttributes(chosenSelector: string): string {
+    // if the chosen selector is a several part selector ending with a data attribute,
+    // check if the data attribute is unique by itself
+    // because the selector string has been through the "finder" library
+    // we can be confident of the format and content
+    const parts = chosenSelector.split(' ')
+    if (parts.length <= 1) {
+        return chosenSelector
+    }
+    const tail = parts[parts.length - 1]
+    return isAttribute(tail) && isUnique(tail) ? tail : chosenSelector
+}
+
+function isAttribute(candidate: string): boolean {
+    // the selector has already been parsed and sanitized so we can do a simple check
+    return candidate.startsWith('[') && candidate.endsWith(']')
+}
+
+function isUnique(selector: string): boolean {
+    const elements = querySelectorAllDeep(selector)
+    return elements.length === 1
 }
 
 export function elementToActionStep(element: HTMLElement, dataAttributes: string[]): ActionStepType {

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -32,7 +32,7 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
     }
 
     for (const { name, value } of Array.from(element.attributes)) {
-        if (dataAttributes.indexOf(name) === -1) {
+        if (!dataAttributes.includes(name)) {
             continue
         }
 


### PR DESCRIPTION
## Problem

People are already asked to give us unique attributes to look for in the HTML of a page. But, with the new CSS selector library in the toolbar we are seeking for longer selectors to make the unique selectors less fragile. Which means even if `[data-attr="blah"]` is unique we are showing `.SideBar [data-attr="blah"]` as the selector.

## Changes

Since the selector library is already parsing and sanitising the selectors and applying an allow list to which attributes make it into the selector we can be pretty naive in how we check for unique attributes.

So, that's what this does. The simplest possible check to try to present data attributes as unique stand-alone selectors

![Screenshot 2023-01-27 at 14 26 48](https://user-images.githubusercontent.com/984817/215111328-64c70c4e-8631-45f4-8207-c663383921fe.png)


## How did you test this code?

ran it locally, then duplicated an element with a data-attr and saw that we used the new unique selector and not the data attribute on its own.
