### PR TITLE
fix: make sure we have products before find() in two other spots

### DIFF
--- a/frontend/src/scenes/billing/v2/billingV2Logic.ts
+++ b/frontend/src/scenes/billing/v2/billingV2Logic.ts
@@ -143,7 +143,7 @@ export const billingV2Logic = kea<billingV2LogicType>([
                     }
                 }
 
-                const productApproachingLimit = billing.products.find(
+                const productApproachingLimit = billing.products?.find(
                     (x) => x.percentage_usage > ALLOCATION_THRESHOLD_ALERT
                 )
 
@@ -169,7 +169,7 @@ export const billingV2Logic = kea<billingV2LogicType>([
                     ((billingVersion === 'v2' &&
                         !billing.has_active_subscription &&
                         !billing.free_trial_until &&
-                        billing.products.find((x) => {
+                        billing.products?.find((x) => {
                             return x.percentage_usage > ALLOCATION_THRESHOLD_BLOCK
                         })) ||
                         billing.deactivated) &&


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/3927055364/?project=4503944059682816

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Make sure we have products in `billing.products` before we try to `find()` in them. 

This should hopefully catch all places where this can happen....

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't, really, because I don't know how to reproduce, but this should fix the error.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
