### PR TITLE
fix(paths): Stop "Paths Cleaning Rules" from disappearing

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
@@ -49,7 +49,7 @@ export function EditorFilterGroup({
                     {editorFilters.map(({ label: Label, tooltip, showOptional, key, component: Component }) => {
                         if (Component && Component.name === 'component') {
                             throw new Error(
-                                `Component for filter ${key} is an anymous function, which is not a valid React component! Use a named function instead.`
+                                `Component for filter ${key} is an anonymous function, which is not a valid React component! Use a named function instead.`
                             )
                         }
                         return (

--- a/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
@@ -47,6 +47,11 @@ export function EditorFilterGroup({
             {isRowExpanded ? (
                 <div className="EditorFilterGroup__content">
                     {editorFilters.map(({ label: Label, tooltip, showOptional, key, component: Component }) => {
+                        if (Component && Component.name === 'component') {
+                            throw new Error(
+                                `Component for filter ${key} is an anymous function, which is not a valid React component! Use a named function instead.`
+                            )
+                        }
                         return (
                             <div key={key}>
                                 <PureField

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -30,7 +30,6 @@ import {
 import { PathsExclusionsDataExploration } from 'scenes/insights/EditorFilters/PathsExclusions'
 import { PathsWildcardGroupsDataExploration } from 'scenes/insights/EditorFilters/PathsWildcardGroups'
 import { PathsAdvancedDataExploration } from 'scenes/insights/EditorFilters/PathsAdvanced'
-import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { FunnelsQueryStepsDataExploration } from 'scenes/insights/EditorFilters/FunnelsQuerySteps'
 import { AttributionDataExploration } from 'scenes/insights/EditorFilters/AttributionFilter'
 import { FunnelsAdvancedDataExploration } from 'scenes/insights/EditorFilters/FunnelsAdvanced'
@@ -212,11 +211,7 @@ export function EditorFilters({ query, setQuery }: EditorFiltersProps): JSX.Elem
                 isPaths && {
                     key: 'paths-advanced',
                     position: 'left',
-                    component: (props) => (
-                        <PayGateMini feature={AvailableFeature.PATHS_ADVANCED}>
-                            <PathsAdvancedDataExploration {...props} />
-                        </PayGateMini>
-                    ),
+                    component: PathsAdvancedDataExploration,
                 },
                 isFunnels && {
                     key: 'funnels-advanced',

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilterGroup.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilterGroup.tsx
@@ -40,6 +40,11 @@ export function EditorFilterGroup({ editorFilterGroup, insight, insightProps }: 
             <div className="EditorFilterGroup__content">
                 {editorFilters.map(
                     ({ label: Label, tooltip, showOptional, key, valueSelector, component: Component }) => {
+                        if (Component && Component.name === 'component') {
+                            throw new Error(
+                                `Component for filter ${key} is an anonymous function, which is not a valid React component! Use a named function instead.`
+                            )
+                        }
                         // Don't calculate editorFilterProps if not needed
                         const editorFilterProps: EditorFilterProps | null =
                             typeof Label === 'function' || Component

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -38,7 +38,6 @@ import {
     isStickinessFilter,
     isTrendsFilter,
 } from 'scenes/insights/sharedUtils'
-import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 
 export interface EditorFiltersProps {
     insightProps: InsightLogicProps
@@ -235,11 +234,7 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
             editorFilters: filterFalsy([
                 isPaths && {
                     key: 'paths-advanced',
-                    component: (props) => (
-                        <PayGateMini feature={AvailableFeature.PATHS_ADVANCED}>
-                            <PathsAdvanced {...props} />
-                        </PayGateMini>
-                    ),
+                    component: PathsAdvanced,
                 },
                 isFunnels && {
                     key: 'funnels-advanced',

--- a/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
@@ -2,7 +2,13 @@ import { useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { InputNumber } from 'antd'
 
-import { EditorFilterProps, PathEdgeParameters, PathsFilterType, QueryEditorFilterProps } from '~/types'
+import {
+    AvailableFeature,
+    EditorFilterProps,
+    PathEdgeParameters,
+    PathsFilterType,
+    QueryEditorFilterProps,
+} from '~/types'
 import { LemonDivider } from '@posthog/lemon-ui'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
 import { pathsDataLogic } from 'scenes/paths/pathsDataLogic'
@@ -12,17 +18,20 @@ import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
 import { IconSettings } from 'lib/lemon-ui/icons'
 
 import { PathCleaningFilter, PathCleaningFilterDataExploration } from '../filters/PathCleaningFilter'
+import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 
 export function PathsAdvancedDataExploration({ insightProps, ...rest }: QueryEditorFilterProps): JSX.Element {
     const { insightFilter } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
 
     return (
-        <PathsAdvancedComponent
-            setFilter={updateInsightFilter}
-            cleaningFilterComponent={<PathCleaningFilterDataExploration insightProps={insightProps} {...rest} />}
-            {...insightFilter}
-        />
+        <PayGateMini feature={AvailableFeature.PATHS_ADVANCED}>
+            <PathsAdvancedComponent
+                setFilter={updateInsightFilter}
+                cleaningFilterComponent={<PathCleaningFilterDataExploration insightProps={insightProps} {...rest} />}
+                {...insightFilter}
+            />
+        </PayGateMini>
     )
 }
 
@@ -31,11 +40,13 @@ export function PathsAdvanced({ insightProps, ...rest }: EditorFilterProps): JSX
     const { setFilter } = useActions(pathsLogic(insightProps))
 
     return (
-        <PathsAdvancedComponent
-            setFilter={setFilter}
-            cleaningFilterComponent={<PathCleaningFilter insightProps={insightProps} {...rest} />}
-            {...filter}
-        />
+        <PayGateMini feature={AvailableFeature.PATHS_ADVANCED}>
+            <PathsAdvancedComponent
+                setFilter={setFilter}
+                cleaningFilterComponent={<PathCleaningFilter insightProps={insightProps} {...rest} />}
+                {...filter}
+            />
+        </PayGateMini>
     )
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1633,6 +1633,7 @@ export interface InsightEditorFilter<T = EditorFilterProps> {
     showOptional?: boolean
     position?: 'left' | 'right'
     valueSelector?: (insight: Partial<InsightModel>) => any
+    /** Editor filter component. Cannot be an anonymous function or the key would not work! */
     component?: (props: T) => JSX.Element | null
 }
 


### PR DESCRIPTION
## Problem

This bug reported by @lharries: https://share.cleanshot.com/Gm4tgXgH

## Changes

Turns out React `key` doesn't work with anonymous functions, and that's what we were using for the `paths-advanced` insight editor group, so the group's state was lost whenever it was rerendered. And the insight editor happens to re-render when `cohortsModel` values change. And those `cohortsModel` values change every 5 seconds because of `loadCohorts` being called regularly. But this only happens if there is a cohort that's being calculated right now!
Anyway, fixed the offending site and added a check to prevent this from happening in the future.

## How did you test this code?

This is a very edgy edge case, so not bothering with automated tests. 