### PR TITLE
feat(rate-limits): Limit API calls based on personal API key only

### DIFF
--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -12,6 +12,8 @@ from posthog.models import Cohort, Organization, Person, Team
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.person import PersonDistinctId
 from posthog.models.person.util import create_person
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.utils import generate_random_token_personal
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -585,12 +587,19 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
     @patch("posthog.rate_limit.statsd.incr")
     @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
     def test_rate_limits_for_persons_are_independent(self, rate_limit_enabled_mock, incr_mock):
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+
         for _ in range(5):
-            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+            response = self.client.get(
+                f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}"
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Call to flags gets rate limited
-        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
         incr_mock.assert_any_call(
@@ -607,9 +616,14 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
         # but not call to persons
         for _ in range(3):
-            response = self.client.get(f"/api/projects/{self.team.pk}/persons/")
+            response = self.client.get(
+                f"/api/projects/{self.team.pk}/persons/", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}"
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            response = self.client.get(f"/api/projects/{self.team.pk}/persons/values/?key=whatever")
+            response = self.client.get(
+                f"/api/projects/{self.team.pk}/persons/values/?key=whatever",
+                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 0)
@@ -617,7 +631,9 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         incr_mock.reset_mock()
 
         # until the limit is reached
-        response = self.client.get(f"/api/projects/{self.team.pk}/persons/")
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/persons/", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
         incr_mock.assert_any_call(

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -13,6 +13,8 @@ from posthog import models, rate_limit
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 from posthog.models.instance_setting import override_instance_config
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.utils import generate_random_token_personal
 from posthog.test.base import APIBaseTest
 
 
@@ -20,7 +22,10 @@ class TestUserAPI(APIBaseTest):
     def setUp(self):
         # ensure the rate limit is reset for each test
         cache.clear()
-        return super().setUp()
+        super().setUp()
+
+        self.personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(self.personal_api_key))
 
     def tearDown(self):
         # ensure the rate limit is reset for any subsequent non-rate-limit tests
@@ -32,11 +37,15 @@ class TestUserAPI(APIBaseTest):
     @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
     def test_default_burst_rate_limit(self, rate_limit_enabled_mock, incr_mock):
         for _ in range(5):
-            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+            response = self.client.get(
+                f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Does not actually block the request, but increments the counter
-        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # mock_calls call object is a tuple of (function, args, kwargs)
@@ -59,14 +68,18 @@ class TestUserAPI(APIBaseTest):
         base_time = now()
         for _ in range(5):
             with freeze_time(base_time):
-                response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+                response = self.client.get(
+                    f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+                )
                 base_time += timedelta(seconds=61)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         with freeze_time(base_time):
             # Does not actually block the request, but increments the counter
             for _ in range(2):
-                response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+                response = self.client.get(
+                    f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+                )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(
                 len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 2
@@ -87,16 +100,22 @@ class TestUserAPI(APIBaseTest):
     def test_clickhouse_burst_rate_limit(self, rate_limit_enabled_mock, incr_mock):
         # Does nothing on /feature_flags endpoint
         for _ in range(10):
-            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+            response = self.client.get(
+                f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert call("rate_limit_exceeded", tags=ANY) not in incr_mock.mock_calls
 
         for _ in range(5):
-            response = self.client.get(f"/api/projects/{self.team.pk}/events")
+            response = self.client.get(
+                f"/api/projects/{self.team.pk}/events", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Does not actually block the request, but increments the counter
-        response = self.client.get(f"/api/projects/{self.team.pk}/events")
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/events", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
@@ -114,12 +133,17 @@ class TestUserAPI(APIBaseTest):
     @patch("posthog.rate_limit.statsd.incr")
     @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
     def test_rate_limits_are_based_on_the_team_not_user(self, rate_limit_enabled_mock, incr_mock):
+        self.client.logout()
         for _ in range(5):
-            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+            response = self.client.get(
+                f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # First user gets rate limited
-        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
         incr_mock.assert_any_call(
@@ -134,12 +158,16 @@ class TestUserAPI(APIBaseTest):
 
         # Create a new user
         new_user = create_user(email="test@posthog.com", password="1234", organization=self.organization)
+        new_personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=new_user, secure_value=hash_key_value(new_personal_api_key))
         self.client.force_login(new_user)
 
         incr_mock.reset_mock()
 
         # Second user gets rate limited after a single request
-        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        response = self.client.get(
+            f"/api/projects/{self.team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {new_personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
@@ -155,24 +183,42 @@ class TestUserAPI(APIBaseTest):
 
         # Create a new team
         new_team = create_team(organization=self.organization)
+        new_user = create_user(email="test2@posthog.com", password="1234", organization=self.organization)
+        new_personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=new_user, secure_value=hash_key_value(new_personal_api_key))
 
         incr_mock.reset_mock()
 
         # Requests to the new team are not rate limited
-        response = self.client.get(f"/api/projects/{new_team.pk}/feature_flags")
+        response = self.client.get(
+            f"/api/projects/{new_team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {new_personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 0)
+
+        # until it hits their specific limit
+        for _ in range(5):
+            response = self.client.get(
+                f"/api/projects/{new_team.pk}/feature_flags", HTTP_AUTHORIZATION=f"Bearer {new_personal_api_key}"
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.statsd.incr")
     @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
     def test_rate_limits_work_on_non_team_endpoints(self, rate_limit_enabled_mock, incr_mock):
+        self.client.logout()
         for _ in range(5):
-            response = self.client.get(f"/api/organizations/{self.organization.pk}/plugins")
+            response = self.client.get(
+                f"/api/organizations/{self.organization.pk}/plugins",
+                HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.client.get(f"/api/organizations/{self.organization.pk}/plugins")
+        response = self.client.get(
+            f"/api/organizations/{self.organization.pk}/plugins", HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 1)
@@ -185,6 +231,19 @@ class TestUserAPI(APIBaseTest):
                 "path": f"/api/organizations/ORG_ID/plugins",
             },
         )
+
+    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
+    @patch("posthog.rate_limit.statsd.incr")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_does_not_rate_limit_non_personal_api_key_endpoints(self, rate_limit_enabled_mock, incr_mock):
+        for _ in range(5):
+            response = self.client.get(f"/api/organizations/{self.organization.pk}/plugins")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get(f"/api/organizations/{self.organization.pk}/plugins")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len([1 for name, args, kwargs in incr_mock.mock_calls if args[0] == "rate_limit_exceeded"]), 0)
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.statsd.incr")
@@ -259,13 +318,19 @@ class TestUserAPI(APIBaseTest):
                     rate_limit, "get_instance_setting", wraps=models.instance_setting.get_instance_setting
                 ) as wrapped_get_instance_setting:
                     for _ in range(10):
-                        self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+                        self.client.get(
+                            f"/api/projects/{self.team.pk}/feature_flags",
+                            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                        )
 
                     assert wrapped_get_instance_setting.call_count == 1
 
                     frozen_time.tick(delta=timedelta(seconds=65))
                     for _ in range(10):
-                        self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+                        self.client.get(
+                            f"/api/projects/{self.team.pk}/feature_flags",
+                            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                        )
                     assert wrapped_get_instance_setting.call_count == 2
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")


### PR DESCRIPTION
## Problem

Blocking in-app requests can make the user experience annoying, if they have, say, a script running on the side that hits the rate limits.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Only rate limit API calls with a personal API key token. Don't block requests made in-app.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
