### PR TITLE
feat: export ingestion lag metric to prometheus

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -346,10 +346,10 @@ def ingestion_lag():
                 "events": list(HEARTBEAT_EVENT_TO_INGESTION_LAG_METRIC.keys()),
             },
         )
-        with pushed_metrics_registry("ingestion_lag") as registry:
+        with pushed_metrics_registry("celery_ingestion_lag") as registry:
             lag_gauge = Gauge(
                 "posthog_celery_observed_ingestion_lag_seconds",
-                "End-to-end ingestion lag through several ingestion scenarios. Prone to ",
+                "End-to-end ingestion lag observed through several scenarios. Can be overestimated by up to 60 seconds.",
                 labelnames=["scenario"],
                 registry=registry,
             )

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -304,14 +304,24 @@ def clickhouse_lag():
 
     from posthog.client import sync_execute
 
-    for table in CLICKHOUSE_TABLES:
-        try:
-            QUERY = """select max(_timestamp) observed_ts, now() now_ts, now() - max(_timestamp) as lag from {table};"""
-            query = QUERY.format(table=table)
-            lag = sync_execute(query)[0][2]
-            statsd.gauge("posthog_celery_clickhouse__table_lag_seconds", lag, tags={"table": table})
-        except:
-            pass
+    with pushed_metrics_registry("celery_clickhouse_lag") as registry:
+        lag_gauge = Gauge(
+            "posthog_celery_clickhouse_lag_seconds",
+            "Age of the latest ingested record per ClickHouse table.",
+            labelnames=["table_name"],
+            registry=registry,
+        )
+        for table in CLICKHOUSE_TABLES:
+            try:
+                QUERY = (
+                    """select max(_timestamp) observed_ts, now() now_ts, now() - max(_timestamp) as lag from {table};"""
+                )
+                query = QUERY.format(table=table)
+                lag = sync_execute(query)[0][2]
+                statsd.gauge("posthog_celery_clickhouse__table_lag_seconds", lag, tags={"table": table})
+                lag_gauge.labels(table_name=table).set(lag)
+            except:
+                pass
 
 
 HEARTBEAT_EVENT_TO_INGESTION_LAG_METRIC = {

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -32,7 +32,7 @@ def pushed_metrics_registry(job_name: str):
     region makes sense (e.g. instance metrics computed by celery jobs).
     """
 
-    from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
+    from django.conf import settings
 
     registry = CollectorRegistry()
     yield registry

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -2,6 +2,7 @@
 from contextlib import contextmanager
 
 import structlog
+from django.conf import settings
 from prometheus_client import CollectorRegistry, push_to_gateway
 from sentry_sdk import capture_exception
 
@@ -32,13 +33,11 @@ def pushed_metrics_registry(job_name: str):
     region makes sense (e.g. instance metrics computed by celery jobs).
     """
 
-    from django.conf import settings
-
     registry = CollectorRegistry()
     yield registry
     try:
-        if PROM_PUSHGATEWAY_ADDRESS:
-            push_to_gateway(PROM_PUSHGATEWAY_ADDRESS, job=job_name, registry=registry)
+        if settings.PROM_PUSHGATEWAY_ADDRESS:
+            push_to_gateway(settings.PROM_PUSHGATEWAY_ADDRESS, job=job_name, registry=registry)
     except Exception as err:
-        logger.error("push_to_gateway", target=PROM_PUSHGATEWAY_ADDRESS, exception=err)
+        logger.error("push_to_gateway", target=settings.PROM_PUSHGATEWAY_ADDRESS, exception=err)
         capture_exception(err)

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -5,8 +5,6 @@ import structlog
 from prometheus_client import CollectorRegistry, push_to_gateway
 from sentry_sdk import capture_exception
 
-from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
-
 logger = structlog.get_logger(__name__)
 
 __doc__ = """
@@ -33,6 +31,8 @@ def pushed_metrics_registry(job_name: str):
     NOTE: only use to expose gauges, for use cases where one value per
     region makes sense (e.g. instance metrics computed by celery jobs).
     """
+
+    from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
 
     registry = CollectorRegistry()
     yield registry

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -1,0 +1,27 @@
+# Shared metrics and labels for prometheus metrics
+from contextlib import contextmanager
+
+import structlog
+from prometheus_client import CollectorRegistry, push_to_gateway
+from sentry_sdk import capture_exception
+
+from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
+
+logger = structlog.get_logger(__name__)
+
+# Common label names
+
+LABEL_TEAM_ID = "team_id"
+
+
+#
+@contextmanager
+def pushed_metrics_registry(job_name: str):
+    registry = CollectorRegistry()
+    yield registry
+    try:
+        if PROM_PUSHGATEWAY_ADDRESS:
+            push_to_gateway(PROM_PUSHGATEWAY_ADDRESS, job=job_name, registry=registry)
+    except Exception as err:
+        logger.error("push_to_gateway", target=PROM_PUSHGATEWAY_ADDRESS, exception=err)
+        capture_exception(err)

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -2,21 +2,38 @@
 from contextlib import contextmanager
 
 import structlog
-from prometheus_client import CollectorRegistry, push_to_gateway
-from sentry_sdk import capture_exception
-
-from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
 
 logger = structlog.get_logger(__name__)
 
-# Common label names
+__doc__ = """
+This module holds common labels, metrics and helpers for Prometheus instrumentation.
 
+- Common label names should be imported from this module for consistency across metrics.
+- Metrics should be declared in the same file than the code that sets them,
+  but they could be declared here if set from several code paths.
+"""
+
+# Common metric labels
 LABEL_TEAM_ID = "team_id"
 
 
-#
 @contextmanager
 def pushed_metrics_registry(job_name: str):
+    """
+    Return a temporary Prometheus registry that will be pushed to the
+    PushGateway when the context closes.
+
+    Parameter job_name: a unique job name to use, all metrics previously
+    pushed with that name will be deleted.
+
+    NOTE: only use to expose gauges, for use cases where one value per
+    region makes sense (e.g. instance metrics computed by celery jobs).
+    """
+    from prometheus_client import CollectorRegistry, push_to_gateway
+    from sentry_sdk import capture_exception
+
+    from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
+
     registry = CollectorRegistry()
     yield registry
     try:

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -2,6 +2,10 @@
 from contextlib import contextmanager
 
 import structlog
+from prometheus_client import CollectorRegistry, push_to_gateway
+from sentry_sdk import capture_exception
+
+from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
 
 logger = structlog.get_logger(__name__)
 
@@ -29,10 +33,6 @@ def pushed_metrics_registry(job_name: str):
     NOTE: only use to expose gauges, for use cases where one value per
     region makes sense (e.g. instance metrics computed by celery jobs).
     """
-    from prometheus_client import CollectorRegistry, push_to_gateway
-    from sentry_sdk import capture_exception
-
-    from posthog.settings import PROM_PUSHGATEWAY_ADDRESS
 
     registry = CollectorRegistry()
     yield registry

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -94,6 +94,7 @@ AUTO_LOGIN = get_from_env("AUTO_LOGIN", False, type_cast=str_to_bool)
 
 CONTAINER_HOSTNAME = os.getenv("HOSTNAME", "unknown")
 
+PROM_PUSHGATEWAY_ADDRESS = os.getenv("PROM_PUSHGATEWAY_ADDRESS", None)
 
 # Extend and override these settings with EE's ones
 if "ee.apps.EnterpriseConfig" in INSTALLED_APPS:


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog-cloud-infra/issues/1052, bring our prod-eu alerting on par with prod-us.

We run celery jobs to export gauges about the health of the PostHog instance. Because the job can be scheduled on one of many pods, we cannot just export it through the main Prometheus registry: pod will have stale values as the job moves around, and we won't be able to distinguish what pod has the freshest value.

This looks like one of the few good use cases for the [PushGateway](https://prometheus.io/docs/practices/pushing/) system: celery tasks push the gauge value to the gateway (a service with a single pod), and that gateway exposes the latest value to the Prometheus server.

The PushGateway comes with a lot of caveats, including:

- counter values are replaced instead of incremented, so we cannot use it to expose counters, only gauges
- metrics are segmented by `job`, and one push to a given `job` erases all the values for it. That's why every celery task must present a unique job name
- the `push_to_gateway` function pushes all of the metrics in the registry (not just the ones we just updated), so we need to create throwaway registries with only the fresh metrics, instead of sharing a global long-lived registry

## Changes

- add a new `PROM_PUSHGATEWAY_ADDRESS` envvar
- add a new `pushed_metrics_registry` helper to handle the lifecycle of creating a throwway registry, waiting for the business logic to feed it, then push it to the gateway
- use it for two celery jobs:
  - the `ingestion_lag` job, exporting the `posthog_celery_observed_ingestion_lag_seconds` gauges
  - the `clickhouse_lag` job, exporting the posthog_celery_clickhouse_lag_seconds` gauges
- for now, push errors are logged and swallowed, and don't fail the celery job. It matches statsd' error swallowing behaviour, but we might want to reconsider that later (as the job is useless if it cannot push its metrics)

## How did you test this code?

- Run the gateway locally with `docker run -p 9091:9091 prom/pushgateway`
- Enable the heartbeat app, then run the local stack with `INGESTION_LAG_METRIC_TEAM_IDS=1 PROM_PUSHGATEWAY_ADDRESS="localhost:9091" DEBUG=1 ./bin/start`
- Wait for the job to succeed, then `curl localhost:9091/metrics`:

![image](https://user-images.githubusercontent.com/6241083/217280638-bc32a950-6084-4c85-be71-e84ff86e1be7.png)
