### PR TITLE
fix: Only record localhost if explicitly set

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -31,7 +31,7 @@ def hostname_in_allowed_url_list(allowed_url_list: Optional[List[str]], hostname
     if not hostname:
         return False
 
-    permitted_domains = ["127.0.0.1", "localhost"]
+    permitted_domains = []
     if allowed_url_list:
         for url in allowed_url_list:
             host = parse_domain(url)


### PR DESCRIPTION
## Problem

For some reason we had a default allow list of localhost domains. I think this from before we had the Authorized Domains which basically override this.

## Changes

* Removes localhost values from the default list of permitted domains

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked this manually 
1. With no AuthDomains, - localhost **does** record
2. With domains `https://example.com` - localhost **doesn't** record
3. 2. With domains `https://example.com,http://localhost:8000` - localhost **does** record
