### PR TITLE
fix(funnels): don't display NaN on an empty funnel

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -700,9 +700,15 @@ export const funnelLogic = kea<funnelLogicType>({
                             },
                         }
                     })
+
+                    const conversionRatesTotal = step.count / steps[0].count
                     const conversionRates = {
                         fromPrevious: previousCount === 0 ? 0 : step.count / previousCount,
-                        total: step.count / steps[0].count,
+
+                        // We get NaN from dividing 0/0 so we just show 0 instead
+                        // This is an empty funnel so dropped off percentage will show as 100%
+                        // and conversion percentage as 0% but that's better for users than `NaN%`
+                        total: Number.isNaN(conversionRatesTotal) ? 0 : conversionRatesTotal,
                     }
                     return {
                         ...step,


### PR DESCRIPTION
Empty funnels (or a sequence of empty steps) would show `NaN%` conversion on the interface. Show 0% instead.

(I wanted to just not show anything when we have NaN but from quickly looking at the code we'd then have to pass `NaN` around and have layers down check for NaN before displaying things. Better to ensure we don't have `NaN`s in our data objects in the first place