### PR TITLE
chore(snapshots): sort fields and thus snapshots

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -194,8 +194,8 @@
                                  e.distinct_id as distinct_id,
                                  e.timestamp as timestamp,
                                  e."$group_0" as aggregation_target,
-                                 e."properties" as "properties",
                                  e."$group_0" as "$group_0",
+                                 e."properties" as "properties",
                                  pdi.person_id as person_id,
                                  person.person_props as person_props,
                                  groups_0.group_properties_0 as group_properties_0

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -45,12 +45,12 @@ class FunnelEventQuery(EventQuery):
         _fields += [
             get_property_string_expr("events", field, f"'{field}'", "properties", table_alias=self.EVENT_TABLE_ALIAS)[0]
             + f' as "{field}"'
-            for field in self._extra_event_properties
+            for field in sorted(self._extra_event_properties)
         ]
 
         _fields.extend(
             f'{self.EVENT_TABLE_ALIAS}."{column_name}" as "{column_name}"'
-            for column_name in self._column_optimizer.event_columns_to_query
+            for column_name in sorted(self._column_optimizer.event_columns_to_query)
         )
 
         if self._using_person_on_events:
@@ -67,7 +67,7 @@ class FunnelEventQuery(EventQuery):
             if self._should_join_persons:
                 _fields.extend(
                     f"{self.PERSON_TABLE_ALIAS}.{column_name} as {column_name}"
-                    for column_name in self._person_query.fields
+                    for column_name in sorted(self._person_query.fields)
                 )
 
         if self._using_person_on_events and groups_on_events_querying_enabled():
@@ -78,7 +78,7 @@ class FunnelEventQuery(EventQuery):
         else:
             _fields.extend(
                 f"groups_{group_index}.group_properties_{group_index} as group_properties_{group_index}"
-                for group_index in self._column_optimizer.group_types_to_query
+                for group_index in sorted(self._column_optimizer.group_types_to_query)
             )
 
         _fields = list(filter(None, _fields))


### PR DESCRIPTION
## Problem

Some snapshots keep getting re-generated. Turns out sort order for a `set` is not defined and can change from one run to another.

## Changes

Sorts a few sets. Many others in the same function were already sorted.

## How did you test this code?

Didn't.