### PR TITLE
fix: make sure we have products before find()

### DIFF
--- a/frontend/src/scenes/billing/v2/billingV2Logic.ts
+++ b/frontend/src/scenes/billing/v2/billingV2Logic.ts
@@ -131,7 +131,7 @@ export const billingV2Logic = kea<billingV2LogicType>([
                     }
                 }
 
-                const productOverLimit = billing.products.find((x) => {
+                const productOverLimit = billing.products?.find((x) => {
                     return x.percentage_usage > 1
                 })
 


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/3925327945/?referrer=slack

Not entirely sure why this happened but this should fix it. Seems like they had a very bad network connection so maybe that's it?

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Make sure we have products before trying to find()

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
