### PR TITLE
chore(time-to-see-data): track person api queries

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -49,6 +49,7 @@ from posthog.queries.actor_base_query import ActorBaseQuery, get_people
 from posthog.queries.funnels import ClickhouseFunnelActors, ClickhouseFunnelTrendsActors
 from posthog.queries.funnels.funnel_strict_persons import ClickhouseFunnelStrictActors
 from posthog.queries.funnels.funnel_unordered_persons import ClickhouseFunnelUnorderedActors
+from posthog.queries.insight import insight_sync_execute
 from posthog.queries.paths import PathsActors
 from posthog.queries.person_query import PersonQuery
 from posthog.queries.properties_timeline import PropertiesTimeline
@@ -197,7 +198,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
         query, params = PersonQuery(filter, team.pk).get_query(paginate=True)
 
-        raw_result = sync_execute(query, params)
+        raw_result = insight_sync_execute(query, params, filter=filter, query_type="person_list")
 
         actor_ids = [row[0] for row in raw_result]
         actors, serialized_actors = get_people(team.pk, actor_ids)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -216,7 +216,7 @@ class CHQueries:
 
 
 class QueryTimeCountingMiddleware:
-    ALLOW_LIST_ROUTES = ["dashboard", "insight", "property_definitions", "properties"]
+    ALLOW_LIST_ROUTES = ["dashboard", "insight", "property_definitions", "properties", "person"]
 
     def __init__(self, get_response):
         self.get_response = get_response


### PR DESCRIPTION
I want to know how long queries to person api endpoints take as some users might be waiting a long time for the home page to load.