### PR TITLE
fix: onboarding bug

### DIFF
--- a/frontend/src/scenes/ingestion/CardContainer.tsx
+++ b/frontend/src/scenes/ingestion/CardContainer.tsx
@@ -7,11 +7,13 @@ export function CardContainer({
     nextProps,
     onContinue,
     finalStep = false,
+    showInviteTeamMembers = true,
 }: {
     children: React.ReactNode
     nextProps?: Partial<IngestionState>
     onContinue?: () => void
     finalStep?: boolean
+    showInviteTeamMembers?: boolean
 }): JSX.Element {
     return (
         // We want a forced width for this view only
@@ -19,7 +21,14 @@ export function CardContainer({
         <div style={{ maxWidth: 800 }}>
             {children}
             <div>
-                {nextProps && <PanelFooter nextProps={nextProps} onContinue={onContinue} finalStep={finalStep} />}
+                {nextProps && (
+                    <PanelFooter
+                        nextProps={nextProps}
+                        onContinue={onContinue}
+                        finalStep={finalStep}
+                        showInviteTeamMembers={showInviteTeamMembers}
+                    />
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/ingestion/panels/PanelComponents.tsx
+++ b/frontend/src/scenes/ingestion/panels/PanelComponents.tsx
@@ -18,10 +18,12 @@ export function PanelFooter({
     nextProps,
     onContinue,
     finalStep = false,
+    showInviteTeamMembers = true,
 }: {
     nextProps: Partial<IngestionState>
     onContinue?: () => void
     finalStep?: boolean
+    showInviteTeamMembers?: boolean
 }): JSX.Element {
     const { next } = useActions(ingestionLogic)
 
@@ -42,7 +44,7 @@ export function PanelFooter({
                 >
                     {finalStep ? 'Complete' : 'Continue'}
                 </LemonButton>
-                <IngestionInviteMembersButton />
+                {showInviteTeamMembers && <IngestionInviteMembersButton />}
             </div>
         </div>
     )

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -22,42 +22,42 @@ export function VerificationPanel(): JSX.Element {
         }
     }, 2000)
 
-    return (
+    return !currentTeam?.ingested_event ? (
         <CardContainer>
             <div className="text-center">
-                {!currentTeam?.ingested_event ? (
-                    <>
-                        <div className="ingestion-listening-for-events">
-                            <Spinner className="text-4xl" />
-                            <h1 className="ingestion-title pt-4">Listening for events...</h1>
-                            <p className="prompt-text">
-                                Once you have integrated the snippet and sent an event, we will verify it was properly
-                                received and continue.
-                            </p>
-                            <EventBufferNotice className="mb-4" />
-                            <IngestionInviteMembersButton />
-                            <LemonButton
-                                fullWidth
-                                center
-                                type="tertiary"
-                                onClick={() => {
-                                    next({ showSuperpowers: true })
-                                    reportIngestionContinueWithoutVerifying()
-                                }}
-                            >
-                                or continue without verifying
-                            </LemonButton>
-                        </div>
-                    </>
-                ) : (
-                    <div>
-                        <h1 className="ingestion-title">Successfully sent events!</h1>
-                        <p className="prompt-text text-muted text-left">
-                            You will now be able to explore PostHog and take advantage of all its features to understand
-                            your users.
-                        </p>
-                    </div>
-                )}
+                <div className="ingestion-listening-for-events">
+                    <Spinner className="text-4xl" />
+                    <h1 className="ingestion-title pt-4">Listening for events...</h1>
+                    <p className="prompt-text">
+                        Once you have integrated the snippet and sent an event, we will verify it was properly received
+                        and continue.
+                    </p>
+                    <EventBufferNotice className="mb-4" />
+                    <IngestionInviteMembersButton />
+                    <LemonButton
+                        fullWidth
+                        center
+                        type="tertiary"
+                        onClick={() => {
+                            next({ showSuperpowers: true })
+                            reportIngestionContinueWithoutVerifying()
+                        }}
+                    >
+                        or continue without verifying
+                    </LemonButton>
+                </div>
+            </div>
+        </CardContainer>
+    ) : (
+        <CardContainer nextProps={{ showSuperpowers: true }} showInviteTeamMembers={false}>
+            <div className="text-center">
+                <div>
+                    <h1 className="ingestion-title">Successfully sent events!</h1>
+                    <p className="prompt-text text-muted text-left">
+                        You will now be able to explore PostHog and take advantage of all its features to understand
+                        your users.
+                    </p>
+                </div>
             </div>
         </CardContainer>
     )


### PR DESCRIPTION
## Problem

One of the onboarding screens was missing the continue button after we redid the panel footer a bit, so people were getting stuck. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Added a continue button to the "events sent" screen.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
