### PR TITLE
fix: text card layout

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCard.scss
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.scss
@@ -1,5 +1,7 @@
 .TextCard {
     background: #fff;
+    height: 20rem;
+    position: relative;
 }
 
 .TextCard-Body {

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.scss
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.scss
@@ -6,6 +6,7 @@
     position: absolute;
     bottom: 0;
     left: 0;
+    overflow-y: auto;
 
     ul {
         list-style: disc;

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.stories.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 import { DashboardTile, InsightColor } from '~/types'
-import { TextCard } from './TextCard'
+import { TextCard, TextCardProps } from './TextCard'
 
 export default {
     title: 'Components/Cards/Text Card',
@@ -29,54 +29,32 @@ const makeTextTile = (body: string, color: InsightColor | null = null): Dashboar
     }
 }
 
-export const Template: Story = () => {
+function CardWrapper(props: Partial<TextCardProps>): JSX.Element {
     return (
-        <div className="flex flex-wrap gap-2">
-            <div>
-                <h5>basic text</h5>
-                <TextCard
-                    className={'react-grid-item react-draggable cssTransforms react-resizable'}
-                    dashboardId={1}
-                    textTile={makeTextTile('basic text')}
-                />
-            </div>
-            <div>
-                <h5>markdown text</h5>
-                <TextCard
-                    className={'react-grid-item react-draggable cssTransforms react-resizable'}
-                    dashboardId={1}
-                    textTile={makeTextTile('# a title \n\n **formatted** _text_')}
-                />
-            </div>
-            <div>
-                <h5>Long text</h5>
-                <TextCard
-                    className={'react-grid-item react-draggable cssTransforms react-resizable'}
-                    style={{ height: '250px', width: '300px' }}
-                    dashboardId={1}
-                    textTile={makeTextTile(
-                        '# long text which has a very long title so is too big both X and Y, what shall we do?! Oh what shall we do?\n\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n'
-                    )}
-                />
-            </div>
-            <div>
-                <h5>with resize handles</h5>
-                <TextCard
-                    className={'react-grid-item react-draggable cssTransforms react-resizable'}
-                    dashboardId={1}
-                    showResizeHandles={true}
-                    canResizeWidth={true}
-                    textTile={makeTextTile('showing handles')}
-                />
-            </div>
-            <div className={'w-full'} style={{ height: '200px' }}>
-                <h5>Large Card</h5>
-                <TextCard
-                    className={'h-full w-full react-grid-item react-draggable cssTransforms react-resizable'}
-                    dashboardId={1}
-                    textTile={makeTextTile('basic text')}
-                />
-            </div>
+        <div className={'w-11/12 max-w-100 h-100 relative'}>
+            <TextCard dashboardId={1} textTile={props.textTile || makeTextTile('unknown')} {...props} />
         </div>
+    )
+}
+
+export const BasicText: Story = () => {
+    return <CardWrapper textTile={makeTextTile('basic text')} />
+}
+
+export const WithResizeHandles: Story = () => {
+    return <CardWrapper showResizeHandles={true} canResizeWidth={true} textTile={makeTextTile('showing handles')} />
+}
+
+export const MarkdownText: Story = () => {
+    return <CardWrapper textTile={makeTextTile('# a title \n\n **formatted** _text_')} />
+}
+
+export const VeryLongText: Story = () => {
+    return (
+        <CardWrapper
+            textTile={makeTextTile(
+                '# long text which has a very long title so is too big both X and Y, what shall we do?! Oh what shall we do?\n\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n * has many lines\n'
+            )}
+        />
     )
 }

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -12,7 +12,7 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import React, { useState } from 'react'
 import { CardMeta, Resizeable } from 'lib/components/Cards/Card'
 
-interface TextCardProps extends React.HTMLAttributes<HTMLDivElement>, Resizeable {
+export interface TextCardProps extends React.HTMLAttributes<HTMLDivElement>, Resizeable {
     dashboardId?: string | number
     textTile: DashboardTile
     children?: JSX.Element

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -23,7 +23,6 @@ import { SubscribeButton, SubscriptionsModal } from 'lib/components/Subscription
 import { router } from 'kea-router'
 import { SharingModal } from 'lib/components/Sharing/SharingModal'
 import { isLemonSelectSection } from 'lib/lemon-ui/LemonSelect'
-import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { TextCardModal } from 'lib/components/Cards/TextCard/TextCardModal'
 import { DeleteDashboardModal } from 'scenes/dashboard/DeleteDashboardModal'
 import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
@@ -295,8 +294,7 @@ export function DashboardHeader(): JSX.Element | null {
                                                         }}
                                                         data-attr="add-text-tile-to-dashboard"
                                                     >
-                                                        Add text card &nbsp;
-                                                        <LemonTag type="warning">BETA</LemonTag>
+                                                        Add text card
                                                     </LemonButton>
                                                 </>
                                             ),


### PR DESCRIPTION
## Problem

Text cards were letting text overflow and their stories were weirdly broken

## Changes

* Text card has scroll on the Y now
* stories are way better
* remove the BETA tag from the add text card button

## How did you test this code?

running story book
and expecting visual regression tests to fail on opening this PR