### PR TITLE
feat(dashboards): simplify auto-refresh options to 30m and 60m

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -21,7 +21,7 @@ export const LastRefreshText = (): JSX.Element => {
 
 // in seconds
 const intervalOptions = [
-    ...Array.from([1800, 2400, 3000, 3600], (v) => ({
+    ...Array.from([1800, 3600], (v) => ({
         label: humanFriendlyDuration(v),
         value: v,
     })),


### PR DESCRIPTION
Quick change based on @lharries suggestion on #14143 