### PR TITLE
spike: move active view up to the insight scene

### DIFF
--- a/frontend/src/scenes/insights/InsightsNav.tsx
+++ b/frontend/src/scenes/insights/InsightsNav.tsx
@@ -1,12 +1,12 @@
 import { useActions, useValues } from 'kea'
 import { InsightType } from '~/types'
-import { insightLogic } from './insightLogic'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { FunnelsCue } from './views/Trends/FunnelsCue'
 import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 
 interface Tab {
     label: string
@@ -15,8 +15,8 @@ interface Tab {
 }
 
 export function InsightsNav(): JSX.Element {
-    const { activeView } = useValues(insightLogic)
-    const { setActiveView } = useActions(insightLogic)
+    const { activeView } = useValues(insightSceneLogic)
+    const { setActiveView } = useActions(insightSceneLogic)
 
     const tabs: Tab[] = [
         {

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -32,6 +32,7 @@ import { cleanFilters } from './utils/cleanFilters'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { getBreakdown, getDisplay } from '~/queries/nodes/InsightViz/utils'
 import { nodeKindToDefaultQuery } from '~/queries/nodes/InsightQuery/defaults'
+import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 
 const defaultQuery = (insightProps: InsightLogicProps): InsightVizNode => {
     const filters = insightProps.cachedInsight?.filters
@@ -57,9 +58,11 @@ export const insightDataLogic = kea<insightDataLogicType>([
         values: [featureFlagLogic, ['featureFlags'], trendsLogic, ['toggledLifecycles as trendsLifecycles']],
         actions: [
             insightLogic,
-            ['setFilters', 'setActiveView', 'setInsight', 'loadInsightSuccess', 'loadResultsSuccess'],
+            ['setFilters', 'setInsight', 'loadInsightSuccess', 'loadResultsSuccess'],
             trendsLogic(props),
             ['setLifecycles as setTrendsLifecycles'],
+            insightSceneLogic,
+            ['setActiveView'],
         ],
     })),
 
@@ -149,18 +152,18 @@ export const insightDataLogic = kea<insightDataLogicType>([
                 }
             }
         },
-        setActiveView: ({ type }) => {
-            if (type === InsightType.TRENDS) {
+        setActiveView: ({ activeView }) => {
+            if (activeView === InsightType.TRENDS) {
                 actions.setQuery(queryFromKind(NodeKind.TrendsQuery))
-            } else if (type === InsightType.FUNNELS) {
+            } else if (activeView === InsightType.FUNNELS) {
                 actions.setQuery(queryFromKind(NodeKind.FunnelsQuery))
-            } else if (type === InsightType.RETENTION) {
+            } else if (activeView === InsightType.RETENTION) {
                 actions.setQuery(queryFromKind(NodeKind.RetentionQuery))
-            } else if (type === InsightType.PATHS) {
+            } else if (activeView === InsightType.PATHS) {
                 actions.setQuery(queryFromKind(NodeKind.PathsQuery))
-            } else if (type === InsightType.STICKINESS) {
+            } else if (activeView === InsightType.STICKINESS) {
                 actions.setQuery(queryFromKind(NodeKind.StickinessQuery))
-            } else if (type === InsightType.LIFECYCLE) {
+            } else if (activeView === InsightType.LIFECYCLE) {
                 actions.setQuery(queryFromKind(NodeKind.LifecycleQuery))
             }
         },

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -30,6 +30,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             logic,
             unmount,
         }),
+        setActiveView: (activeView: InsightType) => ({ activeView }),
     }),
     reducers({
         insightId: [
@@ -66,6 +67,10 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
         ],
     }),
     selectors(() => ({
+        activeView: [
+            (s) => [s.insightCache],
+            (insightCache) => insightCache?.logic?.values?.filters?.insight || InsightType.TRENDS,
+        ],
         insightSelector: [(s) => [s.insightCache], (insightCache) => insightCache?.logic.selectors.insight],
         insight: [(s) => [(state, props) => s.insightSelector?.(state, props)?.(state, props)], (insight) => insight],
         breadcrumbs: [

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -94,6 +94,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             if (logicInsightId !== insightId) {
                 const oldCache = values.insightCache // free old logic after mounting new one
                 if (insightId) {
+                    // when this line runs we get `Error: [KEA] Logic "scenes.insights.insightLogic.new" can not connect to undefined to request action "setActiveView"`
                     const logic = insightLogic.build({ dashboardItemId: insightId })
                     const unmount = logic.mount()
                     actions.setInsightLogic(logic, unmount)


### PR DESCRIPTION
## Problem

Both "Query Insights" and "Filter Insights" need to care about the `InsightNav` leading to coupling between `insightDataLogic` and `insightLogic`

## Changes

I tried to lift `activeView` up to the `insightScene` to separate them a little but now the `insightSceneLogic` tests fail.

I guess I've added a circular dependency that can't be resolved and this is a non-started (at least in this approach)

But opening here so I can ask @mariusandra 🤣 

## How did you test this code?

🙈 