### PR TITLE
fix: Restrict adding a behavioral filter to an active flag

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -130,7 +130,8 @@ class CohortSerializer(serializers.ModelSerializer):
         if isinstance(request_filters, dict) and "properties" in request_filters:
             if self.context["request"].method == "PATCH":
                 parsed_filter = Filter(data=request_filters)
-                cohort_id = self.instance.pk
+                instance = cast(Cohort, self.instance)
+                cohort_id = instance.pk
                 flags: QuerySet[FeatureFlag] = FeatureFlag.objects.filter(
                     team_id=self.context["team_id"], active=True, deleted=False
                 )

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -32,7 +32,7 @@ from posthog.constants import (
     OFFSET,
 )
 from posthog.event_usage import report_user_action
-from posthog.models import Cohort, User
+from posthog.models import Cohort, FeatureFlag, User
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.cohort import get_and_update_pending_version
 from posthog.models.filters.filter import Filter
@@ -128,6 +128,20 @@ class CohortSerializer(serializers.ModelSerializer):
     def validate_filters(self, request_filters: Dict):
 
         if isinstance(request_filters, dict) and "properties" in request_filters:
+            if self.context["request"].method == "PATCH":
+                parsed_filter = Filter(data=request_filters)
+                cohort_id = self.instance.pk
+                flags: QuerySet[FeatureFlag] = FeatureFlag.objects.filter(
+                    team_id=self.context["team_id"], active=True, deleted=False
+                )
+                for prop in parsed_filter.property_groups.flat:
+                    if prop.type == "behavioral":
+                        if [flag for flag in flags if cohort_id in flag.cohort_ids]:
+                            raise serializers.ValidationError(
+                                detail=f"Behavioral filters cannot be added to cohorts used in feature flags.",
+                                code="behavioral_cohort_found",
+                            )
+
             return request_filters
         else:
             raise ValidationError("Filters must be a dictionary with a 'properties' key.")


### PR DESCRIPTION
## Problem

- Bug: You can create a flag with a cohort that does not have a behavioral filter. Then update the cohort to have a behavioral filter

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- return an error to the client if there is a behavioral filter being added to a cohort that is used in a feature flag
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
