### PR TITLE
feat: access other projects from ingestion (round 2)

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -6,7 +6,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
-    overflow: hidden;
+    overflow: scroll;
 
     .BridgePage__main {
         display: flex;
@@ -142,10 +142,5 @@
                 width: 400px;
             }
         }
-    }
-    // This will make the bridgepage compnent full screen, so if there
-    // is anything above or below it, it will be taller than the viewport
-    &.BridgePage--full-screen {
-        min-height: 100vh;
     }
 }

--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -7,6 +7,10 @@
     flex-direction: column;
     flex: 1;
     overflow: scroll;
+    &::-webkit-scrollbar {
+        width: 0 !important;
+    }
+    -ms-overflow-style: none;
 
     .BridgePage__main {
         display: flex;

--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -7,7 +7,6 @@
     flex-direction: column;
     flex: 1;
     overflow: hidden;
-    min-height: 100vh;
 
     .BridgePage__main {
         display: flex;
@@ -143,5 +142,10 @@
                 width: 400px;
             }
         }
+    }
+    // This will make the bridgepage compnent full screen, so if there
+    // is anything above or below it, it will be taller than the viewport
+    &.BridgePage--full-screen {
+        min-height: 100vh;
     }
 }

--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -15,6 +15,7 @@ export type BridgePageCommonProps = {
     sideLogo?: boolean
     fixedWidth?: boolean
     leftContainerContent?: JSX.Element
+    fullScreen?: boolean
 }
 
 interface NoHedgehogProps extends BridgePageCommonProps {
@@ -42,6 +43,7 @@ export function BridgePage({
     fixedWidth = true,
     leftContainerContent,
     hedgehog = false,
+    fullScreen = true,
 }: BridgePageProps): JSX.Element {
     const [messageShowing, setMessageShowing] = useState(false)
 
@@ -53,7 +55,14 @@ export function BridgePage({
     }, [])
 
     return (
-        <div className={clsx('BridgePage', fixedWidth && 'BridgePage--fixed-width', className)}>
+        <div
+            className={clsx(
+                'BridgePage',
+                fixedWidth && 'BridgePage--fixed-width',
+                fullScreen && 'BridgePage--full-screen',
+                className
+            )}
+        >
             <div className="BridgePage__main">
                 {leftContainerContent || hedgehog ? (
                     <div className="BridgePage__left-wrapper">

--- a/frontend/src/lib/components/BridgePage/BridgePage.tsx
+++ b/frontend/src/lib/components/BridgePage/BridgePage.tsx
@@ -59,7 +59,7 @@ export function BridgePage({
             className={clsx(
                 'BridgePage',
                 fixedWidth && 'BridgePage--fixed-width',
-                fullScreen && 'BridgePage--full-screen',
+                fullScreen && 'h-screen overflow-hidden',
                 className
             )}
         >

--- a/frontend/src/scenes/ingestion/IngestionWizard.scss
+++ b/frontend/src/scenes/ingestion/IngestionWizard.scss
@@ -58,26 +58,6 @@
     }
 }
 
-.IngestionSidebar {
-    background: white;
-    display: flex;
-    flex-direction: column;
-    position: relative;
-    align-items: center;
-    width: 250px;
-}
-
-.IngestionSidebar__content {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: 100%;
-    flex: 1;
-    padding: 1rem;
-    position: fixed;
-    width: 250px;
-}
-
 .IngestionSidebar__help {
     display: flex;
     flex-direction: column;

--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -55,7 +55,7 @@ function IngestionContainer({ children }: { children: React.ReactNode }): JSX.El
     const { isSmallScreen } = useValues(ingestionLogic)
 
     return (
-        <div className="flex h-full flex-col">
+        <div className="flex h-screen flex-col">
             <div className="IngestionTopbar">
                 <FriendlyLogo style={{ fontSize: '1.125rem' }} />
                 <div className="flex">
@@ -63,7 +63,6 @@ function IngestionContainer({ children }: { children: React.ReactNode }): JSX.El
                     <SitePopover />
                 </div>
             </div>
-            <InviteModal isOpen={isInviteModalShown} onClose={hideInviteModal} />
             <div className="flex h-full">
                 {!isSmallScreen && <Sidebar />}
                 {/* <div className="IngestionContainer" */}
@@ -72,11 +71,13 @@ function IngestionContainer({ children }: { children: React.ReactNode }): JSX.El
                     noLogo
                     fixedWidth={false}
                     header={<PanelHeader />}
-                    className="IngestionContent"
+                    className="IngestionContent h-full"
+                    fullScreen={false}
                 >
                     {children}
                 </BridgePage>
             </div>
+            <InviteModal isOpen={isInviteModalShown} onClose={hideInviteModal} />
         </div>
     )
 }

--- a/frontend/src/scenes/ingestion/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/Sidebar.tsx
@@ -18,8 +18,8 @@ export function Sidebar(): JSX.Element {
     const currentIndex = sidebarSteps.findIndex((x) => x === currentStep)
 
     return (
-        <div className="IngestionSidebar">
-            <div className="IngestionSidebar__content">
+        <div className="bg-white flex flex-col relative items-center w-60">
+            <div className="flex flex-col justify-between h-full p-4 fixed w-60 pb-20">
                 <div className="IngestionSidebar__steps">
                     {sidebarSteps.map((step: string, index: number) => (
                         <LemonButton

--- a/frontend/src/scenes/ingestion/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/Sidebar.tsx
@@ -2,7 +2,7 @@ import { ingestionLogic } from './ingestionLogic'
 import { useActions, useValues } from 'kea'
 import './IngestionWizard.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { LemonButton, LemonButtonWithSideAction } from 'lib/lemon-ui/LemonButton'
+import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
 import { IconArticle, IconQuestionAnswer } from 'lib/lemon-ui/icons'
 import { HelpType } from '~/types'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
@@ -41,24 +41,21 @@ export function Sidebar(): JSX.Element {
                 <div className="IngestionSidebar__bottom">
                     {currentOrganization?.teams && currentOrganization.teams.length > 1 && (
                         <>
-                            <LemonButtonWithSideAction
+                            <LemonButtonWithDropdown
                                 icon={<Lettermark name={currentOrganization?.name} />}
                                 onClick={() => toggleProjectSwitcher()}
-                                sideAction={{
-                                    'aria-label': 'switch project',
-                                    onClick: () => toggleProjectSwitcher(),
-                                    dropdown: {
-                                        visible: isProjectSwitcherShown,
-                                        onClickOutside: hideProjectSwitcher,
-                                        overlay: <ProjectSwitcherOverlay />,
-                                        actionable: true,
-                                    },
+                                dropdown={{
+                                    visible: isProjectSwitcherShown,
+                                    onClickOutside: hideProjectSwitcher,
+                                    overlay: <ProjectSwitcherOverlay />,
+                                    actionable: true,
+                                    placement: 'top-end',
                                 }}
                                 type="secondary"
                                 fullWidth
                             >
                                 <span className="text-muted">Switch project</span>
-                            </LemonButtonWithSideAction>
+                            </LemonButtonWithDropdown>
                             <LemonDivider thick dashed className="my-6" />
                         </>
                     )}

--- a/frontend/src/scenes/ingestion/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/Sidebar.tsx
@@ -1,19 +1,22 @@
 import { ingestionLogic } from './ingestionLogic'
 import { useActions, useValues } from 'kea'
 import './IngestionWizard.scss'
-import { InviteMembersButton } from '~/layout/navigation/TopBar/SitePopover'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonButton, LemonButtonWithSideAction } from 'lib/lemon-ui/LemonButton'
 import { IconArticle, IconQuestionAnswer } from 'lib/lemon-ui/icons'
 import { HelpType } from '~/types'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { ProjectSwitcherOverlay } from '~/layout/navigation/ProjectSwitcher'
+import { Lettermark } from 'lib/lemon-ui/Lettermark'
+import { organizationLogic } from 'scenes/organizationLogic'
 
 const HELP_UTM_TAGS = '?utm_medium=in-product-onboarding&utm_campaign=help-button-sidebar'
 
 export function Sidebar(): JSX.Element {
-    const { currentStep, sidebarSteps } = useValues(ingestionLogic)
-    const { sidebarStepClick } = useActions(ingestionLogic)
+    const { currentStep, sidebarSteps, isProjectSwitcherShown } = useValues(ingestionLogic)
+    const { sidebarStepClick, toggleProjectSwitcher, hideProjectSwitcher } = useActions(ingestionLogic)
     const { reportIngestionHelpClicked, reportIngestionSidebarButtonClicked } = useActions(eventUsageLogic)
+    const { currentOrganization } = useValues(organizationLogic)
 
     const currentIndex = sidebarSteps.findIndex((x) => x === currentStep)
 
@@ -36,8 +39,29 @@ export function Sidebar(): JSX.Element {
                     ))}
                 </div>
                 <div className="IngestionSidebar__bottom">
-                    <InviteMembersButton center={true} type="primary" />
-                    <LemonDivider thick dashed className="my-6" />
+                    {currentOrganization?.teams && currentOrganization.teams.length > 1 && (
+                        <>
+                            <LemonButtonWithSideAction
+                                icon={<Lettermark name={currentOrganization?.name} />}
+                                onClick={() => toggleProjectSwitcher()}
+                                sideAction={{
+                                    'aria-label': 'switch project',
+                                    onClick: () => toggleProjectSwitcher(),
+                                    dropdown: {
+                                        visible: isProjectSwitcherShown,
+                                        onClickOutside: hideProjectSwitcher,
+                                        overlay: <ProjectSwitcherOverlay />,
+                                        actionable: true,
+                                    },
+                                }}
+                                type="secondary"
+                                fullWidth
+                            >
+                                <span className="text-muted">Switch project</span>
+                            </LemonButtonWithSideAction>
+                            <LemonDivider thick dashed className="my-6" />
+                        </>
+                    )}
                     <div className="IngestionSidebar__help">
                         <a href={`https://posthog.com/slack${HELP_UTM_TAGS}`} rel="noopener" target="_blank">
                             <LemonButton

--- a/frontend/src/scenes/ingestion/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/ingestionLogic.ts
@@ -209,6 +209,8 @@ export const ingestionLogic = kea<ingestionLogicType>([
         goToView: (view: INGESTION_VIEWS) => ({ view }),
         setSidebarSteps: (steps: string[]) => ({ steps }),
         setPollTimeout: (pollTimeout: number) => ({ pollTimeout }),
+        toggleProjectSwitcher: true,
+        hideProjectSwitcher: true,
     }),
     windowValues({
         isSmallScreen: (window: Window) => window.innerWidth < getBreakpoint('md'),
@@ -297,6 +299,13 @@ export const ingestionLogic = kea<ingestionLogicType>([
             0,
             {
                 setPollTimeout: (_, payload) => payload.pollTimeout,
+            },
+        ],
+        isProjectSwitcherShown: [
+            false,
+            {
+                toggleProjectSwitcher: (state) => !state,
+                hideProjectSwitcher: () => false,
             },
         ],
     }),

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -272,7 +272,8 @@ export const sceneLogic = kea<sceneLogicType>({
                         teamLogic.values.currentTeam &&
                         !teamLogic.values.currentTeam.is_demo &&
                         !teamLogic.values.currentTeam.completed_snippet_onboarding &&
-                        !location.pathname.startsWith('/ingestion')
+                        !location.pathname.startsWith('/ingestion') &&
+                        !location.pathname.startsWith('/project/settings')
                     ) {
                         console.log('Ingestion tutorial not completed, redirecting to it')
                         router.actions.replace(urls.ingestion())

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -937,3 +937,23 @@
 .resize-y {
     resize: vertical;
 }
+
+.static {
+    position: static;
+}
+
+.relative {
+    position: relative;
+}
+
+.absolute {
+    position: absolute;
+}
+
+.fixed {
+    position: fixed;
+}
+
+.sticky {
+    position: sticky;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -174,7 +174,7 @@ module.exports = {
         // 'placeholderColor', // The placeholder color utilities like placeholder-red-600
         // 'placeholderOpacity', // The placeholder color opacity utilities like placeholder-opacity-25
         'pointerEvents', // The pointer-events utilities like pointer-events-none
-        // 'position', // The position utilities like absolute
+        'position', // The position utilities like absolute
         // 'preflight', // Tailwind's base/reset styles
         // 'resize', // The resize utilities like resize-y
         // 'ringColor', // The ring-color utilities like ring-green-700


### PR DESCRIPTION
## Problem

A couple customers have complained that they get stuck on the ingestion screen after creating a new project. They can't go back to their existing project, they can't correct a typo in the project name, etc.

https://posthogusers.slack.com/archives/C01GLBKHKQT/p1675785317789679
https://posthogusers.slack.com/archives/C01GLBKHKQT/p1674506196706869

The way around this was to go through the onboarding screens and then skip waiting for events. But this isn't very intuitive. 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

There's now a project switcher in the ingestion sidebar:

![image](https://user-images.githubusercontent.com/18598166/217882832-473924df-7f6e-436c-8261-6da6b8cda83d.png)

If someone clicks the cog icon it allows them to go to the project settings, but trying to go anywhere else in the app (while in that project) will redirect them to `/ingestion` again. 

This used to be an "invite members" button but we have those all over the actual ingestion steps now, so it's fine to replace it.

I also realized there was a "read our docs" button below the "get help on slack" button but due to fixed positioning it was hidden. So that shows up now too!

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

We have no tests here 😬 But I did made a to-do to add tests to the whole ingestion flow!

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
