### PR TITLE
fix: insight legend width is too constrained

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.scss
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.scss
@@ -12,7 +12,6 @@
 .InsightLegendMenu {
     box-shadow: none !important;
     background-color: var(--bg-light);
-    max-width: 300px;
     max-height: 100%;
 
     &.InsightLegendMenu--in-card-view {

--- a/frontend/src/scenes/insights/Insight.scss
+++ b/frontend/src/scenes/insights/Insight.scss
@@ -118,7 +118,7 @@
 
             .insights-graph-container-row-right {
                 height: min(calc(90vh - 16rem), 36rem); // same as .trends-insights-container
-                max-width: 300px;
+                max-width: 45%;
                 width: fit-content;
                 padding: 0 1rem 1rem 0;
                 display: flex;

--- a/frontend/src/scenes/insights/Insight.scss
+++ b/frontend/src/scenes/insights/Insight.scss
@@ -119,6 +119,7 @@
             .insights-graph-container-row-right {
                 height: min(calc(90vh - 16rem), 36rem); // same as .trends-insights-container
                 max-width: 45%;
+                min-width: 300px;
                 width: fit-content;
                 padding: 0 1rem 1rem 0;
                 display: flex;


### PR DESCRIPTION
## Problem

We asked a user to click "Show legend" in the insight editing view and it was comically narrow

## Changes

Sets the legend to be up to 45% of visible space. If someone is turning the legend on, they probably want to see the legend

### on the dashboard

no change

|before|after|
|-|-|
|![Screenshot 2023-02-13 at 16 57 10](https://user-images.githubusercontent.com/984817/218522587-1b338141-5e5f-4546-99d0-78ce512d32eb.png)|![after-wide](https://user-images.githubusercontent.com/984817/218522625-c06da752-26da-40b1-8637-b98a8394d1ce.png)|

### insight view

|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/984817/218522705-1f0b248f-cec2-464d-b920-4c778592fa00.gif)|![after](https://user-images.githubusercontent.com/984817/218522752-07f65252-68e9-4289-a4cc-77242850ff99.gif)|

## How did you test this code?

👀 
