### PR TITLE
fix(flags): Defend against read-only db state

### DIFF
--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -475,7 +475,12 @@ def get_all_feature_flags(
             # would fail server side anyway.
 
         if person_id is not None:
-            set_feature_flag_hash_key_overrides(all_feature_flags, team_id, person_id, hash_key_override)
+            try:
+                set_feature_flag_hash_key_overrides(all_feature_flags, team_id, person_id, hash_key_override)
+            except Exception as e:
+                # If the database is in read-only mode, we can't handle experience continuity flags.
+                # Do not error on decide for this case.
+                capture_exception(e)
 
     # :TRICKY: Consistency matters only when personIDs exist
     # as overrides are stored on personIDs.


### PR DESCRIPTION
## Problem

If the db is in read-only mode, reading from db will work as expected (so our checks for the db being down would return false), but we'll error out when trying to insert something.

This can bring decide down unexpectedly.

This PR ensures this doesn't happen, and we discard the persistence data & continue calculating flags as if there were no overrides.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
