### PR TITLE
feat: poll important changes less so we can release it

### DIFF
--- a/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
+++ b/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import { IconArrowDropDown, IconInfo, IconNotification, IconWithCount } from 'lib/lemon-ui/icons'
+import { IconArrowDropDown, IconInfo, IconNotification, IconRefresh, IconWithCount } from 'lib/lemon-ui/icons'
 import { notificationsLogic } from '~/layout/navigation/TopBar/notificationsLogic'
 import { useActions, useValues } from 'kea'
 import clsx from 'clsx'
@@ -9,11 +9,20 @@ import { ActivityLogRow } from 'lib/components/ActivityLog/ActivityLog'
 import './NotificationsBell.scss'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 
 export function NotificationBell(): JSX.Element {
-    const { unreadCount, hasImportantChanges, importantChanges, isNotificationPopoverOpen, hasUnread } =
-        useValues(notificationsLogic)
-    const { toggleNotificationsPopover, togglePolling } = useActions(notificationsLogic)
+    const {
+        unreadCount,
+        hasImportantChanges,
+        importantChanges,
+        isNotificationPopoverOpen,
+        hasUnread,
+        importantChangesLoading,
+    } = useValues(notificationsLogic)
+    const { toggleNotificationsPopover, togglePolling, loadImportantChanges } = useActions(notificationsLogic)
 
     usePageVisibility((pageIsVisible) => {
         togglePolling(pageIsVisible)
@@ -25,15 +34,34 @@ export function NotificationBell(): JSX.Element {
             onClickOutside={toggleNotificationsPopover}
             overlay={
                 <div className="activity-log notifications-menu">
-                    <h5>
-                        Notifications{' '}
-                        <LemonTag type="warning" className="ml-1">
-                            Beta
-                        </LemonTag>
+                    <h5 className={'flex flex-row justify-between items-center'}>
+                        <div>
+                            Notifications{' '}
+                            <LemonTag type="warning" className="ml-1">
+                                Beta
+                            </LemonTag>
+                        </div>
+                        <LemonButton
+                            size={'small'}
+                            type={'secondary'}
+                            onClick={loadImportantChanges}
+                            icon={importantChangesLoading ? <Spinner monocolor={true} /> : <IconRefresh />}
+                            disabledReason={
+                                hasUnread
+                                    ? 'No need to check, you have unread changes.'
+                                    : importantChangesLoading
+                                    ? 'Checking for changes'
+                                    : false
+                            }
+                            data-attr="check-for-important-changes-button"
+                        >
+                            Check for changes
+                        </LemonButton>
                     </h5>
-                    <p className={'mx-2 text-muted'}>
-                        <IconInfo /> Notifications is in beta. Right now it only shows you changes other users make to
-                        Insights and Feature Flags that you created. Come join{' '}
+                    <p className={'mx-2 text-muted mt-2'}>
+                        <IconInfo /> Notifications is in beta. Right now it only shows you changes other users make to{' '}
+                        <Link to={urls.savedInsights('history')}>Insights</Link> and{' '}
+                        <Link to={urls.featureFlags('history')}>Feature Flags</Link> that you created. Come join{' '}
                         <Link to={'https://posthog.com/slack'}>our community slack</Link> and tell us what else should
                         be here!
                     </p>

--- a/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
+++ b/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import { IconArrowDropDown, IconInfo, IconNotification, IconRefresh, IconWithCount } from 'lib/lemon-ui/icons'
+import { IconArrowDropDown, IconInfo, IconNotification, IconWithCount } from 'lib/lemon-ui/icons'
 import { notificationsLogic } from '~/layout/navigation/TopBar/notificationsLogic'
 import { useActions, useValues } from 'kea'
 import clsx from 'clsx'
@@ -10,19 +10,11 @@ import './NotificationsBell.scss'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { Spinner } from 'lib/lemon-ui/Spinner'
 
 export function NotificationBell(): JSX.Element {
-    const {
-        unreadCount,
-        hasImportantChanges,
-        importantChanges,
-        isNotificationPopoverOpen,
-        hasUnread,
-        importantChangesLoading,
-    } = useValues(notificationsLogic)
-    const { toggleNotificationsPopover, togglePolling, loadImportantChanges } = useActions(notificationsLogic)
+    const { unreadCount, hasImportantChanges, importantChanges, isNotificationPopoverOpen, hasUnread } =
+        useValues(notificationsLogic)
+    const { toggleNotificationsPopover, togglePolling } = useActions(notificationsLogic)
 
     usePageVisibility((pageIsVisible) => {
         togglePolling(pageIsVisible)
@@ -34,29 +26,11 @@ export function NotificationBell(): JSX.Element {
             onClickOutside={toggleNotificationsPopover}
             overlay={
                 <div className="activity-log notifications-menu">
-                    <h5 className={'flex flex-row justify-between items-center'}>
-                        <div>
-                            Notifications{' '}
-                            <LemonTag type="warning" className="ml-1">
-                                Beta
-                            </LemonTag>
-                        </div>
-                        <LemonButton
-                            size={'small'}
-                            type={'secondary'}
-                            onClick={loadImportantChanges}
-                            icon={importantChangesLoading ? <Spinner monocolor={true} /> : <IconRefresh />}
-                            disabledReason={
-                                hasUnread
-                                    ? 'No need to check, you have unread changes.'
-                                    : importantChangesLoading
-                                    ? 'Checking for changes'
-                                    : false
-                            }
-                            data-attr="check-for-important-changes-button"
-                        >
-                            Check for changes
-                        </LemonButton>
+                    <h5>
+                        Notifications{' '}
+                        <LemonTag type="warning" className="ml-1">
+                            Beta
+                        </LemonTag>
                     </h5>
                     <p className={'mx-2 text-muted mt-2'}>
                         <IconInfo /> Notifications is in beta. Right now it only shows you changes other users make to{' '}

--- a/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
@@ -7,7 +7,7 @@ import { ActivityLogItem, humanize, HumanizedActivityLogItem } from 'lib/compone
 import type { notificationsLogicType } from './notificationsLogicType'
 import { describerFor } from 'lib/components/ActivityLog/activityLogLogic'
 
-const POLL_TIMEOUT = 45000
+const POLL_TIMEOUT = 5 * 60 * 1000
 const MARK_READ_TIMEOUT = 7500
 
 export const notificationsLogic = kea<notificationsLogicType>([

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -51,7 +51,7 @@ export const urls = {
     insightSubcription: (id: InsightShortId, subscriptionId: string): string =>
         `/insights/${id}/subscriptions/${subscriptionId}`,
     insightSharing: (id: InsightShortId): string => `/insights/${id}/sharing`,
-    savedInsights: (): string => '/insights',
+    savedInsights: (tab?: string): string => `/insights${tab ? `?tab=${tab}` : ''}`,
     webPerformance: (): string => '/web-performance',
     webPerformanceWaterfall: (pageview?: PerformancePageView): string => {
         // KLUDGE: only allow no pageview param for urlToAction in the logic
@@ -78,7 +78,7 @@ export const urls = {
     cohorts: (): string => '/cohorts',
     experiment: (id: string | number): string => `/experiments/${id}`,
     experiments: (): string => '/experiments',
-    featureFlags: (): string => '/feature_flags',
+    featureFlags: (tab?: string): string => `/feature_flags${tab ? `?tab=${tab}` : ''}`,
     featureFlag: (id: string | number): string => `/feature_flags/${id}`,
     annotations: (): string => '/annotations',
     projectApps: (tab?: PluginTab): string => `/project/apps${tab ? `?tab=${tab}` : ''}`,


### PR DESCRIPTION
## Problem

See private slack thread https://posthog.slack.com/archives/C034XD440RK/p1676490905149899

Feature flags history has strong retention suggesting it's useful to folk.

We have a notification bell on only for PostHog team from the Sep 2022 Rome Hackathon, to make for a good demo it polls frequently so would be painful to turn on for everyone, and we're not in a position to hook up websockets to make it update only when necessary.

We can guess that people care about seeing notable changes when they first open PostHog much more than at other times.

## Changes

* add links to the history pages to the notification popover
* ~~add a manual refresh button to that popover so we can see how thirsty people are~~
* poll once every 5 minutes instead of every 45 seconds

<img width="499" alt="Screenshot 2023-02-16 at 09 35 26" src="https://user-images.githubusercontent.com/984817/219327402-8feb3275-8d6d-4045-8dfc-2ac5942ceddc.png">

## How did you test this code?

Loading the site locally, checking that the API is called on page load, and when you click the button. Checking that the new links navigate to the correct places.