### PR TITLE
fix(data-exploration): Ensure query schema sync

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -65,6 +65,7 @@ jobs:
                         - requirements-dev.txt
                         - mypy.ini
                         - pytest.ini
+                        - frontend/src/queries/schema.json # Used for generating schema.py
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-backend.yml
                         - .github/workflows/backend-tests-action/action.yml

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -358,6 +358,13 @@ class RetentionReference1(str, Enum):
     previous = "previous"
 
 
+class RetentionPeriod(str, Enum):
+    Hour = "Hour"
+    Day = "Day"
+    Week = "Week"
+    Month = "Month"
+
+
 class RetentionType(str, Enum):
     retention_recurring = "retention_recurring"
     retention_first_time = "retention_first_time"
@@ -554,7 +561,7 @@ class RetentionFilter(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    period: Optional[str] = None
+    period: Optional[RetentionPeriod] = None
     retention_reference: Optional[RetentionReference1] = None
     retention_type: Optional[RetentionType] = None
     returning_entity: Optional[Dict[str, Any]] = None
@@ -941,41 +948,6 @@ class TrendsQuery(BaseModel):
     trendsFilter: Optional[TrendsFilter] = Field(None, description="Properties specific to the trends insight")
 
 
-class UnimplementedQuery(BaseModel):
-    class Config:
-        extra = Extra.forbid
-
-    aggregation_group_type_index: Optional[float] = Field(None, description="Groups aggregation")
-    dateRange: Optional[DateRange] = Field(None, description="Date range for the query")
-    filterTestAccounts: Optional[bool] = Field(
-        None, description="Exclude internal and test users by applying the respective filters"
-    )
-    kind: str = Field(
-        "UnimplementedQuery",
-        const=True,
-        description="Used for insights that haven't been converted to the new query format yet",
-    )
-    properties: Optional[
-        Union[
-            List[
-                Union[
-                    EventPropertyFilter,
-                    PersonPropertyFilter,
-                    ElementPropertyFilter,
-                    SessionPropertyFilter,
-                    CohortPropertyFilter,
-                    RecordingDurationFilter,
-                    GroupPropertyFilter,
-                    FeaturePropertyFilter,
-                    HogQLPropertyFilter,
-                    EmptyPropertyFilter,
-                ]
-            ],
-            PropertyGroupFilter,
-        ]
-    ] = Field(None, description="Property filters for all series")
-
-
 class AnyPartialFilterTypeItem(BaseModel):
     class Config:
         extra = Extra.forbid
@@ -1230,7 +1202,7 @@ class AnyPartialFilterTypeItem4(BaseModel):
     insight: Optional[InsightType] = None
     interval: Optional[IntervalType] = None
     new_entity: Optional[List[Dict[str, Any]]] = None
-    period: Optional[str] = None
+    period: Optional[RetentionPeriod] = None
     properties: Optional[
         Union[
             List[
@@ -1472,9 +1444,7 @@ class InsightVizNode(BaseModel):
         extra = Extra.forbid
 
     kind: str = Field("InsightVizNode", const=True)
-    source: Union[
-        TrendsQuery, FunnelsQuery, RetentionQuery, PathsQuery, StickinessQuery, LifecycleQuery, UnimplementedQuery
-    ]
+    source: Union[TrendsQuery, FunnelsQuery, RetentionQuery, PathsQuery, StickinessQuery, LifecycleQuery]
 
 
 class Model(BaseModel):


### PR DESCRIPTION
# Problem

Backend CI checks whether `posthog/schema.py` is in sync with `frontend/src/queries/schema.json`(the source of truth)… but backend CI intentionally doesn't run when only `frontend/*` has changed. So we missed that these two files went out of sync in #14019.

## Changes

Regenerated `schema.py`, and made sure this never happens again by adding `frontend/src/queries/schema.json` as a trigger for backend CI.