### PR TITLE
feat(funnels): stop querying person_properties as a whole

### DIFF
--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -70,7 +70,6 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
-                           e.uuid AS uuid,
                            pdi.person_id as person_id ,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -279,7 +278,6 @@
                        FROM
                          (SELECT e.timestamp as timestamp,
                                  pdi.person_id as aggregation_target,
-                                 e.uuid AS uuid,
                                  pdi.person_id as person_id ,
                                  if(event = '$pageview', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
@@ -428,7 +426,6 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
-                           e.uuid AS uuid,
                            pdi.person_id as person_id ,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -565,7 +562,6 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
-                           e.uuid AS uuid,
                            pdi.person_id as person_id ,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -700,7 +696,6 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
-                           e.uuid AS uuid,
                            pdi.person_id as person_id ,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -36,16 +36,8 @@ class FunnelEventQuery(EventQuery):
             f"{aggregation_target} as aggregation_target",
         ]
 
-        _fields += [f"{self.EVENT_TABLE_ALIAS}.{field} AS {field}" for field in self._extra_fields]
-
         if self._using_person_on_events:
             _fields += [f"{self.EVENT_TABLE_ALIAS}.person_id as person_id"]
-
-            _fields.extend(
-                f'{self.EVENT_TABLE_ALIAS}."{column_name}" as "{column_name}"'
-                for column_name in sorted(self._column_optimizer.person_on_event_columns_to_query)
-            )
-
         else:
             if self._should_join_distinct_ids:
                 _fields += [f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id as person_id"]

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -126,7 +126,6 @@
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
-                              e.uuid AS uuid,
                               pdi.person_id as person_id ,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
@@ -306,7 +305,6 @@
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
-                              e.uuid AS uuid,
                               pdi.person_id as person_id ,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
@@ -486,7 +484,6 @@
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
-                              e.uuid AS uuid,
                               pdi.person_id as person_id ,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -86,7 +86,6 @@
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
-                        e.uuid AS uuid,
                         pdi.person_id as person_id ,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
@@ -223,7 +222,6 @@
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
-                        e.uuid AS uuid,
                         pdi.person_id as person_id ,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
@@ -360,7 +358,6 @@
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
-                        e.uuid AS uuid,
                         pdi.person_id as person_id ,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -104,7 +104,6 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
-                           e.uuid AS uuid,
                            pdi.person_id as person_id ,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -262,7 +261,6 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
-                           e.uuid AS uuid,
                            pdi.person_id as person_id ,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -421,7 +419,6 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
-                           e.uuid AS uuid,
                            pdi.person_id as person_id ,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -54,7 +54,6 @@
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
-                        e.uuid AS uuid,
                         pdi.person_id as person_id ,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
@@ -124,7 +123,6 @@
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
-                        e.uuid AS uuid,
                         pdi.person_id as person_id ,
                         if(event = 'step two', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
@@ -194,7 +192,6 @@
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
-                        e.uuid AS uuid,
                         pdi.person_id as person_id ,
                         if(event = 'step three', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,


### PR DESCRIPTION
Checking from tests and snapshots here whether this change makes sense. This should stop us from unnecessarily querying person_properties since we already figure out the steps in the innermost subquery