### PR TITLE
feat: Added quota limiting for capture

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -15,7 +15,7 @@ class QuotaResource(Enum):
     RECORDINGS = "recordings"
 
 
-def replace_limited_teams(resource: QuotaResource, tokens: Mapping[str, int]) -> None:
+def replace_limited_team_tokens(resource: QuotaResource, tokens: Mapping[str, int]) -> None:
     pipe = get_client().pipeline()
     pipe.delete(f"{RATE_LIMITER_CACHE_KEY}{resource.value}")
     if tokens:
@@ -24,7 +24,7 @@ def replace_limited_teams(resource: QuotaResource, tokens: Mapping[str, int]) ->
 
 
 @cache_for(timedelta(seconds=30), background_refresh=True)
-def list_limited_teams(resource: QuotaResource) -> List[str]:
+def list_limited_team_tokens(resource: QuotaResource) -> List[str]:
     now = timezone.now()
     redis_client = get_client()
     results = redis_client.zrangebyscore(f"{RATE_LIMITER_CACHE_KEY}{resource.value}", min=now.timestamp(), max="+inf")

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -23,7 +23,7 @@ def replace_limited_teams(resource: QuotaResource, tokens: Mapping[str, int]) ->
     pipe.execute()
 
 
-@cache_for(timedelta(seconds=30))
+@cache_for(timedelta(seconds=5), background_refresh=True)
 def list_limited_teams(resource: QuotaResource) -> List[str]:
     now = timezone.now()
     redis_client = get_client()

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -17,7 +17,7 @@ class QuotaResource(Enum):
 
 def replace_limited_teams(resource: QuotaResource, tokens: Mapping[str, int]) -> None:
     pipe = get_client().pipeline()
-    pipe.zremrangebyscore(f"{RATE_LIMITER_CACHE_KEY}{resource.value}", "-inf", "+inf")
+    pipe.delete(f"{RATE_LIMITER_CACHE_KEY}{resource.value}")
     if tokens:
         pipe.zadd(f"{RATE_LIMITER_CACHE_KEY}{resource.value}", tokens)  # type: ignore # (zadd takes a Mapping[str, int] but the derived Union type is wrong)
     pipe.execute()

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -23,7 +23,7 @@ def replace_limited_teams(resource: QuotaResource, tokens: Mapping[str, int]) ->
     pipe.execute()
 
 
-@cache_for(timedelta(seconds=5), background_refresh=True)
+@cache_for(timedelta(seconds=30), background_refresh=True)
 def list_limited_teams(resource: QuotaResource) -> List[str]:
     now = timezone.now()
     redis_client = get_client()

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -1,0 +1,31 @@
+from datetime import timedelta
+from enum import Enum
+from typing import List, Mapping
+
+from django.utils import timezone
+
+from posthog.cache_utils import cache_for
+from posthog.redis import get_client
+
+RATE_LIMITER_CACHE_KEY = "@posthog/quota-limits/"
+
+
+class QuotaResource(Enum):
+    EVENTS = "events"
+    RECORDINGS = "recordings"
+
+
+def replace_limited_teams(resource: QuotaResource, tokens: Mapping[str, int]) -> None:
+    pipe = get_client().pipeline()
+    pipe.zremrangebyscore(f"{RATE_LIMITER_CACHE_KEY}{resource.value}", "-inf", "+inf")
+    if tokens:
+        pipe.zadd(f"{RATE_LIMITER_CACHE_KEY}{resource.value}", tokens)  # type: ignore # (zadd takes a Mapping[str, int] but the derived Union type is wrong)
+    pipe.execute()
+
+
+@cache_for(timedelta(seconds=30))
+def list_limited_teams(resource: QuotaResource) -> List[str]:
+    now = timezone.now()
+    redis_client = get_client()
+    results = redis_client.zrangebyscore(f"{RATE_LIMITER_CACHE_KEY}{resource.value}", min=now.timestamp(), max="+inf")
+    return [x.decode("utf-8") for x in results]

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -228,7 +228,7 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
                     continue
 
         elif token in limited_tokens_events:
-            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="recordings", token=token).inc()
+            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="events", token=token).inc()
             if settings.QUOTA_LIMITING_ENABLED:
                 continue
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -45,8 +45,8 @@ SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 
 
 EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
-    "events_dropped_over_quota",
-    "Dropped requests due to quota-limiting, per resource, and team token.",
+    "capture_events_dropped_over_quota",
+    "Events dropped by capture due to quota-limiting, per resource, and team token.",
     labelnames=["resource", "token"],
 )
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -222,7 +222,6 @@ def drop_events_over_quota(
     limited_tokens_recordings = list_limited_team_tokens(QuotaResource.RECORDINGS)
     team_id = ingestion_context.team_id if ingestion_context else None
 
-
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             if token in limited_tokens_recordings:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -46,8 +46,8 @@ SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 
 EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
     "capture_events_dropped_over_quota",
-    "Events dropped by capture due to quota-limiting, per resource, and team token.",
-    labelnames=["resource", "token"],
+    "Events dropped by capture due to quota-limiting, per resource, team and token.",
+    labelnames=["resource", "token", "team"],
 )
 
 
@@ -209,7 +209,9 @@ def _ensure_web_feature_flags_in_properties(
                 event["properties"][f"$feature/{k}"] = v
 
 
-def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
+def drop_events_over_quota(
+    token: str, events: List[Any], ingestion_context: Optional[EventIngestionContext]
+) -> List[Any]:
     if not settings.EE_AVAILABLE:
         return events
 
@@ -218,16 +220,17 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     results = []
     limited_tokens_events = list_limited_teams(QuotaResource.EVENTS)
     limited_tokens_recordings = list_limited_teams(QuotaResource.RECORDINGS)
+    team_id = ingestion_context.team_id if ingestion_context else None
 
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             if token in limited_tokens_recordings:
-                EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="recordings", token=token).inc()
+                EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="recordings", token=token, team=team_id).inc()
                 if settings.QUOTA_LIMITING_ENABLED:
                     continue
 
         elif token in limited_tokens_events:
-            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="events", token=token).inc()
+            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="events", token=token, team=team_id).inc()
             if settings.QUOTA_LIMITING_ENABLED:
                 continue
 
@@ -299,7 +302,7 @@ def get_event(request):
             events = [data]
 
         try:
-            events = drop_events_over_quota(token, events)
+            events = drop_events_over_quota(token, events, ingestion_context)
         except Exception as e:
             # NOTE: Whilst we are testing this code we want to track exceptions but allow the events through if anything goes wrong
             capture_exception(e)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -208,7 +208,6 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     from ee.billing.quota_limiting import QuotaResource, list_limited_teams
 
     results = []
-    # TODO: these function calls should have a timeout wrapper
     limited_tokens_events = list_limited_teams(QuotaResource.EVENTS)
     limited_tokens_recordings = list_limited_teams(QuotaResource.RECORDINGS)
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -46,8 +46,8 @@ SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 
 EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
     "capture_events_dropped_over_quota",
-    "Events dropped by capture due to quota-limiting, per resource, team and token.",
-    labelnames=["resource", "token", "team"],
+    "Events dropped by capture due to quota-limiting, per resource_type, team_id and token.",
+    labelnames=["resource_type", "team_id", "token"],
 )
 
 
@@ -225,12 +225,12 @@ def drop_events_over_quota(
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             if token in limited_tokens_recordings:
-                EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="recordings", token=token, team=team_id).inc()
+                EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="recordings", team_id=team_id, token=token).inc()
                 if settings.QUOTA_LIMITING_ENABLED:
                     continue
 
         elif token in limited_tokens_events:
-            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="events", token=token, team=team_id).inc()
+            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="events", team=team_id, token=token).inc()
             if settings.QUOTA_LIMITING_ENABLED:
                 continue
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -42,6 +42,14 @@ logger = structlog.get_logger(__name__)
 # fewer restrictions on e.g. the order they need to be processed in.
 SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 
+from prometheus_client import Counter
+
+EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
+    "events_dropped_over_quota",
+    "Dropped requests due to quota-limiting, per resource, and team token.",
+    labelnames=["resource", "token"],
+)
+
 
 def parse_kafka_event_data(
     distinct_id: str,
@@ -214,13 +222,13 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             if token in limited_tokens_recordings:
-                statsd.incr("events_dropped_over_quota", tags={"resource": "recordings", "token": token})
+                EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="recordings", token=token).inc()
 
                 if settings.QUOTA_LIMITING_ENABLED:
                     continue
 
         elif token in limited_tokens_events:
-            statsd.incr("events_dropped_over_quota", tags={"resource": "events", "token": token})
+            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="recordings", token=token).inc()
             if settings.QUOTA_LIMITING_ENABLED:
                 continue
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -212,7 +212,6 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     limited_tokens_events = list_limited_teams(QuotaResource.EVENTS)
     limited_tokens_recordings = list_limited_teams(QuotaResource.RECORDINGS)
 
-    print("wat", settings.QUOTA_LIMITING_ENABLED)
     for event in events:
         if event.get("event") == "$snapshot":
             if token in limited_tokens_recordings:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -292,7 +292,11 @@ def get_event(request):
         else:
             events = [data]
 
-        events = drop_events_over_quota(token, events)
+        try:
+            events = drop_events_over_quota(token, events)
+        except Exception as e:
+            # NOTE: Whilst we are testing this code we want to track exceptions but allow the events through if anything goes wrong
+            capture_exception(e)
 
         try:
             events = preprocess_session_recording_events_for_clickhouse(events)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -215,12 +215,13 @@ def drop_events_over_quota(
     if not settings.EE_AVAILABLE:
         return events
 
-    from ee.billing.quota_limiting import QuotaResource, list_limited_teams
+    from ee.billing.quota_limiting import QuotaResource, list_limited_team_tokens
 
     results = []
-    limited_tokens_events = list_limited_teams(QuotaResource.EVENTS)
-    limited_tokens_recordings = list_limited_teams(QuotaResource.RECORDINGS)
+    limited_tokens_events = list_limited_team_tokens(QuotaResource.EVENTS)
+    limited_tokens_recordings = list_limited_team_tokens(QuotaResource.RECORDINGS)
     team_id = ingestion_context.team_id if ingestion_context else None
+
 
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
@@ -230,7 +231,7 @@ def drop_events_over_quota(
                     continue
 
         elif token in limited_tokens_events:
-            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="events", team=team_id, token=token).inc()
+            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="events", team_id=team_id, token=token).inc()
             if settings.QUOTA_LIMITING_ENABLED:
                 continue
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -212,7 +212,7 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     limited_tokens_recordings = list_limited_teams(QuotaResource.RECORDINGS)
 
     for event in events:
-        if event.get("event") == "$snapshot":
+        if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             if token in limited_tokens_recordings:
                 statsd.incr("events_dropped_over_quota", tags={"resource": "recordings", "token": token})
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from kafka.errors import KafkaError
 from kafka.producer.future import FutureRecordMetadata
+from prometheus_client import Counter
 from rest_framework import status
 from sentry_sdk import configure_scope
 from sentry_sdk.api import capture_exception, start_span
@@ -42,7 +43,6 @@ logger = structlog.get_logger(__name__)
 # fewer restrictions on e.g. the order they need to be processed in.
 SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 
-from prometheus_client import Counter
 
 EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
     "events_dropped_over_quota",

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -223,7 +223,6 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             if token in limited_tokens_recordings:
                 EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource="recordings", token=token).inc()
-
                 if settings.QUOTA_LIMITING_ENABLED:
                     continue
 

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -128,8 +128,8 @@
                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['user did things', 'user signed up']
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-25 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-02-01 23:59:59', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-26 00:00:00', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-02-02 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -128,8 +128,8 @@
                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['user did things', 'user signed up']
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-24 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-01-31 23:59:59', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-25 00:00:00', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-02-01 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -128,8 +128,8 @@
                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['user did things', 'user signed up']
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-26 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-02-02 23:59:59', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-27 00:00:00', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-02-03 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, call, patch
 from urllib.parse import quote
 
 import lzstring
+import pytest
 from django.db import DEFAULT_DB_ALIAS
 from django.db import Error as DjangoDatabaseError
 from django.db import connections
@@ -1383,3 +1384,51 @@ class TestCapture(BaseTest):
             },
             event_data,
         )
+
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    @pytest.mark.ee
+    def test_quota_limits_ignored_if_disabled(self, kafka_produce) -> None:
+        from ee.billing.quota_limiting import QuotaResource, replace_limited_teams
+
+        replace_limited_teams(QuotaResource.RECORDINGS, {self.team.api_token: timezone.now().timestamp() + 10000})
+        replace_limited_teams(QuotaResource.EVENTS, {self.team.api_token: timezone.now().timestamp() + 10000})
+        self._send_session_recording_event()
+        self.assertEqual(kafka_produce.call_count, 1)
+
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    @pytest.mark.ee
+    def test_quota_limits(self, kafka_produce) -> None:
+        from ee.billing.quota_limiting import QuotaResource, replace_limited_teams
+
+        def _produce_events():
+            kafka_produce.reset_mock()
+            self._send_session_recording_event()
+            self.client.post(
+                "/e/",
+                data={
+                    "data": json.dumps(
+                        [
+                            {"event": "beep", "properties": {"distinct_id": "eeee", "token": self.team.api_token}},
+                            {"event": "boop", "properties": {"distinct_id": "aaaa", "token": self.team.api_token}},
+                        ]
+                    ),
+                    "api_key": self.team.api_token,
+                },
+            )
+
+        with self.settings(QUOTA_LIMITING_ENABLED=True):
+            _produce_events()
+            self.assertEqual(kafka_produce.call_count, 3)
+
+            replace_limited_teams(QuotaResource.EVENTS, {self.team.api_token: timezone.now().timestamp() + 10000})
+            _produce_events()
+            self.assertEqual(kafka_produce.call_count, 1)  # Only the recording event
+
+            replace_limited_teams(QuotaResource.RECORDINGS, {self.team.api_token: timezone.now().timestamp() + 10000})
+            _produce_events()
+            self.assertEqual(kafka_produce.call_count, 0)  # No events
+
+            replace_limited_teams(QuotaResource.RECORDINGS, {self.team.api_token: timezone.now().timestamp() - 10000})
+            replace_limited_teams(QuotaResource.EVENTS, {self.team.api_token: timezone.now().timestamp() - 10000})
+            _produce_events()
+            self.assertEqual(kafka_produce.call_count, 3)  # All events as limit-until timestamp is in the past

--- a/posthog/cache_utils.py
+++ b/posthog/cache_utils.py
@@ -20,9 +20,13 @@ def cache_for(cache_time: timedelta, background_refresh=False):
             key = (args, frozenset(sorted(kwargs.items())))
 
             def refresh():
-                value = fn(*args, **kwargs)
-                memoized_fn._cache[key] = (now(), value)
-                memoized_fn._refreshing[key] = None
+                try:
+                    value = fn(*args, **kwargs)
+                    memoized_fn._cache[key] = (now(), value)
+                    memoized_fn._refreshing[key] = None
+                except Exception:
+                    memoized_fn._refreshing[key] = None
+                    raise
 
             if key not in memoized_fn._cache:
                 refresh()

--- a/posthog/cache_utils.py
+++ b/posthog/cache_utils.py
@@ -1,6 +1,6 @@
+import threading
 from datetime import timedelta
 from functools import wraps
-import threading
 from typing import no_type_check
 
 from django.utils.timezone import now
@@ -20,7 +20,8 @@ def cache_for(cache_time: timedelta, background_refresh=False):
             key = (args, frozenset(sorted(kwargs.items())))
 
             def refresh():
-                memoized_fn._cache[key] = (current_time, fn(*args, **kwargs))
+                value = fn(*args, **kwargs)
+                memoized_fn._cache[key] = (now(), value)
                 memoized_fn._refreshing[key] = None
 
             if key not in memoized_fn._cache:

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -1,6 +1,7 @@
 import os
 
 from posthog.settings.utils import get_from_env, get_list
+from posthog.utils import str_to_bool
 
 INGESTION_LAG_METRIC_TEAM_IDS = get_list(os.getenv("INGESTION_LAG_METRIC_TEAM_IDS", ""))
 
@@ -17,3 +18,5 @@ LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS = get_list(os.getenv("LIGHTWEIGHT_CA
 
 # Keep in sync with plugin-server
 EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC = "events_added_to_dead_letter_queue"
+
+QUOTA_LIMITING_ENABLED = get_from_env("QUOTA_LIMITING_ENABLED", False, type_cast=str_to_bool)

--- a/posthog/test/test_cache_utils.py
+++ b/posthog/test/test_cache_utils.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from time import sleep
 from typing import Optional
 from unittest.mock import Mock
 
@@ -8,28 +9,87 @@ from posthog.test.base import APIBaseTest
 mocked_dependency = Mock()
 mocked_dependency.return_value = 1
 
+order_of_events = Mock(side_effect=lambda x: print(x))
+
 
 @cache_for(timedelta(seconds=1))
-def test_func(number: Optional[int] = None) -> int:
+def fn(number: Optional[int] = None) -> int:
     return mocked_dependency(number)
+
+
+@cache_for(timedelta(milliseconds=200), background_refresh=True)
+def fn_background(number: float) -> int:
+    order_of_events("Background task started")
+    value = mocked_dependency()
+    mocked_dependency.return_value += 1
+    sleep(number)
+
+    order_of_events("Background task finished")
+    return value
 
 
 class TestCacheUtils(APIBaseTest):
     def setUp(self):
         mocked_dependency.reset_mock()
+        mocked_dependency.return_value = 1
+        order_of_events.reset_mock()
 
     def test_cache_for_with_different_passed_arguments_styles_when_skipping_cache(self) -> None:
-        assert 1 == test_func(use_cache=False)
-        assert 1 == test_func(2, use_cache=False)
-        assert 1 == test_func(number=2, use_cache=False)
-        assert 1 == test_func(number=2, use_cache=False)
+        assert 1 == fn(use_cache=False)
+        assert 1 == fn(2, use_cache=False)
+        assert 1 == fn(number=2, use_cache=False)
+        assert 1 == fn(number=2, use_cache=False)
 
         assert mocked_dependency.call_count == 4
 
     def test_cache_for_with_different_passed_arguments_styles_when_caching(self) -> None:
-        assert 1 == test_func(2, use_cache=True)
-        assert 1 == test_func(number=2, use_cache=True)
-        assert 1 == test_func(number=2, use_cache=True)
+        assert 1 == fn(2, use_cache=True)
+        assert 1 == fn(number=2, use_cache=True)
+        assert 1 == fn(number=2, use_cache=True)
 
-        # cache treats test_func(2) and test_func(number=2) as two different calls
+        # cache treats fn(2) and fn(number=2) as two different calls
         assert mocked_dependency.call_count == 2
+
+    def test_background_cache_refresh(self) -> None:
+        # First call is not cached and as such takes some time
+        assert mocked_dependency.call_count == 0
+
+        order_of_events("Inital call 1")
+        assert 1 == fn_background(1, use_cache=True)
+        assert mocked_dependency.call_count == 1
+
+        order_of_events("Inital call 2")
+        assert 1 == fn_background(1, use_cache=True)
+        assert mocked_dependency.call_count == 1
+
+        order_of_events("Inital call 3")
+        assert 1 == fn_background(1, use_cache=True)
+        assert mocked_dependency.call_count == 1
+
+        # Let the cache timer expire so we trigger a background refresh
+        sleep(0.3)
+        assert mocked_dependency.call_count == 1  # but we know the cache is being refreshed
+        order_of_events("Expired call 1")
+        assert 1 == fn_background(1, use_cache=True)  # old return value
+
+        # Let the cache timer expire again...
+        sleep(0.5)
+        order_of_events("Expired call 2")
+        assert 1 == fn_background(1, use_cache=True)  # we still get the old return value
+
+        sleep(0.5)  # Let the refresh complete
+        order_of_events("Post refresh call 1")
+        assert 2 == fn_background(1, use_cache=True)  # We get the new return value
+
+        assert [x[0][0] for x in order_of_events.call_args_list] == [
+            "Inital call 1",
+            "Background task started",
+            "Background task finished",
+            "Inital call 2",
+            "Inital call 3",
+            "Expired call 1",
+            "Background task started",
+            "Expired call 2",
+            "Background task finished",
+            "Post refresh call 1",
+        ]

--- a/posthog/test/test_cache_utils.py
+++ b/posthog/test/test_cache_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from time import sleep
 from typing import Optional
 from unittest.mock import Mock
@@ -9,7 +9,7 @@ from posthog.test.base import APIBaseTest
 mocked_dependency = Mock()
 mocked_dependency.return_value = 1
 
-order_of_events = Mock(side_effect=lambda x: print(x))
+order_of_events = Mock(side_effect=lambda x: print(x))  # noqa T201
 
 
 @cache_for(timedelta(seconds=1))

--- a/posthog/test/test_cache_utils.py
+++ b/posthog/test/test_cache_utils.py
@@ -77,7 +77,7 @@ class TestCacheUtils(APIBaseTest):
         order_of_events("Expired call 2")
         assert 1 == fn_background(1, use_cache=True)  # we still get the old return value
 
-        sleep(0.5)  # Let the refresh complete
+        sleep(0.6)  # Let the refresh complete
         order_of_events("Post refresh call 1")
         assert 2 == fn_background(1, use_cache=True)  # We get the new return value
 


### PR DESCRIPTION
## Problem

Pre-requisite PR for https://github.com/PostHog/posthog/pull/13521 just focusing on the actual event dropping part, _not_ the logic to decide when to add a team to the limited list

## Changes

* Adds a filter check to the capture endpoint to filter out any events that are associated with the token for rate limited teams
* This should result in a request to Redis every 30 seconds to refresh the lists. As this is adding a read call to the capture path I definitely would appreciate keen 👀  on that part of the code

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* Tests