### PR TITLE
fix: no filter defaults applied for query insights

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -174,7 +174,7 @@ class InsightBasicSerializer(TaggedItemSerializerMixin, serializers.ModelSeriali
 
         filters = instance.dashboard_filters()
 
-        if not filters.get("date_from"):
+        if not filters.get("date_from") and not instance.query:
             filters.update({"date_from": f"-{DEFAULT_DATE_FROM_DAYS}d"})
         representation["filters"] = filters
 
@@ -450,7 +450,8 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
 
         dashboard: Optional[Dashboard] = self.context.get("dashboard")
         representation["filters"] = instance.dashboard_filters(dashboard=dashboard)
-        if "insight" not in representation["filters"]:
+
+        if "insight" not in representation["filters"] and not representation["query"]:
             representation["filters"]["insight"] = "TRENDS"
 
         representation["filters_hash"] = self.insight_result(instance).cache_key

--- a/posthog/api/test/test_insight_query.py
+++ b/posthog/api/test/test_insight_query.py
@@ -76,6 +76,23 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             expected_status=status.HTTP_201_CREATED,
         )
 
+    def test_no_default_filters_on_insight_query(self) -> None:
+        _, insight_json = self.dashboard_api.create_insight(
+            {
+                "name": "Insight with persons table query",
+                "query": {
+                    "kind": "DataTableNode",
+                    "columns": ["person", "id", "created_at", "person.$delete"],
+                    "source": {
+                        "kind": "PersonsNode",
+                        "properties": [{"type": "person", "key": "$browser", "operator": "exact", "value": "Chrome"}],
+                    },
+                },
+            },
+            expected_status=status.HTTP_201_CREATED,
+        )
+        assert insight_json["filters"] == {}
+
     def test_can_save_insights_query_to_an_insight(self) -> None:
         self.dashboard_api.create_insight(
             {

--- a/posthog/api/test/test_insight_query.py
+++ b/posthog/api/test/test_insight_query.py
@@ -93,6 +93,26 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         )
         assert insight_json["filters"] == {}
 
+    def test_default_filters_on_non_query_insight(self) -> None:
+        _, insight_json = self.dashboard_api.create_insight(
+            {
+                "name": "Old-Fashioned Insight",
+                "filters": {
+                    "events": [
+                        {"id": "$pageview"},
+                    ],
+                },
+            },
+            expected_status=status.HTTP_201_CREATED,
+        )
+        assert insight_json["filters"] == {
+            "events": [
+                {"id": "$pageview"},
+            ],
+            "insight": "TRENDS",
+            "date_from": "-7d",
+        }
+
     def test_can_save_insights_query_to_an_insight(self) -> None:
         self.dashboard_api.create_insight(
             {


### PR DESCRIPTION
## Problem

Checking for empty filters is never going to work if the server is filling up the filters with defaults 🤦 

## Changes

Add defaults for filter-based insights but not for query-based insights

## How did you test this code?

added developer tests