### PR TITLE
fix: show correct toolbar daterange

### DIFF
--- a/frontend/src/toolbar/elements/ElementInfo.tsx
+++ b/frontend/src/toolbar/elements/ElementInfo.tsx
@@ -29,7 +29,7 @@ function ElementStatistic({
 }
 
 export function ElementInfo(): JSX.Element | null {
-    const { clickCount: totalClickCount } = useValues(heatmapLogic)
+    const { clickCount: totalClickCount, dateRange } = useValues(heatmapLogic)
 
     const { hoverElementMeta, selectedElementMeta } = useValues(elementsLogic)
     const { createAction } = useActions(elementsLogic)
@@ -54,7 +54,7 @@ export function ElementInfo(): JSX.Element | null {
                 <div className="p-3" style={{ borderLeft: '5px solid #FF9870', background: 'hsla(19, 99%, 99%, 1)' }}>
                     <h1 className="section-title">Stats</h1>
                     <p>
-                        <IconCalendar /> <u>Last 7 days</u>
+                        <IconCalendar /> <u>{dateRange}</u>
                     </p>
                     <div className={'flex flex-row gap-4'}>
                         <div className={'w-2/3'}>

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -11,6 +11,7 @@ import { elementToSelector, escapeRegex } from 'lib/actionUtils'
 import { FilterType, PropertyFilterType, PropertyOperator } from '~/types'
 import { PaginatedResponse } from 'lib/api'
 import { loaders } from 'kea-loaders'
+import { dateFilterToText } from 'lib/utils'
 
 const emptyElementsStatsPages: PaginatedResponse<ElementsEventType> = {
     next: undefined,
@@ -146,6 +147,12 @@ export const heatmapLogic = kea<heatmapLogicType>([
     })),
 
     selectors(({ cache }) => ({
+        dateRange: [
+            (s) => [s.heatmapFilter],
+            (heatmapFilter: Partial<FilterType>) => {
+                return dateFilterToText(heatmapFilter.date_from, heatmapFilter.date_to, 'Last 7 days')
+            },
+        ],
         elements: [
             (selectors) => [
                 selectors.elementStats,


### PR DESCRIPTION
## Problem

In [this private thread](https://posthog.slack.com/archives/C046YCXSZ2Q/p1675401410795329) a customer notices that the toolbar heatmap modal date range label is hardcoded to "Last 7 days" even though you can change the date range

🙈 

## Changes

format and display the selected date range instead

![heatmap-selector](https://user-images.githubusercontent.com/984817/216548732-b9fbc741-2531-4c50-a880-dfb4979f72ea.gif)

## How did you test this code?

locally with 👁️ 
