### PR TITLE
chore: reorganise some insight things in prep for moving active view

### DIFF
--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -5,45 +5,22 @@ import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { insightLogic } from './insightLogic'
 import { insightCommandLogic } from './insightCommandLogic'
 import { insightDataLogic } from './insightDataLogic'
-import { AvailableFeature, ExporterFormat, InsightModel, InsightShortId, InsightType, ItemMode } from '~/types'
+import { InsightShortId, InsightType, ItemMode } from '~/types'
 import { InsightsNav } from './InsightsNav'
-import { AddToDashboard } from 'lib/components/AddToDashboard/AddToDashboard'
 import { InsightContainer } from 'scenes/insights/InsightContainer'
-import { EditableField } from 'lib/components/EditableField/EditableField'
-import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
-import { InsightSaveButton } from './InsightSaveButton'
-import { userLogic } from 'scenes/userLogic'
-import { PageHeader } from 'lib/components/PageHeader'
-import { IconLock } from 'lib/lemon-ui/icons'
-import { summarizeInsightFilters, summarizeInsightQuery } from './utils'
-import { groupsModel } from '~/models/groupsModel'
-import { cohortsModel } from '~/models/cohortsModel'
-import { mathsLogic } from 'scenes/trends/mathsLogic'
 import { InsightSkeleton } from 'scenes/insights/InsightSkeleton'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { EditorFilters } from './EditorFilters/EditorFilters'
-import { More } from 'lib/lemon-ui/LemonButton/More'
-import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
-import { deleteWithUndo } from 'lib/utils'
-import { teamLogic } from 'scenes/teamLogic'
-import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
-import { router } from 'kea-router'
-import { urls } from 'scenes/urls'
-import { SubscribeButton, SubscriptionsModal } from 'lib/components/Subscriptions/SubscriptionsModal'
-import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
 import clsx from 'clsx'
-import { SharingModal } from 'lib/components/Sharing/SharingModal'
-import { ExportButton } from 'lib/components/ExportButton/ExportButton'
-import { tagsModel } from '~/models/tagsModel'
 import { Query } from '~/queries/Query/Query'
-import { InsightVizNode } from '~/queries/schema'
-import { InlineEditorButton } from '~/queries/nodes/Node/InlineEditorButton'
-import { isInsightVizNode } from '~/queries/utils'
+import { InsightPageHeader } from 'scenes/insights/InsightPageHeader'
 
-export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): JSX.Element {
+export interface InsightSceneProps {
+    insightId: InsightShortId | 'new'
+}
+
+export function Insight({ insightId }: InsightSceneProps): JSX.Element {
     // insightSceneLogic
-    const { insightMode, subscriptionId } = useValues(insightSceneLogic)
-    const { setInsightMode } = useActions(insightSceneLogic)
+    const { insightMode } = useValues(insightSceneLogic)
 
     // insightLogic
     const logic = insightLogic({ dashboardItemId: insightId || 'new' })
@@ -52,29 +29,13 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
         insightLoading,
         filtersKnown,
         filters,
-        canEditInsight,
         insight,
-        insightChanged,
-        tagLoading,
-        insightSaving,
-        exporterResourceParams,
         isUsingDataExploration,
         erroredQueryId,
         isFilterBasedInsight,
         isQueryBasedInsight,
-        isInsightVizQuery,
     } = useValues(logic)
-    const {
-        saveInsight,
-        setInsightMetadata,
-        saveAs,
-        reportInsightViewedForRecentInsights,
-        abortAnyRunningQuery,
-        loadResults,
-    } = useActions(logic)
-
-    // savedInsightsLogic
-    const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
+    const { reportInsightViewedForRecentInsights, abortAnyRunningQuery, loadResults } = useActions(logic)
 
     // insightDataLogic
     const { query: insightVizQuery } = useValues(insightDataLogic(insightProps))
@@ -92,13 +53,6 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
 
     // other logics
     useMountedLogic(insightCommandLogic(insightProps))
-    const { hasAvailableFeature } = useValues(userLogic)
-    const { aggregationLabel } = useValues(groupsModel)
-    const { cohortsById } = useValues(cohortsModel)
-    const { mathDefinitions } = useValues(mathsLogic)
-    const { tags } = useValues(tagsModel)
-    const { currentTeamId } = useValues(teamLogic)
-    const { push } = useActions(router)
 
     useEffect(() => {
         reportInsightViewedForRecentInsights()
@@ -126,216 +80,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
 
     const insightScene = (
         <div className={'insights-page'}>
-            {insightId !== 'new' && (
-                <>
-                    <SubscriptionsModal
-                        isOpen={insightMode === ItemMode.Subscriptions}
-                        closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
-                        insightShortId={insightId}
-                        subscriptionId={subscriptionId}
-                    />
-
-                    <SharingModal
-                        isOpen={insightMode === ItemMode.Sharing}
-                        closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
-                        insightShortId={insightId}
-                        insight={insight}
-                    />
-                </>
-            )}
-            <PageHeader
-                title={
-                    <EditableField
-                        name="name"
-                        value={insight.name || ''}
-                        placeholder={
-                            isUsingDataExploration && isInsightVizQuery
-                                ? summarizeInsightQuery(
-                                      (query as InsightVizNode).source,
-                                      aggregationLabel,
-                                      cohortsById,
-                                      mathDefinitions
-                                  )
-                                : isFilterBasedInsight
-                                ? summarizeInsightFilters(filters, aggregationLabel, cohortsById, mathDefinitions)
-                                : // TODO placeholder for non insight viz queries
-                                  ''
-                        }
-                        onSave={(value) => setInsightMetadata({ name: value })}
-                        saveOnBlur={true}
-                        maxLength={400} // Sync with Insight model
-                        mode={!canEditInsight ? 'view' : undefined}
-                        data-attr="insight-name"
-                        notice={
-                            !canEditInsight
-                                ? {
-                                      icon: <IconLock />,
-                                      tooltip:
-                                          "You don't have edit permissions on any of the dashboards this insight belongs to. Ask a dashboard collaborator with edit access to add you.",
-                                  }
-                                : undefined
-                        }
-                    />
-                }
-                buttons={
-                    <div className="flex justify-between items-center gap-2">
-                        {insightMode !== ItemMode.Edit && (
-                            <>
-                                <More
-                                    overlay={
-                                        <>
-                                            <LemonButton
-                                                status="stealth"
-                                                onClick={() => duplicateInsight(insight as InsightModel, true)}
-                                                fullWidth
-                                                data-attr="duplicate-insight-from-insight-view"
-                                            >
-                                                Duplicate
-                                            </LemonButton>
-                                            <LemonButton
-                                                status="stealth"
-                                                onClick={() =>
-                                                    setInsightMetadata({
-                                                        favorited: !insight.favorited,
-                                                    })
-                                                }
-                                                fullWidth
-                                            >
-                                                {insight.favorited ? 'Remove from favorites' : 'Add to favorites'}
-                                            </LemonButton>
-                                            <LemonDivider />
-
-                                            <LemonButton
-                                                status="stealth"
-                                                onClick={() =>
-                                                    insight.short_id
-                                                        ? push(urls.insightSharing(insight.short_id))
-                                                        : null
-                                                }
-                                                fullWidth
-                                            >
-                                                Share or embed
-                                            </LemonButton>
-                                            {insight.short_id && (
-                                                <>
-                                                    <SubscribeButton insightShortId={insight.short_id} />
-                                                    {exporterResourceParams ? (
-                                                        <ExportButton
-                                                            fullWidth
-                                                            items={[
-                                                                {
-                                                                    export_format: ExporterFormat.PNG,
-                                                                    insight: insight.id,
-                                                                },
-                                                                {
-                                                                    export_format: ExporterFormat.CSV,
-                                                                    export_context: exporterResourceParams,
-                                                                },
-                                                            ]}
-                                                        />
-                                                    ) : null}
-                                                    <LemonDivider />
-                                                </>
-                                            )}
-
-                                            <LemonButton
-                                                status="danger"
-                                                onClick={() =>
-                                                    deleteWithUndo({
-                                                        object: insight,
-                                                        endpoint: `projects/${currentTeamId}/insights`,
-                                                        callback: () => {
-                                                            loadInsights()
-                                                            push(urls.savedInsights())
-                                                        },
-                                                    })
-                                                }
-                                                fullWidth
-                                            >
-                                                Delete insight
-                                            </LemonButton>
-                                        </>
-                                    }
-                                />
-                                <LemonDivider vertical />
-                            </>
-                        )}
-                        {insightMode === ItemMode.Edit && insight.saved && (
-                            <LemonButton type="secondary" onClick={() => setInsightMode(ItemMode.View, null)}>
-                                Cancel
-                            </LemonButton>
-                        )}
-                        {insightMode !== ItemMode.Edit && insight.short_id && (
-                            <AddToDashboard insight={insight} canEditInsight={canEditInsight} />
-                        )}
-                        {insightMode !== ItemMode.Edit ? (
-                            canEditInsight &&
-                            (isFilterBasedInsight || isInsightVizNode(query)) && (
-                                <LemonButton
-                                    type="primary"
-                                    onClick={() => setInsightMode(ItemMode.Edit, null)}
-                                    data-attr="insight-edit-button"
-                                >
-                                    Edit
-                                </LemonButton>
-                            )
-                        ) : (
-                            <InsightSaveButton
-                                saveAs={saveAs}
-                                saveInsight={saveInsight}
-                                isSaved={insight.saved}
-                                addingToDashboard={!!insight.dashboards?.length && !insight.id}
-                                insightSaving={insightSaving}
-                                insightChanged={insightChanged}
-                            />
-                        )}
-                        {isUsingDataExploration && <InlineEditorButton query={query} setQuery={setQuery} />}
-                    </div>
-                }
-                caption={
-                    <>
-                        {!!(canEditInsight || insight.description) && (
-                            <EditableField
-                                multiline
-                                name="description"
-                                value={insight.description || ''}
-                                placeholder="Description (optional)"
-                                onSave={(value) => setInsightMetadata({ description: value })}
-                                saveOnBlur={true}
-                                maxLength={400} // Sync with Insight model
-                                mode={!canEditInsight ? 'view' : undefined}
-                                data-attr="insight-description"
-                                compactButtons
-                                paywall={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
-                            />
-                        )}
-                        {canEditInsight ? (
-                            <ObjectTags
-                                tags={insight.tags ?? []}
-                                onChange={(_, tags) => setInsightMetadata({ tags: tags ?? [] })}
-                                saving={tagLoading}
-                                tagsAvailable={tags}
-                                className="insight-metadata-tags"
-                                data-attr="insight-tags"
-                            />
-                        ) : insight.tags?.length ? (
-                            <ObjectTags
-                                tags={insight.tags}
-                                saving={tagLoading}
-                                className="insight-metadata-tags"
-                                data-attr="insight-tags"
-                                staticOnly
-                            />
-                        ) : null}
-                        <UserActivityIndicator
-                            at={insight.last_modified_at}
-                            by={insight.last_modified_by}
-                            className="mt-2"
-                        />
-                    </>
-                }
-                tabbedPage={insightMode === ItemMode.Edit} // Insight type tabs are only shown in edit mode
-            />
+            <InsightPageHeader insightId={insightId} />
 
             {insightMode === ItemMode.Edit && <InsightsNav />}
 
@@ -348,9 +93,10 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                             'insight-wrapper--singlecolumn': filters.insight === InsightType.FUNNELS,
                         })}
                     >
-                        {showFilterEditing && (
-                            <EditorFilters insightProps={insightProps} showing={insightMode === ItemMode.Edit} />
-                        )}
+                        <EditorFilters
+                            insightProps={insightProps}
+                            showing={showFilterEditing && insightMode === ItemMode.Edit}
+                        />
                         <div className="insights-container" data-attr="insight-view">
                             <InsightContainer insightMode={insightMode} />
                         </div>

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -33,9 +33,6 @@ import { InsightSceneProps } from 'scenes/insights/Insight'
 import { router } from 'kea-router'
 import { SharingModal } from 'lib/components/Sharing/SharingModal'
 
-/**
- * Assume this is used in a scene that has bound an insightLogic
- */
 export function InsightPageHeader({ insightId }: InsightSceneProps): JSX.Element {
     // insightSceneLogic
     const { insightMode, subscriptionId } = useValues(insightSceneLogic)
@@ -273,6 +270,7 @@ export function InsightPageHeader({ insightId }: InsightSceneProps): JSX.Element
                         {canEditInsight ? (
                             <ObjectTags
                                 tags={insight.tags ?? []}
+                                saving={insightSaving}
                                 onChange={(_, tags) => setInsightMetadata({ tags: tags ?? [] })}
                                 tagsAvailable={tags}
                                 className="insight-metadata-tags"
@@ -281,6 +279,7 @@ export function InsightPageHeader({ insightId }: InsightSceneProps): JSX.Element
                         ) : insight.tags?.length ? (
                             <ObjectTags
                                 tags={insight.tags}
+                                saving={insightSaving}
                                 className="insight-metadata-tags"
                                 data-attr="insight-tags"
                                 staticOnly

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -1,0 +1,300 @@
+import { EditableField } from 'lib/components/EditableField/EditableField'
+import { summarizeInsightFilters, summarizeInsightQuery } from 'scenes/insights/utils'
+import { InsightVizNode } from '~/queries/schema'
+import { IconLock } from 'lib/lemon-ui/icons'
+import { AvailableFeature, ExporterFormat, InsightModel, InsightShortId, ItemMode } from '~/types'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { urls } from 'scenes/urls'
+import { SubscribeButton, SubscriptionsModal } from 'lib/components/Subscriptions/SubscriptionsModal'
+import { ExportButton } from 'lib/components/ExportButton/ExportButton'
+import { deleteWithUndo } from 'lib/utils'
+import { AddToDashboard } from 'lib/components/AddToDashboard/AddToDashboard'
+import { isInsightVizNode } from '~/queries/utils'
+import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
+import { InlineEditorButton } from '~/queries/nodes/Node/InlineEditorButton'
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
+import { PageHeader } from 'lib/components/PageHeader'
+import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
+import { insightCommandLogic } from 'scenes/insights/insightCommandLogic'
+import { userLogic } from 'scenes/userLogic'
+import { groupsModel } from '~/models/groupsModel'
+import { cohortsModel } from '~/models/cohortsModel'
+import { mathsLogic } from 'scenes/trends/mathsLogic'
+import { tagsModel } from '~/models/tagsModel'
+import { teamLogic } from 'scenes/teamLogic'
+import { useActions, useMountedLogic, useValues } from 'kea'
+import { InsightSceneProps } from 'scenes/insights/Insight'
+import { router } from 'kea-router'
+import { SharingModal } from 'lib/components/Sharing/SharingModal'
+
+/**
+ * Assume this is used in a scene that has bound an insightLogic
+ */
+export function InsightPageHeader({ insightId }: InsightSceneProps): JSX.Element {
+    // insightSceneLogic
+    const { insightMode, subscriptionId } = useValues(insightSceneLogic)
+    const { setInsightMode } = useActions(insightSceneLogic)
+
+    // insightLogic
+    const logic = insightLogic({ dashboardItemId: insightId || 'new' })
+    const {
+        insightProps,
+        filters,
+        canEditInsight,
+        insight,
+        insightChanged,
+        insightSaving,
+        exporterResourceParams,
+        isUsingDataExploration,
+        isFilterBasedInsight,
+        isQueryBasedInsight,
+        isInsightVizQuery,
+    } = useValues(logic)
+    const { saveInsight, setInsightMetadata, saveAs } = useActions(logic)
+
+    // savedInsightsLogic
+    const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
+
+    // insightDataLogic
+    const { query: insightVizQuery } = useValues(insightDataLogic(insightProps))
+    const { setQuery: insighVizSetQuery } = useActions(insightDataLogic(insightProps))
+
+    // TODO - separate presentation of insight with viz query from insight with query
+    let query = insightVizQuery
+    let setQuery = insighVizSetQuery
+    if (!!insight.query && isQueryBasedInsight) {
+        query = insight.query
+        setQuery = () => {
+            // don't support editing non-insight viz queries _yet_
+        }
+    }
+
+    // other logics
+    useMountedLogic(insightCommandLogic(insightProps))
+    const { hasAvailableFeature } = useValues(userLogic)
+    const { aggregationLabel } = useValues(groupsModel)
+    const { cohortsById } = useValues(cohortsModel)
+    const { mathDefinitions } = useValues(mathsLogic)
+    const { tags } = useValues(tagsModel)
+    const { currentTeamId } = useValues(teamLogic)
+    const { push } = useActions(router)
+
+    return (
+        <>
+            {insightId !== 'new' && (
+                <>
+                    <SubscriptionsModal
+                        isOpen={insightMode === ItemMode.Subscriptions}
+                        closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
+                        insightShortId={insightId}
+                        subscriptionId={subscriptionId}
+                    />
+
+                    <SharingModal
+                        isOpen={insightMode === ItemMode.Sharing}
+                        closeModal={() => push(urls.insightView(insight.short_id as InsightShortId))}
+                        insightShortId={insightId}
+                        insight={insight}
+                    />
+                </>
+            )}
+            <PageHeader
+                title={
+                    <EditableField
+                        name="name"
+                        value={insight.name || ''}
+                        placeholder={
+                            isUsingDataExploration && isInsightVizQuery
+                                ? summarizeInsightQuery(
+                                      (query as InsightVizNode).source,
+                                      aggregationLabel,
+                                      cohortsById,
+                                      mathDefinitions
+                                  )
+                                : isFilterBasedInsight
+                                ? summarizeInsightFilters(filters, aggregationLabel, cohortsById, mathDefinitions)
+                                : // TODO placeholder for non insight viz queries
+                                  ''
+                        }
+                        onSave={(value) => setInsightMetadata({ name: value })}
+                        saveOnBlur={true}
+                        maxLength={400} // Sync with Insight model
+                        mode={!canEditInsight ? 'view' : undefined}
+                        data-attr="insight-name"
+                        notice={
+                            !canEditInsight
+                                ? {
+                                      icon: <IconLock />,
+                                      tooltip:
+                                          "You don't have edit permissions on any of the dashboards this insight belongs to. Ask a dashboard collaborator with edit access to add you.",
+                                  }
+                                : undefined
+                        }
+                    />
+                }
+                buttons={
+                    <div className="flex justify-between items-center gap-2">
+                        {insightMode !== ItemMode.Edit && (
+                            <>
+                                <More
+                                    overlay={
+                                        <>
+                                            <LemonButton
+                                                status="stealth"
+                                                onClick={() => duplicateInsight(insight as InsightModel, true)}
+                                                fullWidth
+                                                data-attr="duplicate-insight-from-insight-view"
+                                            >
+                                                Duplicate
+                                            </LemonButton>
+                                            <LemonButton
+                                                status="stealth"
+                                                onClick={() =>
+                                                    setInsightMetadata({
+                                                        favorited: !insight.favorited,
+                                                    })
+                                                }
+                                                fullWidth
+                                            >
+                                                {insight.favorited ? 'Remove from favorites' : 'Add to favorites'}
+                                            </LemonButton>
+                                            <LemonDivider />
+
+                                            <LemonButton
+                                                status="stealth"
+                                                onClick={() =>
+                                                    insight.short_id
+                                                        ? push(urls.insightSharing(insight.short_id))
+                                                        : null
+                                                }
+                                                fullWidth
+                                            >
+                                                Share or embed
+                                            </LemonButton>
+                                            {insight.short_id && (
+                                                <>
+                                                    <SubscribeButton insightShortId={insight.short_id} />
+                                                    {exporterResourceParams ? (
+                                                        <ExportButton
+                                                            fullWidth
+                                                            items={[
+                                                                {
+                                                                    export_format: ExporterFormat.PNG,
+                                                                    insight: insight.id,
+                                                                },
+                                                                {
+                                                                    export_format: ExporterFormat.CSV,
+                                                                    export_context: exporterResourceParams,
+                                                                },
+                                                            ]}
+                                                        />
+                                                    ) : null}
+                                                    <LemonDivider />
+                                                </>
+                                            )}
+
+                                            <LemonButton
+                                                status="danger"
+                                                onClick={() =>
+                                                    deleteWithUndo({
+                                                        object: insight,
+                                                        endpoint: `projects/${currentTeamId}/insights`,
+                                                        callback: () => {
+                                                            loadInsights()
+                                                            push(urls.savedInsights())
+                                                        },
+                                                    })
+                                                }
+                                                fullWidth
+                                            >
+                                                Delete insight
+                                            </LemonButton>
+                                        </>
+                                    }
+                                />
+                                <LemonDivider vertical />
+                            </>
+                        )}
+                        {insightMode === ItemMode.Edit && insight.saved && (
+                            <LemonButton type="secondary" onClick={() => setInsightMode(ItemMode.View, null)}>
+                                Cancel
+                            </LemonButton>
+                        )}
+                        {insightMode !== ItemMode.Edit && insight.short_id && (
+                            <AddToDashboard insight={insight} canEditInsight={canEditInsight} />
+                        )}
+                        {insightMode !== ItemMode.Edit ? (
+                            canEditInsight &&
+                            (isFilterBasedInsight || isInsightVizNode(query)) && (
+                                <LemonButton
+                                    type="primary"
+                                    onClick={() => setInsightMode(ItemMode.Edit, null)}
+                                    data-attr="insight-edit-button"
+                                >
+                                    Edit
+                                </LemonButton>
+                            )
+                        ) : (
+                            <InsightSaveButton
+                                saveAs={saveAs}
+                                saveInsight={saveInsight}
+                                isSaved={insight.saved}
+                                addingToDashboard={!!insight.dashboards?.length && !insight.id}
+                                insightSaving={insightSaving}
+                                insightChanged={insightChanged}
+                            />
+                        )}
+                        {isUsingDataExploration && <InlineEditorButton query={query} setQuery={setQuery} />}
+                    </div>
+                }
+                caption={
+                    <>
+                        {!!(canEditInsight || insight.description) && (
+                            <EditableField
+                                multiline
+                                name="description"
+                                value={insight.description || ''}
+                                placeholder="Description (optional)"
+                                onSave={(value) => setInsightMetadata({ description: value })}
+                                saveOnBlur={true}
+                                maxLength={400} // Sync with Insight model
+                                mode={!canEditInsight ? 'view' : undefined}
+                                data-attr="insight-description"
+                                compactButtons
+                                paywall={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
+                            />
+                        )}
+                        {canEditInsight ? (
+                            <ObjectTags
+                                tags={insight.tags ?? []}
+                                onChange={(_, tags) => setInsightMetadata({ tags: tags ?? [] })}
+                                tagsAvailable={tags}
+                                className="insight-metadata-tags"
+                                data-attr="insight-tags"
+                            />
+                        ) : insight.tags?.length ? (
+                            <ObjectTags
+                                tags={insight.tags}
+                                className="insight-metadata-tags"
+                                data-attr="insight-tags"
+                                staticOnly
+                            />
+                        ) : null}
+                        <UserActivityIndicator
+                            at={insight.last_modified_at}
+                            by={insight.last_modified_by}
+                            className="mt-2"
+                        />
+                    </>
+                }
+                tabbedPage={insightMode === ItemMode.Edit} // Insight type tabs are only shown in edit mode
+            />
+        </>
+    )
+}

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -156,7 +156,6 @@ export const insightLogic = kea<insightLogicType>([
         saveInsight: (redirectToViewMode = true) => ({ redirectToViewMode }),
         saveInsightSuccess: true,
         saveInsightFailure: true,
-        setTagLoading: (tagLoading: boolean) => ({ tagLoading }),
         fetchedResults: (filters: Partial<FilterType>) => ({ filters }),
         loadInsight: (shortId: InsightShortId) => ({
             shortId,
@@ -569,12 +568,6 @@ export const insightLogic = kea<insightLogicType>([
             {} as Record<string, number>,
             {
                 startQuery: (state, { queryId }) => ({ ...state, [queryId]: performance.now() }),
-            },
-        ],
-        tagLoading: [
-            false,
-            {
-                setTagLoading: (_, { tagLoading }) => tagLoading,
             },
         ],
         insightSaving: [


### PR DESCRIPTION
## Problem

There are lots of lines of code to think about, and it would be nice to ignore them when not changing them.

## Changes

Moves the Insight page header into its own component. 
In the process making clear that there was a completely unused `setTagsLoading` action/reducer

## How did you test this code?

👀  and 🧠 