### PR TITLE
feat(flags): Track which companies use local evaluation

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -13,7 +13,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthentication
-from posthog.event_usage import report_user_action
+from posthog.event_usage import report_local_evaluation_requested, report_user_action
 from posthog.models import FeatureFlag
 from posthog.models.activity_logging.activity_log import Detail, changes_between, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
@@ -317,6 +317,8 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
             else:
                 feature_flag.filters = filters
             parsed_flags.append(feature_flag)
+
+        report_local_evaluation_requested(self.team)
 
         return Response(
             {

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -185,6 +185,14 @@ def report_user_action(user: User, event: str, properties: Dict = {}):
     )
 
 
+def report_local_evaluation_requested(team: Team) -> None:
+    posthoganalytics.capture(
+        str(team.id),
+        "local evaluation request",
+        groups=groups(team.organization, team),
+    )
+
+
 def report_organization_deleted(user: User, organization: Organization):
     posthoganalytics.capture(
         user.distinct_id, "organization deleted", organization.get_analytics_metadata(), groups=groups(organization)


### PR DESCRIPTION
## Problem

on the tin^

realised there's a somewhat clever way we can figure out which teams/orgs are using local evaluation, by checking who is requesting for flags.

Probably shouldn't log on every request though 😅 - that's like thousands of events a minute.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
