### PR TITLE
refactor(data-exploration): make filter to query conversion more robust

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -32,6 +32,8 @@ import {
     midEllipsis,
     numericOperatorMap,
     objectDiffShallow,
+    objectClean,
+    objectCleanWithEmpty,
     pluralize,
     range,
     reverseColonDelimitedDuration,
@@ -589,6 +591,32 @@ describe('objectDiffShallow()', () => {
             b: '3',
             a: '2',
             c: undefined,
+        })
+    })
+})
+
+describe('objectClean()', () => {
+    it('removes undefined values', () => {
+        expect(objectClean({ a: 1, b: 'b', c: null, d: {}, e: [], f: undefined })).toStrictEqual({
+            a: 1,
+            b: 'b',
+            c: null,
+            d: {},
+            e: [],
+        })
+    })
+})
+
+describe('objectCleanWithEmpty()', () => {
+    it('removes undefined and empty values', () => {
+        expect(
+            objectCleanWithEmpty({ a: 1, b: 'b', c: null, d: {}, e: [], f: undefined, g: { x: 1 }, h: [1] })
+        ).toStrictEqual({
+            a: 1,
+            b: 'b',
+            c: null,
+            g: { x: 1 },
+            h: [1],
         })
     })
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -420,6 +420,33 @@ export function objectClean<T extends Record<string | number | symbol, unknown>>
     })
     return response
 }
+export function objectCleanWithEmpty<T extends Record<string | number | symbol, unknown>>(obj: T): T {
+    const response = { ...obj }
+    Object.keys(response).forEach((key) => {
+        // remove undefined values
+        if (response[key] === undefined) {
+            delete response[key]
+        }
+        // remove empty arrays i.e. []
+        if (
+            typeof response[key] === 'object' &&
+            Array.isArray(response[key]) &&
+            (response[key] as unknown[]).length === 0
+        ) {
+            delete response[key]
+        }
+        // remove empty objects i.e. {}
+        if (
+            typeof response[key] === 'object' &&
+            !Array.isArray(response[key]) &&
+            response[key] !== null &&
+            Object.keys(response[key] as Record<string | number | symbol, unknown>).length === 0
+        ) {
+            delete response[key]
+        }
+    })
+    return response
+}
 
 /** Returns "response" from: obj2 = { ...obj1, ...response }  */
 export function objectDiffShallow(obj1: Record<string, any>, obj2: Record<string, any>): Record<string, any> {

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -1,5 +1,41 @@
-import { ActionFilter } from '~/types'
-import { actionsAndEventsToSeries } from './filtersToQueryNode'
+import { FunnelLayout, ShownAsValue } from 'lib/constants'
+import {
+    InsightQueryNode,
+    TrendsQuery,
+    FunnelsQuery,
+    RetentionQuery,
+    StickinessQuery,
+    LifecycleQuery,
+    NodeKind,
+    PathsQuery,
+} from '~/queries/schema'
+import {
+    TrendsFilterType,
+    RetentionFilterType,
+    FunnelsFilterType,
+    PathsFilterType,
+    StickinessFilterType,
+    LifecycleFilterType,
+    ActionFilter,
+    BaseMathType,
+    ChartDisplayType,
+    FilterLogicalOperator,
+    FilterType,
+    InsightType,
+    PropertyFilterType,
+    PropertyMathType,
+    PropertyOperator,
+    FunnelVizType,
+    FunnelStepReference,
+    BreakdownAttributionType,
+    FunnelConversionWindowTimeUnit,
+    StepOrderValue,
+    PathType,
+    FunnelPathType,
+    RetentionPeriod,
+    GroupMathType,
+} from '~/types'
+import { actionsAndEventsToSeries, filtersToQueryNode } from './filtersToQueryNode'
 
 describe('actionsAndEventsToSeries', () => {
     it('sorts series by order', () => {
@@ -28,5 +64,1132 @@ describe('actionsAndEventsToSeries', () => {
         expect(result[0].name).toEqual('itemWithOrder')
         expect(result[1].name).toEqual('item1')
         expect(result[2].name).toEqual('item2')
+    })
+})
+
+describe('filtersToQueryNode', () => {
+    describe('global filters', () => {
+        it('converts test account filter', () => {
+            const filters: Partial<FilterType> = {
+                insight: InsightType.RETENTION,
+                filter_test_accounts: true,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: InsightQueryNode = {
+                kind: NodeKind.RetentionQuery,
+                filterTestAccounts: true,
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts properties', () => {
+            const filters: Partial<FilterType> = {
+                insight: InsightType.RETENTION,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: 'email',
+                                    type: PropertyFilterType.Person,
+                                    value: 'is_set',
+                                    operator: PropertyOperator.IsSet,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: InsightQueryNode = {
+                kind: NodeKind.RetentionQuery,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: 'email',
+                                    type: PropertyFilterType.Person,
+                                    value: 'is_set',
+                                    operator: PropertyOperator.IsSet,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts date range', () => {
+            const filters: Partial<FilterType> = {
+                insight: InsightType.RETENTION,
+                date_to: '2021-12-08',
+                date_from: '2021-12-08',
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: InsightQueryNode = {
+                kind: NodeKind.RetentionQuery,
+                dateRange: {
+                    date_to: '2021-12-08',
+                    date_from: '2021-12-08',
+                },
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('filter with series', () => {
+        it('converts series', () => {
+            const filters: Partial<FilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    { id: '$pageview', type: 'events', order: 0, name: 'item1' },
+                    { id: '$autocapture', type: 'events', order: 2, name: 'item3' },
+                ],
+                actions: [{ type: 'actions', id: 1, order: 1, name: 'item2', math: 'total' }],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: InsightQueryNode = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: '$pageview',
+                        name: 'item1',
+                    },
+                    {
+                        kind: NodeKind.ActionsNode,
+                        id: 1,
+                        math: BaseMathType.TotalCount,
+                        name: 'item2',
+                    },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: '$autocapture',
+                        name: 'item3',
+                    },
+                ],
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts interval', () => {
+            const filters: Partial<FilterType> = {
+                insight: InsightType.TRENDS,
+                interval: 'day',
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: Partial<TrendsQuery> = {
+                kind: NodeKind.TrendsQuery,
+                interval: 'day',
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('trends filter', () => {
+        it('converts all properties', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                smoothing_intervals: 1,
+                show_legend: true,
+                hidden_legend_keys: { 0: true, 10: true },
+                compare: true,
+                aggregation_axis_format: 'numeric',
+                aggregation_axis_prefix: '£',
+                aggregation_axis_postfix: '%',
+                breakdown_histogram_bin_count: 1,
+                formula: 'A+B',
+                shown_as: ShownAsValue.VOLUME,
+                display: ChartDisplayType.ActionsAreaGraph,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: Partial<TrendsQuery> = {
+                kind: NodeKind.TrendsQuery,
+                trendsFilter: {
+                    smoothing_intervals: 1,
+                    show_legend: true,
+                    hidden_legend_keys: { 0: true, 10: true },
+                    compare: true,
+                    aggregation_axis_format: 'numeric',
+                    aggregation_axis_prefix: '£',
+                    aggregation_axis_postfix: '%',
+                    breakdown_histogram_bin_count: 1,
+                    formula: 'A+B',
+                    shown_as: ShownAsValue.VOLUME,
+                    display: ChartDisplayType.ActionsAreaGraph,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('funnels filter', () => {
+        it('converts all properties', () => {
+            const filters: Partial<FunnelsFilterType> = {
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+                funnel_from_step: 1,
+                funnel_to_step: 2,
+                funnel_step_reference: FunnelStepReference.total,
+                funnel_step_breakdown: 1,
+                breakdown_attribution_type: BreakdownAttributionType.AllSteps,
+                breakdown_attribution_value: 1,
+                bin_count: 'auto',
+                funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Day,
+                funnel_window_interval: 7,
+                funnel_order_type: StepOrderValue.ORDERED,
+                exclusions: [
+                    {
+                        funnel_from_step: 0,
+                        funnel_to_step: 1,
+                    },
+                ],
+                funnel_correlation_person_entity: { a: 1 },
+                funnel_correlation_person_converted: 'true',
+                funnel_custom_steps: [1, 2, 3],
+                funnel_advanced: true,
+                layout: FunnelLayout.horizontal,
+                funnel_step: 1,
+                entrance_period_start: 'abc',
+                drop_off: true,
+                hidden_legend_keys: { 0: true, 10: true },
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: Partial<FunnelsQuery> = {
+                kind: NodeKind.FunnelsQuery,
+                funnelsFilter: {
+                    funnel_viz_type: FunnelVizType.Steps,
+                    funnel_from_step: 1,
+                    funnel_to_step: 2,
+                    funnel_step_reference: FunnelStepReference.total,
+                    funnel_step_breakdown: 1,
+                    breakdown_attribution_type: BreakdownAttributionType.AllSteps,
+                    breakdown_attribution_value: 1,
+                    bin_count: 'auto',
+                    funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Day,
+                    funnel_window_interval: 7,
+                    funnel_order_type: StepOrderValue.ORDERED,
+                    exclusions: [
+                        {
+                            funnel_from_step: 0,
+                            funnel_to_step: 1,
+                        },
+                    ],
+                    funnel_correlation_person_entity: { a: 1 },
+                    funnel_correlation_person_converted: 'true',
+                    funnel_custom_steps: [1, 2, 3],
+                    funnel_advanced: true,
+                    layout: FunnelLayout.horizontal,
+                    funnel_step: 1,
+                    entrance_period_start: 'abc',
+                    drop_off: true,
+                    hidden_legend_keys: { 0: true, 10: true },
+                },
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('retention filter', () => {
+        it('converts all properties', () => {
+            const filters: Partial<RetentionFilterType> = {
+                insight: InsightType.RETENTION,
+                retention_type: 'retention_first_time',
+                retention_reference: 'total',
+                total_intervals: 2,
+                returning_entity: [{ a: 1 }],
+                target_entity: [{ b: 1 }],
+                period: RetentionPeriod.Day,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: Partial<RetentionQuery> = {
+                kind: NodeKind.RetentionQuery,
+                retentionFilter: {
+                    retention_type: 'retention_first_time',
+                    retention_reference: 'total',
+                    total_intervals: 2,
+                    returning_entity: [{ a: 1 }],
+                    target_entity: [{ b: 1 }],
+                    period: RetentionPeriod.Day,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('paths filter', () => {
+        it('converts all properties', () => {
+            const filters: Partial<PathsFilterType> = {
+                insight: InsightType.PATHS,
+                path_type: PathType.Screen,
+                include_event_types: [PathType.Screen, PathType.PageView],
+                start_point: 'a',
+                end_point: 'b',
+                path_groupings: ['c', 'd'],
+                funnel_paths: FunnelPathType.between,
+                funnel_filter: { a: 1 },
+                exclude_events: ['e', 'f'],
+                step_limit: 1,
+                path_start_key: 'g',
+                path_end_key: 'h',
+                path_dropoff_key: 'i',
+                path_replacements: true,
+                local_path_cleaning_filters: [{ alias: 'home' }],
+                edge_limit: 1,
+                min_edge_weight: 1,
+                max_edge_weight: 1,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: Partial<PathsQuery> = {
+                kind: NodeKind.PathsQuery,
+                pathsFilter: {
+                    path_type: PathType.Screen,
+                    include_event_types: [PathType.Screen, PathType.PageView],
+                    start_point: 'a',
+                    end_point: 'b',
+                    path_groupings: ['c', 'd'],
+                    funnel_paths: FunnelPathType.between,
+                    funnel_filter: { a: 1 },
+                    exclude_events: ['e', 'f'],
+                    step_limit: 1,
+                    path_start_key: 'g',
+                    path_end_key: 'h',
+                    path_dropoff_key: 'i',
+                    path_replacements: true,
+                    local_path_cleaning_filters: [{ alias: 'home' }],
+                    edge_limit: 1,
+                    min_edge_weight: 1,
+                    max_edge_weight: 1,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('stickiness filter', () => {
+        it('converts all properties', () => {
+            const filters: Partial<StickinessFilterType> = {
+                insight: InsightType.STICKINESS,
+                compare: true,
+                show_legend: true,
+                hidden_legend_keys: { 0: true, 10: true },
+                stickiness_days: 2,
+                shown_as: ShownAsValue.STICKINESS,
+                display: ChartDisplayType.ActionsLineGraph,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: Partial<StickinessQuery> = {
+                kind: NodeKind.StickinessQuery,
+                stickinessFilter: {
+                    compare: true,
+                    show_legend: true,
+                    hidden_legend_keys: { 0: true, 10: true },
+                    stickiness_days: 2,
+                    shown_as: ShownAsValue.STICKINESS,
+                    display: ChartDisplayType.ActionsLineGraph,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('lifecycle filter', () => {
+        it('converts all properties', () => {
+            const filters: Partial<LifecycleFilterType> = {
+                insight: InsightType.LIFECYCLE,
+                shown_as: ShownAsValue.LIFECYCLE,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: Partial<LifecycleQuery> = {
+                kind: NodeKind.LifecycleQuery,
+                lifecycleFilter: {
+                    shown_as: ShownAsValue.LIFECYCLE,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
+    describe('example insights', () => {
+        it('converts `New user retention` insight', () => {
+            const filters: Partial<RetentionFilterType> = {
+                insight: InsightType.RETENTION,
+                period: RetentionPeriod.Week,
+                // TODO: why does the original example have a display here?
+                // display: ChartDisplayType.ActionsTable,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: 'email',
+                                    type: PropertyFilterType.Person,
+                                    value: 'is_set',
+                                    operator: PropertyOperator.IsSet,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                target_entity: {
+                    id: 'signed_up',
+                    name: 'signed_up',
+                    type: 'events',
+                    order: 0,
+                },
+                retention_type: 'retention_first_time',
+                total_intervals: 9,
+                returning_entity: {
+                    id: 1,
+                    name: 'Interacted with file',
+                    type: 'actions',
+                    order: 0,
+                },
+                date_from: '-7d',
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: RetentionQuery = {
+                kind: NodeKind.RetentionQuery,
+                dateRange: {
+                    date_from: '-7d',
+                },
+                retentionFilter: {
+                    period: RetentionPeriod.Week,
+                    target_entity: {
+                        id: 'signed_up',
+                        name: 'signed_up',
+                        type: 'events',
+                        order: 0,
+                    },
+                    retention_type: 'retention_first_time',
+                    total_intervals: 9,
+                    returning_entity: {
+                        id: 1,
+                        name: 'Interacted with file',
+                        type: 'actions',
+                        order: 0,
+                    },
+                },
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: 'email',
+                                    type: PropertyFilterType.Person,
+                                    value: 'is_set',
+                                    operator: PropertyOperator.IsSet,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Active user lifecycle` insight', () => {
+            const filters: Partial<LifecycleFilterType> = {
+                insight: InsightType.LIFECYCLE,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [],
+                },
+                filter_test_accounts: true,
+                date_from: '-8w',
+                entity_type: 'events', // TODO: what does this do?
+                actions: [
+                    {
+                        type: 'actions',
+                        id: 1,
+                        name: 'Interacted with file',
+                        math: 'total',
+                    },
+                ],
+                events: [],
+                interval: 'day',
+                shown_as: ShownAsValue.LIFECYCLE,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: LifecycleQuery = {
+                kind: NodeKind.LifecycleQuery,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [],
+                },
+                filterTestAccounts: true,
+                dateRange: {
+                    date_from: '-8w',
+                },
+                series: [
+                    {
+                        kind: NodeKind.ActionsNode,
+                        id: 1,
+                        name: 'Interacted with file',
+                        math: BaseMathType.TotalCount,
+                    },
+                ],
+                interval: 'day',
+                lifecycleFilter: {
+                    shown_as: ShownAsValue.LIFECYCLE,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Monthly app revenue` insight', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: 'paid_bill',
+                        math: 'sum',
+                        type: 'events',
+                        order: 0,
+                        math_property: 'amount_usd',
+                    },
+                ],
+                actions: [],
+                date_from: '-6m',
+                interval: 'month',
+                display: ChartDisplayType.ActionsLineGraph,
+                properties: [],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'paid_bill',
+                        math: PropertyMathType.Sum,
+                        math_property: 'amount_usd',
+                    },
+                ],
+                dateRange: {
+                    date_from: '-6m',
+                },
+                interval: 'month',
+                trendsFilter: {
+                    display: ChartDisplayType.ActionsLineGraph,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Bills paid` insight', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: 'paid_bill',
+                        math: 'unique_group',
+                        name: 'paid_bill',
+                        type: 'events',
+                        order: 0,
+                        math_group_type_index: 0,
+                    },
+                ],
+                actions: [],
+                compare: true,
+                date_to: null,
+                display: ChartDisplayType.BoldNumber,
+                date_from: '-30d',
+                properties: [],
+                filter_test_accounts: true,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'paid_bill',
+                        name: 'paid_bill',
+                        math: GroupMathType.UniqueGroup,
+                        math_group_type_index: 0,
+                    },
+                ],
+                dateRange: {
+                    date_to: null,
+                    date_from: '-30d',
+                },
+                filterTestAccounts: true,
+                trendsFilter: {
+                    compare: true,
+                    display: ChartDisplayType.BoldNumber,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Daily unique visitors over time` insight', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: '$pageview',
+                        math: 'dau',
+                        type: 'events',
+                        order: 0,
+                    },
+                ],
+                actions: [],
+                display: ChartDisplayType.ActionsLineGraph,
+                interval: 'day',
+                date_from: '-6m',
+                properties: [],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: '$pageview',
+                        math: BaseMathType.UniqueUsers,
+                    },
+                ],
+                dateRange: {
+                    date_from: '-6m',
+                },
+                interval: 'day',
+                trendsFilter: {
+                    display: ChartDisplayType.ActionsLineGraph,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Most popular pages` insight', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: '$pageview',
+                        math: 'total',
+                        type: 'events',
+                        order: 0,
+                    },
+                ],
+                actions: [],
+                display: ChartDisplayType.ActionsTable,
+                breakdown: '$current_url',
+                date_from: '-6m',
+                new_entity: [],
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: '$current_url',
+                                    type: PropertyFilterType.Event,
+                                    value: '/files/',
+                                    operator: PropertyOperator.NotIContains,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                breakdown_type: 'event',
+                breakdown_normalize_url: true,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: '$pageview',
+                        math: BaseMathType.TotalCount,
+                    },
+                ],
+                trendsFilter: {
+                    display: ChartDisplayType.ActionsTable,
+                },
+                breakdown: {
+                    breakdown: '$current_url',
+                    breakdown_type: 'event',
+                    breakdown_normalize_url: true,
+                },
+                dateRange: {
+                    date_from: '-6m',
+                },
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: '$current_url',
+                                    type: PropertyFilterType.Event,
+                                    value: '/files/',
+                                    operator: PropertyOperator.NotIContains,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Weekly signups` insight', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: 'signed_up',
+                        type: 'events',
+                        order: 0,
+                    },
+                ],
+                actions: [],
+                display: ChartDisplayType.ActionsLineGraph,
+                interval: 'week',
+                date_from: '-8w',
+                properties: [],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'signed_up',
+                    },
+                ],
+                trendsFilter: {
+                    display: ChartDisplayType.ActionsLineGraph,
+                },
+                interval: 'week',
+                dateRange: {
+                    date_from: '-8w',
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Homepage view to signup conversion` insight', () => {
+            const filters: Partial<FunnelsFilterType> = {
+                insight: InsightType.FUNNELS,
+                date_from: '-1m',
+                actions: [],
+                events: [
+                    {
+                        id: '$pageview',
+                        name: '$pageview',
+                        type: 'events',
+                        order: 0,
+                        properties: [
+                            {
+                                key: '$current_url',
+                                type: 'event',
+                                value: 'https://hedgebox.net/',
+                                operator: 'exact',
+                            },
+                        ],
+                        custom_name: 'Viewed homepage',
+                    },
+                    {
+                        id: '$pageview',
+                        name: '$pageview',
+                        type: 'events',
+                        order: 1,
+                        properties: [
+                            {
+                                key: '$current_url',
+                                type: 'event',
+                                value: 'https://hedgebox.net/signup/',
+                                operator: 'regex',
+                            },
+                        ],
+                        custom_name: 'Viewed signup page',
+                    },
+                    {
+                        id: 'signed_up',
+                        name: 'signed_up',
+                        type: 'events',
+                        order: 2,
+                        custom_name: 'Signed up',
+                    },
+                ],
+                filter_test_accounts: true,
+                funnel_viz_type: FunnelVizType.Steps,
+                exclusions: [],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: FunnelsQuery = {
+                kind: NodeKind.FunnelsQuery,
+                dateRange: {
+                    date_from: '-1m',
+                },
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: '$pageview',
+                        name: '$pageview',
+                        properties: [
+                            {
+                                key: '$current_url',
+                                type: PropertyFilterType.Event,
+                                value: 'https://hedgebox.net/',
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                        custom_name: 'Viewed homepage',
+                    },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: '$pageview',
+                        name: '$pageview',
+                        properties: [
+                            {
+                                key: '$current_url',
+                                type: PropertyFilterType.Event,
+                                value: 'https://hedgebox.net/signup/',
+                                operator: PropertyOperator.Regex,
+                            },
+                        ],
+                        custom_name: 'Viewed signup page',
+                    },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'signed_up',
+                        name: 'signed_up',
+                        custom_name: 'Signed up',
+                    },
+                ],
+                filterTestAccounts: true,
+                funnelsFilter: {
+                    funnel_viz_type: FunnelVizType.Steps,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Activation` insight', () => {
+            const filters: Partial<FunnelsFilterType> = {
+                insight: InsightType.FUNNELS,
+                date_from: '-1m',
+                actions: [
+                    {
+                        id: 1,
+                        name: 'Interacted with file',
+                        type: 'actions',
+                        order: 3,
+                    },
+                ],
+                events: [
+                    {
+                        id: 'signed_up',
+                        name: 'signed_up',
+                        type: 'events',
+                        order: 2,
+                        custom_name: 'Signed up',
+                    },
+                    {
+                        id: 'upgraded_plan',
+                        name: 'upgraded_plan',
+                        type: 'events',
+                        order: 4,
+                        custom_name: 'Upgraded plan',
+                    },
+                ],
+                filter_test_accounts: true,
+                funnel_viz_type: FunnelVizType.Steps,
+                exclusions: [],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: FunnelsQuery = {
+                kind: NodeKind.FunnelsQuery,
+                dateRange: {
+                    date_from: '-1m',
+                },
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'signed_up',
+                        name: 'signed_up',
+                        custom_name: 'Signed up',
+                    },
+                    {
+                        kind: NodeKind.ActionsNode,
+                        id: 1,
+                        name: 'Interacted with file',
+                    },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'upgraded_plan',
+                        name: 'upgraded_plan',
+                        custom_name: 'Upgraded plan',
+                    },
+                ],
+                filterTestAccounts: true,
+                funnelsFilter: {
+                    funnel_viz_type: FunnelVizType.Steps,
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `Weekly file volume` insight', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: 'uploaded_file',
+                        math: 'sum',
+                        name: 'uploaded_file',
+                        type: 'events',
+                        order: 0,
+                        custom_name: 'Uploaded bytes',
+                        math_property: 'file_size_b',
+                    },
+                    {
+                        id: 'deleted_file',
+                        math: 'sum',
+                        name: 'deleted_file',
+                        type: 'events',
+                        order: 1,
+                        custom_name: 'Deleted bytes',
+                        math_property: 'file_size_b',
+                    },
+                ],
+                actions: [],
+                display: ChartDisplayType.ActionsLineGraph,
+                interval: 'week',
+                date_from: '-8w',
+                new_entity: [],
+                properties: [],
+                filter_test_accounts: true,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'uploaded_file',
+                        name: 'uploaded_file',
+                        custom_name: 'Uploaded bytes',
+                        math: PropertyMathType.Sum,
+                        math_property: 'file_size_b',
+                    },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'deleted_file',
+                        name: 'deleted_file',
+                        custom_name: 'Deleted bytes',
+                        math: PropertyMathType.Sum,
+                        math_property: 'file_size_b',
+                    },
+                ],
+                interval: 'week',
+                trendsFilter: {
+                    display: ChartDisplayType.ActionsLineGraph,
+                },
+                dateRange: {
+                    date_from: '-8w',
+                },
+                filterTestAccounts: true,
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `File interactions` insight', () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: 'uploaded_file',
+                        type: 'events',
+                        order: 0,
+                    },
+                    {
+                        id: 'deleted_file',
+                        type: 'events',
+                        order: 2,
+                    },
+                    {
+                        id: 'downloaded_file',
+                        type: 'events',
+                        order: 1,
+                    },
+                ],
+                actions: [],
+                display: ChartDisplayType.ActionsLineGraph,
+                interval: 'day',
+                date_from: '-30d',
+                properties: [],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'uploaded_file',
+                    },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'downloaded_file',
+                    },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'deleted_file',
+                    },
+                ],
+                interval: 'day',
+                trendsFilter: {
+                    display: ChartDisplayType.ActionsLineGraph,
+                },
+                dateRange: {
+                    date_from: '-30d',
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it('converts `User paths starting at homepage` insight', () => {
+            const filters: Partial<PathsFilterType> = {
+                insight: InsightType.PATHS,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [],
+                },
+                start_point: 'https://hedgebox.net/',
+                step_limit: 5,
+                include_event_types: [PathType.PageView],
+                path_groupings: ['/files/*'],
+                exclude_events: [],
+                date_from: '-30d',
+                date_to: null,
+                funnel_filter: {},
+                local_path_cleaning_filters: [],
+                edge_limit: 50,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: PathsQuery = {
+                kind: NodeKind.PathsQuery,
+                dateRange: {
+                    date_from: '-30d',
+                    date_to: null,
+                },
+                pathsFilter: {
+                    start_point: 'https://hedgebox.net/',
+                    step_limit: 5,
+                    include_event_types: [PathType.PageView],
+                    path_groupings: ['/files/*'],
+                    edge_limit: 50,
+                },
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [],
+                },
+            }
+            expect(result).toEqual(query)
+        })
+
+        it("converts `Last month's signups by country` insight", () => {
+            const filters: Partial<TrendsFilterType> = {
+                insight: InsightType.TRENDS,
+                events: [
+                    {
+                        id: 'signed_up',
+                        type: 'events',
+                        order: 0,
+                    },
+                ],
+                actions: [],
+                display: ChartDisplayType.WorldMap,
+                breakdown: '$geoip_country_code',
+                date_from: '-1m',
+                breakdown_type: 'event',
+                properties: [],
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'signed_up',
+                    },
+                ],
+                trendsFilter: {
+                    display: ChartDisplayType.WorldMap,
+                },
+                breakdown: {
+                    breakdown: '$geoip_country_code',
+                    breakdown_type: 'event',
+                },
+                dateRange: {
+                    date_from: '-1m',
+                },
+            }
+            expect(result).toEqual(query)
+        })
     })
 })

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -1,8 +1,31 @@
-import { InsightQueryNode, EventsNode, ActionsNode, NodeKind, InsightNodeKind } from '~/queries/schema'
+import {
+    InsightQueryNode,
+    EventsNode,
+    ActionsNode,
+    NodeKind,
+    InsightNodeKind,
+    InsightsQueryBase,
+} from '~/queries/schema'
 import { FilterType, InsightType, ActionFilter } from '~/types'
-import { isLifecycleQuery, isStickinessQuery } from '~/queries/utils'
-import { isLifecycleFilter, isStickinessFilter } from 'scenes/insights/sharedUtils'
-import { objectClean } from 'lib/utils'
+import {
+    isTrendsQuery,
+    isFunnelsQuery,
+    isRetentionQuery,
+    isPathsQuery,
+    isStickinessQuery,
+    isLifecycleQuery,
+    isInsightQueryWithBreakdown,
+    isInsightQueryWithSeries,
+} from '~/queries/utils'
+import {
+    isTrendsFilter,
+    isFunnelsFilter,
+    isRetentionFilter,
+    isPathsFilter,
+    isStickinessFilter,
+    isLifecycleFilter,
+} from 'scenes/insights/sharedUtils'
+import { objectCleanWithEmpty } from 'lib/utils'
 
 const reverseInsightMap: Record<InsightType, InsightNodeKind> = {
     [InsightType.TRENDS]: NodeKind.TrendsQuery,
@@ -23,14 +46,14 @@ export const actionsAndEventsToSeries = ({
     const series: any = [...(actions || []), ...(events || []), ...(new_entity || [])]
         .sort((a, b) => (a.order || b.order ? (!a.order ? -1 : !b.order ? 1 : a.order - b.order) : 0))
         .map((f) => {
-            const shared = {
+            const shared = objectCleanWithEmpty({
                 name: f.name || undefined,
                 custom_name: f.custom_name,
                 properties: f.properties,
                 math: f.math,
                 math_property: f.math_property,
                 math_group_type_index: f.math_group_type_index,
-            }
+            })
             if (f.type === 'actions') {
                 return {
                     kind: NodeKind.ActionsNode,
@@ -60,17 +83,29 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
         throw new Error('filtersToQueryNode expects "insight"')
     }
 
-    const { events, actions } = filters
-    const series = actionsAndEventsToSeries({ actions, events } as any)
-    const query: InsightQueryNode = objectClean({
+    const query: InsightsQueryBase = {
         kind: reverseInsightMap[filters.insight],
         properties: filters.properties,
         filterTestAccounts: filters.filter_test_accounts,
-        dateRange: objectClean({
-            date_to: filters.date_to,
-            date_from: filters.date_from,
-        }),
-        breakdown: objectClean({
+    }
+
+    // date range
+    query.dateRange = objectCleanWithEmpty({
+        date_to: filters.date_to,
+        date_from: filters.date_from,
+    })
+
+    // series + interval
+    if (isInsightQueryWithSeries(query)) {
+        const { events, actions } = filters
+        const series = actionsAndEventsToSeries({ actions, events } as any)
+        query.series = series
+        query.interval = filters.interval
+    }
+
+    // breakdown
+    if (isInsightQueryWithBreakdown(query)) {
+        query.breakdown = objectCleanWithEmpty({
             breakdown_type: filters.breakdown_type,
             breakdown: filters.breakdown,
             breakdown_normalize_url: filters.breakdown_normalize_url,
@@ -78,22 +113,108 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             breakdown_value: filters.breakdown_value,
             breakdown_group_type_index: filters.breakdown_group_type_index,
             aggregation_group_type_index: filters.aggregation_group_type_index,
-        }),
-        interval: filters.interval,
-        series,
-    })
-
-    if (isLifecycleFilter(filters) && isLifecycleQuery(query)) {
-        query.lifecycleFilter = objectClean({
-            shown_as: filters.shown_as,
         })
     }
 
-    if (isStickinessFilter(filters) && isStickinessQuery(query)) {
-        query.stickinessFilter = objectClean({
+    // trends filter
+    if (isTrendsFilter(filters) && isTrendsQuery(query)) {
+        query.trendsFilter = objectCleanWithEmpty({
+            smoothing_intervals: filters.smoothing_intervals,
+            show_legend: filters.show_legend,
+            hidden_legend_keys: filters.hidden_legend_keys,
+            compare: filters.compare,
+            aggregation_axis_format: filters.aggregation_axis_format,
+            aggregation_axis_prefix: filters.aggregation_axis_prefix,
+            aggregation_axis_postfix: filters.aggregation_axis_postfix,
+            breakdown_histogram_bin_count: filters.breakdown_histogram_bin_count,
+            formula: filters.formula,
+            shown_as: filters.shown_as,
             display: filters.display,
         })
     }
 
-    return query
+    // funnels filter
+    if (isFunnelsFilter(filters) && isFunnelsQuery(query)) {
+        query.funnelsFilter = objectCleanWithEmpty({
+            funnel_viz_type: filters.funnel_viz_type,
+            funnel_from_step: filters.funnel_from_step,
+            funnel_to_step: filters.funnel_to_step,
+            funnel_step_reference: filters.funnel_step_reference,
+            funnel_step_breakdown: filters.funnel_step_breakdown,
+            breakdown_attribution_type: filters.breakdown_attribution_type,
+            breakdown_attribution_value: filters.breakdown_attribution_value,
+            bin_count: filters.bin_count,
+            funnel_window_interval_unit: filters.funnel_window_interval_unit,
+            funnel_window_interval: filters.funnel_window_interval,
+            funnel_order_type: filters.funnel_order_type,
+            exclusions: filters.exclusions,
+            funnel_correlation_person_entity: filters.funnel_correlation_person_entity,
+            funnel_correlation_person_converted: filters.funnel_correlation_person_converted,
+            funnel_custom_steps: filters.funnel_custom_steps,
+            funnel_advanced: filters.funnel_advanced,
+            layout: filters.layout,
+            funnel_step: filters.funnel_step,
+            entrance_period_start: filters.entrance_period_start,
+            drop_off: filters.drop_off,
+            hidden_legend_keys: filters.hidden_legend_keys,
+        })
+    }
+
+    // retention filter
+    if (isRetentionFilter(filters) && isRetentionQuery(query)) {
+        query.retentionFilter = objectCleanWithEmpty({
+            retention_type: filters.retention_type,
+            retention_reference: filters.retention_reference,
+            total_intervals: filters.total_intervals,
+            returning_entity: filters.returning_entity,
+            target_entity: filters.target_entity,
+            period: filters.period,
+        })
+        // TODO: query.aggregation_group_type_index
+    }
+
+    // paths filter
+    if (isPathsFilter(filters) && isPathsQuery(query)) {
+        query.pathsFilter = objectCleanWithEmpty({
+            path_type: filters.path_type,
+            include_event_types: filters.include_event_types,
+            start_point: filters.start_point,
+            end_point: filters.end_point,
+            path_groupings: filters.path_groupings,
+            funnel_paths: filters.funnel_paths,
+            funnel_filter: filters.funnel_filter,
+            exclude_events: filters.exclude_events,
+            step_limit: filters.step_limit,
+            path_start_key: filters.path_start_key,
+            path_end_key: filters.path_end_key,
+            path_dropoff_key: filters.path_dropoff_key,
+            path_replacements: filters.path_replacements,
+            local_path_cleaning_filters: filters.local_path_cleaning_filters,
+            edge_limit: filters.edge_limit,
+            min_edge_weight: filters.min_edge_weight,
+            max_edge_weight: filters.max_edge_weight,
+        })
+    }
+
+    // stickiness filter
+    if (isStickinessFilter(filters) && isStickinessQuery(query)) {
+        query.stickinessFilter = objectCleanWithEmpty({
+            display: filters.display,
+            compare: filters.compare,
+            show_legend: filters.show_legend,
+            hidden_legend_keys: filters.hidden_legend_keys,
+            stickiness_days: filters.stickiness_days,
+            shown_as: filters.shown_as,
+        })
+    }
+
+    // lifecycle filter
+    if (isLifecycleFilter(filters) && isLifecycleQuery(query)) {
+        query.lifecycleFilter = objectCleanWithEmpty({
+            shown_as: filters.shown_as,
+        })
+    }
+
+    // remove undefined and empty array/objects and return
+    return objectCleanWithEmpty(query as Record<string, any>) as InsightQueryNode
 }

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -40,9 +40,10 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 export interface EditorFiltersProps {
     query: InsightQueryNode
     setQuery: (node: InsightQueryNode) => void
+    showing: boolean
 }
 
-export function EditorFilters({ query, setQuery }: EditorFiltersProps): JSX.Element {
+export function EditorFilters({ query, setQuery, showing }: EditorFiltersProps): JSX.Element {
     const { user } = useValues(userLogic)
     const availableFeatures = user?.organization?.available_features || []
 
@@ -57,8 +58,6 @@ export function EditorFilters({ query, setQuery }: EditorFiltersProps): JSX.Elem
         isStepsFunnel
     const hasPathsAdvanced = availableFeatures.includes(AvailableFeature.PATHS_ADVANCED)
     const hasAttribution = isStepsFunnel
-
-    const showFilters = true // TODO: implement with insightVizLogic
 
     const editorFilters: QueryInsightEditorFilterGroup[] = [
         {
@@ -250,7 +249,7 @@ export function EditorFilters({ query, setQuery }: EditorFiltersProps): JSX.Elem
     ]
 
     return (
-        <CSSTransition in={showFilters} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
+        <CSSTransition in={showing} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
             <div
                 className={clsx('EditorFiltersWrapper', {
                     'EditorFiltersWrapper--singlecolumn': isFunnels,

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -70,7 +70,7 @@ export function InsightViz({ query, setQuery }: InsightVizProps): JSX.Element {
                     'insight-wrapper--singlecolumn': isFunnels,
                 })}
             >
-                <EditorFilters query={query.source} setQuery={setQuerySource} />
+                <EditorFilters query={query.source} setQuery={setQuerySource} showing={insightMode === ItemMode.Edit} />
 
                 <div className="insights-container" data-attr="insight-view">
                     <InsightContainer insightMode={insightMode} />

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -244,7 +244,7 @@ export interface InsightVizNode extends Node {
 }
 
 // Base class should not be used directly
-interface InsightsQueryBase extends Node {
+export interface InsightsQueryBase extends Node {
     /** Date range for the query */
     dateRange?: DateRange
     /** Exclude internal and test users by applying the respective filters */

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -93,6 +93,10 @@ export function isInsightQueryWithBreakdown(node?: Node): node is TrendsQuery | 
     return isTrendsQuery(node) || isFunnelsQuery(node)
 }
 
+export function isInsightQueryWithSeries(node?: Node): node is TrendsQuery | FunnelsQuery {
+    return isTrendsQuery(node) || isFunnelsQuery(node) || isLifecycleQuery(node) || isStickinessQuery(node)
+}
+
 export function isInsightQueryNode(node?: Node): node is InsightQueryNode {
     return (
         isTrendsQuery(node) ||


### PR DESCRIPTION
## Problem

There have been some issues opening saved insights, mostly due to the respective conversion not yet being implemented in the filter-to-query  function.

In this PR I've converted the sample insights from demo data and still have some questions regarding filters resulting from that, see comments 1., 2. and 3. below.

PR can go in without clarification of the questions, just wanted to raise them in case anyone can help me figure this out.

## Changes

This PR
- adds missing functionality to the filter to query function
- adds tests for common properties
- adds tests for each of the insights in demo data
- fixes insight mode (view/edit) for data exploration

## How did you test this code?

Adding the specified tests. I'm going through all demo insights separately and fixing all outstanding issues.