### PR TITLE
feat(flags): Have explicit statement timeouts on decide

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -97,68 +97,35 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
-  '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -184,7 +151,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -203,6 +170,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
@@ -798,45 +781,23 @@
 ---
 # name: TestDecide.test_web_app_queries.4
   '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_web_app_queries.5
   '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -97,35 +97,68 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+  '
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -151,7 +184,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -172,7 +205,7 @@
          AND "posthog_featureflag"."team_id" = 2)
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
   '
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -188,20 +221,474 @@
          AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+# name: TestDecide.test_flag_with_behavioural_cohorts
   '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_behavioural_cohorts.1
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_behavioural_cohorts.2
+  '
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_flag_with_behavioural_cohorts.3
+  '
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  WHERE "posthog_cohort"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_behavioural_cohorts.4
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_behavioural_cohorts.5
+  '
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  WHERE "posthog_cohort"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_behavioural_cohorts.6
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.1
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.2
+  '
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.3
+  '
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  WHERE "posthog_cohort"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.4
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.5
+  '
+  SELECT ("posthog_person"."properties" -> '$some_prop_1') = '"something_1"' AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id_1'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.6
+  '
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  WHERE "posthog_cohort"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.7
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDecide.test_flag_with_regular_cohorts.8
+  '
+  SELECT ("posthog_person"."properties" -> '$some_prop_1') = '"something_1"' AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'another_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_web_app_queries
@@ -311,23 +798,45 @@
 ---
 # name: TestDecide.test_web_app_queries.4
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_web_app_queries.5
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -405,6 +405,44 @@
   '
   SELECT pg_sleep(1);
   
+  SELECT (true) AS "flag_X_condition_0",
+         ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db
+  '
+  SELECT "posthog_persondistinctid"."person_id"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
+         AND "posthog_persondistinctid"."team_id" = 2)
+  ORDER BY "posthog_persondistinctid"."id" ASC
+  LIMIT 1
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.1
+  '
+  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key"
+  FROM "posthog_featureflaghashkeyoverride"
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" = 2
+         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.2
+  '
+  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
+         "posthog_featureflaghashkeyoverride"."hash_key"
+  FROM "posthog_featureflaghashkeyoverride"
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" = 2
+         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.3
+  '
   SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0"
   FROM "posthog_person"
@@ -414,17 +452,28 @@
          AND "posthog_person"."team_id" = 2)
   '
 ---
-# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.1
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.4
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
-  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
-         (true) AS "flag_X_condition_0"
-  FROM "posthog_person"
-  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  SELECT "posthog_persondistinctid"."person_id"
+  FROM "posthog_persondistinctid"
   WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
-         AND "posthog_persondistinctid"."team_id" = 2
-         AND "posthog_person"."team_id" = 2)
+         AND "posthog_persondistinctid"."team_id" = 2)
+  ORDER BY "posthog_persondistinctid"."id" ASC
+  LIMIT 1
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.5
+  '
+  SELECT pg_sleep(1);
+  
+  SELECT "posthog_persondistinctid"."person_id"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'random'
+         AND "posthog_persondistinctid"."team_id" = 2)
+  ORDER BY "posthog_persondistinctid"."id" ASC
+  LIMIT 1
   '
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db
@@ -456,48 +505,6 @@
   '
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.2
-  '
-  SELECT pg_sleep(1);
-  
-  SELECT "posthog_grouptypemapping"."id",
-         "posthog_grouptypemapping"."team_id",
-         "posthog_grouptypemapping"."group_type",
-         "posthog_grouptypemapping"."group_type_index",
-         "posthog_grouptypemapping"."name_singular",
-         "posthog_grouptypemapping"."name_plural"
-  FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."team_id" = 2
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.3
-  '
-  SELECT pg_sleep(1);
-  
-  SELECT "posthog_grouptypemapping"."id",
-         "posthog_grouptypemapping"."team_id",
-         "posthog_grouptypemapping"."group_type",
-         "posthog_grouptypemapping"."group_type_index",
-         "posthog_grouptypemapping"."name_singular",
-         "posthog_grouptypemapping"."name_plural"
-  FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."team_id" = 2
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.4
-  '
-  SELECT pg_sleep(1);
-  
-  SELECT "posthog_grouptypemapping"."id",
-         "posthog_grouptypemapping"."team_id",
-         "posthog_grouptypemapping"."group_type",
-         "posthog_grouptypemapping"."group_type_index",
-         "posthog_grouptypemapping"."name_singular",
-         "posthog_grouptypemapping"."name_plural"
-  FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."team_id" = 2
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.5
   '
   SELECT pg_sleep(1);
   

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -401,3 +401,149 @@
      HAVING max(is_deleted) = 0)
   '
 ---
+# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db
+  '
+  SELECT pg_sleep(4);
+  
+  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.1
+  '
+  SELECT pg_sleep(2);
+  
+  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.2
+  '
+  SELECT pg_sleep(2);
+  
+  
+  RESET statement_timeout
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.3
+  '
+  SELECT pg_sleep(2);
+  
+  show statement_timeout
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.4
+  '
+  SELECT pg_sleep(2);
+  
+  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.5
+  '
+  SELECT pg_sleep(2);
+  
+  
+  RESET statement_timeout
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db
+  '
+  SELECT pg_sleep(4);
+  
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.1
+  '
+  SELECT pg_sleep(4);
+  
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.2
+  '
+  SELECT pg_sleep(4);
+  
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.3
+  '
+  SELECT pg_sleep(4);
+  
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.4
+  '
+  SELECT pg_sleep(4);
+  
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.5
+  '
+  SELECT pg_sleep(4);
+  
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -405,8 +405,8 @@
   '
   SELECT pg_sleep(1);
   
-  SELECT (true) AS "flag_X_condition_0",
-         ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0"
+  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -403,7 +403,7 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
   SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0"
@@ -416,7 +416,7 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.1
   '
-  SELECT pg_sleep(2);
+  SELECT pg_sleep(4);
   
   SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0"
@@ -425,47 +425,11 @@
   WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
          AND "posthog_persondistinctid"."team_id" = 2
          AND "posthog_person"."team_id" = 2)
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.2
-  '
-  SELECT pg_sleep(2);
-  
-  
-  RESET statement_timeout
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.3
-  '
-  SELECT pg_sleep(2);
-  
-  show statement_timeout
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.4
-  '
-  SELECT pg_sleep(2);
-  
-  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
-         (true) AS "flag_X_condition_0"
-  FROM "posthog_person"
-  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
-  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
-         AND "posthog_persondistinctid"."team_id" = 2
-         AND "posthog_person"."team_id" = 2)
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_a_working_slow_db.5
-  '
-  SELECT pg_sleep(2);
-  
-  
-  RESET statement_timeout
   '
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",
@@ -479,7 +443,7 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.1
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",
@@ -493,7 +457,7 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.2
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",
@@ -507,7 +471,7 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.3
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",
@@ -521,7 +485,7 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.4
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",
@@ -535,7 +499,7 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db.5
   '
-  SELECT pg_sleep(4);
+  SELECT pg_sleep(1);
   
   SELECT "posthog_grouptypemapping"."id",
          "posthog_grouptypemapping"."team_id",

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -4,9 +4,9 @@ from typing import Dict, List, Optional
 from unittest.mock import patch
 
 from django.core.cache import cache
-from django.db import connection
+from django.db import connection, connections
 from django.db.utils import OperationalError
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.test.client import RequestFactory
 from django.utils import timezone
 from freezegun.api import freeze_time
@@ -2383,7 +2383,13 @@ class QueryTimeoutWrapper:
         # return execute(*args, **kwargs)
 
 
-class TestResiliency(TestCase, QueryMatchingTest):
+def slow_query(execute, sql, *args, **kwargs):
+    return execute(f"SELECT pg_sleep(4); {sql}", *args, **kwargs)
+
+
+class TestResiliency(TransactionTestCase, QueryMatchingTest):
+    databases = {"default", "decide"}
+
     def test_feature_flags_v3_with_group_properties(self):
         self.organization = Organization.objects.create(name="test")
         self.team = Team.objects.create(organization=self.organization)
@@ -2531,7 +2537,9 @@ class TestResiliency(TestCase, QueryMatchingTest):
             self.assertFalse(errors)
 
         # now db is down
-        with snapshot_postgres_queries_context(self), connection.execute_wrapper(QueryTimeoutWrapper()):
+        with snapshot_postgres_queries_context(self, using="decide"), connection["decide"].execute_wrapper(
+            QueryTimeoutWrapper()
+        ):
             all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id")
 
             self.assertTrue("property-flag" not in all_flags)
@@ -2555,3 +2563,177 @@ class TestResiliency(TestCase, QueryMatchingTest):
                 self.assertFalse(all_flags["property-flag"])
                 self.assertTrue(all_flags["default-flag"])
                 self.assertFalse(errors)
+
+    def test_feature_flags_v3_with_a_working_slow_db(self):
+        self.organization = Organization.objects.create(name="test")
+        self.team = Team.objects.create(organization=self.organization)
+        self.user = User.objects.create_and_join(self.organization, "random@test.com", "password", "first_name")
+
+        team_id = self.team.pk
+        rf = RequestFactory()
+        create_request = rf.post(f"api/projects/{self.team.pk}/feature_flags/", {"name": "xyz"})
+        create_request.user = self.user
+
+        Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
+
+        serialized_data = FeatureFlagSerializer(
+            data={
+                "name": "Alpha feature",
+                "key": "property-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {"key": "email", "value": "tim@posthog.com", "type": "person", "operator": "exact"}
+                            ],
+                            "rollout_percentage": None,
+                        }
+                    ]
+                },
+            },
+            context={"team_id": team_id, "request": create_request},
+        )
+        self.assertTrue(serialized_data.is_valid())
+        serialized_data.save()
+
+        # Should be enabled for everyone
+        serialized_data = FeatureFlagSerializer(
+            data={
+                "name": "Alpha feature",
+                "key": "default-flag",
+                "filters": {"groups": [{"properties": [], "rollout_percentage": None}]},
+            },
+            context={"team_id": team_id, "request": create_request},
+        )
+        self.assertTrue(serialized_data.is_valid())
+        serialized_data.save()
+
+        with self.assertNumQueries(1, using="decide"), self.assertNumQueries(0, using="default"):
+            # 1 query to get person properties
+            all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id")
+
+            self.assertTrue(all_flags["property-flag"])
+            self.assertTrue(all_flags["default-flag"])
+            self.assertFalse(errors)
+
+        # now db is slow and times out
+        with snapshot_postgres_queries_context(self, using="decide"), connections["decide"].execute_wrapper(
+            slow_query
+        ), patch("posthog.models.feature_flag.flag_matching.FLAG_MATCHING_QUERY_TIMEOUT_MS", 1000):
+            all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id")
+
+            self.assertTrue("property-flag" not in all_flags)
+            self.assertTrue(all_flags["default-flag"])
+            self.assertTrue(errors)
+
+            # # now db is down, but decide was sent email parameter with correct email
+            with self.assertNumQueries(0, using="decide"), self.assertNumQueries(0, using="default"):
+                all_flags, _, _, errors = get_all_feature_flags(
+                    team_id, "random", property_value_overrides={"email": "tim@posthog.com"}
+                )
+                self.assertTrue(all_flags["property-flag"])
+                self.assertTrue(all_flags["default-flag"])
+                self.assertFalse(errors)
+
+            # # now db is down, but decide was sent email parameter with different email
+            with self.assertNumQueries(0, using="decide"), self.assertNumQueries(0, using="default"):
+                all_flags, _, _, errors = get_all_feature_flags(
+                    team_id, "example_id", property_value_overrides={"email": "tom@posthog.com"}
+                )
+                self.assertFalse(all_flags["property-flag"])
+                self.assertTrue(all_flags["default-flag"])
+                self.assertFalse(errors)
+
+    def test_feature_flags_v3_with_group_properties_and_slow_db(self):
+        self.organization = Organization.objects.create(name="test")
+        self.team = Team.objects.create(organization=self.organization)
+        self.user = User.objects.create_and_join(self.organization, "random@test.com", "password", "first_name")
+
+        team_id = self.team.pk
+        rf = RequestFactory()
+        create_request = rf.post(f"api/projects/{self.team.pk}/feature_flags/", {"name": "xyz"})
+        create_request.user = self.user
+
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+
+        create_group(team_id=self.team.pk, group_type_index=0, group_key=f"org:1", properties={"industry": f"finance"})
+
+        serialized_data = FeatureFlagSerializer(
+            data={
+                "name": "Alpha feature",
+                "key": "group-flag",
+                "filters": {
+                    "aggregation_group_type_index": 0,
+                    "groups": [
+                        {
+                            "properties": [
+                                {"key": "industry", "value": "finance", "type": "group", "group_type_index": 0}
+                            ],
+                            "rollout_percentage": None,
+                        }
+                    ],
+                },
+            },
+            context={"team_id": team_id, "request": create_request},
+        )
+        self.assertTrue(serialized_data.is_valid())
+        serialized_data.save()
+
+        # Should be enabled for everyone, if groups are given
+        serialized_data = FeatureFlagSerializer(
+            data={
+                "name": "Alpha feature",
+                "key": "default-flag",
+                "filters": {
+                    "aggregation_group_type_index": 0,
+                    "groups": [{"properties": [], "rollout_percentage": None}],
+                },
+            },
+            context={"team_id": team_id, "request": create_request},
+        )
+        self.assertTrue(serialized_data.is_valid())
+        serialized_data.save()
+
+        with self.assertNumQueries(2, using="decide"), self.assertNumQueries(0, using="default"):
+            # one query to get group type mappings, another to get group properties
+            all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id", groups={"organization": "org:1"})
+            self.assertTrue(all_flags["group-flag"])
+            self.assertTrue(all_flags["default-flag"])
+            self.assertFalse(errors)
+
+        # now db is down
+        with snapshot_postgres_queries_context(self, using="decide"), connections["decide"].execute_wrapper(slow_query):
+            all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id", groups={"organization": "org:1"})
+
+            self.assertTrue("group-flag" not in all_flags)
+            # can't be true unless we cache group type mappings as well
+            self.assertTrue("default-flag" not in all_flags)
+            self.assertTrue(errors)
+
+            # # now db is down, but decide was sent correct group property overrides
+            with self.assertNumQueries(2, using="decide"), self.assertNumQueries(0, using="default"):
+                # these 2 queries are "None", not executed
+                all_flags, _, _, errors = get_all_feature_flags(
+                    team_id,
+                    "random",
+                    groups={"organization": "org:1"},
+                    group_property_value_overrides={"organization": {"industry": "finance"}},
+                )
+                self.assertTrue("group-flag" not in all_flags)
+                # can't be true unless we cache group type mappings as well
+                self.assertTrue("default-flag" not in all_flags)
+                self.assertTrue(errors)
+
+            # # now db is down, but decide was sent different group property overrides
+            with self.assertNumQueries(2, using="decide"), self.assertNumQueries(0, using="default"):
+                # these 2 queries are "None", not executed
+                all_flags, _, _, errors = get_all_feature_flags(
+                    team_id,
+                    "exam",
+                    groups={"organization": "org:1"},
+                    group_property_value_overrides={"organization": {"industry": "finna"}},
+                )
+                self.assertTrue("group-flag" not in all_flags)
+                # can't be true unless we cache group type mappings as well
+                self.assertTrue("default-flag" not in all_flags)
+                self.assertTrue(errors)

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -16,6 +16,7 @@ from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.property import GroupTypeIndex, GroupTypeName
 from posthog.models.property.property import Property
+from posthog.models.utils import execute_with_timeout
 from posthog.queries.base import match_property, properties_to_Q
 
 from .feature_flag import (
@@ -70,8 +71,9 @@ class FlagsMatcherCache:
 
     @cached_property
     def group_types_to_indexes(self) -> Dict[GroupTypeName, GroupTypeIndex]:
-        group_type_mapping_rows = GroupTypeMapping.objects.filter(team_id=self.team_id).using("decide")
-        return {row.group_type: row.group_type_index for row in group_type_mapping_rows}
+        with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
+            group_type_mapping_rows = GroupTypeMapping.objects.filter(team_id=self.team_id)
+            return {row.group_type: row.group_type_index for row in group_type_mapping_rows}
 
     @cached_property
     def group_type_index_to_name(self) -> Dict[GroupTypeIndex, GroupTypeName]:
@@ -235,77 +237,85 @@ class FeatureFlagMatcher:
 
     @cached_property
     def query_conditions(self) -> Dict[str, bool]:
+        with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
+            team_id = self.feature_flags[0].team_id
+            person_query: QuerySet = Person.objects.filter(
+                team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id
+            )
+            basic_group_query: QuerySet = Group.objects.filter(team_id=team_id)
+            group_query_per_group_type_mapping: Dict[GroupTypeIndex, Tuple[QuerySet, List[str]]] = {}
+            # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
+            # If no groups for a group type are passed in, we can skip querying for that group type,
+            # since the result will always be `false`.
+            for group_type, group_key in self.groups.items():
+                group_type_index = self.cache.group_types_to_indexes.get(group_type)
+                if group_type_index is not None:
+                    # a tuple of querySet and field names
+                    group_query_per_group_type_mapping[group_type_index] = (
+                        basic_group_query.filter(group_type_index=group_type_index, group_key=group_key),
+                        [],
+                    )
 
-        team_id = self.feature_flags[0].team_id
-        person_query: QuerySet = Person.objects.filter(
-            team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id
-        ).using("decide")
-        basic_group_query: QuerySet = Group.objects.filter(team_id=team_id).using("decide")
-        group_query_per_group_type_mapping: Dict[GroupTypeIndex, Tuple[QuerySet, List[str]]] = {}
-        # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
-        # If no groups for a group type are passed in, we can skip querying for that group type,
-        # since the result will always be `false`.
-        for group_type, group_key in self.groups.items():
-            group_type_index = self.cache.group_types_to_indexes.get(group_type)
-            if group_type_index is not None:
-                # a tuple of querySet and field names
-                group_query_per_group_type_mapping[group_type_index] = (
-                    basic_group_query.filter(group_type_index=group_type_index, group_key=group_key),
-                    [],
-                )
+            person_fields = []
 
-        person_fields = []
-
-        for feature_flag in self.feature_flags:
-            for index, condition in enumerate(feature_flag.conditions):
-                key = f"flag_{feature_flag.pk}_condition_{index}"
-                expr: Any = None
-                if len(condition.get("properties", {})) > 0:
-                    # Feature Flags don't support OR filtering yet
-                    target_properties = self.property_value_overrides
-                    if feature_flag.aggregation_group_type_index is not None:
-                        target_properties = self.group_property_value_overrides.get(
-                            self.cache.group_type_index_to_name[feature_flag.aggregation_group_type_index], {}
+            for feature_flag in self.feature_flags:
+                for index, condition in enumerate(feature_flag.conditions):
+                    key = f"flag_{feature_flag.pk}_condition_{index}"
+                    expr: Any = None
+                    if len(condition.get("properties", {})) > 0:
+                        # Feature Flags don't support OR filtering yet
+                        target_properties = self.property_value_overrides
+                        if feature_flag.aggregation_group_type_index is not None:
+                            target_properties = self.group_property_value_overrides.get(
+                                self.cache.group_type_index_to_name[feature_flag.aggregation_group_type_index], {}
+                            )
+                        expr = properties_to_Q(
+                            Filter(data=condition).property_groups.flat,
+                            override_property_values=target_properties,
                         )
-                    expr = properties_to_Q(
-                        Filter(data=condition).property_groups.flat,
-                        override_property_values=target_properties,
-                    )
 
-                if feature_flag.aggregation_group_type_index is None:
-                    person_query = person_query.annotate(
-                        **{key: ExpressionWrapper(expr if expr else RawSQL("true", []), output_field=BooleanField())}
-                    )
-                    person_fields.append(key)
-                else:
-                    if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
-                        # ignore flags that didn't have the right groups passed in
-                        continue
-                    group_query, group_fields = group_query_per_group_type_mapping[
-                        feature_flag.aggregation_group_type_index
-                    ]
-                    group_query = group_query.annotate(
-                        **{key: ExpressionWrapper(expr if expr else RawSQL("true", []), output_field=BooleanField())}
-                    )
-                    group_fields.append(key)
-                    group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
-                        group_query,
-                        group_fields,
-                    )
+                    if feature_flag.aggregation_group_type_index is None:
+                        person_query = person_query.annotate(
+                            **{
+                                key: ExpressionWrapper(
+                                    expr if expr else RawSQL("true", []), output_field=BooleanField()
+                                )
+                            }
+                        )
+                        person_fields.append(key)
+                    else:
+                        if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
+                            # ignore flags that didn't have the right groups passed in
+                            continue
+                        group_query, group_fields = group_query_per_group_type_mapping[
+                            feature_flag.aggregation_group_type_index
+                        ]
+                        group_query = group_query.annotate(
+                            **{
+                                key: ExpressionWrapper(
+                                    expr if expr else RawSQL("true", []), output_field=BooleanField()
+                                )
+                            }
+                        )
+                        group_fields.append(key)
+                        group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
+                            group_query,
+                            group_fields,
+                        )
 
-        all_conditions = {}
-        if len(person_fields) > 0:
-            person_query = person_query.values(*person_fields)
-            if len(person_query) > 0:
-                all_conditions = {**person_query[0]}
+            all_conditions = {}
+            if len(person_fields) > 0:
+                person_query = person_query.values(*person_fields)
+                if len(person_query) > 0:
+                    all_conditions = {**person_query[0]}
 
-        for group_query, group_fields in group_query_per_group_type_mapping.values():
-            group_query = group_query.values(*group_fields)
-            if len(group_query) > 0:
-                assert len(group_query) == 1, f"Expected 1 group query result, got {len(group_query)}"
-                all_conditions = {**all_conditions, **group_query[0]}
+            for group_query, group_fields in group_query_per_group_type_mapping.values():
+                group_query = group_query.values(*group_fields)
+                if len(group_query) > 0:
+                    assert len(group_query) == 1, f"Expected 1 group query result, got {len(group_query)}"
+                    all_conditions = {**all_conditions, **group_query[0]}
 
-        return all_conditions
+            return all_conditions
 
     def hashed_identifier(self, feature_flag: FeatureFlag) -> Optional[str]:
         """

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -31,18 +31,9 @@ else:
     DATABASE_URL = os.getenv("DATABASE_URL", "")
 
 if DATABASE_URL:
-    DATABASES = {
-        "default": dj_database_url.config(default=DATABASE_URL, conn_max_age=600),
-        "decide": dj_database_url.config(default=DATABASE_URL, conn_max_age=0),
-    }
+    DATABASES = {"default": dj_database_url.config(default=DATABASE_URL, conn_max_age=600)}
     if DISABLE_SERVER_SIDE_CURSORS:
         DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
-
-    DATABASES["decide"]["OPTIONS"] = {
-        "options": "-c statement_timeout=3000",
-    }
-    # DATABASES['decide']['ATOMIC_REQUESTS'] = True
-
 elif os.getenv("POSTHOG_DB_NAME"):
     DATABASES = {
         "default": {

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -31,9 +31,18 @@ else:
     DATABASE_URL = os.getenv("DATABASE_URL", "")
 
 if DATABASE_URL:
-    DATABASES = {"default": dj_database_url.config(default=DATABASE_URL, conn_max_age=600)}
+    DATABASES = {
+        "default": dj_database_url.config(default=DATABASE_URL, conn_max_age=600),
+        "decide": dj_database_url.config(default=DATABASE_URL, conn_max_age=0),
+    }
     if DISABLE_SERVER_SIDE_CURSORS:
         DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
+
+    DATABASES["decide"]["OPTIONS"] = {
+        "options": "-c statement_timeout=3000",
+    }
+    # DATABASES['decide']['ATOMIC_REQUESTS'] = True
+
 elif os.getenv("POSTHOG_DB_NAME"):
     DATABASES = {
         "default": {

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -354,7 +354,9 @@ class QueryMatchingTest:
 
 
 @contextmanager
-def snapshot_postgres_queries_context(testcase: QueryMatchingTest, replace_all_numbers: bool = True):
+def snapshot_postgres_queries_context(
+    testcase: QueryMatchingTest, replace_all_numbers: bool = True, using: str = "default"
+):
     """
     Captures and snapshots select queries from test using `syrupy` library.
     Requires queries to be stable to avoid flakiness.
@@ -381,7 +383,7 @@ def snapshot_postgres_queries_context(testcase: QueryMatchingTest, replace_all_n
                 # Run some code that generates queries
 
     """
-    with CaptureQueriesContext(connections["default"]) as context:
+    with CaptureQueriesContext(connections[using]) as context:
         yield context
 
     for query_with_time in context.captured_queries:

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -952,7 +952,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             key="variant",
         )
 
-        with self.assertNumQueries(4), snapshot_postgres_queries_context(
+        with self.assertNumQueries(10), snapshot_postgres_queries_context(
             self
         ):  # 1 to fill group cache, 2 to match feature flags with group properties (of each type), 1 to match feature flags with person properties
             matches, reasons, payloads, _ = FeatureFlagMatcher(
@@ -1006,7 +1006,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
 
         self.assertEqual(payloads, {"variant": {"color": "blue"}})
 
-        with self.assertNumQueries(3), snapshot_postgres_queries_context(
+        with self.assertNumQueries(9), snapshot_postgres_queries_context(
             self
         ):  # 1 to fill group cache, 1 to match feature flags with group properties (only 1 group provided), 1 to match feature flags with person properties
             matches, reasons, payloads, _ = FeatureFlagMatcher(
@@ -1073,12 +1073,12 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 ]
             }
         )
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "example_id").get_match(feature_flag),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
             )
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "another_id").get_match(feature_flag),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 1),
@@ -1100,7 +1100,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 ]
             }
         )
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={}).get_match(feature_flag),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
@@ -1113,7 +1113,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 1),
             )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag),
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 1),
@@ -1146,7 +1146,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
         # force the query to load group types
         cache.group_type_index_to_name
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(12):
             self.assertEqual(
                 FeatureFlagMatcher(
                     [feature_flag],
@@ -1232,7 +1232,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 1),
             )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag),
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 1),
@@ -1260,7 +1260,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 ]
             }
         )
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(8):
             # None in both because all conditions don't match
             # and user doesn't exist yet
             self.assertEqual(
@@ -1276,7 +1276,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
             )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag),
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
@@ -1327,7 +1327,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
         feature_flag = self.create_feature_flag(
             filters={"groups": [{"properties": [{"key": "email", "operator": "is_not_set"}]}]}
         )
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(8):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={}).get_match(feature_flag),
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
@@ -1339,7 +1339,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
             )
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(8):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
@@ -1530,7 +1530,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             rollout_percentage=50,
             filters={"properties": [{"key": "email", "value": "tim@posthog.com", "type": "person"}]},
         )
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(4):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "example_id").get_match(feature_flag),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),


### PR DESCRIPTION
## Problem

Our statements have no timeout, so when the db is slow, and decide takes longer than 10s, we timeout and return a 500, which is sad :/ . Given the resiliency work before, we're able to handle partial responses, so, we want an aggressive timeout on decide db calls: like 3 seconds.

The below wouldn't work for reasons, so new approach is to set transaction local statement timeouts for every db query. This is a bit fragile w.r.t new changes, but existing tests _should_ help us catch any discrepancies when we forget to use the manager to add timeouts.



----

To do this, I created a separate connection pool on the same db, all connections on which have a statement timeout.

I didn't go the 'set timeout on the session' route, because if things go wrong, like the statement timing out, it can be hard to recover and reset the timeout, and other things connecting to the db might face the same timeout, which can be nasty.

Before I go fix all tests, wanted to put this out here.

Things I don't know yet, which we need to test:

1. Will this make a separate connection pool in django?
2. How does this interact with pgbouncer? - can things go wrong because of bouncer in the middle?
3. That option is supposed to pass the equivalent of a cli arg to postgres. If `default` and `decide` are the same db, how does this work? (tests suggest it's independent, but no clue how yet)
4. Unknown unknowns?? - definitely want to test this in dev before going to prod!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
