### PR TITLE
fix(instrumentation): change feature flag property undefined to false

### DIFF
--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -8,11 +8,11 @@ export type FeatureFlagsSet = {
     [flag: string]: boolean | string
 }
 const eventsNotified: Record<string, boolean> = {}
-function notifyFlagIfNeeded(flag: string, flagState: string | boolean): void {
+function notifyFlagIfNeeded(flag: string, flagState: string | boolean | undefined): void {
     if (!eventsNotified[flag]) {
         posthog.capture('$feature_flag_called', {
             $feature_flag: flag,
-            $feature_flag_response: flagState,
+            $feature_flag_response: flagState === undefined ? false : flagState,
         })
         eventsNotified[flag] = true
     }


### PR DESCRIPTION
## Problem

- when the property passed in for flagState is `undefined` it's not registering for feature flag capture calls
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- check if the value is undefined and make sure it's set as false

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
