### PR TITLE
feat(time-to-see): overview of session in trace view

### DIFF
--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -2214,3 +2214,14 @@ export function IconRobot(props: LemonIconProps): JSX.Element {
         </LemonIconBase>
     )
 }
+
+export function IconSad(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <path
+                fill="currentColor"
+                d="M20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12M22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12M15.5,8C16.3,8 17,8.7 17,9.5C17,10.3 16.3,11 15.5,11C14.7,11 14,10.3 14,9.5C14,8.7 14.7,8 15.5,8M10,9.5C10,10.3 9.3,11 8.5,11C7.7,11 7,10.3 7,9.5C7,8.7 7.7,8 8.5,8C9.3,8 10,8.7 10,9.5M12,14C13.75,14 15.29,14.72 16.19,15.81L14.77,17.23C14.32,16.5 13.25,16 12,16C10.75,16 9.68,16.5 9.23,17.23L7.81,15.81C8.71,14.72 10.25,14 12,14Z"
+            />
+        </LemonIconBase>
+    )
+}

--- a/frontend/src/queries/nodes/TimeToSeeData/TimeToSeeData.tsx
+++ b/frontend/src/queries/nodes/TimeToSeeData/TimeToSeeData.tsx
@@ -5,6 +5,8 @@ import { NodeKind, TimeToSeeDataNode } from '~/queries/schema'
 import { useValues } from 'kea'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
+import { Trace } from './Trace/Trace'
+import { TimeToSeeSessionNode } from './types'
 
 let uniqueNode = 0
 
@@ -41,7 +43,7 @@ export function TimeToSeeData(props: { query: TimeToSeeDataNode }): JSX.Element 
                     )}
                 </AutoSizer>
             ) : (
-                <>trace placeholder</>
+                <Trace timeToSeeSession={response as TimeToSeeSessionNode} />
             )}
         </>
     )

--- a/frontend/src/queries/nodes/TimeToSeeData/Trace/Trace.tsx
+++ b/frontend/src/queries/nodes/TimeToSeeData/Trace/Trace.tsx
@@ -1,0 +1,217 @@
+import { Tooltip } from 'antd'
+import clsx from 'clsx'
+import { BindLogic, useValues } from 'kea'
+import { getSeriesColor } from 'lib/colors'
+import { TZLabel } from 'lib/components/TZLabel'
+import { AlertMessage } from 'lib/lemon-ui/AlertMessage'
+import { IconSad } from 'lib/lemon-ui/icons'
+import { humanFriendlyDuration, humanFriendlyMilliseconds } from 'lib/utils'
+import { RefCallback, useEffect, useState } from 'react'
+import useResizeObserver from 'use-resize-observer'
+import { isInteractionNode, isQueryNode, isSessionNode, TimeToSeeNode, TimeToSeeSessionNode } from '../types'
+import { sessionNodeFacts, SpanData, traceLogic } from './traceLogic'
+
+export interface TraceProps {
+    timeToSeeSession: TimeToSeeSessionNode
+}
+
+export interface SpanProps {
+    maxSpan: number
+    durationContainerWidth: number | undefined
+    spanData: SpanData
+    widthTrackingRef?: RefCallback<HTMLElement>
+    onClick: (s: SpanData) => void
+    parentStart?: number
+}
+
+function SpanBar({
+    spanData,
+    maxSpan,
+    parentStart,
+}: Pick<SpanProps, 'spanData' | 'maxSpan' | 'parentStart'>): JSX.Element {
+    console.log('span bar with max span', maxSpan, 'and span data', spanData)
+    const [durationWidth, setDurationWidth] = useState<number>(0)
+    const [startMargin, setStartMargin] = useState<number>(0)
+
+    useEffect(() => {
+        const nextDurationWidth = (spanData.duration / maxSpan) * 100
+        const nextStartMargin = ((spanData.start - (parentStart || 0)) / maxSpan) * 100
+        if (nextDurationWidth != durationWidth) {
+            setDurationWidth(nextDurationWidth)
+        }
+        if (nextStartMargin !== startMargin) {
+            setStartMargin(nextStartMargin)
+        }
+    }, [spanData, maxSpan])
+
+    return (
+        <div className={clsx('h-full flex relative flex-row')}>
+            <div
+                /* eslint-disable-next-line react/forbid-dom-props */
+                style={{
+                    backgroundColor: getSeriesColor(spanData.depth),
+                    width: `${durationWidth}%`,
+                    marginLeft: `${startMargin}%`,
+                }}
+                className={'text-white pl-1'}
+            >
+                <span>{humanFriendlyMilliseconds(spanData.duration)}</span>
+            </div>
+        </div>
+    )
+}
+
+function DescribeSpan({ node }: { node: TimeToSeeNode }): JSX.Element {
+    const isFrustratingSession = isSessionNode(node) && node.data.frustrating_interactions_count > 0
+    const hasIsFrustrating = isInteractionNode(node) || isQueryNode(node)
+    const isFrustratingInteraction = hasIsFrustrating && !!node.data.is_frustrating
+    return (
+        <div className={clsx('flex flex-row items-center gap-2')}>
+            {isSessionNode(node) ? 'session' : null}
+
+            {(isFrustratingSession || isFrustratingInteraction) && (
+                <Tooltip title={'This was frustrating because it took longer than 5 seconds'}>
+                    <IconSad />
+                </Tooltip>
+            )}
+            {isInteractionNode(node) && (
+                <>
+                    <div>
+                        {node.data.type}
+                        {node.data.action && <> - {node.data.action}</>}
+                    </div>
+                </>
+            )}
+            {isQueryNode(node) && (
+                <>
+                    query
+                    {node.data.query_type && <> - {node.data.query_type}</>}
+                </>
+            )}
+        </div>
+    )
+}
+
+function SpanBarWrapper(props: {
+    ref: RefCallback<HTMLElement> | undefined
+    durationContainerWidth: number | undefined
+    maxSpan: number
+    spanData: SpanData
+    parentStart?: number
+}): JSX.Element {
+    return (
+        <div
+            ref={props.ref}
+            className={'grow self-center'}
+            /* eslint-disable-next-line react/forbid-dom-props */
+            style={{
+                width: props.durationContainerWidth || '100%',
+            }}
+        >
+            <SpanBar maxSpan={props.maxSpan} spanData={props.spanData} parentStart={props.parentStart} />
+        </div>
+    )
+}
+
+function NodeFacts({ facts }: { facts: Record<string, any> }): JSX.Element {
+    return (
+        <div className={clsx('w-full border px-2 py-1 flex flex-col justify-between')}>
+            {Object.entries(facts)
+                .filter((entry) => entry[1] !== undefined && entry[1] !== '')
+                .map(([key, fact], index) => {
+                    return (
+                        <div key={index} className={'flex flex-row w-full overflow-auto whitespace-nowrap'}>
+                            <strong>{key}:</strong> <span>{fact}</span>
+                        </div>
+                    )
+                })}
+        </div>
+    )
+}
+
+function TraceOverview({
+    timeToSeeSession,
+    processedSpans,
+    parentSpanWidth,
+    parentSpanRef,
+}: {
+    processedSpans: SpanData[]
+    timeToSeeSession: TimeToSeeSessionNode
+    parentSpanRef: RefCallback<HTMLElement>
+    parentSpanWidth: number | undefined
+}): JSX.Element {
+    const { maxTimePoint } = useValues(traceLogic)
+    return (
+        <>
+            <div className={'flex flex-col gap-2 border rounded p-4'}>
+                <NodeFacts facts={sessionNodeFacts(timeToSeeSession)} />
+                <h1 className="mb-0">Session Interactions</h1>
+                <AlertMessage type="info">
+                    During sessions we capture metrics as "Interactions". Interactions can contain events and queries.
+                    Any interaction, event, or query that takes longer than 5 seconds is classified as frustrating.
+                    {/* Click on an interaction below to see more details. */}
+                </AlertMessage>
+                <div>
+                    {processedSpans
+                        .filter((spanData) => ['interaction', 'session'].includes(spanData.type))
+                        .map((spanData, i) => {
+                            console.log('processing span', spanData)
+                            let ref = undefined
+                            if (spanData.type === 'session') {
+                                ref = parentSpanRef
+                            }
+
+                            return (
+                                <div key={i}>
+                                    <div
+                                        className={clsx(
+                                            'w-full border px-2 py-1 flex flex-row justify-between',
+                                            `Span__${spanData.type}`
+                                        )}
+                                    >
+                                        <div className={'w-100 relative flex flex-row gap-2'}>
+                                            {spanData.data && <DescribeSpan node={spanData.data} />}
+                                        </div>
+                                        <SpanBarWrapper
+                                            ref={ref}
+                                            // don't set duration container width back onto the element that is generating it
+                                            durationContainerWidth={!!ref ? undefined : parentSpanWidth}
+                                            maxSpan={maxTimePoint}
+                                            spanData={spanData}
+                                        />
+                                    </div>
+                                </div>
+                            )
+                        })}
+                </div>
+            </div>
+        </>
+    )
+}
+
+export function Trace({ timeToSeeSession }: TraceProps): JSX.Element {
+    const { ref: parentSpanRef, width: parentSpanWidth } = useResizeObserver()
+
+    const logic = traceLogic({ sessionNode: timeToSeeSession })
+    const { processedSpans } = useValues(logic)
+
+    return (
+        <BindLogic logic={traceLogic} props={{ sessionNode: timeToSeeSession }}>
+            <div className={'flex flex-col gap-1 border rounded p-4'}>
+                <h2>{timeToSeeSession.data.session_id}</h2>
+                <div>
+                    session length: {humanFriendlyDuration(timeToSeeSession.data.total_interaction_time_to_see_data_ms)}
+                </div>
+                <div>
+                    session start: <TZLabel time={timeToSeeSession.data.session_start} />
+                </div>
+                <TraceOverview
+                    parentSpanRef={parentSpanRef}
+                    parentSpanWidth={parentSpanWidth}
+                    processedSpans={processedSpans}
+                    timeToSeeSession={timeToSeeSession}
+                />
+            </div>
+        </BindLogic>
+    )
+}

--- a/frontend/src/queries/nodes/TimeToSeeData/Trace/traceLogic.tsx
+++ b/frontend/src/queries/nodes/TimeToSeeData/Trace/traceLogic.tsx
@@ -1,0 +1,114 @@
+import { kea, key, path, props, selectors } from 'kea'
+import { dayjs } from 'lib/dayjs'
+import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
+import { humanFriendlyMilliseconds } from 'lib/utils'
+import {
+    isSessionNode,
+    TimeToSeeInteractionNode,
+    TimeToSeeNode,
+    TimeToSeeQueryNode,
+    TimeToSeeSessionNode,
+} from '../types'
+
+import type { traceLogicType } from './traceLogicType'
+
+export interface TraceLogicProps {
+    sessionNode: TimeToSeeSessionNode
+}
+
+export function sessionNodeFacts(node: TimeToSeeNode): Record<string, JSX.Element | string | number> {
+    return isSessionNode(node)
+        ? {
+              type: 'session',
+              session_id: node.data.session_id,
+              user: <ProfilePicture name={node.data.user.first_name} email={node.data.user.email} showName size="sm" />,
+              duration: humanFriendlyMilliseconds(node.data.duration_ms) || 'unknown',
+              sessionEventCount: node.data.events_count,
+              frustratingInteractions: node.data.frustrating_interactions_count,
+          }
+        : {}
+}
+
+export interface SpanData {
+    id: string // not provided by backend
+    type: 'session' | 'interaction' | 'event' | 'query' | 'subquery'
+    start: number // milliseconds after session start
+    duration: number
+    data: TimeToSeeNode
+    depth?: number
+    children: SpanData[]
+}
+
+export function getDurationMs(node: TimeToSeeNode): number {
+    switch (node.type) {
+        case 'session':
+            return node.data.duration_ms
+        case 'interaction':
+        case 'event':
+            return node.data.time_to_see_data_ms
+        case 'query':
+        case 'subquery':
+            return node.data.query_duration_ms
+    }
+}
+
+function walkSpans(
+    nodes: Array<TimeToSeeInteractionNode | TimeToSeeQueryNode>,
+    sessionStart: dayjs.Dayjs,
+    level: number = 1
+): SpanData[] {
+    const spanData: SpanData[] = []
+
+    nodes.forEach((node, index) => {
+        const walkedChildren = walkSpans(node.children, sessionStart, level++)
+
+        const start = dayjs(node.data.timestamp).diff(sessionStart)
+        const duration = getDurationMs(node)
+        spanData.push({
+            id: `${node.type}-${level}-${index}`,
+            type: node.type,
+            start: start,
+            duration: duration,
+            data: node,
+            depth: level,
+            children: walkedChildren,
+        })
+    })
+
+    return spanData
+}
+
+function flattenSpans(timeToSeeSession: TimeToSeeSessionNode): SpanData[] {
+    const walkedChildren = walkSpans(timeToSeeSession.children, dayjs(timeToSeeSession.data.session_start))
+    walkedChildren.unshift({
+        id: timeToSeeSession.data.session_id,
+        type: 'session',
+        start: 0,
+        duration: getDurationMs(timeToSeeSession),
+        data: timeToSeeSession,
+        children: [], // the session's children are shown separately
+    })
+
+    return walkedChildren
+}
+
+export const traceLogic = kea<traceLogicType>([
+    path(['queries', 'nodes', 'TimeToSeeData', 'Trace', 'traceLogic']),
+    props({} as TraceLogicProps),
+    key((props) => props?.sessionNode?.data.session_id || 'pre-init'),
+    selectors(() => ({
+        processedSpans: [() => [(_, props) => props.sessionNode], (sessionNode) => flattenSpans(sessionNode)],
+        maxTimePoint: [
+            (selectors) => [selectors.processedSpans],
+            (processedSpans) => {
+                // the session span duration isn't always the longest value even though it _should_ be
+                // for now make the display make sense and then we can fix the data / parse it more correctly
+                let max = 0
+                for (const span of processedSpans) {
+                    max = Math.max(max, span.start + span.duration)
+                }
+                return max
+            },
+        ],
+    })),
+])

--- a/frontend/src/queries/nodes/TimeToSeeData/types.ts
+++ b/frontend/src/queries/nodes/TimeToSeeData/types.ts
@@ -1,26 +1,29 @@
+import { UserBasicType } from '~/types'
+
 export type TimeToSeeNode = TimeToSeeSessionNode | TimeToSeeInteractionNode | TimeToSeeQueryNode
 
-interface TimeToSeeSessionNode {
+export interface TimeToSeeSessionNode {
     type: 'session'
     data: SessionData
-    children: Array<TimeToSeeNode>
+    children: Array<TimeToSeeInteractionNode | TimeToSeeQueryNode>
 }
 
-interface TimeToSeeInteractionNode {
+export interface TimeToSeeInteractionNode {
     type: 'interaction' | 'event'
     data: InteractionData
-    children: Array<TimeToSeeNode>
+    children: Array<TimeToSeeInteractionNode | TimeToSeeQueryNode>
 }
 
-interface TimeToSeeQueryNode {
+export interface TimeToSeeQueryNode {
     type: 'query' | 'subquery'
     data: QueryData
-    children: Array<TimeToSeeNode>
+    children: Array<TimeToSeeInteractionNode | TimeToSeeQueryNode>
 }
 
-interface SessionData {
+export interface SessionData {
     session_id: string
     user_id: number
+    user: UserBasicType
     team_id: number
     session_start: string
     session_end: string
@@ -30,7 +33,7 @@ interface SessionData {
     events_count: string
     interactions_count: string
     total_interaction_time_to_see_data_ms: string
-    frustrating_interactions_count: string
+    frustrating_interactions_count: number
 }
 
 interface InteractionData {
@@ -87,4 +90,16 @@ interface QueryData {
     log_comment: string
 
     is_frustrating: boolean
+}
+
+export const isSessionNode = (x: TimeToSeeNode | undefined): x is TimeToSeeSessionNode => {
+    return !!x && x.type === 'session'
+}
+
+export const isInteractionNode = (x: TimeToSeeNode | undefined): x is TimeToSeeInteractionNode => {
+    return ['interaction', 'event'].includes(x?.type || 'not present')
+}
+
+export const isQueryNode = (x: TimeToSeeNode | undefined): x is TimeToSeeQueryNode => {
+    return ['query', 'subquery'].includes(x?.type || 'not present')
 }


### PR DESCRIPTION
## Problem

pulling changes out of the spike at https://github.com/PostHog/posthog/pull/13670
stacked on top of https://github.com/PostHog/posthog/pull/14049

## Changes

adds just an overview of a time-to-see session

![Screenshot 2023-02-01 at 12 47 56](https://user-images.githubusercontent.com/984817/216047385-06892e19-302c-4965-811e-a776114fe721.png)

## How did you test this code?

👀 
