### PR TITLE
fix(funnels): remove hidden interval from funnels insight

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -17,6 +17,7 @@ import {
     EmptyPropertyFilter,
     EventType,
     FilterLogicalOperator,
+    FunnelVizType,
     GroupActorType,
     InsightType,
     IntervalType,
@@ -46,6 +47,7 @@ import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { BehavioralFilterKey } from 'scenes/cohorts/CohortFilters/types'
 import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
 import { urls } from 'scenes/urls'
+import { isFunnelsFilter } from 'scenes/insights/sharedUtils'
 
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects
@@ -1169,6 +1171,10 @@ export const disableHourFor: Record<string, boolean> = {
 export function autocorrectInterval(filters: Partial<AnyFilterType>): IntervalType | undefined {
     if ('display' in filters && filters.display && NON_TIME_SERIES_DISPLAY_TYPES.includes(filters.display)) {
         // Non-time-series insights should not have an interval
+        return undefined
+    }
+    if (isFunnelsFilter(filters) && filters.funnel_viz_type !== FunnelVizType.Trends) {
+        // Only trend funnels support intervals
         return undefined
     }
     if (!filters.interval) {

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -87,7 +87,6 @@ export const mockInsight = {
         funnel_to_step: 1,
         funnel_viz_type: 'steps',
         insight: 'FUNNELS',
-        interval: 'day',
         layout: 'vertical',
     },
     order: null,
@@ -494,7 +493,6 @@ describe('funnelLogic', () => {
                 breakdown: undefined,
                 breakdown_type: undefined,
                 insight: 'FUNNELS',
-                interval: 'day',
             }),
             expect.anything()
         )

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -339,4 +339,29 @@ describe('cleanFilters', () => {
 
         expect(cleanedFilters).toHaveProperty('funnel_step_reference', FunnelStepReference.previous)
     })
+
+    it('removes the interval from funnels', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                insight: InsightType.FUNNELS,
+                interval: 'hour',
+            },
+            {}
+        )
+
+        expect(cleanedFilters).toHaveProperty('interval', undefined)
+    })
+
+    it('keeps the interval for trends funnels', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Trends,
+                interval: 'hour',
+            },
+            {}
+        )
+
+        expect(cleanedFilters).toHaveProperty('interval', 'hour')
+    })
 })


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/14017.

## Changes

- Adds a condition to the cleanFilters function, which removes the interval from funnels, except trends funnels.

## How did you test this code?

Verified that the request is sent correctly without interval. I couldn't repro the actual issue locally, so needs testing after it's merged.