### PR TITLE
fix(tests): use msw delay instead of promise for dashboard cancellation (closes #14111)

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.queryCancellation.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.queryCancellation.test.ts
@@ -45,7 +45,7 @@ describe('dashboardLogic query cancellation', () => {
                     previous: null,
                     results: [{ ...dashboards['12'] }],
                 },
-                '/api/projects/:team/insights/:id/': (req) => {
+                '/api/projects/:team/insights/:id/': (req, _res, ctx) => {
                     const clientQueryId = req.url.searchParams.get('client_query_id')
                     if (clientQueryId !== null) {
                         seenQueryIDs.push(clientQueryId)
@@ -64,11 +64,7 @@ describe('dashboardLogic query cancellation', () => {
                         // delay for 2 seconds before response without pausing
                         // but only the first time that dashboard 12 refreshes its results
                         if (dashboardTwelveInsightLoadedCount === 1) {
-                            return new Promise((resolve) =>
-                                setTimeout(() => {
-                                    resolve([200, matched])
-                                }, 2000)
-                            )
+                            return [ctx.status(200), ctx.delay(2000), ctx.json(matched)]
                         }
                     }
                     return [200, matched]


### PR DESCRIPTION
## Problem

Tests for dashboardLogic are [failing sporadically](https://github.com/PostHog/posthog/actions/runs/4107231971/jobs/7099111025). The issue can't be reproduced locally. A promise for delaying a mock service worker response seems to be the root cause. See also https://github.com/PostHog/posthog/pull/14111.

## Changes

This PR replaces the promise with built-in [delay](https://mswjs.io/docs/api/context/delay#implicit-response-delay) of msw. There is a warning `Jest did not exit one second after the test run has completed.`, which indicates there might still be issues with this approach.

## How did you test this code?

Jest tests in this PR are green.