### PR TITLE
chore: remove last onSnapshot reference

### DIFF
--- a/frontend/src/scenes/plugins/edit/CapabilitiesInfo.ts
+++ b/frontend/src/scenes/plugins/edit/CapabilitiesInfo.ts
@@ -2,7 +2,6 @@ export const capabilitiesInfo: Record<string, string> = {
     processEvent: 'Read + modify access to events before ingestion',
     processEventBatch: 'Read + modify access to events before ingestion, in batches',
     onEvent: 'Read-only access to events',
-    onSnapshot: 'Read-only access to session recording events',
     exportEvents: 'Read-only access to events, optimized for export',
     runEveryMinute: 'Runs a task every minute',
     runEveryHour: 'Runs a task every hour',


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Just removing the last reference in our codebase.
Related to https://github.com/PostHog/posthog.com/pull/5159

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
