### PR TITLE
chore: add plugin-server prom metrics 1/n

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -73,7 +73,7 @@
         "pino": "^8.6.0",
         "posthog-node": "2.0.2",
         "pretty-bytes": "^5.6.0",
-        "prom-client": "^14.1.0",
+        "prom-client": "^14.1.1",
         "re2": "^1.17.7",
         "safe-stable-stringify": "^2.4.0",
         "snowflake-sdk": "^1.6.10",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -81,7 +81,7 @@ specifiers:
   posthog-node: 2.0.2
   prettier: ^2.7.1
   pretty-bytes: ^5.6.0
-  prom-client: ^14.1.0
+  prom-client: ^14.1.1
   re2: ^1.17.7
   safe-stable-stringify: ^2.4.0
   snowflake-sdk: ^1.6.10
@@ -131,7 +131,7 @@ dependencies:
   pino: 8.7.0
   posthog-node: 2.0.2
   pretty-bytes: 5.6.0
-  prom-client: 14.1.0
+  prom-client: 14.1.1
   re2: 1.17.7
   safe-stable-stringify: 2.4.1
   snowflake-sdk: 1.6.15_asn1.js@5.4.1
@@ -7284,8 +7284,8 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  /prom-client/14.1.0:
-    resolution: {integrity: sha512-iFWCchQmi4170omLpFXbzz62SQTmPhtBL35v0qGEVRHKcqIeiexaoYeP0vfZTujxEq3tA87iqOdRbC9svS1B9A==}
+  /prom-client/14.1.1:
+    resolution: {integrity: sha512-hFU32q7UZQ59bVJQGUtm3I2PrJ3gWvoCkilX9sF165ks1qflhugVCeK+S1JjJYHvyt3o5kj68+q3bchormjnzw==}
     engines: {node: '>=10'}
     dependencies:
       tdigest: 0.1.2

--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node'
+import { exponentialBuckets, Histogram } from 'prom-client'
 
 import { Hub } from '../types'
 import { timeoutGuard } from '../utils/db/utils'
@@ -22,10 +23,16 @@ export async function runInstrumentedFunction<T, E>({
     const timeout = timeoutGuard(timeoutMessage, {
         event: JSON.stringify(event),
     })
+    const end = instrumentedFunctionDuration.startTimer({
+        function: statsKey,
+    })
     const timer = new Date()
     try {
-        return await func(event)
+        const result = await func(event)
+        end({ success: 'true' })
+        return result
     } catch (error) {
+        end({ success: 'false' })
         status.info('🔔', error)
         Sentry.captureException(error)
         throw error
@@ -35,3 +42,10 @@ export async function runInstrumentedFunction<T, E>({
         clearTimeout(timeout)
     }
 }
+
+const instrumentedFunctionDuration = new Histogram({
+    name: 'instrumented_function_duration_seconds',
+    help: 'Processing time and success status of internal functions',
+    labelNames: ['function', 'success'],
+    buckets: exponentialBuckets(0.025, 2, 12), // Saturates at 51 seconds
+})

--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -47,5 +47,7 @@ const instrumentedFunctionDuration = new Histogram({
     name: 'instrumented_function_duration_seconds',
     help: 'Processing time and success status of internal functions',
     labelNames: ['function', 'success'],
-    buckets: exponentialBuckets(0.025, 2, 12), // Saturates at 51 seconds
+    // We need to cover a pretty wide range, so buckets are set pretty coarse for now
+    // and cover 25ms -> 102seconds. We can revisit them later on.
+    buckets: exponentialBuckets(0.025, 4, 7),
 })


### PR DESCRIPTION
## Problem

We need to move our instrumentation to prometheus, to move to our regional grafana stacks

## Changes

- Update the `prom-client` library to latest patch
- Add `instrumented_function_duration_seconds` histogram and `kafka_protocol_errors_total` counter
- Incidentally, fix the matching of the rebalancing error, that currently goes to sentry because the error message does not match anymore

Note: metrics are not exported from the piscina workers yet, so coverage of `instrumented_function_duration_seconds` will be partial for now.

## How did you test this code?

Manual run:

```
# HELP instrumented_function_duration_seconds Processing time and success status of internal functions
# TYPE instrumented_function_duration_seconds histogram
instrumented_function_duration_seconds_bucket{le="0.025",function="kafka_queue.process_async_handlers",success="true"} 22
instrumented_function_duration_seconds_bucket{le="0.1",function="kafka_queue.process_async_handlers",success="true"} 24
instrumented_function_duration_seconds_bucket{le="0.4",function="kafka_queue.process_async_handlers",success="true"} 24
instrumented_function_duration_seconds_bucket{le="1.6",function="kafka_queue.process_async_handlers",success="true"} 24
instrumented_function_duration_seconds_bucket{le="6.4",function="kafka_queue.process_async_handlers",success="true"} 24
instrumented_function_duration_seconds_bucket{le="25.6",function="kafka_queue.process_async_handlers",success="true"} 24
instrumented_function_duration_seconds_bucket{le="102.4",function="kafka_queue.process_async_handlers",success="true"} 24
instrumented_function_duration_seconds_bucket{le="+Inf",function="kafka_queue.process_async_handlers",success="true"} 24
instrumented_function_duration_seconds_sum{function="kafka_queue.process_async_handlers",success="true"} 0.3773583790000001
instrumented_function_duration_seconds_count{function="kafka_queue.process_async_handlers",success="true"} 24
```

Could not trigger `kafka_protocol_errors_total` locally without getting plugin-server to implode. Leaving it untested
