### PR TITLE
fix(data-exploration): add missing import to insight viz

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -12,6 +12,7 @@ import { InsightQueryNode, InsightVizNode } from '../../schema'
 
 import { InsightContainer } from './InsightContainer'
 import { EditorFilters } from './EditorFilters'
+import { ItemMode } from '~/types'
 
 type InsightVizProps = {
     query: InsightVizNode


### PR DESCRIPTION
## Problem

The [build is broken](https://github.com/PostHog/posthog/actions/runs/4172671103/jobs/7224066896), after https://github.com/PostHog/posthog/pull/14183 was merged into master.

## Changes

This PR adds an import that was lost in the merge.

## How did you test this code?

Local linter passes again.