### PR TITLE
feat(admin): add basic insight list admin functionality

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -27,8 +27,25 @@ admin.site.register(Element)
 admin.site.register(FeatureFlag)
 admin.site.register(Action)
 admin.site.register(ActionStep)
-admin.site.register(Insight)
 admin.site.register(InstanceSetting)
+
+
+@admin.register(Insight)
+class InsightAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+        "short_id",
+        "team",
+        "organization",
+        "created_at",
+        "created_by",
+    )
+    search_fields = ("id", "name", "short_id", "team__name", "team__organization__name")
+    ordering = ("-created_at",)
+
+    def organization(self, insight: Insight):
+        return insight.team.organization.name
 
 
 @admin.register(Plugin)


### PR DESCRIPTION
## Problem

We want to bulk delete insights for a customer and  more.

<img width="1170" alt="Screenshot 2023-02-13 at 16 49 51" src="https://user-images.githubusercontent.com/1851359/218507684-8074fb32-a154-460c-938b-5b86d7199a97.png">


## Changes

This PR configures the admin list for insights to cover basic functionality.

## How did you test this code?

Tried locally.