### PR TITLE
lift insight nav up to insight level

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -4,8 +4,6 @@ import clsx from 'clsx'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
-import { InsightsNav } from 'scenes/insights/InsightsNav'
-import { ItemMode } from '~/types'
 import { isFunnelsQuery } from '~/queries/utils'
 
 import { dataNodeLogic, DataNodeLogicProps } from '../DataNode/dataNodeLogic'
@@ -64,7 +62,6 @@ export function InsightViz({ query, setQuery }: InsightVizProps): JSX.Element {
 
     return (
         <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-            {insightMode === ItemMode.Edit && <InsightsNav />}
             <div
                 className={clsx('insight-wrapper', {
                     'insight-wrapper--singlecolumn': isFunnels,

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -316,11 +316,11 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                 }
             />
 
+            {insightMode === ItemMode.Edit && <InsightsNav />}
             {isUsingDataExploration ? (
                 <Query query={query} setQuery={setQuery} />
             ) : (
                 <>
-                    {insightMode === ItemMode.Edit && <InsightsNav />}
                     <div
                         className={clsx('insight-wrapper', {
                             'insight-wrapper--singlecolumn': filters.insight === InsightType.FUNNELS,


### PR DESCRIPTION
## Problem

The `InsightNav` for choosing type while editing is currently cohesive with the insight scene but coupled closer to the insight container

## Changes

Moves it slightly higher in the stack to make it so we can change Filter or Query insight with less worry about the insight nav

## How did you test this code?

clicking around and seeing it work
