### PR TITLE
feat(flags): feature flag exposures component

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -59,6 +59,7 @@ interface EventsTableProps {
     showPersonColumn?: boolean
     linkPropertiesToFilters?: boolean
     'data-attr'?: string
+    emptyPrompt?: string
 }
 
 export function EventsTable({
@@ -81,6 +82,7 @@ export function EventsTable({
     showPersonColumn = true,
     linkPropertiesToFilters = true,
     'data-attr': dataAttr,
+    emptyPrompt = `No events matching filters found in the last ${fetchMonths} months!`,
 }: EventsTableProps): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const logic = eventsTableLogic({
@@ -98,7 +100,6 @@ export function EventsTable({
         eventFilter,
         automaticLoadEnabled,
         highlightEvents,
-        months,
     } = useValues(logic)
     const { tableWidth, selectedColumns } = useValues(
         tableConfigLogic({
@@ -513,7 +514,7 @@ export function EventsTable({
                     emptyState={
                         isLoading ? undefined : properties.some((filter) => Object.keys(filter).length) ||
                           eventFilter ? (
-                            `No events matching filters found in the last ${months} months!`
+                            emptyPrompt
                         ) : (
                             <>
                                 This project doesn't have any events. If you haven't integrated PostHog yet,{' '}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -26,7 +26,14 @@ import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { groupsModel } from '~/models/groupsModel'
 import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
 import { userLogic } from 'scenes/userLogic'
-import { AnyPropertyFilter, AvailableFeature, Resource } from '~/types'
+import {
+    AnyPropertyFilter,
+    AvailableFeature,
+    EventsTableRowItem,
+    PropertyFilterType,
+    PropertyOperator,
+    Resource,
+} from '~/types'
 import { Link } from 'lib/lemon-ui/Link'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Field } from 'lib/forms/Field'
@@ -485,6 +492,47 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                 </Tabs>
                             </>
                         )}
+                    </>
+                )}
+                <Divider />
+
+                {!isEditingFlag && (
+                    <>
+                        <div className="mb-2">
+                            <b>Exposures</b>
+                        </div>
+                        <EventsTable
+                            fixedFilters={{
+                                event_filter: '$feature_flag_called',
+                                properties: [
+                                    {
+                                        key: '$feature/' + featureFlag.key,
+                                        type: PropertyFilterType.Event,
+                                        value: 'is_set',
+                                        operator: PropertyOperator.IsSet,
+                                    },
+                                ],
+                            }}
+                            fixedColumns={[
+                                {
+                                    title: 'Value',
+                                    key: '$feature/' + featureFlag.key,
+                                    render: function renderTime(_, { event }: EventsTableRowItem) {
+                                        return event?.properties['$feature/' + featureFlag.key].toString()
+                                    },
+                                },
+                            ]}
+                            startingColumns={['person']}
+                            fetchMonths={1}
+                            pageKey={`feature-flag`}
+                            showEventFilter={false}
+                            showPropertyFilter={false}
+                            showCustomizeColumns={false}
+                            showAutoload={false}
+                            showExport={false}
+                            showActionsButton={false}
+                            emptyPrompt={`Feature flag calls for "${featureFlag.key}" will appear here`}
+                        />
                     </>
                 )}
             </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -496,7 +496,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                 )}
                 <Divider />
 
-                {!isEditingFlag && (
+                {!isNewFeatureFlag && !isEditingFlag && (
                     <>
                         <div className="mb-2">
                             <b>Exposures</b>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -65,9 +65,6 @@ import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/uti
 import { featureFlagPermissionsLogic } from './featureFlagPermissionsLogic'
 import { ResourcePermission } from 'scenes/ResourcePermissionModal'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
-import { NodeKind } from '~/queries/schema'
-import { Query } from '~/queries/Query/Query'
-import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { tagsModel } from '~/models/tagsModel'
@@ -463,7 +460,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         </Row>
                                     </Tabs.TabPane>
                                     {featureFlags[FEATURE_FLAGS.EXPOSURES_ON_FEATURE_FLAGS] && featureFlag.key && id && (
-                                        <Tabs.TabPane tab="Exposures" key="exposure">
+                                        <Tabs.TabPane tab="Usage" key="exposure">
                                             <ExposureTab id={id} featureFlagKey={featureFlag.key} />
                                         </Tabs.TabPane>
                                     )}
@@ -500,9 +497,6 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
 }
 
 function ExposureTab({ featureFlagKey }: { id: string; featureFlagKey: string }): JSX.Element {
-    const { featureFlags } = useValues(enabledFeaturesLogic)
-    const featureDataExploration = featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_LIVE_EVENTS]
-
     const propertyFilter: AnyPropertyFilter[] = [
         {
             key: '$feature_flag',
@@ -511,47 +505,40 @@ function ExposureTab({ featureFlagKey }: { id: string; featureFlagKey: string })
             operator: PropertyOperator.Exact,
         },
     ]
-    return featureDataExploration ? (
-        <Query
-            query={{
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.EventsQuery,
-                    select: defaultDataTableColumns(NodeKind.EventsQuery),
-                    event: '$feature_flag_called',
+
+    // TODO: reintegrate HogQL Editor
+    return (
+        <div>
+            <div className="mb-4">
+                <b>Log</b>
+                <div className="text-muted">{`Feature flag calls for "${featureFlagKey}" will appear here`}</div>
+            </div>
+            <EventsTable
+                fixedFilters={{
+                    event_filter: '$feature_flag_called',
                     properties: propertyFilter,
-                },
-                full: true,
-                showEventFilter: false,
-                showPropertyFilter: false,
-            }}
-        />
-    ) : (
-        <EventsTable
-            fixedFilters={{
-                event_filter: '$feature_flag_called',
-                properties: propertyFilter,
-            }}
-            fixedColumns={[
-                {
-                    title: 'Value',
-                    key: '$feature/' + featureFlagKey,
-                    render: function renderTime(_, { event }: EventsTableRowItem) {
-                        return event?.properties['$feature/' + featureFlagKey]?.toString()
+                }}
+                fixedColumns={[
+                    {
+                        title: 'Value',
+                        key: '$feature/' + featureFlagKey,
+                        render: function renderTime(_, { event }: EventsTableRowItem) {
+                            return event?.properties['$feature/' + featureFlagKey]?.toString()
+                        },
                     },
-                },
-            ]}
-            startingColumns={['person']}
-            fetchMonths={1}
-            pageKey={`feature-flag-` + featureFlagKey}
-            showEventFilter={false}
-            showPropertyFilter={false}
-            showCustomizeColumns={false}
-            showAutoload={false}
-            showExport={false}
-            showActionsButton={false}
-            emptyPrompt={`Feature flag calls for "${featureFlagKey}" will appear here`}
-        />
+                ]}
+                startingColumns={['person']}
+                fetchMonths={1}
+                pageKey={`feature-flag-` + featureFlagKey}
+                showEventFilter={false}
+                showPropertyFilter={false}
+                showCustomizeColumns={false}
+                showAutoload={false}
+                showExport={false}
+                showActionsButton={false}
+                emptyPrompt={`No events received`}
+            />
+        </div>
     )
 }
 

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -506,10 +506,10 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                 event_filter: '$feature_flag_called',
                                 properties: [
                                     {
-                                        key: '$feature/' + featureFlag.key,
+                                        key: '$feature_flag',
                                         type: PropertyFilterType.Event,
-                                        value: 'is_set',
-                                        operator: PropertyOperator.IsSet,
+                                        value: featureFlag.key,
+                                        operator: PropertyOperator.Exact,
                                     },
                                 ],
                             }}
@@ -524,7 +524,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                             ]}
                             startingColumns={['person']}
                             fetchMonths={1}
-                            pageKey={`feature-flag`}
+                            pageKey={`feature-flag-` + featureFlag.key}
                             showEventFilter={false}
                             showPropertyFilter={false}
                             showCustomizeColumns={false}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -460,8 +460,8 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         </Row>
                                     </Tabs.TabPane>
                                     {featureFlags[FEATURE_FLAGS.EXPOSURES_ON_FEATURE_FLAGS] && featureFlag.key && id && (
-                                        <Tabs.TabPane tab="Usage" key="exposure">
-                                            <ExposureTab id={id} featureFlagKey={featureFlag.key} />
+                                        <Tabs.TabPane tab="Usage" key="usage">
+                                            <UsageTab id={id} featureFlagKey={featureFlag.key} />
                                         </Tabs.TabPane>
                                     )}
                                     {featureFlag.id && (
@@ -496,7 +496,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
     )
 }
 
-function ExposureTab({ featureFlagKey }: { id: string; featureFlagKey: string }): JSX.Element {
+function UsageTab({ featureFlagKey }: { id: string; featureFlagKey: string }): JSX.Element {
     const propertyFilter: AnyPropertyFilter[] = [
         {
             key: '$feature_flag',


### PR DESCRIPTION
## Problem

- Can't easily tell in feature flag detail page if flags are being called
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- Update the Exposures tab that's existed behind flag `exposures-on-feature-flags` to be rollout ready
- Reduce unnecessary columns and filters on display
- Add title and change tab name from "Exposures" to "Usage"

<!-- If there are frontend changes, please include screenshots. -->


<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
