### PR TITLE
fix: Prettier flexing of playlists

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsList.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsList.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { IconUnfoldLess, IconUnfoldMore, IconInfo } from 'lib/lemon-ui/icons'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { range } from 'lib/utils'
-import React, { Fragment, useState } from 'react'
+import React, { Fragment } from 'react'
 import { SessionRecordingType } from '~/types'
 import {
     SessionRecordingPlaylistItem,
@@ -26,15 +26,18 @@ export type SessionRecordingsListProps = {
     activeRecordingId?: SessionRecordingType['id']
     loading?: boolean
     loadingSkeletonCount?: number
-    collapsable?: boolean
+    collapsed?: boolean
+    onCollapse?: (collapsed: boolean) => void
     empty?: React.ReactNode
+    className?: string
 }
 
 export function SessionRecordingsList({
     listKey,
     titleRight,
     recordings,
-    collapsable,
+    collapsed,
+    onCollapse,
     title,
     loading,
     loadingSkeletonCount = 1,
@@ -43,8 +46,8 @@ export function SessionRecordingsList({
     onRecordingClick,
     onPropertyClick,
     activeRecordingId,
+    className,
 }: SessionRecordingsListProps): JSX.Element {
-    const [collapsed, setCollapsed] = useState(false)
     const { reportRecordingListVisibilityToggled } = useActions(eventUsageLogic)
 
     const logic = sessionRecordingsListPropertiesLogic({
@@ -65,21 +68,19 @@ export function SessionRecordingsList({
     )
 
     const setCollapsedWrapper = (val: boolean): void => {
-        setCollapsed(val)
+        onCollapse?.(val)
         reportRecordingListVisibilityToggled(listKey, !val)
     }
 
     return (
         <div
-            className={clsx('flex flex-col w-full border rounded bg-light', {
+            className={clsx('flex flex-col w-full border rounded bg-light', className, {
                 'border-dashed': !recordings?.length,
-                'flex-1': !collapsed && recordings?.length,
-                'flex-0': collapsed,
                 'overflow-hidden': recordings?.length,
             })}
         >
             <div className="shrink-0 relative flex justify-between items-center p-1 gap-1">
-                {collapsable ? (
+                {onCollapse ? (
                     <LemonButton
                         className="flex-1"
                         status="stealth"


### PR DESCRIPTION
## Problem

Currently when you have at least 1 pinned recording the box takes up 50%.



## Changes

* Moved the collapsing logic to the parent and now we can style differently based on the state of the other box 🥳 

**Standard screen**
![2023-02-03 13 03 51](https://user-images.githubusercontent.com/2536520/216599550-5550b367-e4e0-4606-bf25-6665b0630d6e.gif)


**With good overflow support**
![2023-02-03 13 04 30](https://user-images.githubusercontent.com/2536520/216599535-4f0feca0-bc5b-4579-9183-cf1748b9fb1e.gif)



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 