### PR TITLE
Fix logging into proxy

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -362,7 +362,7 @@ class CaptureMiddleware:
             # If we're a multi_tenancy instance, but the host is not posthog.com it's probably a proxy
             # in which case we only want to give access to
             if settings.MULTI_TENANCY and not request.get_host().endswith(".posthog.com"):
-                return redirect("https://app.posthog.com/")
+                return redirect("https://app.posthog.com/", permanent=True)
 
         response = self.get_response(request)
         return response

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -47,6 +47,7 @@ MIDDLEWARE = [
     "django_structlog.middlewares.CeleryMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "posthog.middleware.CaptureMiddleware",
+    "posthog.middleware.ExternalProxyMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
     # using dependencies that the healthcheck should be checking. It should be
     # ok below the above middlewares however.

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -63,6 +63,7 @@ class TestUrls(APIBaseTest):
             self.assertRedirects(
                 response,
                 "https://app.posthog.com/",
+                status_code=301,
                 fetch_redirect_response=False,
             )
 
@@ -73,6 +74,7 @@ class TestUrls(APIBaseTest):
             self.assertRedirects(
                 response,
                 "https://app.posthog.com/",
+                status_code=301,
                 fetch_redirect_response=False,
             )
 

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -55,29 +55,6 @@ class TestUrls(APIBaseTest):
         response = self.client.get(f"/login")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_cloud_proxy_redirect(self):
-        with self.settings(MULTI_TENANCY=True):
-            self.client.logout()
-
-            response = self.client.get("/", HTTP_HOST="proxy.somedomain.com")
-            self.assertRedirects(
-                response,
-                "https://app.posthog.com/",
-                status_code=301,
-                fetch_redirect_response=False,
-            )
-
-            response = self.client.get("/", HTTP_HOST="app.posthog.com")
-            self.assertRedirects(response, "/login?next=/", fetch_redirect_response=False)
-
-            response = self.client.get(f"/signup/{uuid.uuid4()}", HTTP_HOST="proxy.someotherdomain.com")
-            self.assertRedirects(
-                response,
-                "https://app.posthog.com/",
-                status_code=301,
-                fetch_redirect_response=False,
-            )
-
     def test_authorize_and_redirect_domain(self):
         self.team.app_urls = ["https://domain.com", "https://not.com"]
         self.team.save()


### PR DESCRIPTION
## Problem

There are non-zero amount of users who log directly into their proxy ([internal link](https://app.posthog.com/insights/AKD4IPH6)). This could cause a couple of issues, including the fact that these get indexed into Google.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

If multi_tenancy is set and the URL isn't on the posthog.com domain we redirect back to app.posthog.com.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests. Hard to test this working entirely and it is a spicy change so would love another pair of eyes.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
