### PR TITLE
refactor(capture): Only update status time on setInterval

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -453,12 +453,7 @@ export function addHistoricalEventsExportCapabilityV2(
         const interval = setInterval(async () => {
             const now = Date.now()
             createLog(`Still running, updating ${payload.statusKey} statusTime for plugin ${pluginConfig.id} to ${now}`)
-            await meta.storage.set(payload.statusKey, {
-                ...payload,
-                done: false,
-                progress: progress,
-                statusTime: now,
-            } as ExportChunkStatus)
+            await meta.storage.updateStatusTime(payload.statusKey)
         }, 60 * 1000)
 
         if (events.length > 0) {

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -173,6 +173,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
             })
 
             jest.spyOn(vm.meta.storage, 'set')
+            jest.spyOn(vm.meta.storage, 'updateStatusTime')
             jest.spyOn(global, 'clearInterval')
 
             const defaultProgress =
@@ -182,9 +183,10 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
             jest.mocked(vm.methods.exportEvents).mockImplementationOnce(async () => {
                 let advanced = 0
                 while (advanced < 3) {
-                    // The +1 accounts for the first status update that happens once at the beginning of
+                    // This 1 check accounts for the first status update that happens once at the beginning of
                     // exportHistoricalEvents.
-                    expect(vm.meta.storage.set).toHaveBeenCalledTimes(advanced + 1)
+                    expect(vm.meta.storage.set).toHaveBeenCalledTimes(1)
+                    expect(vm.meta.storage.updateStatusTime).toHaveBeenCalledTimes(advanced)
 
                     expect(await storage().get('statusKey', null)).toEqual({
                         ...defaultPayload,


### PR DESCRIPTION
## Problem

Even after #14119 was merged, there is still a risk that queries arrive to Postgres out of order. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Let's account for this by letting Postgres set times as it sees them, only if they are newer. Moreover, we should only set status time to remove the risk of overwritten other important keys (like `done`). 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


## How did you test this code?

Changed up unit tests a bit to support new method. It's likely more tests are missing, but want to get input first. This will likely break due to type things until we do some updates.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
