### PR TITLE
fix: billing alert exponential number bug

### DIFF
--- a/frontend/src/scenes/billing/v2/billingV2Logic.ts
+++ b/frontend/src/scenes/billing/v2/billingV2Logic.ts
@@ -151,9 +151,9 @@ export const billingV2Logic = kea<billingV2LogicType>([
                     return {
                         status: 'info',
                         title: 'You will soon hit your usage limit',
-                        message: `You have currently used ${(
-                            productApproachingLimit.percentage_usage * 100
-                        ).toPrecision(2)}% of your ${productApproachingLimit.type.toLowerCase()} allocation.`,
+                        message: `You have currently used ${parseFloat(
+                            (productApproachingLimit.percentage_usage * 100).toPrecision(2)
+                        )}% of your ${productApproachingLimit.type.toLowerCase()} allocation.`,
                     }
                 }
             },


### PR DESCRIPTION
## Problem
significant digits in app render 100 as 1.0e2

## Changes
- Remove the exponential number formatting

## How did you test this code?
Locally