### PR TITLE
fix(exports-logs): Use context dict for logging exports

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -387,12 +387,10 @@ export function addHistoricalEventsExportCapabilityV2(
     }
 
     async function exportHistoricalEvents(payload: ExportHistoricalEventsJobPayload): Promise<void> {
-        status.info(
-            'ℹ️',
-            `Running export historical events with config ${pluginConfig.id} for payload: ${JSON.stringify(
-                payload
-            )}`
-        )
+        status.info('ℹ️', 'Running export historical events', {
+            pluginConfigId: pluginConfig.id,
+            payload,
+        })
 
         const activeExportParameters = await getExportParameters()
         if (activeExportParameters?.id != payload.exportId) {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -387,7 +387,12 @@ export function addHistoricalEventsExportCapabilityV2(
     }
 
     async function exportHistoricalEvents(payload: ExportHistoricalEventsJobPayload): Promise<void> {
-        status.info('ℹ️', `Running export historical events with config ${pluginConfig} for payload: ${payload}`)
+        status.info(
+            'ℹ️',
+            `Running export historical events with config ${JSON.stringify(pluginConfig)} for payload: ${JSON.stringify(
+                payload
+            )}`
+        )
 
         const activeExportParameters = await getExportParameters()
         if (activeExportParameters?.id != payload.exportId) {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -389,7 +389,7 @@ export function addHistoricalEventsExportCapabilityV2(
     async function exportHistoricalEvents(payload: ExportHistoricalEventsJobPayload): Promise<void> {
         status.info(
             'ℹ️',
-            `Running export historical events with config ${JSON.stringify(pluginConfig)} for payload: ${JSON.stringify(
+            `Running export historical events with config ${pluginConfig.id} for payload: ${JSON.stringify(
                 payload
             )}`
         )


### PR DESCRIPTION
## Problem

I'm seeing a lot of [object Object]. 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Hopefully `JSON.stringify`-ing them is the fix. I'm not a JS connoisseur if it was not already obvious.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
