### PR TITLE
fix(event-explorer): order by timestamp by default

### DIFF
--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -217,6 +217,8 @@ def run_events_query(
     else:
         if "count(*)" in select_columns or "count()" in select_columns:
             order_by_list.append("count() DESC")
+        elif "timestamp" in select_columns:
+            order_by_list.append("timestamp DESC")
         else:
             order_by_list.append(select_columns[0] + " ASC")
 


### PR DESCRIPTION
## Problem

The events table sorted in a random order on the person's event pages.

## Changes

Makes it sort descending by timestamp if the column is available

## How did you test this code?

Locally the interface sorted the right way

## Note

Going to merge it in to fix the live bug. Happy to fix secondary issues in followup -> e.g. the arrow doesn't show immediately.