### PR TITLE
feat(app-metrics): use WITH FILL for app metrics time series

### DIFF
--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -142,19 +142,6 @@ FROM (
         sum(failures) AS failures
     FROM (
         SELECT
-            dateTrunc(%(interval)s, toDateTime(%(date_from)s) + {interval_function}(number), %(timezone)s) AS date,
-            0 AS successes,
-            0 AS successes_on_retry,
-            0 AS failures
-        FROM numbers(
-            dateDiff(
-                %(interval)s,
-                dateTrunc(%(interval)s, toDateTime(%(date_from)s), %(timezone)s),
-                dateTrunc(%(interval)s, toDateTime(%(date_to)s) + {interval_function}(1), %(timezone)s)
-            )
-        )
-        UNION ALL
-        SELECT
             dateTrunc(%(interval)s, timestamp, %(timezone)s) AS date,
             sum(successes) AS successes,
             sum(successes_on_retry) AS successes_on_retry,
@@ -170,6 +157,10 @@ FROM (
     )
     GROUP BY date
     ORDER BY date
+    WITH FILL
+        FROM dateTrunc(%(interval)s, toDateTime(%(date_from)s), %(timezone)s)
+        TO dateTrunc(%(interval)s, toDateTime(%(date_to)s) + {interval_function}(1), %(timezone)s)
+        STEP %(with_fill_step)s
 )
 """
 

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -14,7 +14,7 @@ from posthog.models.event.util import format_clickhouse_timestamp
 from posthog.models.filters.mixins.base import IntervalType
 from posthog.models.team.team import Team
 from posthog.queries.app_metrics.serializers import AppMetricsErrorsRequestSerializer, AppMetricsRequestSerializer
-from posthog.queries.util import format_ch_timestamp
+from posthog.queries.util import format_ch_timestamp, get_time_in_seconds_for_period
 from posthog.utils import relative_date_parse
 
 
@@ -74,6 +74,7 @@ class AppMetricsQuery:
             "date_to": format_ch_timestamp(self.date_to),
             "timezone": self.team.timezone,
             "interval": self.interval,
+            "with_fill_step": get_time_in_seconds_for_period(self.interval),
         }
 
     @property

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -111,15 +111,10 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT dateTrunc('day', toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
-               0 AS successes,
-               0 AS successes_on_retry,
-               0 AS failures
-        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC')))
-        UNION ALL SELECT dateTrunc('day', timestamp, 'UTC') AS date,
-                         sum(successes) AS successes,
-                         sum(successes_on_retry) AS successes_on_retry,
-                         sum(failures) AS failures
+       (SELECT dateTrunc('day', timestamp, 'UTC') AS date,
+               sum(successes) AS successes,
+               sum(successes_on_retry) AS successes_on_retry,
+               sum(failures) AS failures
         FROM app_metrics
         WHERE team_id = 2
           AND plugin_config_id = 3
@@ -128,7 +123,8 @@
           AND timestamp < '2021-12-05 13:23:00'
         GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
-     ORDER BY date)
+     ORDER BY date WITH FILL
+     FROM dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC') TO dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC') STEP 86400)
   '
 ---
 # name: TestAppMetricsQuery.test_filter_by_hourly_date_range
@@ -143,15 +139,10 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT dateTrunc('hour', toDateTime('2021-12-05 00:00:00') + toIntervalHour(number), 'UTC') AS date,
-               0 AS successes,
-               0 AS successes_on_retry,
-               0 AS failures
-        FROM numbers(dateDiff('hour', dateTrunc('hour', toDateTime('2021-12-05 00:00:00'), 'UTC'), dateTrunc('hour', toDateTime('2021-12-05 08:00:00') + toIntervalHour(1), 'UTC')))
-        UNION ALL SELECT dateTrunc('hour', timestamp, 'UTC') AS date,
-                         sum(successes) AS successes,
-                         sum(successes_on_retry) AS successes_on_retry,
-                         sum(failures) AS failures
+       (SELECT dateTrunc('hour', timestamp, 'UTC') AS date,
+               sum(successes) AS successes,
+               sum(successes_on_retry) AS successes_on_retry,
+               sum(failures) AS failures
         FROM app_metrics
         WHERE team_id = 2
           AND plugin_config_id = 3
@@ -160,7 +151,8 @@
           AND timestamp < '2021-12-05 08:00:00'
         GROUP BY dateTrunc('hour', timestamp, 'UTC'))
      GROUP BY date
-     ORDER BY date)
+     ORDER BY date WITH FILL
+     FROM dateTrunc('hour', toDateTime('2021-12-05 00:00:00'), 'UTC') TO dateTrunc('hour', toDateTime('2021-12-05 08:00:00') + toIntervalHour(1), 'UTC') STEP 3600)
   '
 ---
 # name: TestAppMetricsQuery.test_filter_by_job_id
@@ -175,15 +167,10 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT dateTrunc('day', toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
-               0 AS successes,
-               0 AS successes_on_retry,
-               0 AS failures
-        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC')))
-        UNION ALL SELECT dateTrunc('day', timestamp, 'UTC') AS date,
-                         sum(successes) AS successes,
-                         sum(successes_on_retry) AS successes_on_retry,
-                         sum(failures) AS failures
+       (SELECT dateTrunc('day', timestamp, 'UTC') AS date,
+               sum(successes) AS successes,
+               sum(successes_on_retry) AS successes_on_retry,
+               sum(failures) AS failures
         FROM app_metrics
         WHERE team_id = 2
           AND plugin_config_id = 3
@@ -193,7 +180,8 @@
           AND timestamp < '2021-12-05 13:23:00'
         GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
-     ORDER BY date)
+     ORDER BY date WITH FILL
+     FROM dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC') TO dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC') STEP 86400)
   '
 ---
 # name: TestAppMetricsQuery.test_ignores_unrelated_data
@@ -208,15 +196,10 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT dateTrunc('day', toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
-               0 AS successes,
-               0 AS successes_on_retry,
-               0 AS failures
-        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC')))
-        UNION ALL SELECT dateTrunc('day', timestamp, 'UTC') AS date,
-                         sum(successes) AS successes,
-                         sum(successes_on_retry) AS successes_on_retry,
-                         sum(failures) AS failures
+       (SELECT dateTrunc('day', timestamp, 'UTC') AS date,
+               sum(successes) AS successes,
+               sum(successes_on_retry) AS successes_on_retry,
+               sum(failures) AS failures
         FROM app_metrics
         WHERE team_id = 2
           AND plugin_config_id = 3
@@ -225,7 +208,8 @@
           AND timestamp < '2021-12-05 13:23:00'
         GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
-     ORDER BY date)
+     ORDER BY date WITH FILL
+     FROM dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC') TO dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC') STEP 86400)
   '
 ---
 # name: TestTeamPluginsDeliveryRateQuery.test_query_delivery_rate

--- a/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
@@ -10,15 +10,10 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT dateTrunc('hour', toDateTime('2021-08-25 00:00:00') + toIntervalHour(number), 'UTC') AS date,
-               0 AS successes,
-               0 AS successes_on_retry,
-               0 AS failures
-        FROM numbers(dateDiff('hour', dateTrunc('hour', toDateTime('2021-08-25 00:00:00'), 'UTC'), dateTrunc('hour', toDateTime('2021-08-25 06:00:00') + toIntervalHour(1), 'UTC')))
-        UNION ALL SELECT dateTrunc('hour', timestamp, 'UTC') AS date,
-                         sum(successes) AS successes,
-                         sum(successes_on_retry) AS successes_on_retry,
-                         sum(failures) AS failures
+       (SELECT dateTrunc('hour', timestamp, 'UTC') AS date,
+               sum(successes) AS successes,
+               sum(successes_on_retry) AS successes_on_retry,
+               sum(failures) AS failures
         FROM app_metrics
         WHERE team_id = 2
           AND plugin_config_id = 3
@@ -28,7 +23,8 @@
           AND timestamp < '2021-08-25 06:00:00'
         GROUP BY dateTrunc('hour', timestamp, 'UTC'))
      GROUP BY date
-     ORDER BY date)
+     ORDER BY date WITH FILL
+     FROM dateTrunc('hour', toDateTime('2021-08-25 00:00:00'), 'UTC') TO dateTrunc('hour', toDateTime('2021-08-25 06:00:00') + toIntervalHour(1), 'UTC') STEP 3600)
   '
 ---
 # name: TestHistoricalExports.test_historical_export_metrics.1

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -81,6 +81,15 @@ def get_interval_func_ch(period: Optional[str]) -> str:
     return ch_function
 
 
+def get_time_in_seconds_for_period(period: Optional[str]) -> str:
+    if period is None:
+        period = "day"
+    seconds_in_period = TIME_IN_SECONDS.get(period.lower())
+    if seconds_in_period is None:
+        raise ValidationError(f"Interval {period} is unsupported.")
+    return seconds_in_period
+
+
 def deep_dump_object(params: Dict[str, Any]) -> Dict[str, Any]:
     for key in params:
         if isinstance(params[key], dict) or isinstance(params[key], list):


### PR DESCRIPTION
## Problem

#13617 

WITH FILL is cleaner, simpler to work with, and the more CH-onic way of generating a time series.

## Changes

Took the easiest query to convert to using WITH FILL to show it in action.

## How did you test this code?

Existing tests pass
