### PR TITLE
fix: Set timestamp to now if the timestamp is in the future (ingestion)

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -84,8 +84,9 @@ const WARNING_TYPE_RENDERER = {
         }
         return (
             <>
-                Timestamp computed to <code>{details.result}</code> from the following input:
+                The event timestamp computed too far in the future, so the capture time was used instead. Event values:
                 <ul>
+                    <li>Computed timestamp: {details.result}</li>
                     {details.timestamp ? <li>Client provided timestamp: {details.timestamp}</li> : ''}
                     {details.sentAt ? <li>Client provided sent_at: {details.sentAt}</li> : ''}
                     {details.offset ? <li>Client provided time offset: {details.offset}</li> : ''}

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -6,7 +6,7 @@ import { status } from '../../utils/status'
 
 type IngestionWarningCallback = (type: string, details: Record<string, any>) => void
 
-const FutureEventHoursCutoffMillis = 23 * 3600 * 1000
+const FutureEventHoursCutoffMillis = 23 * 3600 * 1000 // 23 hours
 
 export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarningCallback): DateTime {
     const now = DateTime.fromISO(data['now']).toUTC() // now is set by the capture endpoint and assumed valid

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -85,6 +85,7 @@ function handleTimestamp(
 
     // Events in the future would indicate an instrumentation bug, lets' ingest them
     // but publish an integration warning to help diagnose such issues.
+    // We will also 'fix' the date to be now()
     if (nowDiff > FutureEventHoursCutoffMillis) {
         callback?.('event_timestamp_in_future', {
             timestamp: data['timestamp'] ?? '',
@@ -96,7 +97,7 @@ function handleTimestamp(
             eventName: data['event'],
         })
 
-        parsedTs = timestamp
+        parsedTs = now
     }
 
     return parsedTs

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -176,7 +176,7 @@ describe('parseEventTimestamp()', () => {
             ],
         ])
 
-        expect(timestamp.toISO()).toEqual('2021-10-29T02:30:00.000Z')
+        expect(timestamp.toISO()).toEqual('2021-10-29T01:00:00.000Z')
     })
 
     it('reports event_timestamp_in_future with negative offset', () => {


### PR DESCRIPTION
- fix: Set timestamp to now if the timestamp is in the future
- update test

## Problem

We have events showing up in views that are 50+ years into the future. This is not a great look for us. We need some way to tell customers that they are sending us bad data while also keeping the value of the data.

Here we are setting the timestamp for the event to now if it is in the future as a guard. We are also notifying users in the ingestion warnings that things are broken

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
