### PR TITLE
fix(personal-key): Ensure updates happen only after the hour

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -84,7 +84,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         key_last_used_at = personal_api_key_object.last_used_at
         # Only updating last_used_at if the hour's changed
         # This is to avooid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
-        if key_last_used_at is None or now - key_last_used_at > timedelta(hours=1):
+        if key_last_used_at is None or (now - key_last_used_at > timedelta(hours=1)):
             personal_api_key_object.last_used_at = now
             personal_api_key_object.save(update_fields=["last_used_at"])
         assert personal_api_key_object.user is not None

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from datetime import timedelta
 from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urlsplit
 
@@ -83,14 +84,9 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         key_last_used_at = personal_api_key_object.last_used_at
         # Only updating last_used_at if the hour's changed
         # This is to avooid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
-        if key_last_used_at is None or (now.year, now.month, now.day, now.hour) > (
-            key_last_used_at.year,
-            key_last_used_at.month,
-            key_last_used_at.day,
-            key_last_used_at.hour,
-        ):
+        if key_last_used_at is None or now - key_last_used_at > timedelta(hours=1):
             personal_api_key_object.last_used_at = now
-            personal_api_key_object.save()
+            personal_api_key_object.save(update_fields=["last_used_at"])
         assert personal_api_key_object.user is not None
 
         # :KLUDGE: CHMiddleware does not receive the correct user when authenticating by api key.

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -89,7 +89,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             key_last_used_at.day,
             key_last_used_at.hour,
         ):
-            key_last_used_at = now
+            personal_api_key_object.last_used_at = now
             personal_api_key_object.save()
         assert personal_api_key_object.user is not None
 


### PR DESCRIPTION
## Problem

The personal API key should be updated hourly only, rather than on every request.

This caused locks on the table when the API load increased massively.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
