### PR TITLE
fix: groupidentify to always update props and ignore timestamps

### DIFF
--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -1,22 +1,13 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
-import {
-    Group,
-    GroupTypeIndex,
-    PropertiesLastOperation,
-    PropertiesLastUpdatedAt,
-    PropertyUpdateOperation,
-    TeamId,
-} from '../../types'
+import { Group, GroupTypeIndex, TeamId } from '../../types'
 import { DB } from '../../utils/db/db'
 import { RaceConditionError } from '../../utils/utils'
 
 interface PropertiesUpdate {
     updated: boolean
     properties: Properties
-    properties_last_updated_at: PropertiesLastUpdatedAt
-    properties_last_operation: PropertiesLastOperation
 }
 
 export async function upsertGroup(
@@ -35,14 +26,7 @@ export async function upsertGroup(
             const createdAt = DateTime.min(group?.created_at || DateTime.now(), timestamp)
             const version = (group?.version || 0) + 1
 
-            const propertiesUpdate = calculateUpdate(
-                group?.group_properties || {},
-                properties,
-                {},
-                group?.properties_last_updated_at || {},
-                group?.properties_last_operation || {},
-                timestamp
-            )
+            const propertiesUpdate = calculateUpdate(group?.group_properties || {}, properties)
 
             if (!group) {
                 propertiesUpdate.updated = true
@@ -56,8 +40,8 @@ export async function upsertGroup(
                         groupKey,
                         propertiesUpdate.properties,
                         createdAt,
-                        propertiesUpdate.properties_last_updated_at,
-                        propertiesUpdate.properties_last_operation,
+                        {},
+                        {},
                         version,
                         client
                     )
@@ -69,8 +53,8 @@ export async function upsertGroup(
                         groupKey,
                         propertiesUpdate.properties,
                         createdAt,
-                        propertiesUpdate.properties_last_updated_at,
-                        propertiesUpdate.properties_last_operation,
+                        {},
+                        {},
                         version,
                         client
                     )
@@ -99,136 +83,17 @@ export async function upsertGroup(
     }
 }
 
-export function shouldUpdateProperty(
-    operation: PropertyUpdateOperation,
-    timestamp: DateTime,
-    lastOperation: PropertyUpdateOperation,
-    lastTimestamp: DateTime
-): boolean {
-    if (
-        operation == PropertyUpdateOperation.SetOnce &&
-        lastOperation === PropertyUpdateOperation.SetOnce &&
-        lastTimestamp > timestamp
-    ) {
-        return true
-    }
-    if (
-        operation == PropertyUpdateOperation.Set &&
-        (lastOperation === PropertyUpdateOperation.SetOnce || lastTimestamp < timestamp)
-    ) {
-        return true
-    }
-    return false
-}
-
-export function calculateUpdateSingleProperty(
-    result: PropertiesUpdate,
-    key: string,
-    value: any,
-    operation: PropertyUpdateOperation,
-    timestamp: DateTime,
-    currentPropertiesLastOperation: PropertiesLastOperation,
-    currentPropertiesLastUpdatedAt: PropertiesLastUpdatedAt
-): void {
-    if (
-        !(key in result.properties) ||
-        shouldUpdateProperty(
-            operation,
-            timestamp,
-            getPropertiesLastOperationOrSet(currentPropertiesLastOperation, key),
-            getPropertyLastUpdatedAtDateTimeOrEpoch(currentPropertiesLastUpdatedAt, key)
-        )
-    ) {
-        result.updated = true
-        result.properties[key] = value
-        result.properties_last_operation[key] = operation
-        result.properties_last_updated_at[key] = timestamp.toISO()
-    }
-}
-
-export function calculateUpdateForMerge(
-    currentProperties: Properties,
-    currentPropertiesLastUpdatedAt: PropertiesLastUpdatedAt,
-    currentPropertiesLastOperation: PropertiesLastOperation,
-    newProperties: Properties,
-    newPropertiesLastUpdatedAt: PropertiesLastUpdatedAt,
-    newPropertiesLastOperation: PropertiesLastOperation
-): PropertiesUpdate {
+export function calculateUpdate(currentProperties: Properties, properties: Properties): PropertiesUpdate {
     const result: PropertiesUpdate = {
         updated: false,
         properties: { ...currentProperties },
-        properties_last_updated_at: { ...currentPropertiesLastUpdatedAt },
-        properties_last_operation: { ...currentPropertiesLastOperation },
     }
 
-    Object.entries(newProperties).forEach(([key, value]) => {
-        const operation = getPropertiesLastOperationOrSet(newPropertiesLastOperation, key)
-        const timestamp = getPropertyLastUpdatedAtDateTimeOrEpoch(newPropertiesLastUpdatedAt, key)
-        calculateUpdateSingleProperty(
-            result,
-            key,
-            value,
-            operation,
-            timestamp,
-            currentPropertiesLastOperation,
-            currentPropertiesLastUpdatedAt
-        )
+    // We always update properties at ingestion time and ignore the timestamps events sent
+    Object.entries(properties).forEach(([key, value]) => {
+        if (!(key in result.properties) || value != result.properties[key]) {
+            ;(result.updated = true), (result.properties[key] = value)
+        }
     })
     return result
-}
-
-export function calculateUpdate(
-    currentProperties: Properties,
-    properties: Properties,
-    propertiesOnce: Properties,
-    currentPropertiesLastUpdatedAt: PropertiesLastUpdatedAt,
-    currentPropertiesLastOperation: PropertiesLastOperation,
-    timestamp: DateTime
-): PropertiesUpdate {
-    const result: PropertiesUpdate = {
-        updated: false,
-        properties: { ...currentProperties },
-        properties_last_updated_at: { ...currentPropertiesLastUpdatedAt },
-        properties_last_operation: { ...currentPropertiesLastOperation },
-    }
-
-    const allProperties: [Properties, PropertyUpdateOperation][] = [
-        [propertiesOnce, PropertyUpdateOperation.SetOnce],
-        [properties, PropertyUpdateOperation.Set],
-    ]
-    allProperties.forEach(([props, operation]) => {
-        Object.entries(props).forEach(([key, value]) => {
-            calculateUpdateSingleProperty(
-                result,
-                key,
-                value,
-                operation,
-                timestamp,
-                currentPropertiesLastOperation,
-                currentPropertiesLastUpdatedAt
-            )
-        })
-    })
-    return result
-}
-
-function getPropertyLastUpdatedAtDateTimeOrEpoch(
-    propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
-    key: string
-): DateTime {
-    const lookup = propertiesLastUpdatedAt[key]
-    if (lookup) {
-        return DateTime.fromISO(lookup)
-    }
-    return DateTime.fromMillis(0)
-}
-
-function getPropertiesLastOperationOrSet(
-    propertiesLastOperation: PropertiesLastOperation,
-    key: string
-): PropertyUpdateOperation {
-    if (!(key in propertiesLastOperation)) {
-        return PropertyUpdateOperation.Set
-    }
-    return propertiesLastOperation[key]
 }

--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -89,7 +89,14 @@ export function calculateUpdate(currentProperties: Properties, properties: Prope
         properties: { ...currentProperties },
     }
 
-    // We always update properties at ingestion time and ignore the timestamps events sent
+    // Ideally we'd keep track of event timestamps, for when properties were updated
+    // and only update the values if a newer timestamped event set them.
+    // However to do that we would need to keep track of previous set timestamps,
+    // which means that even if the property value didn't change
+    // we would need to trigger an update to update the timestamps.
+    // This can kill Postgres if someone sends us lots of groupidentify events.
+    // So instead we just process properties updates based on ingestion time,
+    // i.e. always update if value has changed.
     Object.entries(properties).forEach(([key, value]) => {
         if (!(key in result.properties) || value != result.properties[key]) {
             ;(result.updated = true), (result.properties[key] = value)

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -19,7 +19,6 @@ import {
     Person,
     PluginsServerConfig,
     PropertyDefinitionTypeEnum,
-    PropertyUpdateOperation,
     Team,
 } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
@@ -2259,8 +2258,8 @@ test('groupidentify', async () => {
         group_key: 'org::5',
         group_properties: { foo: 'bar' },
         created_at: now,
-        properties_last_updated_at: { foo: now.toISO() },
-        properties_last_operation: { foo: PropertyUpdateOperation.Set },
+        properties_last_updated_at: {},
+        properties_last_operation: {},
         version: 1,
     })
 })
@@ -2269,16 +2268,7 @@ test('$groupidentify updating properties', async () => {
     const next: DateTime = now.plus({ minutes: 1 })
 
     await createPerson(hub, team, ['distinct_id1'])
-    await hub.db.insertGroup(
-        team.id,
-        0,
-        'org::5',
-        { a: 1, b: 2 },
-        now,
-        { a: now.toISO(), b: now.toISO() },
-        { a: PropertyUpdateOperation.Set, b: PropertyUpdateOperation.Set },
-        1
-    )
+    await hub.db.insertGroup(team.id, 0, 'org::5', { a: 1, b: 2 }, now, {}, {}, 1)
 
     await processEvent(
         'distinct_id1',
@@ -2322,12 +2312,8 @@ test('$groupidentify updating properties', async () => {
         group_key: 'org::5',
         group_properties: { a: 3, b: 2, foo: 'bar' },
         created_at: now,
-        properties_last_updated_at: { a: next.toISO(), b: now.toISO(), foo: next.toISO() },
-        properties_last_operation: {
-            a: PropertyUpdateOperation.Set,
-            b: PropertyUpdateOperation.Set,
-            foo: PropertyUpdateOperation.Set,
-        },
+        properties_last_updated_at: {},
+        properties_last_operation: {},
         version: 2,
     })
 })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We had an incident, where someone spammed us with lots of `$groupidentify` events. 

While the existing code is great for handing properties updates correctly in terms of respecting user timestamps it also means that we'll trigger an update each time we see a `$groupidentify` event even if nothing changes.

It's better for us from Postgres health perspective to not do that and just always override properties at ingestion time.

See more background https://posthog.slack.com/archives/C04NH2SJKUN/p1675908517989299 

Added a Harry style comment too (or tried my best).

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unittests, one of which failed with previous code.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
