### PR TITLE
feat(queries): bring back join algo testing for non-celery queries

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -60,8 +60,8 @@ def clickhouse_at_least_228() -> bool:
     return is_ch_version_228_or_above
 
 
-def extra_settings(query_id: Optional[str], tags: Dict[str, Any]) -> Dict[str, Any]:
-    if tags.get("kind") != "celery" or not clickhouse_at_least_228():
+def extra_settings(query_id: Optional[str]) -> Dict[str, Any]:
+    if not clickhouse_at_least_228():
         return {}
 
     # The `default` option for join_algorithm was introduced with CH 22.8
@@ -118,7 +118,7 @@ def sync_execute(
         prepared_sql, prepared_args, tags = _prepare_query(client=client, query=query, args=args, workload=workload)
 
         query_id = validated_client_query_id()
-        core_settings = {**default_settings(), **(settings or {}), **extra_settings(query_id, tags)}
+        core_settings = {**default_settings(), **(settings or {}), **extra_settings(query_id)}
         tags["query_settings"] = core_settings
         settings = {**core_settings, "log_comment": json.dumps(tags, separators=(",", ":"))}
         try:

--- a/posthog/clickhouse/client/test/test_execute.py
+++ b/posthog/clickhouse/client/test/test_execute.py
@@ -6,21 +6,21 @@ from posthog.clickhouse.client.execute import extra_settings
 @patch("posthoganalytics.get_feature_flag")
 def test_extra_settings_join_algorithm_valid_value(mock_get_feature_flag):
     mock_get_feature_flag.return_value = "hash"
-    settings = extra_settings("some_query_id", {"kind": "celery"})
+    settings = extra_settings("some_query_id")
     assert settings == {"join_algorithm": "hash"}
 
 
 @patch("posthoganalytics.get_feature_flag")
 def test_extra_settings_join_algorithm_default_value(mock_get_feature_flag):
     mock_get_feature_flag.return_value = None
-    settings = extra_settings("some_query_id", {"kind": "celery"})
+    settings = extra_settings("some_query_id")
     assert settings == {"join_algorithm": "default"}
 
 
 @patch("posthoganalytics.get_feature_flag")
 def test_extra_settings_join_algorithm_multiple_values(mock_get_feature_flag):
     mock_get_feature_flag.return_value = "hash,parallel_hash,full_sorting_merge"
-    settings = extra_settings("some_query_id", {"kind": "celery"})
+    settings = extra_settings("some_query_id")
     assert settings == {"join_algorithm": "hash,parallel_hash,full_sorting_merge"}
 
 
@@ -28,10 +28,5 @@ def test_extra_settings_join_algorithm_multiple_values(mock_get_feature_flag):
 def test_extra_settings_join_algorithm_invalid_value(mock_get_feature_flag):
     # parallel-hash is a typo, should be parallel_hash
     mock_get_feature_flag.return_value = "hash,parallel-hash,full_sorting_merge"
-    settings = extra_settings("some_query_id", {"kind": "celery"})
+    settings = extra_settings("some_query_id")
     assert settings == {"join_algorithm": "default"}
-
-
-def test_extra_settings_join_algorithm_not_celery():
-    settings = extra_settings("some_query_id", {})
-    assert settings == {}


### PR DESCRIPTION
Being extra safe, I'll do a 50%, 75%, 100% rollout via a feature flag tomorrow for parallel_hash, keep an eye on things, and then put up a PR to hardcode `direct,parallel_hash` as the default algorithm in the codebase