### PR TITLE
fix: URL-encode user and password in plugin server DB URL

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -227,7 +227,9 @@ export function overrideWithEnv(
     }
 
     if (!newConfig.DATABASE_URL) {
-        newConfig.DATABASE_URL = `postgres://${newConfig.POSTHOG_DB_USER}:${newConfig.POSTHOG_DB_PASSWORD}@${newConfig.POSTHOG_POSTGRES_HOST}:${newConfig.POSTHOG_POSTGRES_PORT}/${newConfig.POSTHOG_DB_NAME}`
+        const encodedUser = encodeURIComponent(newConfig.POSTHOG_DB_USER)
+        const encodedPassword = encodeURIComponent(newConfig.POSTHOG_DB_PASSWORD)
+        newConfig.DATABASE_URL = `postgres://${encodedUser}:${encodedPassword}@${newConfig.POSTHOG_POSTGRES_HOST}:${newConfig.POSTHOG_POSTGRES_PORT}/${newConfig.POSTHOG_DB_NAME}`
     }
 
     if (!newConfig.JOB_QUEUE_GRAPHILE_URL) {

--- a/plugin-server/tests/config.test.ts
+++ b/plugin-server/tests/config.test.ts
@@ -39,16 +39,16 @@ describe('config', () => {
             )
         })
 
-        test('Set DATABASE_URL to a string composed of connection options if DATABASE_URL is not explictly set', () => {
+        test('Set DATABASE_URL to a string composed of URL-encoded connection options if DATABASE_URL is not explictly set', () => {
             const env = {
                 DATABASE_URL: '',
                 POSTHOG_DB_NAME: 'mydb',
-                POSTHOG_DB_USER: 'user1',
-                POSTHOG_DB_PASSWORD: 'strongpassword',
+                POSTHOG_DB_USER: 'user1@domain',
+                POSTHOG_DB_PASSWORD: 'strong?password',
                 POSTHOG_POSTGRES_HOST: 'my.host',
             }
             const config = overrideWithEnv(getDefaultConfig(), env)
-            expect(config.DATABASE_URL).toEqual('postgres://user1:strongpassword@my.host:5432/mydb')
+            expect(config.DATABASE_URL).toEqual('postgres://user1%40domain:strong%3Fpassword@my.host:5432/mydb')
         })
 
         test('DATABASE_URL takes precedence to individual config options', () => {


### PR DESCRIPTION
Copy of https://github.com/PostHog/posthog/pull/14103 but within our repo so the tests run. Otherwise we need to wait on e.g. https://github.com/PostHog/posthog/pull/13747 to be merged.

## Problem

PostgreSQL database usernames and passwords can cause errors if they have certain special characters in them.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Username and password are URL-encoded before building the DATABASE_URL that's passed to pg.



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated an existing unit test to use special characters.

Fixes #13103

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
