### PR TITLE
fix(billing): deactivate button on free plan

### DIFF
--- a/frontend/src/scenes/billing/v2/PlanTable.tsx
+++ b/frontend/src/scenes/billing/v2/PlanTable.tsx
@@ -135,14 +135,14 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                 fullWidth
                 center
                 disableClientSideRouting
-                disabled={plan.is_free && !billing?.billing_period}
+                disabled={plan.is_free && !billing?.has_active_subscription}
                 onClick={() => {
                     if (!plan.is_free) {
                         reportBillingUpgradeClicked(plan.name)
                     }
                 }}
             >
-                {!billing?.billing_period && plan.is_free ? 'Current plan' : 'Upgrade'}
+                {!billing?.has_active_subscription && plan.is_free ? 'Current plan' : 'Upgrade'}
             </LemonButton>
         </td>
     ))


### PR DESCRIPTION
## Problem

Now everyone has a billing period (so we know when their monthly free allotment refreshes), so our check for disabling the upgrade button on the free plan was wrong.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Disables the button on the free plan if the plan is free and the person doesn't have an active subscription.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
