### PR TITLE
fix(capture-logging): Bind team_id to logger context vars when available

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -254,6 +254,9 @@ def drop_events_over_quota(
 @csrf_exempt
 @timed("posthog_cloud_event_endpoint")
 def get_event(request):
+    # At this point, we don't now which team_id we are working with, so unbind if set.
+    structlog.contextvars.unbind_contextvars("team_id")
+
     # handle cors request
     if request.method == "OPTIONS":
         return cors_response(request, JsonResponse({"status": 1}))
@@ -269,9 +272,6 @@ def get_event(request):
 
     if error_response:
         return error_response
-
-    # At this point, we don't now which team_id we are working with, so unbind if set.
-    structlog.contextvars.unbind_contextvars("team_id")
 
     with start_span(op="request.authenticate"):
         token = get_token(data, request)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -300,6 +300,9 @@ def get_event(request):
             if db_error:
                 send_events_to_dead_letter_queue = True
 
+    team_id = ingestion_context.team_id if ingestion_context else None
+    structlog.contextvars.bind_contextvars(team_id=team_id)
+
     with start_span(op="request.process"):
         if isinstance(data, dict):
             if data.get("batch"):  # posthog-python and posthog-ruby
@@ -364,7 +367,6 @@ def get_event(request):
                 )
                 continue
 
-            team_id = ingestion_context.team_id if ingestion_context else None
             try:
                 futures.append(
                     capture_internal(

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -270,6 +270,9 @@ def get_event(request):
     if error_response:
         return error_response
 
+    # At this point, we don't now which team_id we are working with, so unbind if set.
+    structlog.contextvars.unbind_contextvars("team_id")
+
     with start_span(op="request.authenticate"):
         token = get_token(data, request)
 


### PR DESCRIPTION
## Problem

Capture logs are showing up incorrect `team_id` in the context. I believe this is because we never bind the `team_id` in `capture` so it's getting it's value from somewhere else.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Now, we clear off `team_id` at the beginning of capture, and bind `team_id` to the context as soon as we get it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a couple of assert statements to the capture endpoint tests. These assert the correct logging context in a couple of scenarios.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
