### PR TITLE
chore: Add exception catching if there are no team_tokens

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -89,8 +89,7 @@ def sync_org_quota_limits(organization: Organization):
     if not organization.usage:
         return None
 
-    team_tokens = list(organization.teams.values_list("api_token", flat=True))
-    team_tokens = [x for x in team_tokens if x]
+    team_tokens: List[str] = [x for x in list(organization.teams.values_list("api_token", flat=True)) if x]
 
     if not team_tokens:
         capture_exception(Exception(f"quota_limiting: No team tokens found for organization: {organization.id}"))
@@ -100,9 +99,9 @@ def sync_org_quota_limits(organization: Organization):
         rate_limited_until = org_quota_limited_until(organization, resource)
 
         if rate_limited_until:
-            add_limited_team_tokens(resource, {x: rate_limited_until for x in team_tokens if x})
+            add_limited_team_tokens(resource, {x: rate_limited_until for x in team_tokens})
         else:
-            remove_limited_team_tokens(resource, [x for x in team_tokens if x])
+            remove_limited_team_tokens(resource, team_tokens)
 
 
 def set_org_usage_summary(


### PR DESCRIPTION
## Problem

Somehow we have a sentry issue where the sync process can't find any team tokens for an org. Hard to understand why this would happen so for now adding a dedicated catch check so that we can get more insights about it ([Sentry issue](https://posthog.sentry.io/issues/3938145688/?project=4503944059682816&referrer=slack))

## Changes

* Catch the exception if there are no team tokens

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
