### PR TITLE
feat: more position relative fangling and debounce the scroll listener in the elements logic

### DIFF
--- a/frontend/src/toolbar/elements/InfoWindow.tsx
+++ b/frontend/src/toolbar/elements/InfoWindow.tsx
@@ -26,6 +26,7 @@ export function InfoWindow(): JSX.Element | null {
 
     const windowWidth = Math.min(document.documentElement.clientWidth, window.innerWidth)
     const windowHeight = Math.min(document.documentElement.clientHeight, window.innerHeight)
+    const positioningHeight = document.documentElement.offsetHeight
 
     let left = rect.left + window.pageXOffset + (rect.width > 300 ? (rect.width - 300) / 2 : 0)
     let width = 300
@@ -49,7 +50,7 @@ export function InfoWindow(): JSX.Element | null {
 
     if (spaceAbove > spaceBelow) {
         top = undefined
-        bottom = windowHeight - rect.top + 10 - window.pageYOffset - relativePositionCompensation
+        bottom = positioningHeight - rect.top + 10 - window.pageYOffset - relativePositionCompensation
         maxHeight = spaceAbove
     } else {
         maxHeight = spaceBelow

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -19,7 +19,7 @@ function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
     func: F,
     waitFor: number
 ): (...args: Parameters<F>) => void {
-    let timeout: NodeJS.Timeout
+    let timeout: ReturnType<typeof setTimeout>
     return (...args: Parameters<F>): void => {
         clearTimeout(timeout)
         timeout = setTimeout(() => func(...args), waitFor)

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -15,6 +15,17 @@ import { collectAllElementsDeep } from 'query-selector-shadow-dom'
 export type ActionElementMap = Map<HTMLElement, ActionElementWithMetadata[]>
 export type ElementMap = Map<HTMLElement, ElementWithMetadata>
 
+function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
+    func: F,
+    waitFor: number
+): (...args: Parameters<F>) => void {
+    let timeout: NodeJS.Timeout
+    return (...args: Parameters<F>): void => {
+        clearTimeout(timeout)
+        timeout = setTimeout(() => func(...args), waitFor)
+    }
+}
+
 export const elementsLogic = kea<elementsLogicType>({
     path: ['toolbar', 'elements', 'elementsLogic'],
     actions: {
@@ -325,7 +336,7 @@ export const elementsLogic = kea<elementsLogicType>({
 
     events: ({ cache, values, actions }) => ({
         afterMount: () => {
-            cache.updateRelativePosition = () => {
+            cache.updateRelativePosition = debounce(() => {
                 const relativePositionCompensation =
                     window.getComputedStyle(document.body).position === 'relative'
                         ? document.documentElement.getBoundingClientRect().y - document.body.getBoundingClientRect().y
@@ -333,7 +344,7 @@ export const elementsLogic = kea<elementsLogicType>({
                 if (relativePositionCompensation !== values.relativePositionCompensation) {
                     actions.setRelativePositionCompensation(relativePositionCompensation)
                 }
-            }
+            }, 100)
             cache.onClick = () => actions.updateRects()
             cache.onScrollResize = () => {
                 window.clearTimeout(cache.clickDelayTimeout)


### PR DESCRIPTION
## Problem

A customer with `position:relative` on the body isn't having a great time with the toolbar.

Things are better with #13969 but still not perfect

## Changes

* use `documentElement.offsetHeight` to calculate bottom of `InfoWindow`. This appears to be more consistent than `clientHeight`
* debounces the scroll listener in the `elementsLogic`

## How did you test this code?

running it locally and seeing it work with and without `position:relative` on the body
