### PR TITLE
refactor(plugin-server): speed up person state tests

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1125,7 +1125,9 @@
       -- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication
       -- for details.
       ENGINE = ReplicatedReplacingMergeTree(
-          '/clickhouse/tables/noshard/posthog_test.person_overrides',
+          -- NOTE: for testing we use a uuid to ensure that we don't get conflicts
+          -- when the tests tear down and recreate the table.
+          '/clickhouse/tables/{uuid}noshard/posthog_test.person_overrides',
           '{replica}-{shard}',
           version
       )
@@ -1774,7 +1776,9 @@
       -- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication
       -- for details.
       ENGINE = ReplicatedReplacingMergeTree(
-          '/clickhouse/tables/noshard/posthog_test.person_overrides',
+          -- NOTE: for testing we use a uuid to ensure that we don't get conflicts
+          -- when the tests tear down and recreate the table.
+          '/clickhouse/tables/{uuid}noshard/posthog_test.person_overrides',
           '{replica}-{shard}',
           version
       )

--- a/posthog/models/person_overrides/sql.py
+++ b/posthog/models/person_overrides/sql.py
@@ -11,6 +11,8 @@
 # table to the `sharded_events` table to find all events that were associated
 # and therefore reconcile the events to be associated with the same Person.
 
+from django.conf import settings
+
 from posthog.kafka_client.topics import KAFKA_PERSON_OVERRIDE
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, KAFKA_HOSTS
 
@@ -61,7 +63,9 @@ PERSON_OVERRIDES_CREATE_TABLE_SQL = f"""
     -- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication
     -- for details.
     ENGINE = ReplicatedReplacingMergeTree(
-        '/clickhouse/tables/noshard/{CLICKHOUSE_DATABASE}.person_overrides',
+        -- NOTE: for testing we use a uuid to ensure that we don't get conflicts
+        -- when the tests tear down and recreate the table.
+        '/clickhouse/tables/{'{uuid}' if settings.TEST else ''}noshard/{CLICKHOUSE_DATABASE}.person_overrides',
         '{{replica}}-{{shard}}',
         version
     )


### PR DESCRIPTION
This removes the reset db that would happen on every test.

I also add something to prevent the person_overrides table in ClickHouse
from failing to be created after being torn down. The path for the
replica sticks around in Zookeeper so we end up with a conflict on
creation.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
