### PR TITLE
feat(funnels-correlation): simplify method for extracting property keys + values

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -291,7 +291,7 @@ class FunnelCorrelation:
             """
         else:
             array_join_query = f"""
-                JSONExtractKeysAndValues(properties, 'String') as prop
+                arrayJoin(JSONExtractKeysAndValues(properties, 'String')) as prop
             """
 
         query = f"""
@@ -527,7 +527,7 @@ class FunnelCorrelation:
         if "$all" in cast(list, self._filter.correlation_property_names):
             return (
                 f"""
-                JSONExtractKeysAndValues({aggregation_properties_alias}, 'String') as prop
+                arrayJoin(JSONExtractKeysAndValues({aggregation_properties_alias}, 'String')) as prop
             """,
                 {},
             )

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -292,7 +292,7 @@ class FunnelCorrelation:
             """
         else:
             array_join_query = f"""
-                arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(properties)) as prop_keys,
+                JSONExtractKeys(properties) as prop_keys,
                 arrayMap(x -> {trim_quotes_expr("JSONExtractRaw(properties, x)")}, prop_keys) as prop_values,
                 arrayJoin(arrayZip(prop_keys, prop_values)) as prop
             """
@@ -531,7 +531,7 @@ class FunnelCorrelation:
             map_expr = trim_quotes_expr(f"JSONExtractRaw({aggregation_properties_alias}, x)")
             return (
                 f"""
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw({aggregation_properties_alias})) as person_prop_keys,
+            JSONExtractKeys({aggregation_properties_alias}) as person_prop_keys,
             arrayJoin(
                 arrayZip(
                     person_prop_keys,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -1054,9 +1054,7 @@
     (SELECT actors.actor_id as actor_id,
             actors.steps as steps,
             events.event as event_name,
-            JSONExtractKeys(properties) as prop_keys,
-            arrayMap(x -> replaceRegexpAll(JSONExtractRaw(properties, x), '^"|"$', ''), prop_keys) as prop_values,
-            arrayJoin(arrayZip(prop_keys, prop_values)) as prop
+            arrayJoin(JSONExtractKeysAndValues(properties, 'String')) as prop
      FROM events AS event
      JOIN funnel_actors AS actors ON actors.actor_id = events.$group_1
      WHERE toTimeZone(toDateTime(event.timestamp), 'UTC') >= date_from
@@ -1145,9 +1143,7 @@
     (SELECT actors.actor_id as actor_id,
             actors.steps as steps,
             events.event as event_name,
-            JSONExtractKeys(properties) as prop_keys,
-            arrayMap(x -> replaceRegexpAll(JSONExtractRaw(properties, x), '^"|"$', ''), prop_keys) as prop_values,
-            arrayJoin(arrayZip(prop_keys, prop_values)) as prop
+            arrayJoin(JSONExtractKeysAndValues(properties, 'String')) as prop
      FROM events AS event
      JOIN funnel_actors AS actors ON actors.actor_id = events.$group_1
      WHERE toTimeZone(toDateTime(event.timestamp), 'UTC') >= date_from
@@ -2282,8 +2278,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
+            arrayJoin(JSONExtractKeysAndValues(groups_0.group_properties_0, 'String')) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,
@@ -2755,8 +2750,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
+            arrayJoin(JSONExtractKeysAndValues(groups_0.group_properties_0, 'String')) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,
@@ -3228,8 +3222,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
+            arrayJoin(JSONExtractKeysAndValues(groups_0.group_properties_0, 'String')) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,
@@ -3701,8 +3694,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
+            arrayJoin(JSONExtractKeysAndValues(groups_0.group_properties_0, 'String')) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -1054,7 +1054,7 @@
     (SELECT actors.actor_id as actor_id,
             actors.steps as steps,
             events.event as event_name,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(properties)) as prop_keys,
+            JSONExtractKeys(properties) as prop_keys,
             arrayMap(x -> replaceRegexpAll(JSONExtractRaw(properties, x), '^"|"$', ''), prop_keys) as prop_values,
             arrayJoin(arrayZip(prop_keys, prop_values)) as prop
      FROM events AS event
@@ -1145,7 +1145,7 @@
     (SELECT actors.actor_id as actor_id,
             actors.steps as steps,
             events.event as event_name,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(properties)) as prop_keys,
+            JSONExtractKeys(properties) as prop_keys,
             arrayMap(x -> replaceRegexpAll(JSONExtractRaw(properties, x), '^"|"$', ''), prop_keys) as prop_values,
             arrayJoin(arrayZip(prop_keys, prop_values)) as prop
      FROM events AS event
@@ -2282,7 +2282,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
+            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
             arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
      FROM funnel_actors
      INNER JOIN
@@ -2755,7 +2755,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
+            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
             arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
      FROM funnel_actors
      INNER JOIN
@@ -3228,7 +3228,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
+            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
             arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
      FROM funnel_actors
      INNER JOIN
@@ -3701,7 +3701,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
+            JSONExtractKeys(groups_0.group_properties_0) as person_prop_keys,
             arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
      FROM funnel_actors
      INNER JOIN


### PR DESCRIPTION
We do a whole bunch of stuff just to get a a 2d array with property keys and values as strings, but we can simplify it all by using `JSONExtractKeysAndValues` and force a string cast rather than using regex replace.

Proof this works as expected:

https://fiddle.clickhouse.com/da1ef638-79ba-47bf-9123-48506ce9e769


