### PR TITLE
fix: avoid sending distinct ids to billing

### DIFF
--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -215,7 +215,6 @@ class TestBillingAPI(APILicensedTest):
             "id": self.license.key.split("::")[0],
             "organization_id": str(self.organization.id),
             "organization_name": "Test",
-            "distinct_ids": [self.user.distinct_id],
         }
 
     @patch("ee.api.billing.requests.get")


### PR DESCRIPTION
## Problem
We currently send all users distinct_ids to the billing service for tracking reasons.
That becomes a problem when there are too many distinct ids, as the jwt token becomes too big.
We don't need to do tracking in this way, so we can remove it.

## Changes
Remove distinct_ids from the jwt token.

## How did you test this code?
No need
