### PR TITLE
chore: Add placeholder and instructions to ff payloads

### DIFF
--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -24,7 +24,7 @@ export function IconWithCount({
     )
 }
 
-interface LemonIconProps {
+export interface LemonIconProps {
     color?: string
     fontSize?: string
     style?: CSSProperties

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -7,7 +7,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { LockOutlined } from '@ant-design/icons'
 import { defaultPropertyOnFlag, featureFlagLogic } from './featureFlagLogic'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
-import { FeatureFlagInstructions } from './FeatureFlagInstructions'
+import { FeatureFlagInstructions, FeatureFlagPayloadInstructions } from './FeatureFlagInstructions'
 import { PageHeader } from 'lib/components/PageHeader'
 import './FeatureFlag.scss'
 import {
@@ -742,19 +742,6 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
             {featureFlags[FEATURE_FLAGS.FF_JSON_PAYLOADS] && !multivariateEnabled && (
                 <div className="mb-6">
                     <h3 className="l4">Payload</h3>
-                    {!readOnly && (
-                        <div className="text-muted mb-4">
-                            Specify a json payload to be returned when the served value is{' '}
-                            <strong>
-                                <code>true</code>
-                            </strong>
-                            . Examples: <code>"A string"</code>
-                            {', '}
-                            <code>2500</code>
-                            {', '}
-                            <code>{'{"key": "value"}'}</code>
-                        </div>
-                    )}
                     {readOnly ? (
                         featureFlag.filters.payloads?.['true'] ? (
                             <JSONEditorInput readOnly={readOnly} value={featureFlag.filters.payloads?.['true']} />
@@ -762,11 +749,28 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                             <span>No payload associated with this flag</span>
                         )
                     ) : (
-                        <Group name={['filters', 'payloads']}>
-                            <Field name="true">
-                                <JSONEditorInput readOnly={readOnly} />
-                            </Field>
-                        </Group>
+                        <Row gutter={16}>
+                            <Col span={12}>
+                                <div className="text-muted mb-4">
+                                    Specify a payload to be returned when the served value is{' '}
+                                    <strong>
+                                        <code>true</code>
+                                    </strong>
+                                </div>
+                                <Group name={['filters', 'payloads']}>
+                                    <Field name="true">
+                                        <JSONEditorInput
+                                            readOnly={readOnly}
+                                            placeholder={'Examples: "A string", 2500, {"key": "value"}'}
+                                        />
+                                    </Field>
+                                </Group>
+                            </Col>
+
+                            <Col span={12}>
+                                <FeatureFlagPayloadInstructions featureFlagKey={featureFlag.key || 'my-flag'} />
+                            </Col>
+                        </Row>
                     )}
                 </div>
             )}
@@ -784,7 +788,9 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                 <Col span={8}>
                                     <div style={{ display: 'flex', flexDirection: 'column', fontWeight: 'normal' }}>
                                         <b>Payload</b>
-                                        <span className="text-muted">Specify return JSON payload when key matches</span>
+                                        <span className="text-muted">
+                                            Specify return payload when the variant key matches
+                                        </span>
                                     </div>
                                 </Col>
                                 <Col span={4}>
@@ -826,7 +832,13 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                         <Col span={8}>
                                             <Field name={['payloads', index]}>
                                                 {({ value, onChange }) => {
-                                                    return <JSONEditorInput onChange={onChange} value={value} />
+                                                    return (
+                                                        <JSONEditorInput
+                                                            onChange={onChange}
+                                                            value={value}
+                                                            placeholder={'{"key": "value"}'}
+                                                        />
+                                                    )
                                                 }}
                                             </Field>
                                         </Col>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -741,7 +741,12 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
             )}
             {featureFlags[FEATURE_FLAGS.FF_JSON_PAYLOADS] && !multivariateEnabled && (
                 <div className="mb-6">
-                    <h3 className="l4">Payload</h3>
+                    <h3 className="l4">
+                        Payload
+                        <LemonTag type="warning" className="uppercase ml-2">
+                            Beta
+                        </LemonTag>
+                    </h3>
                     {readOnly ? (
                         featureFlag.filters.payloads?.['true'] ? (
                             <JSONEditorInput readOnly={readOnly} value={featureFlag.filters.payloads?.['true']} />
@@ -787,7 +792,12 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                 <Col span={6}>Description</Col>
                                 <Col span={8}>
                                     <div style={{ display: 'flex', flexDirection: 'column', fontWeight: 'normal' }}>
-                                        <b>Payload</b>
+                                        <b>
+                                            Payload
+                                            <LemonTag type="warning" className="uppercase ml-2">
+                                                Beta
+                                            </LemonTag>
+                                        </b>
                                         <span className="text-muted">
                                             Specify return payload when the variant key matches
                                         </span>

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -10,6 +10,7 @@ import {
     IconPHP,
     IconRuby,
     IconGolang,
+    LemonIconProps,
 } from 'lib/lemon-ui/icons'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import {
@@ -24,11 +25,19 @@ import {
 } from 'scenes/feature-flags/FeatureFlagSnippets'
 
 import './FeatureFlagInstructions.scss'
+import { JSPayloadSnippet, NodeJSPayloadSnippet } from 'scenes/feature-flags/FeatureFlagPayloadSnippets'
 
 const DOC_BASE_URL = 'https://posthog.com/docs/'
 const FF_ANCHOR = '#feature-flags'
 
-const OPTIONS = [
+interface InstructionOption {
+    value: string
+    documentationLink: string
+    Icon: (props: LemonIconProps) => JSX.Element
+    Snippet: ({ flagKey }: { flagKey: string }) => JSX.Element
+}
+
+const OPTIONS: InstructionOption[] = [
     {
         value: 'JavaScript',
         documentationLink: `${DOC_BASE_URL}integrations/js-integration${UTM_TAGS}${FF_ANCHOR}`,
@@ -76,15 +85,19 @@ const OPTIONS = [
 function FeatureFlagInstructionsHeader({
     selectedOptionValue,
     selectOption,
+    headerPrompt,
+    options,
 }: {
     selectedOptionValue: string
     selectOption: (selectedValue: string) => void
+    headerPrompt: string
+    options: InstructionOption[]
 }): JSX.Element {
     return (
         <Row className="FeatureFlagInstructionsHeader" justify="space-between" align="middle">
             <div className="FeatureFlagInstructionsHeader__header-title">
                 <IconFlag className="FeatureFlagInstructionsHeader__header-title__icon" />
-                <b>Learn how to use feature flags in your code</b>
+                <b>{headerPrompt}</b>
             </div>
 
             <Select
@@ -93,7 +106,7 @@ function FeatureFlagInstructionsHeader({
                 style={{ width: 140 }}
                 onChange={selectOption}
             >
-                {OPTIONS.map(({ value, Icon }, index) => (
+                {options.map(({ value, Icon }, index) => (
                     <Select.Option
                         data-attr={'feature-flag-instructions-select-option-' + value}
                         key={index}
@@ -112,23 +125,31 @@ function FeatureFlagInstructionsHeader({
     )
 }
 
-function FeatureFlagInstructionsFooter({ documenrationLink }: { documenrationLink: string }): JSX.Element {
+function FeatureFlagInstructionsFooter({ documentationLink }: { documentationLink: string }): JSX.Element {
     return (
         <div className="mt-4">
             Need more information?{' '}
-            <a data-attr="feature-flag-doc-link" target="_blank" rel="noopener" href={documenrationLink}>
+            <a data-attr="feature-flag-doc-link" target="_blank" rel="noopener" href={documentationLink}>
                 Check the docs <IconOpenInNew />
             </a>
         </div>
     )
 }
 
-export function FeatureFlagInstructions({ featureFlagKey }: { featureFlagKey: string }): JSX.Element {
-    const [defaultSelectedOption] = OPTIONS
+function CodeInstructions({
+    featureFlagKey,
+    options,
+    headerPrompt,
+}: {
+    featureFlagKey: string
+    options: InstructionOption[]
+    headerPrompt: string
+}): JSX.Element {
+    const [defaultSelectedOption] = options
     const [selectedOption, setSelectedOption] = useState(defaultSelectedOption)
 
     const selectOption = (selectedValue: string): void => {
-        const option = OPTIONS.find((option) => option.value === selectedValue)
+        const option = options.find((option) => option.value === selectedValue)
 
         if (option) {
             setSelectedOption(option)
@@ -137,13 +158,53 @@ export function FeatureFlagInstructions({ featureFlagKey }: { featureFlagKey: st
 
     return (
         <Card size="small">
-            <FeatureFlagInstructionsHeader selectedOptionValue={selectedOption.value} selectOption={selectOption} />
+            <FeatureFlagInstructionsHeader
+                options={options}
+                headerPrompt={headerPrompt}
+                selectedOptionValue={selectedOption.value}
+                selectOption={selectOption}
+            />
             <LemonDivider />
             <div className="mt mb">
                 <selectedOption.Snippet data-attr="feature-flag-instructions-snippet" flagKey={featureFlagKey} />
             </div>
             <LemonDivider />
-            <FeatureFlagInstructionsFooter documenrationLink={selectedOption.documentationLink} />
+            <FeatureFlagInstructionsFooter documentationLink={selectedOption.documentationLink} />
         </Card>
+    )
+}
+
+export function FeatureFlagInstructions({ featureFlagKey }: { featureFlagKey: string }): JSX.Element {
+    return (
+        <CodeInstructions
+            featureFlagKey={featureFlagKey}
+            headerPrompt="Learn how to use feature flags in your code"
+            options={OPTIONS}
+        />
+    )
+}
+
+const PAYLOAD_OPTIONS = [
+    {
+        value: 'JavaScript',
+        documentationLink: `${DOC_BASE_URL}integrations/js-integration${UTM_TAGS}${FF_ANCHOR}`,
+        Icon: IconJavascript,
+        Snippet: JSPayloadSnippet,
+    },
+    {
+        value: 'Node.js',
+        documentationLink: `${DOC_BASE_URL}integrations/node-integration${UTM_TAGS}${FF_ANCHOR}`,
+        Icon: IconNodeJS,
+        Snippet: NodeJSPayloadSnippet,
+    },
+]
+
+export function FeatureFlagPayloadInstructions({ featureFlagKey }: { featureFlagKey: string }): JSX.Element {
+    return (
+        <CodeInstructions
+            featureFlagKey={featureFlagKey}
+            headerPrompt="Using feature flag payloads in your code"
+            options={PAYLOAD_OPTIONS}
+        />
     )
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagPayloadSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagPayloadSnippets.tsx
@@ -1,0 +1,21 @@
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+
+export function NodeJSPayloadSnippet({ flagKey }: { flagKey: string }): JSX.Element {
+    return (
+        <>
+            <CodeSnippet language={Language.JavaScript} wrap>
+                {`const matchedFlayPayload = await client.getFeatureFlagPayload('${flagKey}', 'user distinct id')`}
+            </CodeSnippet>
+        </>
+    )
+}
+
+export function JSPayloadSnippet({ flagKey }: { flagKey: string }): JSX.Element {
+    return (
+        <>
+            <CodeSnippet language={Language.JavaScript} wrap>
+                {`posthog.getFeatureFlagPayload('${flagKey ?? ''}')`}
+            </CodeSnippet>
+        </>
+    )
+}

--- a/frontend/src/scenes/feature-flags/JSONEditorInput.scss
+++ b/frontend/src/scenes/feature-flags/JSONEditorInput.scss
@@ -1,4 +1,5 @@
 .JsonEditorInput {
+    position: relative;
     .border {
         border-radius: var(--radius);
         .monaco-editor {
@@ -6,6 +7,24 @@
             .overflow-guard {
                 border-radius: inherit;
             }
+        }
+    }
+    .placeholder {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        height: 100%;
+        width: 100%;
+        pointer-events: none;
+
+        .placeholderLabelContainer {
+            display: flex;
+            align-items: center;
+            pointer-events: none;
+            height: 100%;
+            padding-left: 18px;
+            color: gray;
         }
     }
 }

--- a/frontend/src/scenes/feature-flags/JSONEditorInput.tsx
+++ b/frontend/src/scenes/feature-flags/JSONEditorInput.tsx
@@ -9,10 +9,12 @@ interface EditorProps {
     defaultNumberOfLines?: number
     value?: JsonType
     readOnly?: boolean
+    placeholder?: string
 }
 
 export function JSONEditorInput({
     onChange,
+    placeholder,
     lineHeight = 20,
     defaultNumberOfLines = 1,
     value = '',
@@ -23,6 +25,7 @@ export function JSONEditorInput({
     const defaultLines = Math.max(defaultNumberOfLines, valString.split(/\r\n|\r|\n/).length) + 1
     const defaultHeight = _lineHeight * defaultLines
     const [height, setHeight] = useState(defaultHeight)
+    const [focused, setFocused] = useState(false)
 
     const updateHeight = (val: string | undefined): void => {
         if (val) {
@@ -34,8 +37,11 @@ export function JSONEditorInput({
         }
     }
 
+    const onFocus = (): void => setFocused(true)
+    const onBlur = (): void => setFocused(false)
+
     return (
-        <div className="JsonEditorInput">
+        <div className="JsonEditorInput" onFocus={onFocus} onBlur={onBlur}>
             <MonacoEditor
                 theme="vs-light"
                 className="border"
@@ -76,6 +82,11 @@ export function JSONEditorInput({
                     onChange?.(val)
                 }}
             />
+            {!focused && !value?.toString() && placeholder && (
+                <div className="placeholder">
+                    <div className="placeholderLabelContainer">{placeholder}</div>
+                </div>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

- Adds more context as to how to use feature flag payloads. The placeholders are within field now too.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
<img width="1210" alt="Screen Shot 2023-02-07 at 2 13 54 PM" src="https://user-images.githubusercontent.com/13127476/217342850-d6a77338-d56e-45eb-917a-8062c25a8654.png">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
