### PR TITLE
fix: Removed error handler catch in favour of player error state

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -412,6 +412,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         },
         setErrorPlayerState: ({ show }) => {
             if (show) {
+                actions.incrementErrorCount()
                 actions.stopAnimation()
             }
         },
@@ -667,9 +668,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             if (cache.originalWarning) {
                 console.warn = cache.originalWarning
             }
-            if (cache.errorHandler) {
-                window.removeEventListener('error', cache.errorHandler)
-            }
             actions.reportRecordingViewedSummary({
                 viewed_time_ms: cache.openTime !== undefined ? performance.now() - cache.openTime : undefined,
                 recording_duration_ms: values.sessionPlayerData?.metadata
@@ -693,11 +691,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             }
 
             cache.openTime = performance.now()
-
-            cache.errorHandler = () => {
-                actions.incrementErrorCount()
-            }
-            window.addEventListener('error', cache.errorHandler)
             cache.originalWarning = console.warn
             console.warn = function (...args: Array<unknown>) {
                 if (typeof args[0] === 'string' && args[0].includes('[replayer]')) {


### PR DESCRIPTION
## Problem

We are currently tracking errors in the player by catching the overall error occurrence. This ends up being a useless metric as there are all sorts of errors unrelated to Recordings that happen.

## Changes

* Removes the global error handler and instead just tracks if the player has to show the error state.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 