### PR TITLE
refactor: remove timekeeper, use jest fake timers, create hub once

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -123,7 +123,6 @@
         "parse-prometheus-text-format": "^1.1.1",
         "pino-pretty": "^9.1.0",
         "prettier": "^2.7.1",
-        "timekeeper": "^2.2.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.7.4"

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -85,7 +85,6 @@ specifiers:
   re2: ^1.17.7
   safe-stable-stringify: ^2.4.0
   snowflake-sdk: ^1.6.10
-  timekeeper: ^2.2.0
   ts-node: ^10.9.1
   ts-node-dev: ^2.0.0
   typescript: ^4.7.4
@@ -181,7 +180,6 @@ devDependencies:
   parse-prometheus-text-format: 1.1.1
   pino-pretty: 9.1.1
   prettier: 2.7.1
-  timekeeper: 2.2.0
   ts-node: 10.9.1_uusaoo756f3l7x5w4ayk4pz43y
   ts-node-dev: 2.0.0_uusaoo756f3l7x5w4ayk4pz43y
   typescript: 4.8.4
@@ -8149,10 +8147,6 @@ packages:
   /through/2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: false
-
-  /timekeeper/2.2.0:
-    resolution: {integrity: sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==}
-    dev: true
 
   /tiny-lru/9.0.3:
     resolution: {integrity: sha512-/i9GruRjXsnDgehxvy6iZ4AFNVxngEFbwzirhdulomMNPGPVV3ECMZOWSw0w4sRMZ9Al9m4jy08GPvRxRUGYlw==}

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -330,7 +330,7 @@ export const createOrganization = async (pgClient: Pool) => {
         available_features: [],
         domain_whitelist: [],
         is_member_join_email_enabled: false,
-        slug: Math.round(Math.random() * 20000),
+        slug: new UUIDT().toString(),
     })
     return organizationId
 }

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -1,5 +1,4 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import tk from 'timekeeper'
 
 import { parseDate, parseEventTimestamp } from '../../../src/worker/ingestion/timestamps'
 
@@ -31,10 +30,10 @@ describe('parseDate()', () => {
 
 describe('parseEventTimestamp()', () => {
     beforeEach(() => {
-        tk.freeze('2020-08-12T01:02:00.000Z')
+        jest.useFakeTimers().setSystemTime(new Date('2020-08-12T01:02:00.000Z'))
     })
     afterEach(() => {
-        tk.reset()
+        jest.useRealTimers()
     })
 
     it('captures sent_at to adjusts timestamp', () => {


### PR DESCRIPTION
This removes the timekeeper library and uses jest fake timers instead.
This also creates the hub once and reuses it for all tests, which is
faster than creating a new hub for each test.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
