### PR TITLE
feat: delete deleted person table data from clickhouse regularly

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -143,10 +143,16 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
 
         sender.add_periodic_task(get_crontab("0 6 * * *"), count_teams_with_no_property_query_count.s())
 
-    clear_clickhouse_crontab = get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON)
-    if clear_clickhouse_crontab:
+    if clear_clickhouse_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON):
         sender.add_periodic_task(
             clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
+        )
+
+    if clear_clickhouse_deleted_person_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON):
+        sender.add_periodic_task(
+            clear_clickhouse_deleted_person_crontab,
+            clear_clickhouse_deleted_person.s(),
+            name="clickhouse clear deleted person data",
         )
 
     if settings.EE_AVAILABLE:
@@ -470,6 +476,13 @@ def clickhouse_clear_removed_data():
     cohort_runner = AsyncCohortDeletion()
     cohort_runner.mark_deletions_done()
     cohort_runner.run()
+
+
+@app.task(ignore_result=True)
+def clear_clickhouse_deleted_person():
+    from posthog.models.async_deletion.delete_person import remove_deleted_person_data
+
+    remove_deleted_person_data()
 
 
 @app.task(ignore_result=True)

--- a/posthog/models/async_deletion/delete_person.py
+++ b/posthog/models/async_deletion/delete_person.py
@@ -1,0 +1,12 @@
+from posthog.clickhouse.client import sync_execute
+
+
+def remove_deleted_person_data(mutations_sync=False):
+    settings = {"mutations_sync": 1 if mutations_sync else 0}
+    sync_execute(
+        """
+        ALTER TABLE person
+        DELETE WHERE id IN (SELECT id FROM person WHERE is_deleted > 0)
+        """,
+        settings=settings,
+    )

--- a/posthog/models/async_deletion/test_delete_person.py
+++ b/posthog/models/async_deletion/test_delete_person.py
@@ -1,0 +1,23 @@
+import pytest
+
+from posthog.client import sync_execute
+from posthog.models.async_deletion.delete_person import remove_deleted_person_data
+from posthog.models.person.util import create_person
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+
+@pytest.mark.ee
+class TestDeletePerson(BaseTest, ClickhouseTestMixin):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_delete_person(self):
+        uuid = create_person(team_id=self.team.pk, version=0, is_deleted=False)
+        create_person(uuid=uuid, team_id=self.team.pk, version=1, is_deleted=True)
+        create_person(team_id=self.team.pk, version=0, is_deleted=True)
+        create_person(team_id=self.team.pk, version=0)
+
+        remove_deleted_person_data(mutations_sync=True)
+
+        count = sync_execute("SELECT count() FROM person")[0][0]
+
+        assert count == 1

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -40,3 +40,11 @@ CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON = get_from_env(
     # Defaults to 5AM UTC on Sunday
     "0 5 * * SUN",
 )
+
+# Schedule to delete redundant ClickHouse data on. Follows crontab syntax.
+# Use empty string to prevent this
+CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON = get_from_env(
+    "CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON",
+    # Every third month 5AM UTC on 1st of the month
+    "0 5 1 */3 *",
+)


### PR DESCRIPTION
We currently have ~2.6% of persons as deleted in ClickHouse. This task will periodically clean this data up