### PR TITLE
fix: Recording event payload might not be a dict

### DIFF
--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -449,6 +449,8 @@ def test_get_events_summary_from_snapshot_data():
         {"type": 2, "timestamp": timestamp, "foo": "bar"},
         # include standard properties
         {"type": 1, "timestamp": timestamp, "data": {"source": 3}},
+        # Payload as list when we expect a dict
+        {"type": 1, "timestamp": timestamp, "data": {"source": 3, "payload": [1, 2, 3]}},
         # include only allowed values
         {
             "type": 1,
@@ -480,6 +482,7 @@ def test_get_events_summary_from_snapshot_data():
 
     assert get_events_summary_from_snapshot_data(snapshot_events) == [
         {"timestamp": timestamp, "type": 2, "data": {}},
+        {"timestamp": timestamp, "type": 1, "data": {"source": 3}},
         {"timestamp": timestamp, "type": 1, "data": {"source": 3}},
         {
             "timestamp": timestamp,

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -329,11 +329,13 @@ def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> 
         }
         # Some events have a payload, some values of which we want
         if event.get("data", {}).get("payload"):
-            data["payload"] = {
-                key: value
-                for key, value in event["data"]["payload"].items()
-                if type(value) in [str, int] and f"payload.{key}" in EVENT_SUMMARY_DATA_INCLUSIONS
-            }
+            # Make sure the payload is a dict before we access it
+            if isinstance(event["data"]["payload"], dict):
+                data["payload"] = {
+                    key: value
+                    for key, value in event["data"]["payload"].items()
+                    if type(value) in [str, int] and f"payload.{key}" in EVENT_SUMMARY_DATA_INCLUSIONS
+                }
 
         events_summary.append(
             SessionRecordingEventSummary(


### PR DESCRIPTION
## Problem

It seems from one user we are getting an interesting payload, different to what we expect. [Sentry issue](https://posthog.sentry.io/issues/3936717872/events/1133552912dd445eaebe204f58f94ceb/?project=1899813)

## Changes

* Extra check to make sure we are definitely parsing things right


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests