### PR TITLE
chore(plugin-server): add logging when createPerson fails

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -135,6 +135,7 @@ export class PersonState {
                 this.personContainer = this.personContainer.with(person)
                 return true
             } catch (error) {
+                status.error('🚨', 'create_person_failed', { error, teamId: this.teamId, distinctId: this.distinctId })
                 if (!error.message || !error.message.includes('duplicate key value violates unique constraint')) {
                     Sentry.captureException(error, {
                         extra: {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -46,7 +46,7 @@ import { fetchEventsForInterval } from '../utils/fetchEventsForInterval'
 
 const TEN_MINUTES = 1000 * 60 * 10
 const TWELVE_HOURS = 1000 * 60 * 60 * 12
-export const EVENTS_PER_RUN_SMALL = 5000
+export const EVENTS_PER_RUN_SMALL = 500
 export const EVENTS_PER_RUN_BIG = 10000
 
 export const EXPORT_PARAMETERS_KEY = 'EXPORT_PARAMETERS'

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -760,7 +760,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 { plugin: { name: 'S3 Export Plugin' } } as any,
                 vm
             ).eventsPerRun
-            expect(eventsPerRun).toEqual(5000)
+            expect(eventsPerRun).toEqual(500)
 
             // Set the handlesLargeBatches flag to true and expect a big batch size
             vm.methods.getSettings = jest.fn().mockReturnValue({
@@ -782,7 +782,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 { plugin: { name: 'foo' } } as any,
                 vm
             ).eventsPerRun
-            expect(eventsPerRun).toEqual(5000)
+            expect(eventsPerRun).toEqual(500)
         })
     })
 


### PR DESCRIPTION
This is to help debug a problem where we're getting a lot of errors from
fetching by distinct_id.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
