### PR TITLE
chore: Add separate health check role for decide

### DIFF
--- a/posthog/health.py
+++ b/posthog/health.py
@@ -38,7 +38,7 @@ from posthog.kafka_client.client import can_connect as can_connect_to_kafka
 
 logger = get_logger(__name__)
 
-ServiceRole = Literal["events", "web", "worker"]
+ServiceRole = Literal["events", "web", "worker", "decide"]
 
 service_dependencies: Dict[ServiceRole, List[str]] = {
     "events": ["http", "kafka_connected"],
@@ -58,6 +58,7 @@ service_dependencies: Dict[ServiceRole, List[str]] = {
     # of reading from a durable queue rather that being required to perform
     # request/response, we are more resilient to service downtime.
     "worker": ["http", "postgres", "postgres_migrations_uptodate", "clickhouse", "celery_broker"],
+    "decide": ["http", "cache"],
 }
 
 

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -186,6 +186,34 @@ def test_readyz_accepts_no_role_and_fails_on_everything(client: Client):
 
 
 @pytest.mark.django_db
+def test_readyz_accepts_role_decide_and_filters_by_relevant_services(client: Client):
+    with simulate_kafka_cannot_connect():
+        resp = get_readyz(client=client, role="decide")
+
+    assert resp.status_code == 200, resp.content
+
+    with simulate_postgres_error():
+        resp = get_readyz(client=client, role="decide")
+
+    assert resp.status_code == 200, resp.content
+
+    with simulate_clickhouse_cannot_connect():
+        resp = get_readyz(client=client, role="decide")
+
+    assert resp.status_code == 200, resp.content
+
+    with simulate_celery_cannot_connect():
+        resp = get_readyz(client=client, role="decide")
+
+    assert resp.status_code == 200, resp.content
+
+    with simulate_cache_cannot_connect():
+        resp = get_readyz(client=client, role="decide")
+
+    assert resp.status_code == 503, resp.content
+
+
+@pytest.mark.django_db
 def test_readyz_complains_if_role_does_not_exist(client: Client):
     """
     We want to be sure that, if we specify a role, we end up using the expected


### PR DESCRIPTION
## Problem

Decide has a separate deployment, and now doesn't need to depend on Kafka/postgres/CH to work.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
