### PR TITLE
feat: allow json config editing for plugin config

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -5,6 +5,7 @@ import { PluginConfigSchema } from '@posthog/plugin-scaffold/src/types'
 import { EditOutlined } from '@ant-design/icons'
 import { SECRET_FIELD_VALUE } from 'scenes/plugins/utils'
 import MonacoEditor from '@monaco-editor/react'
+import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 
 function JsonConfigField(props: {
     onChange: (value: any) => void
@@ -13,21 +14,23 @@ function JsonConfigField(props: {
     value: any
 }): JSX.Element {
     return (
-        <div className="min-h-60">
-            <MonacoEditor
-                theme="vs-light"
-                className="border"
-                language="json"
-                value={props.value}
-                onChange={(v) => props.onChange(v ?? '')}
-                height={'100%'}
-                options={{
-                    minimap: {
-                        enabled: false,
-                    },
-                }}
-            />
-        </div>
+        <AutoSizer disableWidth className="min-h-60">
+            {({ height }) => (
+                <MonacoEditor
+                    theme="vs-light"
+                    className="border"
+                    language="json"
+                    value={props.value}
+                    onChange={(v) => props.onChange(v ?? '')}
+                    height={height}
+                    options={{
+                        minimap: {
+                            enabled: false,
+                        },
+                    }}
+                />
+            )}
+        </AutoSizer>
     )
 }
 

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -4,6 +4,32 @@ import { useState } from 'react'
 import { PluginConfigSchema } from '@posthog/plugin-scaffold/src/types'
 import { EditOutlined } from '@ant-design/icons'
 import { SECRET_FIELD_VALUE } from 'scenes/plugins/utils'
+import MonacoEditor from '@monaco-editor/react'
+
+function JsonConfigField(props: {
+    onChange: (value: any) => void
+    className: string
+    autoFocus: boolean
+    value: any
+}): JSX.Element {
+    return (
+        <div className="min-h-60">
+            <MonacoEditor
+                theme="vs-light"
+                className="border"
+                language="json"
+                value={props.value}
+                onChange={(v) => props.onChange(v ?? '')}
+                height={'100%'}
+                options={{
+                    minimap: {
+                        enabled: false,
+                    },
+                }}
+            />
+        </div>
+    )
+}
 
 export function PluginField({
     value,
@@ -38,6 +64,8 @@ export function PluginField({
         <UploadField value={value} onChange={onChange} />
     ) : fieldConfig.type === 'string' ? (
         <Input value={value} onChange={onChange} autoFocus={editingSecret} className="ph-no-capture" />
+    ) : fieldConfig.type === 'json' ? (
+        <JsonConfigField value={value} onChange={onChange} autoFocus={editingSecret} className="ph-no-capture" />
     ) : fieldConfig.type === 'choice' ? (
         <Select dropdownMatchSelectWidth={false} value={value} className="ph-no-capture" onChange={onChange} showSearch>
             {fieldConfig.choices.map((choice) => (


### PR DESCRIPTION
## Problem

The front-end allows "json" as a plugin config type. But also shows an error if you try to use it

To allow multi-event mappings in the SalesForce plugin I want to use JSON as config.

## Changes

Shows a monaco editor if the config type is JSON

![Screenshot 2023-02-02 at 19 14 49](https://user-images.githubusercontent.com/984817/216428629-aa37ee2f-9d31-4add-81f5-d0bb795704a7.png)

## How did you test this code?

ran it locally and saw I could edit and save json