### PR TITLE
fix(query-settings): dont set join_algorithm on older ClickHouse versions

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -61,11 +61,11 @@ def clickhouse_at_least_228() -> bool:
 
 
 def extra_settings(query_id: Optional[str], tags: Dict[str, Any]) -> Dict[str, Any]:
-    if tags.get("kind") != "celery":
+    if tags.get("kind") != "celery" or not clickhouse_at_least_228():
         return {}
 
     # The `default` option for join_algorithm was introduced with CH 22.8
-    default_join_algorithm = "default" if clickhouse_at_least_228() else "direct,hash"
+    default_join_algorithm = "default"
 
     join_algorithm = (
         posthoganalytics.get_feature_flag(


### PR DESCRIPTION
Not all join algorithms are guaranteed to have been supported in past versions