### PR TITLE
fix(rate-limits): Separate out often used endpoints into their own scope

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -27,7 +27,13 @@ from posthog.models.feature_flag import (
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.property import Property
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.rate_limit import PassThroughFeatureFlagThrottle
+from posthog.rate_limit import PassThroughBurstRateThrottle
+
+
+class PassThroughFeatureFlagThrottle(PassThroughBurstRateThrottle):
+    # Throttle class that's scoped just to the local evaluation endpoint.
+    # This makes the rate limit independent of other endpoints.
+    scope = "feature_flag_evaluations"
 
 
 class CanEditFeatureFlag(BasePermission):

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -98,6 +98,13 @@ def get_person_name(person: Person) -> str:
     return person.pk
 
 
+class PersonsThrottle(PassThroughClickHouseSustainedRateThrottle):
+    # Throttle class that's scoped just to the person endpoint.
+    # This makes the rate limit apply to all endpoints under /api/person/
+    # and independent of other endpoints.
+    scope = "persons"
+
+
 class PersonSerializer(serializers.HyperlinkedModelSerializer):
     name = serializers.SerializerMethodField()
 
@@ -158,7 +165,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
     serializer_class = PersonSerializer
     pagination_class = PersonLimitOffsetPagination
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
-    throttle_classes = [PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle]
+    throttle_classes = [PassThroughClickHouseBurstRateThrottle, PersonsThrottle]
     lifecycle_class = Lifecycle
     retention_class = Retention
     stickiness_class = Stickiness

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1890,7 +1890,7 @@ class TestFeatureFlag(APIBaseTest):
         assert flags is not None
         self.assertEqual(len(flags), 0)
 
-    @patch("posthog.rate_limit.PassThroughFeatureFlagThrottle.rate", new="7/minute")
+    @patch("posthog.api.feature_flag.PassThroughFeatureFlagThrottle.rate", new="7/minute")
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.statsd.incr")
     @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1,6 +1,7 @@
 import json
 from typing import Dict, List, Optional, cast
 from unittest import mock
+from unittest.mock import patch
 
 from django.utils import timezone
 from freezegun.api import freeze_time
@@ -578,6 +579,56 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
         created_ids.reverse()  # ids are returned in desc order
         self.assertEqual(returned_ids, created_ids, returned_ids)
+
+    @patch("posthog.api.person.PersonsThrottle.rate", new="6/minute")
+    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
+    @patch("posthog.rate_limit.statsd.incr")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_rate_limits_for_persons_are_independent(self, rate_limit_enabled_mock, incr_mock):
+        for _ in range(5):
+            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Call to flags gets rate limited
+        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
+        incr_mock.assert_any_call(
+            "rate_limit_exceeded",
+            tags={
+                "team_id": self.team.pk,
+                "scope": "burst",
+                "rate": "5/minute",
+                "path": f"/api/projects/TEAM_ID/feature_flags",
+            },
+        )
+
+        incr_mock.reset_mock()
+
+        # but not call to persons
+        for _ in range(3):
+            response = self.client.get(f"/api/projects/{self.team.pk}/persons/")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response = self.client.get(f"/api/projects/{self.team.pk}/persons/values/?key=whatever")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 0)
+
+        incr_mock.reset_mock()
+
+        # until the limit is reached
+        response = self.client.get(f"/api/projects/{self.team.pk}/persons/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
+        incr_mock.assert_any_call(
+            "rate_limit_exceeded",
+            tags={
+                "team_id": self.team.pk,
+                "scope": "persons",
+                "rate": "6/minute",
+                "path": f"/api/projects/TEAM_ID/persons/",
+            },
+        )
 
     def _get_person_activity(self, person_id: Optional[str] = None, *, expected_status: int = status.HTTP_200_OK):
         if person_id:

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -170,7 +170,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         # Filter by distinct ID
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             response = self.client.get("/api/person/?distinct_id=distinct_id")  # must be exact matches
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 1)

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -170,7 +170,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         # Filter by distinct ID
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get("/api/person/?distinct_id=distinct_id")  # must be exact matches
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 1)

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -149,10 +149,3 @@ class PassThroughClickHouseSustainedRateThrottle(PassThroughTeamRateThrottle):
     # Intended to block slower but sustained bursts of requests
     scope = "clickhouse_sustained"
     rate = "1200/hour"
-
-
-class PassThroughFeatureFlagThrottle(PassThroughTeamRateThrottle):
-    # Throttle class that's applied on the decide endpoint
-    # Intended to block quick bursts of requests
-    scope = "feature_flag_evaluations"
-    rate = "400/minute"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Changed a bit how we scope rate limits, to make it more extensible, rather than having a new custom limit for every endpoint (note the deletion of the old feature flag custom rate limit)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
