### PR TITLE
perf(frontend): Lazy-load `prettier` in production bundle

### DIFF
--- a/frontend/src/scenes/plugins/source/formatSource.ts
+++ b/frontend/src/scenes/plugins/source/formatSource.ts
@@ -1,6 +1,8 @@
-import * as prettier from 'prettier/standalone'
-import * as parserTypeScript from 'prettier/parser-typescript'
-export function formatSource(filename: string, source: string): string {
+export async function formatSource(filename: string, source: string): Promise<string> {
+    // Lazy-load prettier, as it's pretty big and its only use is formatting app source code
+    const prettier = (await import('prettier/standalone')).default
+    const parserTypeScript = (await import('prettier/parser-typescript')).default
+
     if (filename.endsWith('.json')) {
         return JSON.stringify(JSON.parse(source), null, 4) + '\n'
     }
@@ -9,7 +11,7 @@ export function formatSource(filename: string, source: string): string {
         filepath: filename,
         parser: 'typescript',
         plugins: [parserTypeScript],
-        // coped from .prettierrc
+        // copied from .prettierrc
         semi: false,
         trailingComma: 'es5',
         singleQuote: true,

--- a/frontend/src/scenes/plugins/source/pluginSourceLogic.tsx
+++ b/frontend/src/scenes/plugins/source/pluginSourceLogic.tsx
@@ -48,13 +48,13 @@ export const pluginSourceLogic = kea<pluginSourceLogicType>([
             errors: (values) => ({
                 'plugin.json': !validateJson(values['plugin.json']) ? 'Not valid JSON' : '',
             }),
-            preSubmit: () => {
+            preSubmit: async () => {
                 const changes = {}
                 const errors = {}
                 for (const [file, source] of Object.entries(values.pluginSource)) {
                     if (source && file.match(/\.(ts|tsx|js|jsx|json)$/)) {
                         try {
-                            const prettySource = formatSource(file, source)
+                            const prettySource = await formatSource(file, source)
                             if (prettySource !== source) {
                                 changes[file] = prettySource
                             }


### PR DESCRIPTION
## Problem

I noticed today that by far the largest part of our production bundle is… `prettier`. Which is only used for formatting app source code, and that's only available for the PostHog Inc. organization. Almost a megabyte of data.

<img width="433" alt="Screenshot 2023-02-01 at 12 19 49" src="https://user-images.githubusercontent.com/4550621/216097665-35048538-da3e-41f4-b951-d94c5520412a.png">

## Changes

Makes it so that `prettier` is only loaded when called upon.