### PR TITLE
feat: Improve routing to Recordings

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -4,7 +4,7 @@ import { useActions, useValues } from 'kea'
 import { actionEditLogic, ActionEditLogicProps } from './actionEditLogic'
 import { ActionStep } from './ActionStep'
 import { Col, Row } from 'antd'
-import { combineUrl, router } from 'kea-router'
+import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -144,20 +144,18 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                             {id ? (
                                 <LemonButton
                                     type="secondary"
-                                    to={
-                                        combineUrl(urls.sessionRecordings(), {
-                                            filters: {
-                                                actions: [
-                                                    {
-                                                        id: id,
-                                                        type: 'actions',
-                                                        order: 0,
-                                                        name: action.name,
-                                                    },
-                                                ],
-                                            },
-                                        }).url
-                                    }
+                                    to={urls.sessionRecordings(undefined, {
+                                        filters: {
+                                            actions: [
+                                                {
+                                                    id: id,
+                                                    type: 'actions',
+                                                    order: 0,
+                                                    name: action.name,
+                                                },
+                                            ],
+                                        },
+                                    })}
                                     sideIcon={<IconPlayCircle />}
                                     data-attr="action-view-recordings"
                                 >

--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -154,20 +154,18 @@ export function ActionsTable(): JSX.Element {
                                 </LemonButton>
                                 <LemonButton
                                     status="stealth"
-                                    to={
-                                        combineUrl(urls.sessionRecordings(), {
-                                            filters: {
-                                                actions: [
-                                                    {
-                                                        id: action.id,
-                                                        type: 'actions',
-                                                        order: 0,
-                                                        name: action.name,
-                                                    },
-                                                ],
-                                            },
-                                        }).url
-                                    }
+                                    to={urls.sessionRecordings(undefined, {
+                                        filters: {
+                                            actions: [
+                                                {
+                                                    id: action.id,
+                                                    type: 'actions',
+                                                    order: 0,
+                                                    name: action.name,
+                                                },
+                                            ],
+                                        },
+                                    })}
                                     sideIcon={<IconPlayCircle />}
                                     fullWidth
                                     data-attr="action-table-view-recordings"

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -95,20 +95,18 @@ export function Cohorts(): JSX.Element {
                                 </LemonButton>
                                 <LemonButton
                                     status="stealth"
-                                    to={
-                                        combineUrl(urls.sessionRecordings(), {
-                                            filters: {
-                                                properties: [
-                                                    {
-                                                        key: 'id',
-                                                        label: cohort.name,
-                                                        type: 'cohort',
-                                                        value: cohort.id,
-                                                    },
-                                                ],
-                                            },
-                                        }).url
-                                    }
+                                    to={urls.sessionRecordings(undefined, {
+                                        filters: {
+                                            properties: [
+                                                {
+                                                    key: 'id',
+                                                    label: cohort.name,
+                                                    type: 'cohort', // TODO: fix this
+                                                    value: cohort.id,
+                                                },
+                                            ],
+                                        },
+                                    })}
                                     fullWidth
                                 >
                                     View session recordings

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -28,7 +28,6 @@ import { EventsTable } from 'scenes/events'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { NotFound } from 'lib/components/NotFound'
 import { IconPlayCircle } from 'lib/lemon-ui/icons'
-import { combineUrl } from 'kea-router/lib/utils'
 import { urls } from 'scenes/urls'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -128,20 +127,18 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                                 {isEvent && (
                                     <LemonButton
                                         type="secondary"
-                                        to={
-                                            combineUrl(urls.sessionRecordings(), {
-                                                filters: {
-                                                    events: [
-                                                        {
-                                                            id: definition.name,
-                                                            type: 'events',
-                                                            order: 0,
-                                                            name: definition.name,
-                                                        },
-                                                    ],
-                                                },
-                                            }).url
-                                        }
+                                        to={urls.sessionRecordings(undefined, {
+                                            filters: {
+                                                events: [
+                                                    {
+                                                        id: definition.name,
+                                                        type: 'events',
+                                                        order: 0,
+                                                        name: definition.name,
+                                                    },
+                                                ],
+                                            },
+                                        })}
                                         sideIcon={<IconPlayCircle />}
                                         data-attr="event-definition-view-recordings"
                                     >

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -23,7 +23,6 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { LemonButton, LemonInput, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { urls } from 'scenes/urls'
-import { combineUrl } from 'kea-router'
 import { IconPlayCircle } from 'lib/lemon-ui/icons'
 
 const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
@@ -121,20 +120,18 @@ export function EventDefinitionsTable(): JSX.Element {
                             <>
                                 <LemonButton
                                     status="stealth"
-                                    to={
-                                        combineUrl(urls.sessionRecordings(), {
-                                            filters: {
-                                                events: [
-                                                    {
-                                                        id: definition.name,
-                                                        type: 'events',
-                                                        order: 0,
-                                                        name: definition.name,
-                                                    },
-                                                ],
-                                            },
-                                        }).url
-                                    }
+                                    to={urls.sessionRecordings(undefined, {
+                                        filters: {
+                                            events: [
+                                                {
+                                                    id: definition.name,
+                                                    type: 'events',
+                                                    order: 0,
+                                                    name: definition.name,
+                                                },
+                                            ],
+                                        },
+                                    })}
                                     fullWidth
                                     sideIcon={<IconPlayCircle />}
                                     data-attr="event-definitions-table-view-recordings"

--- a/frontend/src/scenes/feature-flags/FeatureFlagRecordingsCard.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagRecordingsCard.tsx
@@ -1,7 +1,6 @@
 import { useValues } from 'kea'
 import { CompactList } from 'lib/components/CompactList/CompactList'
 import { RecordingRow } from 'scenes/project-homepage/RecentRecordings'
-import { SessionPlayerModal } from 'scenes/session-recordings/player/modal/SessionPlayerModal'
 import { urls } from 'scenes/urls'
 import { RecordingFilters, SessionRecordingType } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
@@ -28,10 +27,9 @@ export function FeatureFlagRecordings({ flagKey }: FeatureFlagRecordingsProps): 
 
     return (
         <>
-            <SessionPlayerModal />
             <CompactList
                 title="Recordings with current feature flag"
-                viewAllURL={urls.sessionRecordings(undefined, filters)}
+                viewAllURL={urls.sessionRecordings(undefined, { filters })}
                 loading={sessionRecordingsResponseLoading}
                 emptyMessage={
                     currentTeam?.session_recording_opt_in
@@ -50,7 +48,11 @@ export function FeatureFlagRecordings({ flagKey }: FeatureFlagRecordingsProps): 
                 }
                 items={sessionRecordings.slice(0, 5)}
                 renderRow={(recording: SessionRecordingType, index) => (
-                    <RecordingRow key={index} recording={recording} />
+                    <RecordingRow
+                        key={index}
+                        recording={recording}
+                        url={urls.sessionRecordings(undefined, { filters, sessionRecordingId: recording.id })}
+                    />
                 )}
             />
         </>

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -289,11 +289,9 @@ export const personsLogic = kea<personsLogicType>({
                 }
             }
         },
-        '/person/*': ({ _: rawPersonDistinctId }, { sessionRecordingId }, { activeTab }) => {
+        '/person/*': ({ _: rawPersonDistinctId }, {}, { activeTab }) => {
             if (props.syncWithUrl) {
-                if (sessionRecordingId) {
-                    actions.navigateToTab(PersonsTabType.SESSION_RECORDINGS)
-                } else if (activeTab && values.activeTab !== activeTab) {
+                if (activeTab && values.activeTab !== activeTab) {
                     actions.navigateToTab(activeTab as PersonsTabType)
                 }
 

--- a/frontend/src/scenes/project-homepage/RecentRecordings.tsx
+++ b/frontend/src/scenes/project-homepage/RecentRecordings.tsx
@@ -1,5 +1,5 @@
 import { dayjs } from 'lib/dayjs'
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 
 import './ProjectHomepage.scss'
 import { CompactList } from 'lib/components/CompactList/CompactList'
@@ -8,22 +8,17 @@ import { asDisplay } from 'scenes/persons/PersonHeader'
 import { sessionRecordingsListLogic } from 'scenes/session-recordings/playlist/sessionRecordingsListLogic'
 import { urls } from 'scenes/urls'
 import { SessionRecordingType } from '~/types'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { humanFriendlyDuration } from 'lib/utils'
 import { IconPlayCircle } from 'lib/lemon-ui/icons'
-import { SessionPlayerModal } from 'scenes/session-recordings/player/modal/SessionPlayerModal'
 import { teamLogic } from 'scenes/teamLogic'
-import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { ProjectHomePageCompactListItem } from './ProjectHomePageCompactListItem'
 
 interface RecordingRowProps {
     recording: SessionRecordingType
+    url?: string
 }
 
-export function RecordingRow({ recording }: RecordingRowProps): JSX.Element {
-    const { openSessionPlayer } = useActions(sessionPlayerModalLogic)
-    const { reportRecordingOpenedFromRecentRecordingList } = useActions(eventUsageLogic)
-
+export function RecordingRow({ recording, url }: RecordingRowProps): JSX.Element {
     return (
         <ProjectHomePageCompactListItem
             title={asDisplay(recording.person)}
@@ -35,13 +30,7 @@ export function RecordingRow({ recording }: RecordingRowProps): JSX.Element {
                     <IconPlayCircle className="text-2xl ml-2" />
                 </div>
             }
-            onClick={() => {
-                openSessionPlayer({
-                    id: recording.id,
-                    matching_events: recording.matching_events,
-                })
-                reportRecordingOpenedFromRecentRecordingList()
-            }}
+            to={url || urls.sessionRecordings(undefined, { sessionRecordingId: recording.id })}
         />
     )
 }
@@ -53,7 +42,6 @@ export function RecentRecordings(): JSX.Element {
 
     return (
         <>
-            <SessionPlayerModal />
             <CompactList
                 title="Recent recordings"
                 viewAllURL={urls.sessionRecordings()}

--- a/frontend/src/scenes/session-recordings/SessionsRecordings.stories.tsx
+++ b/frontend/src/scenes/session-recordings/SessionsRecordings.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/react'
 import recordings from './__mocks__/recordings.json'
 import { useEffect } from 'react'
 import { mswDecorator } from '~/mocks/browser'
-import { combineUrl, router } from 'kea-router'
+import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { App } from 'scenes/App'
 import recordingSnapshotsJson from 'scenes/session-recordings/__mocks__/recording_snapshots.json'
@@ -39,9 +39,7 @@ export function RecordingsList(): JSX.Element {
 
 export function Recording(): JSX.Element {
     useEffect(() => {
-        router.actions.push(
-            combineUrl(urls.sessionRecordings(), undefined, { sessionRecordingId: recordings[0].id }).url
-        )
+        router.actions.push(urls.sessionRecordings(undefined, { sessionRecordingId: recordings[0].id }))
     }, [])
     return <App />
 }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -19,6 +19,7 @@ import { loaders } from 'kea-loaders'
 export type PersonUUID = string
 interface Params {
     filters?: RecordingFilters
+    sessionRecordingId?: SessionRecordingId
 }
 
 interface HashParams {
@@ -300,14 +301,13 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                       filters: values.filters,
                   }
                 : {}
-            const hashParams: HashParams = {
-                ...router.values.hashParams,
+
+            if (values.selectedRecordingId) {
+                params.sessionRecordingId = values.selectedRecordingId
             }
-            if (!values.selectedRecordingId) {
-                delete hashParams.sessionRecordingId
-            } else {
-                hashParams.sessionRecordingId = values.selectedRecordingId
-            }
+
+            const hashParams = { ...router.values.hashParams }
+            delete hashParams.sessionRecordingId // Remove legacy hash param
 
             return [router.values.location.pathname, params, hashParams, { replace }]
         }
@@ -321,7 +321,8 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
 
     urlToAction(({ actions, values, props }) => {
         const urlToAction = (_: any, params: Params, hashParams: HashParams): void => {
-            const nulledSessionRecordingId = hashParams.sessionRecordingId ?? null
+            const nulledSessionRecordingId = params.sessionRecordingId ?? hashParams.sessionRecordingId ?? null
+
             if (nulledSessionRecordingId !== values.selectedRecordingId) {
                 actions.setSelectedRecordingId(nulledSessionRecordingId)
             }

--- a/frontend/src/scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic.ts
+++ b/frontend/src/scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic.ts
@@ -209,12 +209,11 @@ export const savedSessionRecordingPlaylistsLogic = kea<savedSessionRecordingPlay
                 const nextValues = values.filters
                 const urlValues = objectClean(router.values.searchParams)
                 if (!objectsEqual(nextValues, urlValues)) {
-                    return [urls.sessionRecordings(SessionRecordingsTabs.Playlists), nextValues, {}, { replace: false }]
+                    return [urls.sessionRecordings(SessionRecordingsTabs.Playlists), nextValues, {}, { replace: true }]
                 }
             }
         }
         return {
-            loadPlaylists: changeUrl,
             setSavedPlaylistsFilters: changeUrl,
         }
     }),

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -60,8 +60,10 @@ export const urls = {
         return `/web-performance/waterfall${queryParams}`
     },
 
-    sessionRecordings: (tab?: SessionRecordingsTabs, filters?: Partial<FilterType>): string =>
-        combineUrl(tab ? `/recordings/${tab}` : '/recordings/recent', filters ? { filters } : {}).url,
+    sessionRecordings: (
+        tab?: SessionRecordingsTabs,
+        params?: { filters?: Partial<FilterType>; sessionRecordingId?: string }
+    ): string => combineUrl(tab ? `/recordings/${tab}` : '/recordings/recent', params ? params : {}).url,
     sessionRecordingPlaylist: (id: string, filters?: Partial<FilterType>): string =>
         combineUrl(`/recordings/playlists/${id}`, filters ? { filters } : {}).url,
     sessionRecording: (id: string, filters?: Partial<FilterType>): string =>


### PR DESCRIPTION
## Problem

We currently use Modals for Recordings where it would actually be nicer to just send people to Recordings with appropriate filters.

Also we are using hashParams for routing where searchParams would make more sense.

## Changes

* Change homepage and Feature flag routing to go to Recordings
* Fix up issues with going back on Playlists page

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->


## TODO
- [ ] Still haven't got the routing for Playlists quite correct
- [ ] New tracking items (maybe with utm style params) to know where recording visitors came from