### PR TITLE
fix: Test if a batch of 5000 works better than 500 for 'small' exports 

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -46,7 +46,7 @@ import { fetchEventsForInterval } from '../utils/fetchEventsForInterval'
 
 const TEN_MINUTES = 1000 * 60 * 10
 const TWELVE_HOURS = 1000 * 60 * 60 * 12
-export const EVENTS_PER_RUN_SMALL = 500
+export const EVENTS_PER_RUN_SMALL = 5000
 export const EVENTS_PER_RUN_BIG = 10000
 
 export const EXPORT_PARAMETERS_KEY = 'EXPORT_PARAMETERS'

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -760,7 +760,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 { plugin: { name: 'S3 Export Plugin' } } as any,
                 vm
             ).eventsPerRun
-            expect(eventsPerRun).toEqual(500)
+            expect(eventsPerRun).toEqual(5000)
 
             // Set the handlesLargeBatches flag to true and expect a big batch size
             vm.methods.getSettings = jest.fn().mockReturnValue({
@@ -782,7 +782,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 { plugin: { name: 'foo' } } as any,
                 vm
             ).eventsPerRun
-            expect(eventsPerRun).toEqual(500)
+            expect(eventsPerRun).toEqual(5000)
         })
     })
 


### PR DESCRIPTION
## Problem

S3 exports are going extremely slowly for large customers due to poor query performance. This may speed things up a bit.

changes export batch size for small batches from 500 to 5000
