### PR TITLE
feat(flags): Have a separate rate limit for flag evaluations

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -27,6 +27,7 @@ from posthog.models.feature_flag import (
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.property import Property
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
+from posthog.rate_limit import PassThroughFeatureFlagThrottle
 
 
 class CanEditFeatureFlag(BasePermission):
@@ -301,7 +302,7 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
 
         return Response(flags)
 
-    @action(methods=["GET"], detail=False)
+    @action(methods=["GET"], detail=False, throttle_classes=[PassThroughFeatureFlagThrottle])
     def local_evaluation(self, request: request.Request, **kwargs):
 
         feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.filter(team=self.team, deleted=False)

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -128,8 +128,8 @@
                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['user did things', 'user signed up']
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-24 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-01-31 23:59:59', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2023-01-25 00:00:00', 'UTC')
+                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2023-02-01 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1890,6 +1890,37 @@ class TestFeatureFlag(APIBaseTest):
         assert flags is not None
         self.assertEqual(len(flags), 0)
 
+    @patch("posthog.rate_limit.PassThroughFeatureFlagThrottle.rate", new="7/minute")
+    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
+    @patch("posthog.rate_limit.statsd.incr")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_rate_limits_for_local_evaluation_are_independent(self, rate_limit_enabled_mock, incr_mock):
+        for _ in range(5):
+            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Call to flags gets rate limited
+        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
+        incr_mock.assert_any_call(
+            "rate_limit_exceeded",
+            tags={
+                "team_id": self.team.pk,
+                "scope": "burst",
+                "rate": "5/minute",
+                "path": f"/api/projects/TEAM_ID/feature_flags",
+            },
+        )
+
+        incr_mock.reset_mock()
+
+        # but not call to local evaluation
+        for _ in range(7):
+            response = self.client.get(f"/api/feature_flag/local_evaluation")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 0)
+
 
 class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
     @snapshot_clickhouse_queries

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -134,3 +134,10 @@ class PassThroughClickHouseSustainedRateThrottle(PassThroughTeamRateThrottle):
     # Intended to block slower but sustained bursts of requests
     scope = "clickhouse_sustained"
     rate = "1200/hour"
+
+
+class PassThroughFeatureFlagThrottle(PassThroughTeamRateThrottle):
+    # Throttle class that's applied on the decide endpoint
+    # Intended to block quick bursts of requests
+    scope = "feature_flag_evaluations"
+    rate = "400/minute"


### PR DESCRIPTION
## Problem

local evaluation endpoint is called from SDKs, and needs to have a more relaxed sustained limit

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
