### PR TITLE
feat: install all templates and update them when listing them

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
@@ -1,17 +1,15 @@
 import { dashboardTemplatesLogic } from 'scenes/dashboard/dashboards/templates/dashboardTemplatesLogic'
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { DashboardTemplatesRepositoryEntry } from 'scenes/dashboard/dashboards/templates/types'
 import { dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
-import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { CommunityTag } from 'lib/CommunityTag'
-import { IconCloudUpload } from 'lib/lemon-ui/icons'
+import { IconGithub } from 'lib/lemon-ui/icons'
+import { Link } from '@posthog/lemon-ui'
 
 export const DashboardTemplatesTable = (): JSX.Element => {
     const { searchTerm } = useValues(dashboardsLogic)
-    const { repository, repositoryLoading, templateLoading, templateBeingSaved } = useValues(dashboardTemplatesLogic)
-    const { installTemplate } = useActions(dashboardTemplatesLogic)
+    const { repository, repositoryLoading } = useValues(dashboardTemplatesLogic)
 
     return (
         <LemonTable
@@ -42,29 +40,15 @@ export const DashboardTemplatesTable = (): JSX.Element => {
                         sorter: (a, b) => (a.name ?? 'Untitled').localeCompare(b.name ?? 'Untitled'),
                     },
                     {
-                        title: 'Install',
-                        dataIndex: 'installed',
+                        title: 'URL',
+                        dataIndex: 'url',
                         width: '0',
-                        render: function Render(
-                            installed: boolean | undefined,
-                            record: DashboardTemplatesRepositoryEntry
-                        ) {
+                        render: function Render(url: string) {
                             return (
                                 <div className="template-installed">
-                                    {installed && !record.has_new_version ? (
-                                        <LemonSnack>INSTALLED</LemonSnack>
-                                    ) : (
-                                        <LemonButton
-                                            status={'primary'}
-                                            type={'primary'}
-                                            icon={<IconCloudUpload />}
-                                            onClick={() => installTemplate({ name: record.name, url: record.url })}
-                                            loading={templateLoading && templateBeingSaved === record.name}
-                                            disabledReason={templateLoading ? 'Installing template...' : undefined}
-                                        >
-                                            {record.has_new_version ? 'Update' : 'Install'}
-                                        </LemonButton>
-                                    )}
+                                    <Link to={url} disableClientSideRouting target="blank">
+                                        View in GitHub <IconGithub />
+                                    </Link>
                                 </div>
                             )
                         },

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
@@ -1,4 +1,4 @@
-import { afterMount, kea, listeners, path, reducers } from 'kea'
+import { afterMount, kea, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { DashboardTemplatesRepositoryEntry } from 'scenes/dashboard/dashboards/templates/types'
@@ -24,23 +24,8 @@ export const dashboardTemplatesLogic = kea<dashboardTemplatesLogicType>([
                 },
             },
         ],
-        template: [
-            null,
-            {
-                installTemplate: async (payload: { name: string; url: string }) => {
-                    return await api.create('api/projects/@current/dashboard_templates/', payload)
-                },
-            },
-        ],
     }),
     reducers(() => ({
-        templateBeingSaved: [
-            null as string | null,
-            {
-                installTemplateSuccess: () => null,
-                installTemplate: (_, { name }) => name,
-            },
-        ],
         templatesList: [
             [] as LemonSelectOption<string>[],
             {
@@ -55,9 +40,6 @@ export const dashboardTemplatesLogic = kea<dashboardTemplatesLogicType>([
                 },
             },
         ],
-    })),
-    listeners(({ actions }) => ({
-        installTemplateSuccess: () => actions.loadRepository(),
     })),
     afterMount(({ actions }) => {
         actions.loadRepository()

--- a/posthog/api/dashboards/test/test_dashboard_templates.py
+++ b/posthog/api/dashboards/test/test_dashboard_templates.py
@@ -1,36 +1,25 @@
 import json
-from typing import Any, Dict, List
+from typing import Dict
 from unittest.mock import Mock, PropertyMock, patch
 
 from rest_framework import status
 
+from posthog.api.dashboards.dashboard_templates import og_template_listing_json
 from posthog.models.dashboard_templates import DashboardTemplate
 from posthog.test.base import APIBaseTest
 
-template_listing_json: List[Dict] = [
-    {
-        "name": "Product analytics",
-        "url": "some url",
-        "description": "The OG PostHog product analytics dashboard template",
-        "verified": True,
-        "maintainer": "official",
-    },
-    {
-        "name": "Website traffic",
-        "url": "a github url",
-        "description": "The website analytics dashboard that PostHog uses",
-        "verified": True,
-        "maintainer": "official",
-    },
-]
+website_template_json: Dict = {
+    "name": "Website traffic",
+    "url": "website-traffic-github-url",
+    "description": "The website analytics dashboard that PostHog uses",
+    "verified": True,
+    "maintainer": "official",
+}
 
-updated_template_listing_json: List[Dict] = [
-    template_listing_json[0],
-    {
-        **template_listing_json[1],
-        "url": "https://github.com/PostHog/templates-repository/blob/a-new-commit-hash/dashboards/posthog-website-traffic.json",
-    },
-]
+updated_website_template_json: Dict = {
+    **website_template_json,
+    "url": "updated-website-traffic-github-url",
+}
 
 website_traffic_template_listing: Dict = {
     "template_name": "Website traffic",
@@ -60,112 +49,73 @@ website_traffic_template_listing: Dict = {
 }
 
 
+def mock_responses(*args, **kwargs) -> Mock:
+    if args[0] == "https://raw.githubusercontent.com/PostHog/templates-repository/main/dashboards/dashboards.json":
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_text = PropertyMock(return_value=json.dumps([website_template_json]))
+        type(mock_response).text = mock_text
+        mock_response.json.return_value = [website_template_json]
+        return mock_response
+    elif args[0] == "website-traffic-github-url":
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_text = PropertyMock(return_value=json.dumps(website_traffic_template_listing))
+        type(mock_response).text = mock_text
+        mock_response.json.return_value = website_traffic_template_listing
+        return mock_response
+    else:
+        raise Exception("Unexpected request to " + args[0])
+
+
+def mock_updated_responses(*args, **kwargs) -> Mock:
+    if args[0] == "https://raw.githubusercontent.com/PostHog/templates-repository/main/dashboards/dashboards.json":
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_text = PropertyMock(return_value=json.dumps([updated_website_template_json]))
+        type(mock_response).text = mock_text
+        mock_response.json.return_value = [updated_website_template_json]
+        return mock_response
+    elif args[0] == "updated-website-traffic-github-url":
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_text = PropertyMock(
+            return_value=json.dumps({**website_traffic_template_listing, "tags": ["with", "tags"]})
+        )
+        type(mock_response).text = mock_text
+        mock_response.json.return_value = {**website_traffic_template_listing, "tags": ["with", "tags"]}
+        return mock_response
+    else:
+        raise Exception("Unexpected request to " + args[0])
+
+
 class TestDashboardTemplates(APIBaseTest):
-    @patch("posthog.api.dashboards.dashboard_templates.requests.get")
-    def test_repository_calls_to_github_and_returns_the_listing(self, patched_requests) -> None:
-        self._patch_request_get(patched_requests, template_listing_json)
-
-        response = self.client.get(f"/api/projects/{self.team.pk}/dashboard_templates/repository")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
-
-        expected_listing: List[Dict[str, Any]] = []
-        for tl in template_listing_json:
-            expected_listing.append({**tl, "installed": tl["name"] == "Product analytics", "has_new_version": False})
-
-        assert response.json() == expected_listing
-
-    @patch("posthog.api.dashboards.dashboard_templates.requests.get")
-    def test_repository_can_install_from_github(self, patched_requests) -> None:
-        self._patch_request_get(patched_requests, website_traffic_template_listing)
-
+    @patch("posthog.api.dashboards.dashboard_templates.requests.get", side_effect=mock_responses)
+    def test_repository_calls_to_github_and_returns_the_listing(self, _patched_requests) -> None:
         assert DashboardTemplate.objects.count() == 0
 
-        response = self.client.post(
-            f"/api/projects/{self.team.pk}/dashboard_templates",
-            {"name": "Website traffic", "url": "a github url"},
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
-
-        patched_requests.assert_called_with("a github url")
-
-        assert DashboardTemplate.objects.count() == 1
-
-        # all now show as installed
-
-        self._patch_request_get(patched_requests, template_listing_json)
-
         response = self.client.get(f"/api/projects/{self.team.pk}/dashboard_templates/repository")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
-        assert len(response.json()) == 2
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response)
 
-        expected_listing: List[Dict[str, Any]] = []
-        for tl in template_listing_json:
-            expected_listing.append({**tl, "installed": True, "has_new_version": False})
+        assert response.json() == [og_template_listing_json, website_template_json]
 
-        assert response.json() == expected_listing
+        # we didn't install the OG template in the DB, but we did install the template loaded from repository
+        assert list(DashboardTemplate.objects.values_list("template_name", flat=True)) == ["Website traffic"]
 
     @patch("posthog.api.dashboards.dashboard_templates.requests.get")
     def test_repository_can_update_from_github(self, patched_requests) -> None:
-        self._patch_request_get(patched_requests, website_traffic_template_listing)
+        patched_requests.side_effect = mock_responses
 
         assert DashboardTemplate.objects.count() == 0
 
-        response = self.client.post(
-            f"/api/projects/{self.team.pk}/dashboard_templates",
-            {"name": "Website traffic", "url": "a github url"},
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
-
-        patched_requests.assert_called_with("a github url")
+        self.client.get(f"/api/projects/{self.team.pk}/dashboard_templates/repository")
 
         assert DashboardTemplate.objects.count() == 1
         assert DashboardTemplate.objects.first().tags == []  # type: ignore
 
-        self._patch_request_get(patched_requests, updated_template_listing_json)
+        patched_requests.side_effect = mock_updated_responses
 
-        response = self.client.get(f"/api/projects/{self.team.pk}/dashboard_templates/repository")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
-        assert [r["has_new_version"] for r in response.json()] == [False, True]
-
-        self._patch_request_get(
-            patched_requests,
-            {
-                **website_traffic_template_listing,
-                "tags": ["updated"],
-            },
-        )
-
-        response = self.client.post(
-            f"/api/projects/{self.team.pk}/dashboard_templates",
-            {"name": "Website traffic", "url": "a github url"},
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.client.get(f"/api/projects/{self.team.pk}/dashboard_templates/repository")
 
         assert DashboardTemplate.objects.count() == 1
-        assert DashboardTemplate.objects.first().tags == ["updated"]  # type: ignore
-
-    @patch("posthog.api.dashboards.dashboard_templates.requests.get")
-    def test_validation_that_names_have_to_match(self, patched_requests) -> None:
-        self._patch_request_get(patched_requests, website_traffic_template_listing)
-
-        assert DashboardTemplate.objects.count() == 0
-
-        response = self.client.post(
-            f"/api/projects/{self.team.pk}/dashboard_templates",
-            {"name": "this is never going to match", "url": "a github url"},
-        )
-        response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response_json)
-        assert (
-            response_json["detail"]
-            == 'The requested template "this is never going to match" does not match the requested template URL which loaded the template "Website traffic"'
-        )
-
-    @staticmethod
-    def _patch_request_get(patched_requests, json_response):
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_text = PropertyMock(return_value=json.dumps(json_response))
-        type(mock_response).text = mock_text
-        mock_response.json.return_value = json_response
-        patched_requests.return_value = mock_response
+        assert DashboardTemplate.objects.first().tags == ["with", "tags"]  # type: ignore


### PR DESCRIPTION
## Changes

* Strip external dashboard templates interactions back. 
* any available templates are installed  whenever they are listed

(this is a bit odd, i.e. they're not always installed, because they are external but can be a stepping stone to whatever we choose)

## How did you test this code?

developer tests and checking it locally
