### PR TITLE
fix(funnels): fix position of funnel tab hint

### DIFF
--- a/frontend/src/scenes/insights/InsightsNav.tsx
+++ b/frontend/src/scenes/insights/InsightsNav.tsx
@@ -1,10 +1,9 @@
 import { Tabs } from 'antd'
 import { useActions, useValues } from 'kea'
-import { ReactNode, RefObject, useMemo, useRef } from 'react'
+import { RefObject, useEffect, useState, useRef } from 'react'
 import { InsightType } from '~/types'
 import { insightLogic } from './insightLogic'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import clsx from 'clsx'
 import { FunnelsCue } from './views/Trends/FunnelsCue'
 import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { Link } from 'lib/lemon-ui/Link'
@@ -17,90 +16,88 @@ interface Tab {
     type: InsightType
     dataAttr: string
     ref?: RefObject<HTMLSpanElement>
-    className?: string
 }
 
 export function InsightsNav(): JSX.Element {
     const { activeView, filters } = useValues(insightLogic)
     const { setActiveView } = useActions(insightLogic)
+    const trendsTab = useRef<HTMLSpanElement>(null)
     const funnelTab = useRef<HTMLSpanElement>(null)
+    const [tooltipPosition, setTooltipPosition] = useState<number | undefined>()
 
-    const tabs: Tab[] = useMemo(
-        () => [
-            {
-                label: 'Trends',
-                type: InsightType.TRENDS,
-                dataAttr: 'insight-trends-tab',
-            },
-            {
-                label: 'Funnels',
-                type: InsightType.FUNNELS,
-                dataAttr: 'insight-funnels-tab',
-                ref: funnelTab,
-            },
-            {
-                label: 'Retention',
-                type: InsightType.RETENTION,
-                dataAttr: 'insight-retention-tab',
-            },
-            {
-                label: 'User Paths',
-                type: InsightType.PATHS,
-                dataAttr: 'insight-path-tab',
-            },
-            {
-                label: 'Stickiness',
-                type: InsightType.STICKINESS,
-                dataAttr: 'insight-stickiness-tab',
-            },
-            {
-                label: 'Lifecycle',
-                type: InsightType.LIFECYCLE,
-                dataAttr: 'insight-lifecycle-tab',
-            },
-        ],
-        [funnelTab]
-    )
+    const tabs: Tab[] = [
+        {
+            label: 'Trends',
+            type: InsightType.TRENDS,
+            dataAttr: 'insight-trends-tab',
+            ref: trendsTab,
+        },
+        {
+            label: 'Funnels',
+            type: InsightType.FUNNELS,
+            dataAttr: 'insight-funnels-tab',
+            ref: funnelTab,
+        },
+        {
+            label: 'Retention',
+            type: InsightType.RETENTION,
+            dataAttr: 'insight-retention-tab',
+        },
+        {
+            label: 'User Paths',
+            type: InsightType.PATHS,
+            dataAttr: 'insight-path-tab',
+        },
+        {
+            label: 'Stickiness',
+            type: InsightType.STICKINESS,
+            dataAttr: 'insight-stickiness-tab',
+        },
+        {
+            label: 'Lifecycle',
+            type: InsightType.LIFECYCLE,
+            dataAttr: 'insight-lifecycle-tab',
+        },
+    ]
+
+    useEffect(() => {
+        if (trendsTab.current && funnelTab.current) {
+            const f = funnelTab.current.getBoundingClientRect()
+            const t = trendsTab.current.getBoundingClientRect()
+            const arrowWidth = 10
+            const offset = f.x - t.x + f.width / 2 - arrowWidth / 2
+            setTooltipPosition(offset)
+        }
+    }, [trendsTab.current, funnelTab.current])
 
     return (
         <>
-            <FunnelsCue
-                tooltipPosition={
-                    // 1.5x because it's 2 tabs (trends & funnels) + margin between tabs
-                    funnelTab?.current ? funnelTab.current.getBoundingClientRect().width * 1.5 + 16 : undefined
-                }
-            />
+            <FunnelsCue tooltipPosition={tooltipPosition} />
             <Tabs
                 activeKey={activeView}
                 className="top-bar"
                 onChange={(key) => setActiveView(key as InsightType)}
                 animated={false}
             >
-                {tabs.map(({ label, type, dataAttr, ref, className }) => {
-                    const Outer = ({ children }: { children: ReactNode }): JSX.Element =>
-                        INSIGHT_TYPES_METADATA[type]?.description ? (
-                            <Tooltip placement="top" title={INSIGHT_TYPES_METADATA[type].description}>
-                                {children}
-                            </Tooltip>
-                        ) : (
-                            <span ref={ref}>{children}</span>
-                        )
-                    return (
-                        <TabPane
-                            key={type}
-                            tab={
-                                <Link
-                                    className={clsx('tab-text', className)}
-                                    to={urls.insightNew({ ...filters, insight: type })}
-                                    preventClick
-                                    data-attr={dataAttr}
-                                >
-                                    <Outer>{label}</Outer>
-                                </Link>
-                            }
-                        />
-                    )
-                })}
+                {tabs.map(({ label, type, dataAttr, ref }) => (
+                    <TabPane
+                        key={type}
+                        tab={
+                            <Link
+                                className="tab-text"
+                                to={urls.insightNew({ ...filters, insight: type })}
+                                preventClick
+                                data-attr={dataAttr}
+                            >
+                                <span ref={ref}>
+                                    <Tooltip placement="top" title={INSIGHT_TYPES_METADATA[type].description}>
+                                        {label}
+                                    </Tooltip>
+                                </span>
+                            </Link>
+                        }
+                    />
+                ))}
             </Tabs>
         </>
     )


### PR DESCRIPTION
## Problem

The calculation for the funnel tab hint wasn't working. Not sure if it's worth fixing, as we'd might want to change it with LemonTabs anyway, feel free to close.

## Changes

The ref for calculating the funnel tab position was never set, as the ternary always evaluated the other way. Also the calculation didn't work as intended (assumed tabs were equal width).

<img width="845" alt="Screenshot 2023-02-06 at 13 53 04" src="https://user-images.githubusercontent.com/1851359/216977947-3d5d49e7-6f1c-48ad-a39a-5c32eec1face.png">

## How did you test this code?

Manual testing.