### PR TITLE
fix: better error for invalid pk or uuid

### DIFF
--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -424,7 +424,11 @@ def get_pk_or_uuid(queryset: QuerySet, key: Union[int, str]) -> QuerySet:
         UUID(key)  # type: ignore
         return queryset.filter(uuid=key)
     except ValueError:
+        pass
+    try:
         return queryset.filter(pk=key)
+    except ValueError:
+        raise ValueError("Key is not a valid UUID or primary key.")
 
 
 def parse_bool(value: Union[str, List[str]]) -> bool:


### PR DESCRIPTION
## Problem

https://posthogusers.slack.com/archives/C01GLBKHKQT/p1676267707755219

## Changes

Return a better error message if key is not valid `uuid` or `pk`.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally
