### PR TITLE
feat: export query tiles as CSV

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1115,6 +1115,15 @@ const api = {
         ): Promise<PaginatedResponse<PerformanceEvent>> {
             return new ApiRequest().performanceEvents(teamId).withQueryString(toParams(params)).get()
         },
+        recentPageViewsURL(teamId: TeamType['id'] = getCurrentTeamId(), dateFrom?: string, dateTo?: string): string {
+            return new ApiRequest()
+                .recentPageViewPerformanceEvents(
+                    dateFrom || dayjs().subtract(1, 'hour').toISOString(),
+                    dateTo || dayjs().toISOString(),
+                    teamId
+                )
+                .assembleEndpointUrl()
+        },
         async recentPageViews(
             teamId: TeamType['id'] = getCurrentTeamId(),
             dateFrom?: string,
@@ -1130,6 +1139,9 @@ const api = {
         },
     },
 
+    queryURL: (): string => {
+        return new ApiRequest().query().assembleEndpointUrl()
+    },
     async query<T extends Record<string, any> = QuerySchema>(
         query: T,
         options?: ApiMethodOptions

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -7,10 +7,11 @@ import {
     isTimeToSeeDataSessionsQuery,
     isTimeToSeeDataQuery,
     isRecentPerformancePageViewNode,
+    isDataTableNode,
 } from './utils'
 import api, { ApiMethodOptions } from 'lib/api'
 import { getCurrentTeamId } from 'lib/utils/logics'
-import { AnyPartialFilterType } from '~/types'
+import { AnyPartialFilterType, OnlineExportContext } from '~/types'
 import {
     filterTrendsClientSideParams,
     isFunnelsFilter,
@@ -28,6 +29,62 @@ import { currentSessionId } from 'lib/internalMetrics'
 const EVENTS_DAYS_FIRST_FETCH = 5
 
 export const DEFAULT_QUERY_LIMIT = 100
+
+//get export context for a given query
+export function queryExportContext<N extends DataNode = DataNode>(
+    query: N,
+    methodOptions?: ApiMethodOptions,
+    refresh?: boolean
+): OnlineExportContext {
+    if (isEventsQuery(query)) {
+        return {
+            path: api.queryURL(),
+            method: 'POST',
+            body: {
+                ...query,
+                after: now().subtract(EVENTS_DAYS_FIRST_FETCH, 'day').toISOString(),
+            },
+        }
+    } else if (isPersonsNode(query)) {
+        return { path: getPersonsEndpoint(query) }
+    } else if (isInsightQueryNode(query)) {
+        return legacyInsightQueryExportContext({
+            filters: queryNodeToFilter(query),
+            currentTeamId: getCurrentTeamId(),
+            refresh,
+        })
+    } else if (isLegacyQuery(query)) {
+        return legacyInsightQueryExportContext({
+            filters: query.filters,
+            currentTeamId: getCurrentTeamId(),
+            methodOptions,
+        })
+    } else if (isTimeToSeeDataSessionsQuery(query)) {
+        return {
+            path: '/api/time_to_see_data/sessions',
+            method: 'POST',
+            body: {
+                team_id: query.teamId ?? getCurrentTeamId(),
+            },
+        }
+    } else if (isTimeToSeeDataQuery(query)) {
+        return {
+            path: '/api/time_to_see_data/session_events',
+            method: 'POST',
+            body: {
+                team_id: query.teamId ?? getCurrentTeamId(),
+                session_id: query.sessionId ?? currentSessionId(),
+                session_start: query.sessionStart ?? now().subtract(1, 'day').toISOString(),
+                session_end: query.sessionEnd ?? now().toISOString(),
+            },
+        }
+    } else if (isRecentPerformancePageViewNode(query)) {
+        return { path: api.performanceEvents.recentPageViewsURL() }
+    } else if (isDataTableNode(query)) {
+        return queryExportContext(query.source, methodOptions, refresh)
+    }
+    throw new Error(`Unsupported query: ${query.kind}`)
+}
 
 // Return data for a given query
 export async function query<N extends DataNode = DataNode>(
@@ -119,29 +176,71 @@ interface LegacyInsightQueryParams {
     refresh?: boolean
 }
 
+export function legacyInsightQueryURL({ filters, currentTeamId, refresh }: LegacyInsightQueryParams): string {
+    if (isTrendsFilter(filters) || isStickinessFilter(filters) || isLifecycleFilter(filters)) {
+        return `api/projects/${currentTeamId}/insights/trend/?${toParams(filterTrendsClientSideParams(filters))}${
+            refresh ? '&refresh=true' : ''
+        }`
+    } else if (isRetentionFilter(filters)) {
+        return `api/projects/${currentTeamId}/insights/retention/?${toParams(filters)}${refresh ? '&refresh=true' : ''}`
+    } else if (isFunnelsFilter(filters)) {
+        return `api/projects/${currentTeamId}/insights/funnel/${refresh ? '?refresh=true' : ''}`
+    } else if (isPathsFilter(filters)) {
+        return `api/projects/${currentTeamId}/insights/path${refresh ? '&refresh=true' : ''}`
+    } else {
+        throw new Error(`Unsupported insight type: ${filters.insight}`)
+    }
+}
+
+export function legacyInsightQueryExportContext({
+    filters,
+    currentTeamId,
+    refresh,
+}: LegacyInsightQueryParams): OnlineExportContext {
+    const apiUrl = legacyInsightQueryURL({ filters, currentTeamId, refresh })
+
+    if (isTrendsFilter(filters) || isStickinessFilter(filters) || isLifecycleFilter(filters)) {
+        return {
+            path: apiUrl,
+            method: 'GET',
+        }
+    } else if (isRetentionFilter(filters)) {
+        return {
+            path: apiUrl,
+            method: 'GET',
+        }
+    } else if (isFunnelsFilter(filters)) {
+        return {
+            path: apiUrl,
+            method: 'POST',
+            body: filters,
+        }
+    } else if (isPathsFilter(filters)) {
+        return {
+            path: apiUrl,
+            method: 'POST',
+            body: filters,
+        }
+    } else {
+        throw new Error(`Unsupported insight type: ${filters.insight}`)
+    }
+}
+
 export async function legacyInsightQuery({
     filters,
     currentTeamId,
     methodOptions,
     refresh,
 }: LegacyInsightQueryParams): Promise<[Response, string]> {
-    let apiUrl: string
+    const apiUrl = legacyInsightQueryURL({ filters, currentTeamId, refresh })
     let fetchResponse: Response
     if (isTrendsFilter(filters) || isStickinessFilter(filters) || isLifecycleFilter(filters)) {
-        apiUrl = `api/projects/${currentTeamId}/insights/trend/?${toParams(filterTrendsClientSideParams(filters))}${
-            refresh ? '&refresh=true' : ''
-        }`
         fetchResponse = await api.getResponse(apiUrl, methodOptions)
     } else if (isRetentionFilter(filters)) {
-        apiUrl = `api/projects/${currentTeamId}/insights/retention/?${toParams(filters)}${
-            refresh ? '&refresh=true' : ''
-        }`
         fetchResponse = await api.getResponse(apiUrl, methodOptions)
     } else if (isFunnelsFilter(filters)) {
-        apiUrl = `api/projects/${currentTeamId}/insights/funnel/${refresh ? '?refresh=true' : ''}`
         fetchResponse = await api.createResponse(apiUrl, filters, methodOptions)
     } else if (isPathsFilter(filters)) {
-        apiUrl = `api/projects/${currentTeamId}/insights/path${refresh ? '&refresh=true' : ''}`
         fetchResponse = await api.createResponse(apiUrl, filters, methodOptions)
     } else {
         throw new Error(`Unsupported insight type: ${filters.insight}`)

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -57,7 +57,7 @@ import { parseProperties } from 'lib/components/PropertyFilters/utils'
 import { insightsModel } from '~/models/insightsModel'
 import { toLocalFilters } from './filters/ActionFilter/entityFilterLogic'
 import { loaders } from 'kea-loaders'
-import { legacyInsightQuery } from '~/queries/query'
+import { legacyInsightQuery, queryExportContext } from '~/queries/query'
 import { tagsModel } from '~/models/tagsModel'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
@@ -696,31 +696,38 @@ export const insightLogic = kea<insightLogicType>([
 
                 const filename = ['export', insight.name || insight.derived_name].join('-')
 
-                if (isTrendsFilter(filters) || isStickinessFilter(filters) || isLifecycleFilter(filters)) {
-                    return {
-                        path: `api/projects/${currentTeamId}/insights/trend/?${toParams(
-                            filterTrendsClientSideParams(params)
-                        )}`,
-                        filename,
-                    }
-                } else if (isRetentionFilter(filters)) {
-                    return { filename, path: `api/projects/${currentTeamId}/insights/retention/?${toParams(params)}` }
-                } else if (isFunnelsFilter(filters)) {
-                    return {
-                        filename,
-                        method: 'POST',
-                        path: `api/projects/${currentTeamId}/insights/funnel`,
-                        body: params,
-                    }
-                } else if (isPathsFilter(filters)) {
-                    return {
-                        filename,
-                        method: 'POST',
-                        path: `api/projects/${currentTeamId}/insights/path`,
-                        body: params,
-                    }
+                if (!!insight.query) {
+                    return { ...queryExportContext(insight.query), filename }
                 } else {
-                    return null
+                    if (isTrendsFilter(filters) || isStickinessFilter(filters) || isLifecycleFilter(filters)) {
+                        return {
+                            path: `api/projects/${currentTeamId}/insights/trend/?${toParams(
+                                filterTrendsClientSideParams(params)
+                            )}`,
+                            filename,
+                        }
+                    } else if (isRetentionFilter(filters)) {
+                        return {
+                            filename,
+                            path: `api/projects/${currentTeamId}/insights/retention/?${toParams(params)}`,
+                        }
+                    } else if (isFunnelsFilter(filters)) {
+                        return {
+                            filename,
+                            method: 'POST',
+                            path: `api/projects/${currentTeamId}/insights/funnel`,
+                            body: params,
+                        }
+                    } else if (isPathsFilter(filters)) {
+                        return {
+                            filename,
+                            method: 'POST',
+                            path: `api/projects/${currentTeamId}/insights/path`,
+                            body: params,
+                        }
+                    } else {
+                        return null
+                    }
                 }
             },
         ],


### PR DESCRIPTION
## Changes

Support generation of export context for CSV exports of queries

stacked on top of #13980 
see #13927 

## How did you test this code?

running it locally and seeing a datatable export the right data