### PR TITLE
chore: Only set join_algorithm in celery

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -54,7 +54,10 @@ def default_settings() -> Dict:
         return {"optimize_move_to_prewhere": 0}
 
 
-def extra_settings(query_id) -> Dict[str, Any]:
+def extra_settings(query_id: Optional[str], tags: Dict[str, Any]) -> Dict[str, Any]:
+    if tags.get("kind") != "celery":
+        return {}
+
     join_algorithm = (
         posthoganalytics.get_feature_flag(
             "join-algorithm",
@@ -106,7 +109,7 @@ def sync_execute(
         prepared_sql, prepared_args, tags = _prepare_query(client=client, query=query, args=args, workload=workload)
 
         query_id = validated_client_query_id()
-        core_settings = {**default_settings(), **(settings or {}), **extra_settings(query_id)}
+        core_settings = {**default_settings(), **(settings or {}), **extra_settings(query_id, tags)}
         tags["query_settings"] = core_settings
         settings = {**core_settings, "log_comment": json.dumps(tags, separators=(",", ":"))}
         try:

--- a/posthog/clickhouse/client/test/test_execute.py
+++ b/posthog/clickhouse/client/test/test_execute.py
@@ -6,21 +6,21 @@ from posthog.clickhouse.client.execute import extra_settings
 @patch("posthoganalytics.get_feature_flag")
 def test_extra_settings_join_algorithm_valid_value(mock_get_feature_flag):
     mock_get_feature_flag.return_value = "hash"
-    settings = extra_settings("some_query_id")
+    settings = extra_settings("some_query_id", {"kind": "celery"})
     assert settings == {"join_algorithm": "hash"}
 
 
 @patch("posthoganalytics.get_feature_flag")
 def test_extra_settings_join_algorithm_default_value(mock_get_feature_flag):
     mock_get_feature_flag.return_value = None
-    settings = extra_settings("some_query_id")
+    settings = extra_settings("some_query_id", {"kind": "celery"})
     assert settings == {"join_algorithm": "default"}
 
 
 @patch("posthoganalytics.get_feature_flag")
 def test_extra_settings_join_algorithm_multiple_values(mock_get_feature_flag):
     mock_get_feature_flag.return_value = "hash,parallel_hash,full_sorting_merge"
-    settings = extra_settings("some_query_id")
+    settings = extra_settings("some_query_id", {"kind": "celery"})
     assert settings == {"join_algorithm": "hash,parallel_hash,full_sorting_merge"}
 
 
@@ -28,5 +28,10 @@ def test_extra_settings_join_algorithm_multiple_values(mock_get_feature_flag):
 def test_extra_settings_join_algorithm_invalid_value(mock_get_feature_flag):
     # parallel-hash is a typo, should be parallel_hash
     mock_get_feature_flag.return_value = "hash,parallel-hash,full_sorting_merge"
-    settings = extra_settings("some_query_id")
+    settings = extra_settings("some_query_id", {"kind": "celery"})
     assert settings == {"join_algorithm": "default"}
+
+
+def test_extra_settings_join_algorithm_not_celery():
+    settings = extra_settings("some_query_id", {})
+    assert settings == {}


### PR DESCRIPTION
This was a false lead yesterday and affecting (live) user queries impacts users making it hard to test out 'worse' algorithms.
