### PR TITLE
fix(trends): fix whitespace in trends tooltip

### DIFF
--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -327,8 +327,8 @@ export const mathsLogic = kea<mathsLogicType>({
                                     <br />
                                     <i>
                                         Example: If 7 users in a single $
-                                        {aggregationLabel(groupType.group_type_index).singular}
-                                        perform an event 9 times in the given period, it counts only as 1.
+                                        {aggregationLabel(groupType.group_type_index).singular} perform an event 9 times
+                                        in the given period, it counts only as 1.
                                     </i>
                                 </>
                             ),


### PR DESCRIPTION
## Problem

The trends tooltip for groups is missing a space in between the dynamic group name and the rest of the help text.

<img width="612" alt="missing_space" src="https://user-images.githubusercontent.com/1851359/218599109-e685ea3e-7b9d-4e67-8627-68db33a59dc7.png">


## Changes

Adds the test.

## How did you test this code?

Verified the space is there.