### PR TITLE
chore: use common metric labels

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -31,6 +31,7 @@ from posthog.exceptions import generate_exception_response
 from posthog.kafka_client.client import KafkaProducer
 from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE, KAFKA_SESSION_RECORDING_EVENTS
 from posthog.logging.timing import timed
+from posthog.metrics import LABEL_RESOURCE_TYPE, LABEL_TEAM_ID
 from posthog.models.feature_flag import get_all_feature_flags
 from posthog.models.utils import UUIDT
 from posthog.session_recordings.session_recording_helpers import preprocess_session_recording_events_for_clickhouse
@@ -58,7 +59,7 @@ SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
     "capture_events_dropped_over_quota",
     "Events dropped by capture due to quota-limiting, per resource_type, team_id and token.",
-    labelnames=["resource_type", "team_id", "token"],
+    labelnames=[LABEL_RESOURCE_TYPE, LABEL_TEAM_ID, "token"],
 )
 
 

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -17,6 +17,8 @@ This module holds common labels, metrics and helpers for Prometheus instrumentat
 """
 
 # Common metric labels
+LABEL_PATH = "path"
+LABEL_RESOURCE_TYPE = "resource_type"
 LABEL_TEAM_ID = "team_id"
 
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -9,19 +9,20 @@ from sentry_sdk.api import capture_exception
 from statshog.defaults.django import statsd
 
 from posthog.auth import PersonalAPIKeyAuthentication
+from posthog.metrics import LABEL_PATH, LABEL_TEAM_ID
 from posthog.models.instance_setting import get_instance_setting
 from posthog.settings.utils import get_list
 
 RATE_LIMIT_EXCEEDED_COUNTER = Counter(
     "rate_limit_exceeded_total",
     "Dropped requests due to rate-limiting, per team_id, scope and path.",
-    labelnames=["team_id", "scope", "path"],
+    labelnames=[LABEL_TEAM_ID, "scope", LABEL_PATH],
 )
 
 RATE_LIMIT_BYPASSED_COUNTER = Counter(
     "rate_limit_bypassed_total",
     "Requests that should be dropped by rate-limiting but allowed by configuration.",
-    labelnames=["team_id", "path"],
+    labelnames=[LABEL_TEAM_ID, LABEL_PATH],
 )
 
 


### PR DESCRIPTION
## Problem

Metrics will be easier to navigate if labels are consistent, and we don't have a mix of `team_id`, `teamid` and `team` labels to sift through.

## Changes

Change the existing prom metric definition to use common labels when relevant.

## How did you test this code?

yolo