### PR TITLE
Proposal: Query fragments for query building

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -96,7 +96,7 @@
           AND event IN ['$pageview']
           AND timestamp <= now()
           AND timestamp >= now() - INTERVAL 2 year
-        GROUP BY person_id) behavior_query
+        GROUP BY person_id) funnel_query
      INNER JOIN
        (SELECT *,
                id AS person_id
@@ -111,7 +111,7 @@
                   AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+           AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = funnel_query.person_id
      WHERE 1 = 1
        AND ((((performed_event_condition_5_level_level_0_level_0_level_0_0)))) ) as person
   UNION ALL
@@ -161,7 +161,7 @@
                       AND event IN ['$pageview']
                       AND timestamp <= now()
                       AND timestamp >= now() - INTERVAL 2 year
-                    GROUP BY person_id) behavior_query
+                    GROUP BY person_id) funnel_query
                  INNER JOIN
                    (SELECT *,
                            id AS person_id
@@ -176,7 +176,7 @@
                               AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+                       AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = funnel_query.person_id
                  WHERE 1 = 1
                    AND ((((performed_event_condition_7_level_level_0_level_0_level_0_0)))) ) ))
   '
@@ -191,7 +191,7 @@
          1 AS sign,
          0 AS version
   FROM
-    (SELECT behavior_query.person_id AS id
+    (SELECT funnel_query.person_id AS id
      FROM
        (SELECT pdi.person_id AS person_id,
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
@@ -206,7 +206,7 @@
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
           AND event IN ['signup']
-        GROUP BY person_id) behavior_query
+        GROUP BY person_id) funnel_query
      WHERE 1 = 1
        AND (((first_time_condition_8_level_level_0_level_0_0))) ) as person
   UNION ALL
@@ -232,7 +232,7 @@
          1 AS sign,
          0 AS version
   FROM
-    (SELECT behavior_query.person_id AS id
+    (SELECT funnel_query.person_id AS id
      FROM
        (SELECT pdi.person_id AS person_id,
                countIf(timestamp > now() - INTERVAL 2 year
@@ -250,7 +250,7 @@
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
           AND event IN ['$pageview', 'signup']
-        GROUP BY person_id) behavior_query
+        GROUP BY person_id) funnel_query
      WHERE 1 = 1
        AND ((((performed_event_condition_9_level_level_0_level_0_level_0_0))
              AND ((((NOT first_time_condition_9_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person

--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -291,23 +291,21 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         else:
             person_prop_query = QueryFragment("")
 
-        event_param_name = f"{self._cohort_pk}_event_ids"
         new_query = QueryFragment(
             """
             SELECT {fields}
             FROM events AS {alias}
             {distinct_id_query}
             WHERE team_id = %(team_id)s
-            AND event IN %({event_param_name})s
+            AND event IN %(__event_ids)s
             {date_condition}
             {person_prop_query}
             """,
-            {"team_id": self._team_id, event_param_name: self._events},
+            {"team_id": self._team_id, UniqueName("__event_ids"): self._events},
         ).format(
             fields=QueryFragment.join(", ", _inner_fields),
             alias=self.EVENT_TABLE_ALIAS,
             distinct_id_query=self._get_distinct_id_query(),
-            event_param_name=event_param_name,
             date_condition=date_condition,
             person_prop_query=person_prop_query,
         )

--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Tuple, cast
 
+from posthog.clickhouse.query_fragment import QueryFragment, QueryFragmentLike
 from posthog.constants import PropertyOperatorType
 from posthog.models.cohort.util import get_count_operator
 from posthog.models.filters.mixins.utils import cached_property
@@ -42,79 +43,68 @@ def check_negation_clause(prop: PropertyGroup) -> Tuple[bool, bool]:
 
 class EnterpriseCohortQuery(FOSSCohortQuery):
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
-
         if not self._outer_property_groups:
             # everything is pushed down, no behavioral stuff to do
             # thus, use personQuery directly
             return self._person_query.get_query(prepend=self._cohort_pk)
 
         # TODO: clean up this kludge. Right now, get_conditions has to run first so that _fields is populated for _get_behavioral_subquery()
-        conditions, condition_params = self._get_conditions()
-        self.params.update(condition_params)
-
-        subq = []
-
-        if self.sequence_filters_to_query:
-            sequence_query, sequence_params, sequence_query_alias = self._get_sequence_query()
-            subq.append((sequence_query, sequence_query_alias))
-            self.params.update(sequence_params)
-        else:
-            behavior_subquery, behavior_subquery_params, behavior_query_alias = self._get_behavior_subquery()
-            subq.append((behavior_subquery, behavior_query_alias))
-            self.params.update(behavior_subquery_params)
-
-        person_query, person_params, person_query_alias = self._get_persons_query(prepend=str(self._cohort_pk))
-        subq.append((person_query, person_query_alias))
-        self.params.update(person_params)
+        conditions = self._get_conditions()
 
         # Since we can FULL OUTER JOIN, we may end up with pairs of uuids where one side is blank. Always try to choose the non blank ID
-        q, fields = self._build_sources(subq)
+        q, fields = self._build_sources(
+            [
+                (
+                    self._get_sequence_query() if self.sequence_filters_to_query else self._get_behavior_subquery(),
+                    self.FUNNEL_QUERY_ALIAS,
+                ),
+                (self._get_persons_query(prepend=str(self._cohort_pk)), self.PERSON_TABLE_ALIAS),
+            ]
+        )
 
-        final_query = f"""
-        SELECT {fields} AS id  FROM
-        {q}
+        final_query = QueryFragment(
+            """
+        SELECT {fields} AS id
+        FROM {q}
         WHERE 1 = 1
         {conditions}
         """
+        ).format(fields=fields, q=q, conditions=conditions)
 
-        return final_query, self.params
+        return final_query.sql, final_query.params
 
-    def _get_condition_for_property(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
-
-        res: str = ""
-        params: Dict[str, Any] = {}
-
+    def _get_condition_for_property(self, prop: Property, prepend: str, idx: int) -> QueryFragment:
         if prop.type == "behavioral":
             if prop.value == "performed_event":
-                res, params = self.get_performed_event_condition(prop, prepend, idx)
+                return self.get_performed_event_condition(prop, prepend, idx)
             elif prop.value == "performed_event_multiple":
-                res, params = self.get_performed_event_multiple(prop, prepend, idx)
+                return self.get_performed_event_multiple(prop, prepend, idx)
             elif prop.value == "stopped_performing_event":
-                res, params = self.get_stopped_performing_event(prop, prepend, idx)
+                return self.get_stopped_performing_event(prop, prepend, idx)
             elif prop.value == "restarted_performing_event":
-                res, params = self.get_restarted_performing_event(prop, prepend, idx)
+                return self.get_restarted_performing_event(prop, prepend, idx)
             elif prop.value == "performed_event_first_time":
-                res, params = self.get_performed_event_first_time(prop, prepend, idx)
+                return self.get_performed_event_first_time(prop, prepend, idx)
             elif prop.value == "performed_event_sequence":
-                res, params = self.get_performed_event_sequence(prop, prepend, idx)
+                return self.get_performed_event_sequence(prop, prepend, idx)
             elif prop.value == "performed_event_regularly":
-                res, params = self.get_performed_event_regularly(prop, prepend, idx)
+                return self.get_performed_event_regularly(prop, prepend, idx)
         elif prop.type == "person":
-            res, params = self.get_person_condition(prop, prepend, idx)
+            return self.get_person_condition(prop, prepend, idx)
         elif (
             prop.type == "static-cohort"
         ):  # "cohort" and "precalculated-cohort" are handled by flattening during initialization
-            res, params = self.get_static_cohort_condition(prop, prepend, idx)
+            return self.get_static_cohort_condition(prop, prepend, idx)
         else:
             raise ValueError(f"Invalid property type for Cohort queries: {prop.type}")
 
-        return res, params
+        return QueryFragment("")
 
-    def get_stopped_performing_event(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
+    def get_stopped_performing_event(self, prop: Property, prepend: str, idx: int) -> QueryFragment:
         event = (prop.event_type, prop.key)
         column_name = f"stopped_event_condition_{prepend}_{idx}"
 
-        entity_query, entity_params = self._get_entity(event, prepend, idx)
+        entity_query = self._get_entity(event, prepend, idx)
         date_value = parse_and_validate_positive_integer(prop.time_value, "time_value")
         date_param = f"{prepend}_date_{idx}"
         date_interval = validate_interval(prop.time_interval)
@@ -128,24 +118,24 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         self._check_earliest_date((date_value, date_interval))
 
         # The user was doing the event in this time period
-        event_was_happening_period = f"countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp <= now() - INTERVAL %({seq_date_param})s {seq_date_interval} AND {entity_query})"
+        event_was_happening_period = f"countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp <= now() - INTERVAL %({seq_date_param})s {seq_date_interval} AND {entity_query.sql})"
         # Then stopped in this time period
-        event_stopped_period = f"countIf(timestamp > now() - INTERVAL %({seq_date_param})s {seq_date_interval} AND timestamp <= now() AND {entity_query})"
+        event_stopped_period = f"countIf(timestamp > now() - INTERVAL %({seq_date_param})s {seq_date_interval} AND timestamp <= now() AND {entity_query.sql})"
 
-        full_condition = f"({event_was_happening_period} > 0 AND {event_stopped_period} = 0) as {column_name}"
+        full_condition = QueryFragment(
+            f"({event_was_happening_period} > 0 AND {event_stopped_period} = 0) as {column_name}",
+            {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_query.params},
+        )
 
         self._fields.append(full_condition)
 
-        return (
-            f"{'NOT' if prop.negation else ''} {column_name}",
-            {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_params},
-        )
+        return QueryFragment(f"{'NOT' if prop.negation else ''} {column_name}")
 
-    def get_restarted_performing_event(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
+    def get_restarted_performing_event(self, prop: Property, prepend: str, idx: int) -> QueryFragment:
         event = (prop.event_type, prop.key)
         column_name = f"restarted_event_condition_{prepend}_{idx}"
 
-        entity_query, entity_params = self._get_entity(event, prepend, idx)
+        entity_query = self._get_entity(event, prepend, idx)
         date_value = parse_and_validate_positive_integer(prop.time_value, "time_value")
         date_param = f"{prepend}_date_{idx}"
         date_interval = validate_interval(prop.time_interval)
@@ -159,26 +149,26 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         self._restrict_event_query_by_time = False
 
         # Events should have been fired in the initial_period
-        initial_period = f"countIf(timestamp <= now() - INTERVAL %({date_param})s {date_interval} AND {entity_query})"
+        initial_period = (
+            f"countIf(timestamp <= now() - INTERVAL %({date_param})s {date_interval} AND {entity_query.sql})"
+        )
         # Then stopped in the event_stopped_period
         event_stopped_period = f"countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp <= now() - INTERVAL %({seq_date_param})s {seq_date_interval} AND {entity_query})"
         # Then restarted in the final event_restart_period
-        event_restarted_period = f"countIf(timestamp > now() - INTERVAL %({seq_date_param})s {seq_date_interval} AND timestamp <= now() AND {entity_query})"
+        event_restarted_period = f"countIf(timestamp > now() - INTERVAL %({seq_date_param})s {seq_date_interval} AND timestamp <= now() AND {entity_query.sql})"
 
-        full_condition = (
-            f"({initial_period} > 0 AND {event_stopped_period} = 0 AND {event_restarted_period} > 0) as {column_name}"
+        full_condition = QueryFragment(
+            f"({initial_period} > 0 AND {event_stopped_period} = 0 AND {event_restarted_period} > 0) as {column_name}",
+            {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_query.params},
         )
 
         self._fields.append(full_condition)
 
-        return (
-            f"{'NOT' if prop.negation else ''} {column_name}",
-            {f"{date_param}": date_value, f"{seq_date_param}": seq_date_value, **entity_params},
-        )
+        return QueryFragment(f"{'NOT' if prop.negation else ''} {column_name}")
 
-    def get_performed_event_first_time(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
+    def get_performed_event_first_time(self, prop: Property, prepend: str, idx: int) -> QueryFragment:
         event = (prop.event_type, prop.key)
-        entity_query, entity_params = self._get_entity(event, prepend, idx)
+        entity_query = self._get_entity(event, prepend, idx)
 
         column_name = f"first_time_condition_{prepend}_{idx}"
 
@@ -188,15 +178,18 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
 
         self._restrict_event_query_by_time = False
 
-        field = f"minIf(timestamp, {entity_query}) >= now() - INTERVAL %({date_param})s {date_interval} AND minIf(timestamp, {entity_query}) < now() as {column_name}"
+        field = QueryFragment(
+            "minIf(timestamp, {entity_query}) >= now() - INTERVAL %({date_param})s {date_interval} AND minIf(timestamp, {entity_query}) < now() as {column_name}",
+            {date_param: date_value},
+        ).format(entity_query=entity_query, date_param=date_param, date_interval=date_interval, column_name=column_name)
 
         self._fields.append(field)
 
-        return (f"{'NOT' if prop.negation else ''} {column_name}", {f"{date_param}": date_value, **entity_params})
+        return QueryFragment(f"{'NOT' if prop.negation else ''} {column_name}")
 
-    def get_performed_event_regularly(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
+    def get_performed_event_regularly(self, prop: Property, prepend: str, idx: int) -> QueryFragment:
         event = (prop.event_type, prop.key)
-        entity_query, entity_params = self._get_entity(event, prepend, idx)
+        entity_query = self._get_entity(event, prepend, idx)
 
         column_name = f"performed_event_regularly_{prepend}_{idx}"
 
@@ -220,29 +213,51 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
                 )
             )
 
-        params = {
-            time_value_param: time_value,
-            operator_value_param: operator_value,
-            min_periods_param: min_period_count,
-        }
         periods = []
 
         if total_period_count:
             for period in range(total_period_count):
-                start_time_value = f"%({time_value_param})s * {period}"
-                end_time_value = f"%({time_value_param})s * ({period} + 1)"
                 # Clause that returns 1 if the event was performed the expected number of times in the given time interval, otherwise 0
                 periods.append(
-                    f"if(countIf({entity_query} and timestamp <= now() - INTERVAL {start_time_value} {date_interval} and timestamp > now() - INTERVAL {end_time_value} {date_interval}) {get_count_operator(prop.operator)} %({operator_value_param})s, 1, 0)"
+                    QueryFragment(
+                        """
+                        if(
+                            countIf(
+                                {entity_query} and timestamp <= now() - INTERVAL {start_time_value} {date_interval} and timestamp > now() - INTERVAL {end_time_value} {date_interval}
+                            ) {operator} %({operator_value_param})s,
+                            1,
+                            0
+                        )
+                        """,
+                        {
+                            time_value_param: time_value,
+                            operator_value_param: operator_value,
+                            min_periods_param: min_period_count,
+                        },
+                    ).format(
+                        entity_query=entity_query,
+                        start_time_value=f"%({time_value_param})s * {period}",
+                        date_interval=date_interval,
+                        end_time_value=f"%({time_value_param})s * ({period} + 1)",
+                        operator=get_count_operator(prop.operator),
+                        operator_value_param=operator_value_param,
+                    )
                 )
         earliest_date = (total_period_count * time_value, date_interval)
         self._check_earliest_date(earliest_date)
 
-        field = "+".join(periods) + f">= %({min_periods_param})s" + f" as {column_name}"
+        field = QueryFragment(
+            "{expr} >= %({min_periods_param})s AS {column_name}",
+            {
+                time_value_param: time_value,
+                operator_value_param: operator_value,
+                min_periods_param: min_period_count,
+            },
+        ).format(expr=QueryFragment.join("+", periods), min_periods_param=min_periods_param, column_name=column_name)
 
         self._fields.append(field)
 
-        return (f"{'NOT' if prop.negation else ''} {column_name}", {**entity_params, **params})
+        return QueryFragment(f"{'NOT' if prop.negation else ''} {column_name}")
 
     @cached_property
     def sequence_filters_to_query(self) -> List[Property]:
@@ -260,72 +275,76 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         return lookup
 
     def _get_sequence_query(self) -> Tuple[str, Dict[str, Any], str]:
-        params = {}
-
         names = ["event", "properties", "distinct_id", "timestamp"]
-
-        person_prop_query = ""
-        person_prop_params: dict = {}
-
         _inner_fields = [
-            f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id AS person_id"
+            f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id AS person_id",
+            *names,
         ]
-        _intermediate_fields = ["person_id"]
+        _intermediate_fields = ["person_id", *names]
         _outer_fields = ["person_id"]
 
-        _inner_fields.extend(names)
-        _intermediate_fields.extend(names)
-
         for idx, prop in enumerate(self.sequence_filters_to_query):
-            step_cols, intermediate_cols, aggregate_cols, seq_params = self._get_sequence_filter(prop, idx)
+            step_cols, intermediate_cols, aggregate_cols = self._get_sequence_filter(prop, idx)
             _inner_fields.extend(step_cols)
             _intermediate_fields.extend(intermediate_cols)
             _outer_fields.extend(aggregate_cols)
-            params.update(seq_params)
 
-        date_condition, date_params = self._get_date_condition()
-        params.update(date_params)
-
-        event_param_name = f"{self._cohort_pk}_event_ids"
+        date_condition = self._get_date_condition()
 
         if self.should_pushdown_persons and self._using_person_on_events:
-            person_prop_query, person_prop_params = self._get_prop_groups(
-                self._inner_property_groups,
-                person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS,
-                person_id_joined_alias=f"{self.EVENT_TABLE_ALIAS}.person_id",
+            person_prop_query = QueryFragment(
+                self._get_prop_groups(
+                    self._inner_property_groups,
+                    person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS,
+                    person_id_joined_alias=f"{self.EVENT_TABLE_ALIAS}.person_id",
+                )
             )
+        else:
+            person_prop_query = QueryFragment("")
 
-        new_query = f"""
-        SELECT {", ".join(_inner_fields)} FROM events AS {self.EVENT_TABLE_ALIAS}
-        {self._get_distinct_id_query()}
-        WHERE team_id = %(team_id)s
-        AND event IN %({event_param_name})s
-        {date_condition}
-        {person_prop_query}
-        """
-
-        intermediate_query = f"""
-        SELECT {", ".join(_intermediate_fields)} FROM ({new_query})
-        """
-
-        _outer_fields.extend(self._fields)
-
-        outer_query = f"""
-        SELECT {", ".join(_outer_fields)} FROM ({intermediate_query})
-        GROUP BY person_id
-        """
-        return (
-            outer_query,
-            {"team_id": self._team_id, event_param_name: self._events, **params, **person_prop_params},
-            self.FUNNEL_QUERY_ALIAS,
+        event_param_name = f"{self._cohort_pk}_event_ids"
+        new_query = QueryFragment(
+            """
+            SELECT {fields}
+            FROM events AS {alias}
+            {self._get_distinct_id_query()}
+            WHERE team_id = %(team_id)s
+            AND event IN %({event_param_name})s
+            {date_condition}
+            {person_prop_query}
+            """,
+            {"team_id": self._team_id, event_param_name: self._events},
+        ).format(
+            fields=QueryFragment.join(", ", _inner_fields),
+            alias=self.EVENT_TABLE_ALIAS,
+            event_param_name=event_param_name,
+            date_condition=date_condition,
+            person_prop_query=person_prop_query,
         )
 
-    def _get_sequence_filter(self, prop: Property, idx: int) -> Tuple[List[str], List[str], List[str], Dict[str, Any]]:
+        return QueryFragment(
+            """
+            SELECT {outer_fields}
+            FROM (
+                SELECT {intermediate_fields}
+                FROM ({new_query})
+            )
+            GROUP BY person_id
+            """
+        ).format(
+            outer_fields=QueryFragment.join(", ", _outer_fields + self._fields),
+            intermediate_fields=QueryFragment.join(", ", _intermediate_fields),
+            new_query=new_query,
+        )
+
+    def _get_sequence_filter(
+        self, prop: Property, idx: int
+    ) -> Tuple[List[QueryFragmentLike], List[QueryFragmentLike], List[QueryFragmentLike]]:
         event = validate_entity((prop.event_type, prop.key))
-        entity_query, entity_params = self._get_entity(event, f"event_sequence_{self._cohort_pk}", idx)
+        entity_query = self._get_entity(event, f"event_sequence_{self._cohort_pk}", idx)
         seq_event = validate_entity((prop.seq_event_type, prop.seq_event))
 
-        seq_entity_query, seq_entity_params = self._get_entity(seq_event, f"seq_event_sequence_{self._cohort_pk}", idx)
+        seq_entity_query = self._get_entity(seq_event, f"seq_event_sequence_{self._cohort_pk}", idx)
 
         time_value = parse_and_validate_positive_integer(prop.time_value, "time_value")
         time_interval = validate_interval(prop.time_interval)
@@ -339,27 +358,50 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         if event == seq_event:
             duplicate_event = 1
 
-        aggregate_cols = []
-        aggregate_condition = f"{'NOT' if prop.negation else ''} max(if({entity_query} AND {event_prepend}_latest_0 < {event_prepend}_latest_1 AND {event_prepend}_latest_1 <= {event_prepend}_latest_0 + INTERVAL {seq_date_value} {seq_date_interval}, 2, 1)) = 2 AS {self.SEQUENCE_FIELD_ALIAS}_{self.sequence_filters_lookup[str(prop.to_dict())]}"
-        aggregate_cols.append(aggregate_condition)
+        aggregate_cols = [
+            QueryFragment(
+                """
+                {negation} max(
+                    if({entity_query} AND {event_prepend}_latest_0 < {event_prepend}_latest_1 AND {event_prepend}_latest_1 <= {event_prepend}_latest_0 + INTERVAL {seq_date_value} {seq_date_interval}, 2, 1)
+                ) = 2 AS {alias}
+                """
+            ).format(
+                negation="NOT" if prop.negation else "",
+                entity_query=entity_query,
+                event_prepend=event_prepend,
+                seq_date_value=seq_date_value,
+                seq_date_interval=seq_date_interval,
+                alias=f"{self.SEQUENCE_FIELD_ALIAS}_{self.sequence_filters_lookup[str(prop.to_dict())]}",
+            )
+        ]
 
-        condition_cols = []
-        timestamp_condition = f"min({event_prepend}_latest_1) over (PARTITION by person_id ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND {duplicate_event} PRECEDING) {event_prepend}_latest_1"
-        condition_cols.append(f"{event_prepend}_latest_0")
-        condition_cols.append(timestamp_condition)
+        condition_cols = [
+            f"{event_prepend}_latest_0",
+            f"min({event_prepend}_latest_1) over (PARTITION by person_id ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND {duplicate_event} PRECEDING) {event_prepend}_latest_1",
+        ]
 
-        step_cols = []
-        step_cols.append(
-            f"if({entity_query} AND timestamp > now() - INTERVAL {time_value} {time_interval}, 1, 0) AS {event_prepend}_step_0"
-        )
-        step_cols.append(f"if({event_prepend}_step_0 = 1, timestamp, null) AS {event_prepend}_latest_0")
+        step_cols = [
+            QueryFragment(
+                "if({entity_query} AND timestamp > now() - INTERVAL {time_value} {time_interval}, 1, 0) AS {event_prepend}_step_0"
+            ).format(
+                entity_query=entity_query,
+                time_value=time_value,
+                time_interval=time_interval,
+                event_prepend=event_prepend,
+            ),
+            f"if({event_prepend}_step_0 = 1, timestamp, null) AS {event_prepend}_latest_0",
+            QueryFragment(
+                "if({seq_entity_query} AND timestamp > now() - INTERVAL {time_value} {time_interval}, 1, 0) AS {event_prepend}_step_1"
+            ).format(
+                seq_entity_query=seq_entity_query,
+                time_value=time_value,
+                time_interval=time_interval,
+                event_prepend=event_prepend,
+            ),
+            f"if({event_prepend}_step_1 = 1, timestamp, null) AS {event_prepend}_latest_1",
+        ]
 
-        step_cols.append(
-            f"if({seq_entity_query} AND timestamp > now() - INTERVAL {time_value} {time_interval}, 1, 0) AS {event_prepend}_step_1"
-        )
-        step_cols.append(f"if({event_prepend}_step_1 = 1, timestamp, null) AS {event_prepend}_latest_1")
-
-        return step_cols, condition_cols, aggregate_cols, {**entity_params, **seq_entity_params}
+        return step_cols, condition_cols, aggregate_cols
 
     def get_performed_event_sequence(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
         return f"{self.SEQUENCE_FIELD_ALIAS}_{self.sequence_filters_lookup[str(prop.to_dict())]}", {}

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -24,7 +24,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND event IN ['$pageview', '$pageview', '$autocapture']
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   INNER JOIN
     (SELECT *,
             id AS person_id
@@ -39,11 +39,11 @@
                AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
+        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
-           OR (performed_event_condition_None_level_level_0_level_0_level_1_0))
-          AND ((first_time_condition_None_level_level_0_level_1_level_0_0))))
+    AND (performed_event_condition_None_level_level_0_level_0_level_0_0
+         OR performed_event_condition_None_level_level_0_level_0_level_1_0
+         AND first_time_condition_None_level_level_0_level_1_level_0_0)
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_another_cohort_with_event_sequence
@@ -54,7 +54,7 @@
     (SELECT person_id,
             max(if(event = '$pageview'
                    AND event_0_latest_0 < event_0_latest_1
-                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0,
+                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0 ,
             max(if(event = '$new_view'
                    AND event_1_latest_0 < event_1_latest_1
                    AND event_1_latest_1 <= event_1_latest_0 + INTERVAL 8 day, 2, 1)) = 2 AS steps_1
@@ -117,8 +117,8 @@
         HAVING max(is_deleted) = 0
         AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND ((((steps_0))
-          AND (steps_1)))
+    AND (steps_0
+         AND steps_1)
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_extra
@@ -142,7 +142,7 @@
        AND event IN ['$pageview']
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   INNER JOIN
     (SELECT *,
             id AS person_id
@@ -157,15 +157,15 @@
                AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))))) person ON person.person_id = behavior_query.person_id
+        AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (((performed_event_condition_None_level_level_0_level_0_0)))
+    AND (performed_event_condition_None_level_level_0_level_0_0)
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.1
   '
   
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
   FROM
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
@@ -183,7 +183,7 @@
        AND event IN ['$pageview']
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   FULL OUTER JOIN
     (SELECT *,
             id AS person_id
@@ -193,10 +193,10 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
-          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0))))
+    AND (has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))
+         OR performed_event_condition_None_level_level_0_level_1_level_0_0)
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence
@@ -243,7 +243,7 @@
              AND timestamp >= now() - INTERVAL 7 day ))
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
-    AND (((steps_0)))
+    AND (steps_0)
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence_and_clause_with_additional_event
@@ -254,7 +254,7 @@
     (SELECT person_id,
             max(if(event = '$pageview'
                    AND event_0_latest_0 < event_0_latest_1
-                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0,
+                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0 ,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$new_view') >= 1 AS performed_event_multiple_condition_None_level_level_0_level_1_0
@@ -293,8 +293,8 @@
              AND timestamp >= now() - INTERVAL 1 week ))
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
-    AND (((steps_0)
-          OR (performed_event_multiple_condition_None_level_level_0_level_1_0)))
+    AND (steps_0
+         OR performed_event_multiple_condition_None_level_level_0_level_1_0)
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence_with_person_properties
@@ -305,7 +305,7 @@
     (SELECT person_id,
             max(if(event = '$pageview'
                    AND event_0_latest_0 < event_0_latest_1
-                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0,
+                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0 ,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$pageview') >= 1 AS performed_event_multiple_condition_None_level_level_0_level_1_0
@@ -359,14 +359,14 @@
         HAVING max(is_deleted) = 0
         AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (((steps_0)
-          AND (performed_event_multiple_condition_None_level_level_0_level_1_0)))
+    AND (steps_0
+         AND performed_event_multiple_condition_None_level_level_0_level_1_0)
   '
 ---
 # name: TestCohortQuery.test_person
   '
   
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
   FROM
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
@@ -384,7 +384,7 @@
        AND event IN ['$pageview']
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   FULL OUTER JOIN
     (SELECT *,
             id AS person_id
@@ -394,16 +394,16 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (((performed_event_condition_None_level_level_0_level_0_0)
-          OR (has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', '')))))
+    AND (performed_event_condition_None_level_level_0_level_0_0
+         OR has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', '')))
   '
 ---
 # name: TestCohortQuery.test_person_materialized
   '
   
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
   FROM
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
@@ -421,7 +421,7 @@
        AND event IN ['$pageview']
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   FULL OUTER JOIN
     (SELECT *,
             id AS person_id
@@ -431,60 +431,10 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (((performed_event_condition_None_level_level_0_level_0_0)
-          OR (has(['test@posthog.com'], "pmat_$sample_field"))))
-  '
----
-# name: TestCohortQuery.test_person_properties_with_pushdowns
-  '
-  
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
-  FROM
-    (SELECT pdi.person_id AS person_id,
-            countIf(timestamp > now() - INTERVAL 1 day
-                    AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_0_0,
-            countIf(timestamp > now() - INTERVAL 2 week
-                    AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_1_0,
-            minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
-                               AND event = '$autocapture'))) >= now() - INTERVAL 2 week
-     AND minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
-                            AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_level_0_0
-     FROM events e
-     INNER JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2
-        WHERE team_id = 2
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-     WHERE team_id = 2
-       AND event IN ['$pageview', '$pageview', '$autocapture']
-     GROUP BY person_id) behavior_query
-  FULL OUTER JOIN
-    (SELECT *,
-            id AS person_id
-     FROM
-       (SELECT id,
-               argMax(properties, version) as person_props
-        FROM person
-        WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
-        GROUP BY id
-        HAVING max(is_deleted) = 0
-        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
-  WHERE 1 = 1
-    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
-           OR (performed_event_condition_None_level_level_0_level_0_level_1_0)
-           OR (has(['special'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
-          AND ((first_time_condition_None_level_level_0_level_1_level_0_0))))
+    AND (performed_event_condition_None_level_level_0_level_0_0
+         OR has(['test@posthog.com'], "pmat_$sample_field"))
   '
 ---
 # name: TestCohortQuery.test_person_props_only
@@ -573,17 +523,17 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person
   WHERE 1 = 1
-    AND (((id IN
-             (SELECT person_id as id
-              FROM person_static_cohort
-              WHERE cohort_id = 2
-                AND team_id = 2))))
+    AND (id IN
+           (SELECT person_id as id
+            FROM person_static_cohort
+            WHERE cohort_id = 2
+              AND team_id = 2))
   '
 ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra
   '
   
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
   FROM
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
@@ -601,7 +551,7 @@
        AND event IN ['$pageview']
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   FULL OUTER JOIN
     (SELECT *,
             id AS person_id
@@ -610,20 +560,20 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (((id IN
-             (SELECT person_id as id
-              FROM person_static_cohort
-              WHERE cohort_id = 2
-                AND team_id = 2))
-          AND (performed_event_condition_None_level_level_0_level_1_0)))
+    AND (id IN
+           (SELECT person_id as id
+            FROM person_static_cohort
+            WHERE cohort_id = 2
+              AND team_id = 2)
+         AND performed_event_condition_None_level_level_0_level_1_0)
   '
 ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra.1
   '
   
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
   FROM
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
@@ -641,7 +591,7 @@
        AND event IN ['$pageview']
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 1 week
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   FULL OUTER JOIN
     (SELECT *,
             id AS person_id
@@ -650,20 +600,20 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND ((((id IN
-              (SELECT person_id as id
-               FROM person_static_cohort
-               WHERE cohort_id = 2
-                 AND team_id = 2)))
-          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0))))
+    AND (id IN
+           (SELECT person_id as id
+            FROM person_static_cohort
+            WHERE cohort_id = 2
+              AND team_id = 2)
+         OR performed_event_condition_None_level_level_0_level_1_level_0_0)
   '
 ---
 # name: TestCohortQuery.test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts
   '
   
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
   FROM
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 7 day
@@ -684,7 +634,7 @@
        AND event IN ['$new_view', '$pageview']
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 7 day
-     GROUP BY person_id) behavior_query
+     GROUP BY person_id) funnel_query
   FULL OUTER JOIN
     (SELECT *,
             id AS person_id
@@ -693,14 +643,14 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
-           AND (id NOT IN
-                  (SELECT person_id as id
-                   FROM person_static_cohort
-                   WHERE cohort_id = 2
-                     AND team_id = 2)))
-          OR (performed_event_condition_None_level_level_0_level_1_0)))
+    AND (performed_event_condition_None_level_level_0_level_0_level_0_0
+         AND id NOT IN
+           (SELECT person_id as id
+            FROM person_static_cohort
+            WHERE cohort_id = 2
+              AND team_id = 2)
+         OR performed_event_condition_None_level_level_0_level_1_0)
   '
 ---

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -41,9 +41,9 @@
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (performed_event_condition_None_level_level_0_level_0_level_0_0
-         OR performed_event_condition_None_level_level_0_level_0_level_1_0
-         AND first_time_condition_None_level_level_0_level_1_level_0_0)
+    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
+           OR (performed_event_condition_None_level_level_0_level_0_level_1_0))
+          AND ((first_time_condition_None_level_level_0_level_1_level_0_0))))
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_another_cohort_with_event_sequence
@@ -117,8 +117,8 @@
         HAVING max(is_deleted) = 0
         AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (steps_0
-         AND steps_1)
+    AND ((((steps_0))
+          AND (steps_1)))
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_extra
@@ -159,7 +159,7 @@
         HAVING max(is_deleted) = 0
         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (performed_event_condition_None_level_level_0_level_0_0)
+    AND (((performed_event_condition_None_level_level_0_level_0_0)))
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.1
@@ -195,8 +195,8 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))
-         OR performed_event_condition_None_level_level_0_level_1_level_0_0)
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0))))
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence
@@ -243,7 +243,7 @@
              AND timestamp >= now() - INTERVAL 7 day ))
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
-    AND (steps_0)
+    AND (((steps_0)))
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence_and_clause_with_additional_event
@@ -293,8 +293,8 @@
              AND timestamp >= now() - INTERVAL 1 week ))
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
-    AND (steps_0
-         OR performed_event_multiple_condition_None_level_level_0_level_1_0)
+    AND (((steps_0)
+          OR (performed_event_multiple_condition_None_level_level_0_level_1_0)))
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence_with_person_properties
@@ -359,8 +359,8 @@
         HAVING max(is_deleted) = 0
         AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (steps_0
-         AND performed_event_multiple_condition_None_level_level_0_level_1_0)
+    AND (((steps_0)
+          AND (performed_event_multiple_condition_None_level_level_0_level_1_0)))
   '
 ---
 # name: TestCohortQuery.test_person
@@ -396,8 +396,8 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (performed_event_condition_None_level_level_0_level_0_0
-         OR has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', '')))
+    AND (((performed_event_condition_None_level_level_0_level_0_0)
+          OR (has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', '')))))
   '
 ---
 # name: TestCohortQuery.test_person_materialized
@@ -433,8 +433,58 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (performed_event_condition_None_level_level_0_level_0_0
-         OR has(['test@posthog.com'], "pmat_$sample_field"))
+    AND (((performed_event_condition_None_level_level_0_level_0_0)
+          OR (has(['test@posthog.com'], "pmat_$sample_field"))))
+  '
+---
+# name: TestCohortQuery.test_person_properties_with_pushdowns
+  '
+  
+  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
+  FROM
+    (SELECT pdi.person_id AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 day
+                    AND timestamp < now()
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_0_0,
+            countIf(timestamp > now() - INTERVAL 2 week
+                    AND timestamp < now()
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_1_0,
+            minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
+                               AND event = '$autocapture'))) >= now() - INTERVAL 2 week
+     AND minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
+                            AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_level_0_0
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND event IN ['$pageview', '$pageview', '$autocapture']
+     GROUP BY person_id) funnel_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
+        GROUP BY id
+        HAVING max(is_deleted) = 0
+        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
+  WHERE 1 = 1
+    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
+           OR (performed_event_condition_None_level_level_0_level_0_level_1_0)
+           OR (has(['special'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          AND ((first_time_condition_None_level_level_0_level_1_level_0_0))))
   '
 ---
 # name: TestCohortQuery.test_person_props_only
@@ -523,11 +573,11 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person
   WHERE 1 = 1
-    AND (id IN
-           (SELECT person_id as id
-            FROM person_static_cohort
-            WHERE cohort_id = 2
-              AND team_id = 2))
+    AND (((id IN
+             (SELECT person_id as id
+              FROM person_static_cohort
+              WHERE cohort_id = 2
+                AND team_id = 2))))
   '
 ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra
@@ -562,12 +612,12 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (id IN
-           (SELECT person_id as id
-            FROM person_static_cohort
-            WHERE cohort_id = 2
-              AND team_id = 2)
-         AND performed_event_condition_None_level_level_0_level_1_0)
+    AND (((id IN
+             (SELECT person_id as id
+              FROM person_static_cohort
+              WHERE cohort_id = 2
+                AND team_id = 2))
+          AND (performed_event_condition_None_level_level_0_level_1_0)))
   '
 ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra.1
@@ -602,12 +652,12 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (id IN
-           (SELECT person_id as id
-            FROM person_static_cohort
-            WHERE cohort_id = 2
-              AND team_id = 2)
-         OR performed_event_condition_None_level_level_0_level_1_level_0_0)
+    AND ((((id IN
+              (SELECT person_id as id
+               FROM person_static_cohort
+               WHERE cohort_id = 2
+                 AND team_id = 2)))
+          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0))))
   '
 ---
 # name: TestCohortQuery.test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts
@@ -645,12 +695,12 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (performed_event_condition_None_level_level_0_level_0_level_0_0
-         AND id NOT IN
-           (SELECT person_id as id
-            FROM person_static_cohort
-            WHERE cohort_id = 2
-              AND team_id = 2)
-         OR performed_event_condition_None_level_level_0_level_1_0)
+    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
+           AND (id NOT IN
+                  (SELECT person_id as id
+                   FROM person_static_cohort
+                   WHERE cohort_id = 2
+                     AND team_id = 2)))
+          OR (performed_event_condition_None_level_level_0_level_1_0)))
   '
 ---

--- a/posthog/clickhouse/query_fragment.py
+++ b/posthog/clickhouse/query_fragment.py
@@ -48,7 +48,7 @@ class QueryFragment:
 
     @staticmethod
     def join(by: str, fragments: Sequence[QueryFragmentLike]) -> "QueryFragment":
-        indexed = {str(key): fragment for key, fragment in enumerate(fragments)}
+        indexed = {f"k{key}": fragment for key, fragment in enumerate(fragments)}
         unformatted_sql = by.join("{" + key + "}" for key in indexed.keys())
         return QueryFragment(unformatted_sql).format(**indexed)
 
@@ -63,6 +63,9 @@ class QueryFragment:
             }
         else:
             self.params = cast(ParamsType, self._params)
+
+    def __repr__(self):
+        return f"QueryFragment({repr(self.sql)}, {repr(self.params)})"
 
 
 QF = QueryFragment

--- a/posthog/clickhouse/query_fragment.py
+++ b/posthog/clickhouse/query_fragment.py
@@ -68,9 +68,6 @@ class QueryFragment:
         return f"QueryFragment({repr(self.sql)}, {repr(self.params)})"
 
 
-QF = QueryFragment
-
-
 def reset_unique_sequence():
     global unique_sequence
     unique_sequence = itertools.count()

--- a/posthog/clickhouse/query_fragment.py
+++ b/posthog/clickhouse/query_fragment.py
@@ -1,25 +1,40 @@
+import itertools
 from dataclasses import dataclass
-from typing import Dict, Sequence, Tuple, Union
+from functools import cached_property
+from typing import Dict, Sequence, Tuple, Union, cast
 
-ParamType = Union[str, int, float, None]
-ParamsType = Dict[str, ParamType]
+ParamValueType = Union[str, int, float, None]
+ParamsType = Dict[str, ParamValueType]
 QueryFragmentLike = Union["QueryFragment", str]
+
+unique_sequence = itertools.count()
 
 
 @dataclass
+class UniqueParamName:
+    name: str
+
+    @cached_property
+    def unique_name(self):
+        return f"{self.name}::{next(unique_sequence)}"
+
+
 class QueryFragment:
     sql: str
     params: ParamsType = {}
+    _params: Dict[Union[str, UniqueParamName], ParamValueType]
 
-    def __init__(self, sql: Union[str, "QueryFragment", Tuple[str, ParamsType]], params={}):
+    def __init__(self, sql: Union[str, "QueryFragment", Tuple[Union[str, UniqueParamName], ParamsType]], params={}):
         if isinstance(sql, str):
             self.sql = sql
-            self.params = params
+            self._params = params
         elif isinstance(sql, QueryFragment):
             self.sql = sql.sql
-            self.params = sql.params
+            self._params = sql.params
         else:
-            self.sql, self.params = sql
+            self.sql, self._params = sql
+
+        self._update_sql_with_unique_param_names()
 
     def format(self, **fragments: QueryFragmentLike) -> "QueryFragment":
         new_params = {**self.params}
@@ -37,8 +52,25 @@ class QueryFragment:
         unformatted_sql = by.join("{" + key + "}" for key in indexed.keys())
         return QueryFragment(unformatted_sql).format(**indexed)
 
+    def _update_sql_with_unique_param_names(self):
+        unique_param_names = [key for key in self._params if isinstance(key, UniqueParamName)]
+
+        if len(unique_param_names) > 0:
+            self.sql = self.sql.format(**{key.name: key.unique_name for key in unique_param_names})
+            self.params = {
+                (key.unique_name if isinstance(key, UniqueParamName) else key): value
+                for key, value in self._params.items()
+            }
+        else:
+            self.params = cast(ParamsType, self._params)
+
 
 QF = QueryFragment
+
+
+def reset_unique_sequence():
+    global unique_sequence
+    unique_sequence = itertools.count()
 
 
 def _get_sql(fragment: QueryFragmentLike) -> str:

--- a/posthog/clickhouse/query_fragment.py
+++ b/posthog/clickhouse/query_fragment.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Dict, Sequence, Tuple, Union
+
+ParamType = Union[str, int, float, None]
+ParamsType = Dict[str, ParamType]
+QueryFragmentLike = Union["QueryFragment", str]
+
+
+@dataclass
+class QueryFragment:
+    sql: str
+    params: ParamsType = {}
+
+    def __init__(self, sql: Union[str, "QueryFragment", Tuple[str, ParamsType]], params={}):
+        if isinstance(sql, str):
+            self.sql = sql
+            self.params = params
+        elif isinstance(sql, QueryFragment):
+            self.sql = sql.sql
+            self.params = sql.params
+        else:
+            self.sql, self.params = sql
+
+    def format(self, **fragments: QueryFragmentLike) -> "QueryFragment":
+        new_params = {**self.params}
+        for fragment in fragments.values():
+            if isinstance(fragment, QueryFragment):
+                new_params.update(fragment.params)
+
+        return QueryFragment(
+            self.sql.format(**{key: _get_sql(fragment) for key, fragment in fragments.items()}), new_params
+        )
+
+    @staticmethod
+    def join(by: str, fragments: Sequence[QueryFragmentLike]) -> "QueryFragment":
+        indexed = {key: fragment for key, fragment in enumerate(fragments)}
+        return QueryFragment(by.join("{" + key + "}" for key in indexed.keys())).format(**indexed)
+
+
+QF = QueryFragment
+
+
+def _get_sql(fragment: QueryFragmentLike) -> str:
+    if isinstance(fragment, QueryFragment):
+        return fragment.sql
+    else:
+        return fragment

--- a/posthog/clickhouse/query_fragment.py
+++ b/posthog/clickhouse/query_fragment.py
@@ -1,9 +1,9 @@
 import itertools
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Dict, Sequence, Tuple, Union, cast
+from typing import Any, Dict, List, Sequence, Tuple, Union, cast
 
-ParamValueType = Union[str, int, float, None]
+ParamValueType = Union[str, int, float, None, List]
 ParamsType = Dict[str, ParamValueType]
 QueryFragmentLike = Union["QueryFragment", str]
 
@@ -11,7 +11,7 @@ unique_sequence = itertools.count()
 
 
 @dataclass
-class UniqueParamName:
+class UniqueParamName(str):
     name: str
 
     @cached_property
@@ -22,15 +22,15 @@ class UniqueParamName:
 class QueryFragment:
     sql: str
     params: ParamsType = {}
-    _params: Dict[Union[str, UniqueParamName], ParamValueType]
+    _params: ParamsType
 
-    def __init__(self, sql: Union[str, "QueryFragment", Tuple[Union[str, UniqueParamName], ParamsType]], params={}):
+    def __init__(self, sql: Union[str, "QueryFragment", Tuple[str, Any]], params: ParamsType = {}):
         if isinstance(sql, str):
             self.sql = sql
             self._params = params
         elif isinstance(sql, QueryFragment):
             self.sql = sql.sql
-            self._params = sql.params
+            self._params = cast(ParamsType, sql.params)
         else:
             self.sql, self._params = sql
 
@@ -62,7 +62,7 @@ class QueryFragment:
                 for key, value in self._params.items()
             }
         else:
-            self.params = cast(ParamsType, self._params)
+            self.params = self._params
 
     def __repr__(self):
         return f"QueryFragment({repr(self.sql)}, {repr(self.params)})"

--- a/posthog/clickhouse/query_fragment.py
+++ b/posthog/clickhouse/query_fragment.py
@@ -33,8 +33,9 @@ class QueryFragment:
 
     @staticmethod
     def join(by: str, fragments: Sequence[QueryFragmentLike]) -> "QueryFragment":
-        indexed = {key: fragment for key, fragment in enumerate(fragments)}
-        return QueryFragment(by.join("{" + key + "}" for key in indexed.keys())).format(**indexed)
+        indexed = {str(key): fragment for key, fragment in enumerate(fragments)}
+        unformatted_sql = by.join("{" + key + "}" for key in indexed.keys())
+        return QueryFragment(unformatted_sql).format(**indexed)
 
 
 QF = QueryFragment

--- a/posthog/clickhouse/query_fragment.py
+++ b/posthog/clickhouse/query_fragment.py
@@ -16,7 +16,7 @@ class UniqueParamName:
 
     @cached_property
     def unique_name(self):
-        return f"{self.name}::{next(unique_sequence)}"
+        return f"{self.name}_{next(unique_sequence)}"
 
 
 class QueryFragment:

--- a/posthog/clickhouse/test/test_query_fragment.py
+++ b/posthog/clickhouse/test/test_query_fragment.py
@@ -1,4 +1,4 @@
-from posthog.clickhouse.query_fragment import QueryFragment, UniqueParamName
+from posthog.clickhouse.query_fragment import QueryFragment, UniqueName
 
 
 def test_formatting_strings():
@@ -14,8 +14,8 @@ def test_formatting_other_fragments():
 
 
 def test_unique_param_name():
-    __a = UniqueParamName("__a")
-    __ab = UniqueParamName("__ab")
+    __a = UniqueName("__a")
+    __ab = UniqueName("__ab")
     assert QueryFragment("__a + __a + __ab + 3", {__a: 4, __ab: 5}) == QueryFragment(
         "__a_0 + __a_0 + __ab_1 + 3", {"__a_0": 4, "__ab_1": 5}
     )

--- a/posthog/clickhouse/test/test_query_fragment.py
+++ b/posthog/clickhouse/test/test_query_fragment.py
@@ -1,0 +1,21 @@
+from posthog.clickhouse.query_fragment import QueryFragment, UniqueParamName
+
+
+def test_formatting_strings():
+    assert QueryFragment("{a}").format(a="some_expression") == QueryFragment("some_expression")
+    assert QueryFragment("{a} + {a}").format(a="some_expression") == QueryFragment("some_expression + some_expression")
+    assert QueryFragment("%({a})s", {"key": 5}).format(a="key") == QueryFragment("%(key)s", {"key": 5})
+
+
+def test_formatting_other_fragments():
+    assert QueryFragment("{a} + {b}", {"x": 1}).format(
+        a=QueryFragment("m", {"y": 2}), b=QueryFragment("n", {"z": 3})
+    ) == QueryFragment("m + n", {"x": 1, "y": 2, "z": 3})
+
+
+def test_unique_param_name():
+    __a = UniqueParamName("__a")
+    __ab = UniqueParamName("__ab")
+    assert QueryFragment("__a + __a + __ab + 3", {__a: 4, __ab: 5}) == QueryFragment(
+        "__a_0 + __a_0 + __ab_1 + 3", {"__a_0": 4, "__ab_1": 5}
+    )

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -397,11 +397,11 @@ class FOSSCohortQuery(EventQuery):
             if isinstance(prop, PropertyGroup):
                 conditions = []
                 for idx, p in enumerate(prop.values):
-                    fragment = build_conditions(p, f"{prepend}_level_{num}", idx)  # type: ignore
+                    fragment = build_conditions(cast(Union[PropertyGroup, Property], p), f"{prepend}_level_{num}", idx)
                     if fragment.sql != "":
                         conditions.append(fragment)
 
-                return QueryFragment.join(f" {prop.type} ", conditions)
+                return QueryFragment("({condition})").format(condition=QueryFragment.join(f" {prop.type} ", conditions))
             else:
                 return self._get_condition_for_property(prop, prepend, num)
 

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -316,7 +316,7 @@ class FOSSCohortQuery(EventQuery):
         event_param_name = f"{self._cohort_pk}_event_ids"
 
         if self._should_join_behavioral_query:
-            _fields = [
+            _fields: List[QueryFragmentLike] = [
                 f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id AS person_id"
             ]
             _fields.extend(self._fields)
@@ -336,7 +336,7 @@ class FOSSCohortQuery(EventQuery):
                 """
                 SELECT {fields}
                 FROM events {alias}
-                {distinct_id_query}}
+                {distinct_id_query}
                 WHERE team_id = %(team_id)s
                 AND event IN %({event_param_name})s
                 {date_condition}
@@ -362,7 +362,7 @@ class FOSSCohortQuery(EventQuery):
     def _get_persons_query(self, prepend: str = "") -> QueryFragment:
         if self._should_join_persons:
             return QueryFragment("SELECT *, id AS person_id FROM ({person_query})").format(
-                person_query=self._person_query.get_query(prepend=prepend)
+                person_query=QueryFragment(self._person_query.get_query(prepend=prepend))
             )
         else:
             return QueryFragment("")
@@ -455,7 +455,7 @@ class FOSSCohortQuery(EventQuery):
         self._check_earliest_date((date_value, date_interval))
 
         field = QueryFragment(
-            "countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp < now() AND {entity_query}}) > 0 AS {column_name}",
+            "countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp < now() AND {entity_query}) > 0 AS {column_name}",
             {date_param: date_value},
         ).format(
             date_param=date_param,
@@ -482,7 +482,6 @@ class FOSSCohortQuery(EventQuery):
         self._check_earliest_date((date_value, date_interval))
 
         field = QueryFragment(
-            "countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp < now() AND {entity_query}}) > 0 AS {column_name}",
             """
             countIf(
                 timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp < now() AND {entity_query}

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -270,7 +270,7 @@ class FOSSCohortQuery(EventQuery):
 
     def _build_sources(self, subq: List[Tuple[QueryFragment, str]]) -> Tuple[QueryFragment, QueryFragment]:
         q = QueryFragment("")
-        filtered_queries = [(q, alias) for (q, alias) in subq if q and len(q)]
+        filtered_queries = [(sq, alias) for (sq, alias) in subq if sq.sql != ""]
 
         prev_alias: Optional[str] = None
         fields = QueryFragment("")


### PR DESCRIPTION
## Problem

ClickHouse SQL building is hard to deal with. I argue that part of the problem for us is missing abstractions: We handle params and raw sql strings separately.

This in turn leads to wonky code where params are updated implicitly in one place and sql is passed forward in another making the whole hard to debug.

When dealing with recursive property groups or other tricky filters, making sure parameter names are unique can also cause issues.

## Changes

Creates a new class `QueryFragment` which wraps the raw sql and params together.

Refactors Cohort query classes to demonstrate whether the abstraction works or not. Note that the refactoring is pretty superficial as you may see in code - a full rewrite would remove some of the clunkyness of the old code.

It also introduces `UniqueName` - when used in combination with `QueryFragment`, this helps generate unique names for parameters. :)

Depends on https://github.com/PostHog/posthog/pull/13830 to avoid introducing merge conflict hell.