### PR TITLE
fix(paths): render svg icons with correct size

### DIFF
--- a/frontend/src/scenes/paths/Paths.scss
+++ b/frontend/src/scenes/paths/Paths.scss
@@ -5,9 +5,7 @@
     height: 720px;
 
     .Paths__canvas {
-        svg {
-            height: 100% !important;
-            width: 100%;
-        }
+        height: 100% !important;
+        width: 100%;
     }
 }

--- a/frontend/src/scenes/paths/Paths.scss
+++ b/frontend/src/scenes/paths/Paths.scss
@@ -4,8 +4,10 @@
     width: 100%;
     height: 720px;
 
-    svg {
-        height: 100% !important;
-        width: 100%;
+    .Paths__canvas {
+        svg {
+            height: 100% !important;
+            width: 100%;
+        }
     }
 }


### PR DESCRIPTION
## Problem

Sizing of icons inside paths visualization is broken **in Safari**. See below.

<img width="1044" alt="Screenshot 2023-02-07 at 19 51 54" src="https://user-images.githubusercontent.com/1851359/217674252-602cdbcd-3710-495a-a2da-72c91ac11c77.png">

## Changes

Use a more specific css selector.

## How did you test this code?

Tested in Safari, Chrome and Firefox.