### PR TITLE
fix: 0/0 causing enabled plugins to not be listed

### DIFF
--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -125,11 +125,13 @@ SELECT
 """
 
 QUERY_APP_METRICS_DELIVERY_RATE = """
-SELECT plugin_config_id, (sum(successes) + sum(successes_on_retry)) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
-FROM app_metrics
-WHERE team_id = %(team_id)s
-  AND timestamp > %(from_date)s
-GROUP BY plugin_config_id
+SELECT plugin_config_id, if(total > 0, success/total, 1) as rate FROM (
+    SELECT plugin_config_id, sum(successes) + sum(successes_on_retry) AS success, sum(successes) + sum(successes_on_retry) + sum(failures) AS total
+    FROM app_metrics
+    WHERE team_id = %(team_id)s
+        AND timestamp > %(from_date)s
+    GROUP BY plugin_config_id
+)
 """
 
 QUERY_APP_METRICS_TIME_SERIES = """

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -232,10 +232,14 @@
   '
   
   SELECT plugin_config_id,
-         (sum(successes) + sum(successes_on_retry)) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
-  FROM app_metrics
-  WHERE team_id = 2
-    AND timestamp > '2021-12-04 13:23:00.000000'
-  GROUP BY plugin_config_id
+         if(total > 0, success/total, 1) as rate
+  FROM
+    (SELECT plugin_config_id,
+            sum(successes) + sum(successes_on_retry) AS success,
+            sum(successes) + sum(successes_on_retry) + sum(failures) AS total
+     FROM app_metrics
+     WHERE team_id = 2
+       AND timestamp > '2021-12-04 13:23:00.000000'
+     GROUP BY plugin_config_id)
   '
 ---

--- a/posthog/queries/app_metrics/test/test_app_metrics.py
+++ b/posthog/queries/app_metrics/test/test_app_metrics.py
@@ -84,9 +84,18 @@ class TestTeamPluginsDeliveryRateQuery(ClickhouseTestMixin, BaseTest):
             successes=5,
             successes_on_retry=15,
         )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=4,
+            timestamp="2021-12-05T00:10:00Z",
+            successes=0,  # handles all zero rows
+            successes_on_retry=0,
+            failures=0,
+        )
 
         results = TeamPluginsDeliveryRateQuery(self.team).run()
-        self.assertEqual(results, {1: 0, 2: 0.5, 3: 1})
+        self.assertEqual(results, {1: 0, 2: 0.5, 3: 1, 4: 1})
 
     @freeze_time("2021-12-05T13:23:00Z")
     def test_ignores_out_of_bound_metrics(self):


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
See this thread 
https://posthog.slack.com/archives/C0460J93NBU/p1676315697866639?thread_ts=1676059091.243959&cid=C0460J93NBU

In case the entry in the plugin metrics table was 0,0,0, which might not be valid entry, but there's no validation so it can happen. In that case this query can result in 0/0, which CH helpful returns `nan`, which then gets sent as payload to frontend, which fails, because that's not valid json. Which meant we ignored the plugin_config completely (including the fact that these plugins were enabled), which lead the list of enabled plugins to show up as empty, but some exports happening could cause the issue to disappear suddenly.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

The unit test fails before changes to code
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
