### PR TITLE
chore: remove no-migrations from ./bin/tests

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -30,13 +30,4 @@ PG_PASSWORD="${PGPASSWORD:=posthog}"
 PG_PORT="${PGPORT:=5432}"
 PGOPTIONS='--client-min-messages=warning' psql posthog -d "postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}" -c "drop database if exists test_posthog" 1> /dev/null
 
-if [[ "$*" == *"migration"* ]]
-then
-    echo "Looks like you're testing a migration. Running all migrations first."
-    MIGRATIONS=""
-else
-    MIGRATIONS="--no-migrations"
-    export SKIP_TRIGRAM_INDEX_FOR_TESTS=1
-fi
-
 nodemon -w ./posthog -w ./ee --ext py --exec "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES pytest --reuse-db --durations-min=2.0 ${MIGRATIONS} -s $* --snapshot-update; mypy posthog ee"

--- a/posthog/models/event_definition.py
+++ b/posthog/models/event_definition.py
@@ -1,5 +1,3 @@
-import os
-
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
 from django.utils import timezone
@@ -24,15 +22,11 @@ class EventDefinition(UUIDModel):
 
     class Meta:
         unique_together = ("team", "name")
-        indexes = (
-            [
-                GinIndex(
-                    name="index_event_definition_name", fields=["name"], opclasses=["gin_trgm_ops"]
-                )  # To speed up DB-based fuzzy searching
-            ]
-            if not os.environ.get("SKIP_TRIGRAM_INDEX_FOR_TESTS")
-            else []
-        )  # This index breaks the --no-migrations option when running tests
+        indexes = [
+            GinIndex(
+                name="index_event_definition_name", fields=["name"], opclasses=["gin_trgm_ops"]
+            )  # To speed up DB-based fuzzy searching
+        ]
 
     def __str__(self) -> str:
         return f"{self.name} / {self.team.name}"


### PR DESCRIPTION
## Problem

see https://posthog.slack.com/archives/C0374DA782U/p1676031826665739

## Changes

removes -no-migrations since it only slows down the first run of the tests

## How did you test this code?

it is self testing
