### PR TITLE
feat(performance): prevent dashboards from being refreshed more often than every 5 minutes

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -1,5 +1,5 @@
 import { Radio, Space, RadioChangeEvent } from 'antd'
-import { dashboardLogic, DASHBOARD_REFRESH_INTERVAL_MINUTES } from 'scenes/dashboard/dashboardLogic'
+import { dashboardLogic, DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES } from 'scenes/dashboard/dashboardLogic'
 import { useActions, useValues } from 'kea'
 import { humanFriendlyDuration } from 'lib/utils'
 import clsx from 'clsx'
@@ -42,7 +42,7 @@ export function DashboardReloadAction(): JSX.Element {
                 data-attr="dashboard-items-action-refresh"
                 disabledReason={
                     blockRefresh
-                        ? `Dashboards can only be refreshed every ${DASHBOARD_REFRESH_INTERVAL_MINUTES} minutes.`
+                        ? `Dashboards can only be refreshed every ${DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES} minutes.`
                         : ''
                 }
                 sideAction={{

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -1,5 +1,5 @@
 import { Radio, Space, RadioChangeEvent } from 'antd'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { dashboardLogic, DASHBOARD_REFRESH_INTERVAL_MINUTES } from 'scenes/dashboard/dashboardLogic'
 import { useActions, useValues } from 'kea'
 import { humanFriendlyDuration } from 'lib/utils'
 import clsx from 'clsx'
@@ -28,7 +28,7 @@ const intervalOptions = [
 ]
 
 export function DashboardReloadAction(): JSX.Element {
-    const { itemsLoading, autoRefresh, refreshMetrics } = useValues(dashboardLogic)
+    const { itemsLoading, autoRefresh, refreshMetrics, blockRefresh } = useValues(dashboardLogic)
     const { refreshAllDashboardItemsManual, setAutoRefresh } = useActions(dashboardLogic)
 
     return (
@@ -40,6 +40,11 @@ export function DashboardReloadAction(): JSX.Element {
                 icon={itemsLoading ? <Spinner monocolor={true} /> : <IconRefresh />}
                 size="small"
                 data-attr="dashboard-items-action-refresh"
+                disabledReason={
+                    blockRefresh
+                        ? `Dashboards can only be refreshed every ${DASHBOARD_REFRESH_INTERVAL_MINUTES} minutes.`
+                        : ''
+                }
                 sideAction={{
                     'data-attr': 'dashboard-items-action-refresh-dropdown',
                     dropdown: {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -44,7 +44,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { teamLogic } from '../teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
-import { dayjs, now } from 'lib/dayjs'
+import { dayjs, now, Dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { Link } from 'lib/lemon-ui/Link'
 import { captureTimeToSeeData, currentSessionId, TimeToSeeDataPayload } from 'lib/internalMetrics'
@@ -664,7 +664,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         lastRefreshed: [
             (s) => [s.insightTiles],
-            (insightTiles) => {
+            (insightTiles): Dayjs | null => {
                 if (!insightTiles || !insightTiles.length) {
                     return null
                 }
@@ -676,7 +676,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
         blockRefresh: [
             (s) => [s.lastRefreshed],
-            (lastRefreshed) => {
+            (lastRefreshed: Dayjs) => {
                 return (
                     !!lastRefreshed &&
                     now()

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -61,7 +61,7 @@ export const BREAKPOINT_COLUMN_COUNTS: Record<DashboardLayoutSize, number> = { s
 export const MIN_ITEM_WIDTH_UNITS = 3
 export const MIN_ITEM_HEIGHT_UNITS = 5
 
-export const DASHBOARD_REFRESH_INTERVAL_MINUTES = 5
+export const DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES = 5
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
@@ -679,8 +679,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (lastRefreshed) => {
                 return (
                     !!lastRefreshed &&
-                    dayjs()
-                        .subtract(DASHBOARD_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes')
+                    now()
+                        .subtract(DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes')
                         .isBefore(lastRefreshed)
                 )
             },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -61,6 +61,8 @@ export const BREAKPOINT_COLUMN_COUNTS: Record<DashboardLayoutSize, number> = { s
 export const MIN_ITEM_WIDTH_UNITS = 3
 export const MIN_ITEM_HEIGHT_UNITS = 5
 
+export const DASHBOARD_REFRESH_INTERVAL_MINUTES = 5
+
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
 export interface DashboardLogicProps {
@@ -670,6 +672,17 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 const oldest = sortDates(insightTiles.map((i) => i.last_refresh))
                 const candidateShortest = oldest.length > 0 ? dayjs(oldest[0]) : null
                 return candidateShortest?.isValid() ? candidateShortest : null
+            },
+        ],
+        blockRefresh: [
+            (s) => [s.lastRefreshed],
+            (lastRefreshed) => {
+                return (
+                    !!lastRefreshed &&
+                    dayjs()
+                        .subtract(DASHBOARD_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes')
+                        .isBefore(lastRefreshed)
+                )
             },
         ],
         dashboard: [


### PR DESCRIPTION
Getting started on the work for #14143.

We'll be moving to handling things at the API level but need to clarify things a bit beforehand, so just getting started with a simple change that should be non-controversial and at least prevent yesterday's event from happening again.

----

For the record, what I'm thinking going forward is:

Given the concept of a dashboard refresh doesn't exist in the backend (we just do `refresh=true` for the associated insights), I'm thinking we'll issue a refresh request to the backend for all insights, which will then decide if they should be refreshed based on dynamic settings (i.e. not 3min for all, but something "smarter"). We then need be clear on the UI which insights we did and which we didn't refresh e.g. "Did not refresh insight since it was already refreshed 4min ago".

