### PR TITLE
fix(feature-flag-usage-tab): add property to reduce noise

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -504,6 +504,12 @@ function UsageTab({ featureFlagKey }: { id: string; featureFlagKey: string }): J
             value: featureFlagKey,
             operator: PropertyOperator.Exact,
         },
+        {
+            key: '$feature/' + featureFlagKey,
+            type: PropertyFilterType.Event,
+            value: 'is_set',
+            operator: PropertyOperator.IsSet,
+        },
     ]
 
     // TODO: reintegrate HogQL Editor
@@ -530,6 +536,7 @@ function UsageTab({ featureFlagKey }: { id: string; featureFlagKey: string }): J
                 startingColumns={['person']}
                 fetchMonths={1}
                 pageKey={`feature-flag-` + featureFlagKey}
+                showPersonColumn={true}
                 showEventFilter={false}
                 showPropertyFilter={false}
                 showCustomizeColumns={false}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -505,7 +505,7 @@ function UsageTab({ featureFlagKey }: { id: string; featureFlagKey: string }): J
             operator: PropertyOperator.Exact,
         },
         {
-            key: '$feature/' + featureFlagKey,
+            key: '$feature_flag_response',
             type: PropertyFilterType.Event,
             value: 'is_set',
             operator: PropertyOperator.IsSet,
@@ -529,7 +529,7 @@ function UsageTab({ featureFlagKey }: { id: string; featureFlagKey: string }): J
                         title: 'Value',
                         key: '$feature/' + featureFlagKey,
                         render: function renderTime(_, { event }: EventsTableRowItem) {
-                            return event?.properties['$feature/' + featureFlagKey]?.toString()
+                            return event?.properties['$feature_flag_response']?.toString()
                         },
                     },
                 ]}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -527,8 +527,8 @@ function UsageTab({ featureFlagKey }: { id: string; featureFlagKey: string }): J
                 fixedColumns={[
                     {
                         title: 'Value',
-                        key: '$feature/' + featureFlagKey,
-                        render: function renderTime(_, { event }: EventsTableRowItem) {
+                        key: 'value',
+                        render: function renderEventProperty(_, { event }: EventsTableRowItem) {
                             return event?.properties['$feature_flag_response']?.toString()
                         },
                     },


### PR DESCRIPTION
## Problem

- there are a lot of feature flag called events that aren't accompanied by a property
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- filter those out for now

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
