### PR TITLE
fix: Don't send events on feature flag eval in execute.py

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -60,6 +60,7 @@ def extra_settings(query_id) -> Dict[str, Any]:
             "join-algorithm",
             str(query_id),
             only_evaluate_locally=True,
+            send_feature_flag_events=False,
         )
         or "default"
     )


### PR DESCRIPTION
## Problem

We are creating a lot of random people on PH

## Changes

no track feature flags

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
