### PR TITLE
fix(toolbar): support body position:relative

### DIFF
--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -20,6 +20,7 @@ export function Elements(): JSX.Element {
         selectedElement,
         inspectEnabled,
         highlightElementMeta,
+        relativePositionCompensation,
     } = useValues(elementsLogic)
     const { setHoverElement, selectElement } = useActions(elementsLogic)
     const { highestClickCount, shiftPressed } = useValues(heatmapLogic)
@@ -47,7 +48,7 @@ export function Elements(): JSX.Element {
                     width: '100%',
                     height: '100%',
                     position: 'absolute',
-                    top: 0,
+                    top: relativePositionCompensation,
                     left: 0,
                     zIndex: 2147483010,
                     pointerEvents: 'none',

--- a/frontend/src/toolbar/elements/InfoWindow.tsx
+++ b/frontend/src/toolbar/elements/InfoWindow.tsx
@@ -49,7 +49,7 @@ export function InfoWindow(): JSX.Element | null {
 
     if (spaceAbove > spaceBelow) {
         top = undefined
-        bottom = windowHeight - rect.top + 10 - window.pageYOffset
+        bottom = windowHeight - rect.top + 10 - window.pageYOffset - relativePositionCompensation
         maxHeight = spaceAbove
     } else {
         maxHeight = spaceBelow

--- a/frontend/src/toolbar/elements/InfoWindow.tsx
+++ b/frontend/src/toolbar/elements/InfoWindow.tsx
@@ -4,7 +4,8 @@ import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { ElementInfo } from '~/toolbar/elements/ElementInfo'
 
 export function InfoWindow(): JSX.Element | null {
-    const { hoverElement, hoverElementMeta, selectedElement, selectedElementMeta } = useValues(elementsLogic)
+    const { hoverElement, hoverElementMeta, selectedElement, selectedElementMeta, relativePositionCompensation } =
+        useValues(elementsLogic)
     const { setSelectedElement } = useActions(elementsLogic)
 
     // use rectUpdateCounter to reload component when it changes, but discard the output
@@ -36,7 +37,9 @@ export function InfoWindow(): JSX.Element | null {
         }
     }
 
-    let top: number | undefined = Math.max(window.pageYOffset + 16, rect.top + rect.height + 10 + window.pageYOffset)
+    let top: number | undefined =
+        Math.max(window.pageYOffset + 16, rect.top + rect.height + 10 + window.pageYOffset) +
+        relativePositionCompensation
     let bottom: number | undefined
     const minHeight: number | undefined = 50
     let maxHeight: number | undefined


### PR DESCRIPTION
## Problem

The toolbar positioned itself wrong if the body had `position:relative`

## Changes

Now it works

![2023-01-27 21 49 50](https://user-images.githubusercontent.com/53387/215194601-1d120a2c-5136-47af-9d49-638944bfb056.gif)

It "doesn't work" when I change the CSS property only because it doesn't detect those kinds of changes, but double checks on scroll/resize. I assume nobody is toggling this dynamically when using the toolbar.

## How did you test this code?

I tried locally the posthog app with position relative and absolute in the body. I did not try any of the 20 other sites I should try before releasing this.

Also, don't ask me why this works 🙈 