### PR TITLE
fix: Truncation of recording event

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/v2/components/ItemEvent.tsx
@@ -13,24 +13,29 @@ export interface ItemEventProps {
 
 export function ItemEvent({ item, expanded, setExpanded }: ItemEventProps): JSX.Element {
     const insightUrl = insightUrlForEvent(item.data)
+
+    const subValue =
+        item.data.event === '$pageview'
+            ? item.data.properties.$pathname || item.data.properties.$current_url
+            : item.data.event === '$screen'
+            ? item.data.properties.$screen_name
+            : undefined
+
     return (
         <div>
             <LemonButton noPadding onClick={() => setExpanded(!expanded)} status={'primary-alt'} fullWidth>
                 <div className="flex gap-2 items-start p-2 text-xs cursor-pointer truncate">
                     <PropertyKeyInfo
-                        className="font-medium"
+                        className="font-medium shrink-0"
                         disablePopover
                         ellipsis={true}
                         value={capitalizeFirstLetter(autoCaptureEventToDescription(item.data))}
                     />
                     {item.data.event === '$autocapture' ? <span className="text-muted-alt">(Autocapture)</span> : null}
-                    {item.data.event === '$pageview' ? (
-                        <span className="text-muted-alt">
-                            {item.data.properties.$pathname || item.data.properties.$current_url}
+                    {subValue ? (
+                        <span className="text-muted-alt truncate" title={subValue}>
+                            {subValue}
                         </span>
-                    ) : null}
-                    {item.data.event === '$screen' ? (
-                        <span className="text-muted-alt">{item.data.properties.$screen_name}</span>
                     ) : null}
                 </div>
             </LemonButton>


### PR DESCRIPTION
## Problem

Missing truncation for pageview events in recordings inspector

## Changes

|Before|After|
|----|----|
|<img width="561" alt="Screenshot 2023-02-03 at 13 26 22" src="https://user-images.githubusercontent.com/2536520/216603543-7ccea735-ec0e-44f6-bddd-62131ffa5ecf.png">|<img width="512" alt="Screenshot 2023-02-03 at 13 26 11" src="https://user-images.githubusercontent.com/2536520/216603546-3c81c938-5eab-4cfa-a019-f3f1c9e4776d.png">|

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
