### PR TITLE
fix(exports-historical): Do not resume running tasks

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -45,7 +45,6 @@ import { isTestEnv } from '../../../../utils/env-utils'
 import { status } from '../../../../utils/status'
 import { fetchEventsForInterval } from '../utils/fetchEventsForInterval'
 
-const SIXTY_MINUTES = 1000 * 60 * 60
 const TEN_MINUTES = 1000 * 60 * 10
 const TWELVE_HOURS = 1000 * 60 * 60 * 12
 export const EVENTS_PER_RUN_SMALL = 500
@@ -629,8 +628,8 @@ export function addHistoricalEventsExportCapabilityV2(
         // NOTE from the future: we discovered that 10 minutes was not enough time as we have exports running for longer
         // without failing, and this logic was triggering multiple simultaneous resumes. Simultaneous resumes start to fight to update
         // the status, and cause duplicate data to be exported. Overall, a nightmare.
-        // As a temporary solution, we are bumping this to 60 minutes, and coming back later to apply a more resilient fix.
-        return now >= status.statusTime + SIXTY_MINUTES + retryDelaySeconds(status.retriesPerformedSoFar + 1) * 1000
+        // To mitigate this, we have historialExportEvents update the status as it waits.
+        return now >= status.statusTime + TEN_MINUTES + retryDelaySeconds(status.retriesPerformedSoFar + 1) * 1000
     }
 
     function nextCursor(payload: ExportHistoricalEventsJobPayload, eventCount: number): OffsetParams {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -451,12 +451,12 @@ export function addHistoricalEventsExportCapabilityV2(
 
         // We bump the statusTime every minute to let the coordinator know we are still
         // alive and we don't need to be resumed.
-        const interval = setInterval(meta.storage.set, 1000 * 60, payload.statusKey, {
+        const interval = setInterval(() => meta.storage.set(1000 * 60, payload.statusKey, {
             ...payload,
             done: false,
             progress: progress,
             statusTime: Date.now(),
-        } as ExportChunkStatus)
+        } as ExportChunkStatus))
 
         if (events.length > 0) {
             try {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -449,6 +449,8 @@ export function addHistoricalEventsExportCapabilityV2(
             return
         }
 
+        // We bump the statusTime every minute to let the coordinator know we are still
+        // alive and we don't need to be resumed.
         const interval = setInterval(meta.storage.set, 1000 * 60, payload.statusKey, {
             ...payload,
             done: false,
@@ -481,12 +483,14 @@ export function addHistoricalEventsExportCapabilityV2(
                 })
             } catch (error) {
                 clearInterval(interval)
+
                 await handleExportError(error, activeExportParameters, payload, events.length)
                 return
             }
         }
 
         clearInterval(interval)
+
         const { timestampCursor, fetchTimeInterval, offset } = nextCursor(payload, events.length)
 
         await meta.jobs

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -451,13 +451,15 @@ export function addHistoricalEventsExportCapabilityV2(
 
         // We bump the statusTime every minute to let the coordinator know we are still
         // alive and we don't need to be resumed.
-        const interval = setInterval(() =>
-            meta.storage.set(1000 * 60, payload.statusKey, {
-                ...payload,
-                done: false,
-                progress: progress,
-                statusTime: Date.now(),
-            } as ExportChunkStatus)
+        const interval = setInterval(
+            () =>
+                meta.storage.set(payload.statusKey, {
+                    ...payload,
+                    done: false,
+                    progress: progress,
+                    statusTime: Date.now(),
+                } as ExportChunkStatus),
+            1000 * 60
         )
 
         if (events.length > 0) {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -451,12 +451,14 @@ export function addHistoricalEventsExportCapabilityV2(
 
         // We bump the statusTime every minute to let the coordinator know we are still
         // alive and we don't need to be resumed.
-        const interval = setInterval(() => meta.storage.set(1000 * 60, payload.statusKey, {
-            ...payload,
-            done: false,
-            progress: progress,
-            statusTime: Date.now(),
-        } as ExportChunkStatus))
+        const interval = setInterval(() =>
+            meta.storage.set(1000 * 60, payload.statusKey, {
+                ...payload,
+                done: false,
+                progress: progress,
+                statusTime: Date.now(),
+            } as ExportChunkStatus)
+        )
 
         if (events.length > 0) {
             try {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -333,6 +333,7 @@ export function addHistoricalEventsExportCapabilityV2(
                 doneDates.add(date)
                 runningDates.delete(date)
                 progress += progressPerDay
+                continue
             } else {
                 progress += progressPerDay * (dateStatus?.progress ?? 0)
             }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -452,14 +452,14 @@ export function addHistoricalEventsExportCapabilityV2(
         // We bump the statusTime every minute to let the coordinator know we are still
         // alive and we don't need to be resumed.
         const interval = setInterval(
-            () =>
-                meta.storage.set(payload.statusKey, {
+            async () =>
+                await meta.storage.set(payload.statusKey, {
                     ...payload,
                     done: false,
                     progress: progress,
                     statusTime: Date.now(),
                 } as ExportChunkStatus),
-            1000 * 60
+            60 * 1000
         )
 
         if (events.length > 0) {

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -652,6 +652,32 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 exportIsDone: false,
             })
         })
+
+        it('does not resume tasks that are done', async () => {
+            const dateStatus = {
+                done: true,
+                progress: 1,
+                statusTime: Date.now() - 70 * 60 * 1000,
+                retriesPerformedSoFar: 0,
+            }
+            await storage().set('EXPORT_DATE_STATUS_2021-10-29T00:00:00.000Z', dateStatus)
+
+            const result = await calculateCoordination(params, [], [
+                '2021-10-29T00:00:00.000Z',
+                '2021-10-30T00:00:00.000Z',
+                '2021-10-31T00:00:00.000Z',
+            ] as ISOTimestamp[])
+
+            expect(result).toEqual({
+                hasChanges: true,
+                done: ['2021-10-29T00:00:00.000Z'],
+                running: ['2021-10-30T00:00:00.000Z', '2021-10-31T00:00:00.000Z', '2021-11-01T00:00:00.000Z'],
+                toStartRunning: [['2021-11-01T00:00:00.000Z', '2021-11-01T05:00:00.000Z']],
+                toResume: [],
+                progress: 0.25,
+                exportIsDone: false,
+            })
+        })
     })
 
     describe('nextCursor()', () => {

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -631,7 +631,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
             const dateStatus = {
                 done: false,
                 progress: 0.5,
-                statusTime: Date.now() - 20 * 60 * 1000,
+                statusTime: Date.now() - 70 * 60 * 1000,
                 retriesPerformedSoFar: 0,
             }
             await storage().set('EXPORT_DATE_STATUS_2021-10-29T00:00:00.000Z', dateStatus)
@@ -923,7 +923,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
     describe('shouldResume()', () => {
         const shouldResume = getTestMethod('shouldResume')
 
-        it('resumes task when a bit over 10 minutes have passed', () => {
+        it('resumes task when a bit over 60 minutes have passed', () => {
             const status = {
                 statusTime: 10_000_000_000,
                 retriesPerformedSoFar: 0,
@@ -933,8 +933,8 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
             expect(shouldResume(status, 9_000_000_000)).toEqual(false)
             expect(shouldResume(status, 10_000_060_000)).toEqual(false)
             expect(shouldResume(status, 10_000_590_000)).toEqual(false)
-            expect(shouldResume(status, 10_000_660_000)).toEqual(true)
-            expect(shouldResume(status, 10_001_000_000)).toEqual(true)
+            expect(shouldResume(status, 10_000_660_000)).toEqual(false)
+            expect(shouldResume(status, 10_003_660_000)).toEqual(true)
         })
 
         it('accounts for retries exponential backoff', () => {


### PR DESCRIPTION
## Problem

Logs are showing that multiple historical exports are resumed despite still being alive and running. This is causing multiple simultaneous export jobs to run. This causes **a lot of problems**:
* Slow progress report as all jobs need to finish before status is considered done.
* Also inconsistent progress report as we now report more events have been exported than actual events (because each job reports it's own progress).
* Duplicate data: we have multiple jobs exporting the same data.
* Jobs re-running due to race conditions.
* Puppies not receiving pets.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

As a solution, we are:
* ~~Bumping the ten minute resume timeout to sixty minutes, so that we are less eager to trigger resumes~~ EDIT: This should not be necessary with the other two solutions in place, so we are not doing it. 
* Having jobs update the db status while an export is running even if there is no (apparent) progress on our end. Progress may be happening in an export plugin!
* Fixing a bug that was resuming potentially finished jobs (see the `does not resume tasks that are done` test case).

Overall, this is hard ~~which is why we should have probably just used Airflow or really any other alternative~~.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
