### PR TITLE
fix: Network events should show full URL if different

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
@@ -5,7 +5,7 @@ import { humanizeBytes, humanFriendlyMilliseconds, isURL } from 'lib/utils'
 import { PerformanceEvent } from '~/types'
 import { SimpleKeyValueList } from './SimpleKeyValueList'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { Fragment, useMemo } from 'react'
+import { Fragment } from 'react'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 
 export interface ItemPerformanceEvent {

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
@@ -96,20 +96,11 @@ export function ItemPerformanceEvent({
     const startTime = item.start_time || item.fetch_start || 0
     const duration = item.duration || 0
 
-    const eventName = useMemo(() => {
-        // If the $current_url domain is the same as event's domain then we just display the path
-        let val = item.name || '(missing)'
+    const callerOrigin = isURL(item.current_url) ? new URL(item.current_url).origin : undefined
+    const eventName = item.name || '(empty string)'
 
-        if (item.name && isURL(item.name) && isURL(item.current_url)) {
-            const eventUrl = new URL(item.name)
-            const currentUrl = new URL(item.current_url)
-
-            if (eventUrl.hostname === currentUrl.hostname) {
-                val = eventUrl.pathname
-            }
-        }
-        return val
-    }, [item.name, item.current_url])
+    const shortEventName =
+        callerOrigin && eventName.startsWith(callerOrigin) ? eventName.replace(callerOrigin, '') : eventName
 
     const contextLengthMs = finalTimestamp?.diff(dayjs(item.time_origin), 'ms') || 1000
 
@@ -164,7 +155,7 @@ export function ItemPerformanceEvent({
                         <>
                             <div className="flex gap-2 items-start p-2 text-xs">
                                 <span className={clsx('flex-1 overflow-hidden', !expanded && 'truncate')}>
-                                    Navigated to {eventName}
+                                    Navigated to {shortEventName}
                                 </span>
                             </div>
                             <LemonDivider className="my-0" />
@@ -199,7 +190,9 @@ export function ItemPerformanceEvent({
                         </>
                     ) : (
                         <div className="flex gap-2 items-start p-2 text-xs cursor-pointer">
-                            <span className={clsx('flex-1 overflow-hidden', !expanded && 'truncate')}>{eventName}</span>
+                            <span className={clsx('flex-1 overflow-hidden', !expanded && 'truncate')}>
+                                {shortEventName}
+                            </span>
                             {/* We only show the status if it exists and is an error status */}
                             {otherProps.response_status && otherProps.response_status >= 400 ? (
                                 <span


### PR DESCRIPTION
## Problem

We always truncate the url path but we actually want to only truncate it if it is different to the page domain, so it is clear when you are looking at a cross origin network request

## Changes
* Fixes this
* Also fixes network events loading even if Person is missing

<img width="296" alt="Screenshot 2023-02-07 at 14 37 02" src="https://user-images.githubusercontent.com/2536520/217259774-c7bb065e-0047-4db1-8fe9-6d37894705f5.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
