### PR TITLE
fix(events-explorer): group filter

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -89,8 +89,8 @@ export function Group(): JSX.Element {
                                         {
                                             key: `$group_${groupTypeIndex}`,
                                             value: groupKey,
+                                            type: PropertyFilterType.Event,
                                             operator: PropertyOperator.Exact,
-                                            type: PropertyFilterType.Group,
                                         },
                                     ],
                                 },
@@ -104,7 +104,7 @@ export function Group(): JSX.Element {
                                     {
                                         key: `$group_${groupTypeIndex}`,
                                         value: groupKey,
-                                        type: PropertyFilterType.Group,
+                                        type: PropertyFilterType.Event,
                                         operator: PropertyOperator.Exact,
                                     },
                                 ],


### PR DESCRIPTION
## Problem

You couldn't filter by group in the events explorer.

## Changes

Works now.

## How did you test this code?

Locally the list for all group events would either fail or show everything. This reduced the list to the 

The bug was introduced in [this PR](https://github.com/PostHog/posthog/commit/963c27114cbd419b54fddd1ae0559c071bb17f19), where I had basically done:

```diff
- fixedProperties: [{ key: `$group_${groupTypeIndex}`, value: groupKey }],
+ fixedProperties: [
+     {
+         key: `$group_${groupTypeIndex}`,
+         value: groupKey,
+         operator: PropertyOperator.Exact,
+         type: PropertyFilterType.Group,
+     },
+ ],
```

It was actually an event property 🤦 