### PR TITLE
fix: Formating of absolute times in recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -185,7 +185,7 @@ function PlayerInspectorListItem({
                 >
                     <span className="p-1 text-xs">
                         {timestampMode === 'absolute' ? (
-                            <TZLabel time={item.timestamp} formatDate="DD, MMM" formatTime="hh:mm:ss" noStyles />
+                            <TZLabel time={item.timestamp} formatDate="DD, MMM" formatTime="HH:mm:ss" noStyles />
                         ) : (
                             <>
                                 {item.timeInRecording < 0 ? (


### PR DESCRIPTION
## Problem

We are displaying the time for an event as 12 hour time instead of 24 hour.

## Changes

Fixes this!

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*