### PR TITLE
fix(ch-queries-modal): hide copy button when query not displayed in full

### DIFF
--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -40,7 +40,12 @@ function QueryCol({ item }: { item: Query }): JSX.Element {
     }
     return (
         <>
-            <CodeSnippet language={Language.SQL} copyDescription="Copy query" style={{ maxWidth: 600, fontSize: 12 }}>
+            <CodeSnippet
+                hideCopyButton={!expanded}
+                language={Language.SQL}
+                copyDescription="Copy query"
+                style={{ maxWidth: 600, fontSize: 12 }}
+            >
                 {expanded ? item.query : item.query.slice(0, has5lines)}
             </CodeSnippet>
             <LemonButton size="small" onClick={() => setExpanded(!expanded)}>


### PR DESCRIPTION
Currently clicking copy on a collapsed query only copies the shown portion of the query, when I'd expect to copy all of it.

Ideally we'd make that work, but this is just a quick fix to make things more intuitive.

i.e. only display the copy button when the whole query is displayed and the entire content is then copied.