### PR TITLE
refactor: Set key to null during batching to process in parallel

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -102,7 +102,8 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Event ingestion has overflowed capacity for distinct_id{' '}
-                <Link to={urls.person(details.overflowDistinctId)}>{details.overflowDistinctId}</Link>
+                <Link to={urls.person(details.overflowDistinctId)}>{details.overflowDistinctId}</Link>. Events will
+                still be processed, but are likely to be delayed longer than usual.
             </>
         )
     },

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -84,7 +84,7 @@ export async function eachBatchIngestionWithOverflow(
             const seenKey = `${pluginEvent.team_id}:${pluginEvent.distinct_id}`
 
             // Events with a null key should have been produced to the the
-            // KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOWtopic, so we shouldn't see them here as this consumer's
+            // KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW topic, so we shouldn't see them here as this consumer's
             // topic is set to KAFKA_EVENTS_PLUGIN_INGESTION. However, there could be some lingering events
             // from before the new *_OVERFLOW topic was initialized. Any events with a null key or that
             // exceed capacity are redirected to the *_OVERFLOW topic.

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -94,7 +94,7 @@ export async function eachBatchIngestionWithOverflow(
                 message.key = null
             }
 
-            if (currentBatch.length === batchSize || (message.key != null && seenIds.has(seenKey))) {
+            if (currentBatch.length >= batchSize || (message.key != null && seenIds.has(seenKey))) {
                 seenIds.clear()
                 batches.push(currentBatch)
                 currentBatch = []

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -28,10 +28,10 @@ export const startAnalyticsEventsIngestionConsumer = async ({
         Consumes analytics events from the Kafka topic `events_plugin_ingestion`
         and processes them for ingestion into ClickHouse.
 
-        Before processing, if an event has overflowed the capacity for its
-        (team_id, distinct_id) pair, it will not be processed here but instead
-        re-produced into the `events_plugin_ingestion_overflow` topic for later
-        processing.
+        Before processing, if isIngestionOverflowEnabled and an event has
+        overflowed the capacity for its (team_id, distinct_id) pair, it will not
+        be processed here but instead re-produced into the
+        `events_plugin_ingestion_overflow` topic for later processing.
 
         At the moment this is just a wrapper around `IngestionConsumer`. We may
         want to further remove that abstraction in the future.

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -81,14 +81,7 @@ describe('eachBatchIngestionWithOverflow', () => {
             captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
             1
         )
-        expect(captureIngestionWarning).toHaveBeenCalledWith(
-            queue.pluginsServer.hub.db,
-            captureEndpointEvent['team_id'],
-            'ingestion_capacity_overflow',
-            {
-                overflowDistinctId: captureEndpointEvent['distinct_id'],
-            }
-        )
+        expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(queue.pluginsServer.kafkaProducer.queueMessage).toHaveBeenCalledWith({
             topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
             messages: [

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -1,0 +1,130 @@
+import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
+import { eachBatchIngestionFromOverflow } from '../../../src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer'
+import { WarningLimiter } from '../../../src/utils/token-bucket'
+import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
+
+jest.mock('../../../src/utils/status')
+jest.mock('./../../../src/worker/ingestion/utils')
+
+const captureEndpointEvent = {
+    uuid: 'uuid1',
+    distinct_id: 'id',
+    ip: null,
+    site_url: '',
+    data: JSON.stringify({
+        event: 'event',
+        properties: {},
+    }),
+    team_id: 1,
+    now: null,
+    sent_at: null,
+}
+
+describe('eachBatchIngestionWithOverflow', () => {
+    let queue: any
+
+    function createBatchWithMultipleEventsWithKeys(events: any[], timestamp?: any): any {
+        return {
+            batch: {
+                partition: 0,
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION,
+                messages: events.map((event) => ({
+                    value: JSON.stringify(event),
+                    timestamp,
+                    offset: event.offset,
+                    key: event.team_id + ':' + event.distinct_id,
+                })),
+            },
+            resolveOffset: jest.fn(),
+            heartbeat: jest.fn(),
+            commitOffsetsIfNecessary: jest.fn(),
+            isRunning: jest.fn(() => true),
+            isStale: jest.fn(() => false),
+        }
+    }
+
+    beforeEach(() => {
+        queue = {
+            bufferSleep: jest.fn(),
+            pluginsServer: {
+                WORKER_CONCURRENCY: 1,
+                TASKS_PER_WORKER: 10,
+                BUFFER_CONVERSION_SECONDS: 60,
+                statsd: {
+                    timing: jest.fn(),
+                    increment: jest.fn(),
+                    histogram: jest.fn(),
+                    gauge: jest.fn(),
+                },
+                kafkaProducer: {
+                    queueMessage: jest.fn(),
+                },
+                hub: {
+                    db: 'database',
+                },
+            },
+            workerMethods: {
+                runAsyncHandlersEventPipeline: jest.fn(),
+                runEventPipeline: jest.fn(),
+                runBufferEventPipeline: jest.fn(),
+            },
+        }
+    })
+
+    it('raises warning when capacity available', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const consume = jest.spyOn(WarningLimiter, 'consume').mockImplementation(() => true)
+
+        await eachBatchIngestionFromOverflow(batch, queue)
+
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
+            1
+        )
+        expect(captureIngestionWarning).toHaveBeenCalledWith(
+            queue.pluginsServer.hub.db,
+            captureEndpointEvent['team_id'],
+            'ingestion_capacity_overflow',
+            {
+                overflowDistinctId: captureEndpointEvent['distinct_id'],
+            }
+        )
+    })
+
+    it('does not raise warning capacity limit', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const consume = jest.spyOn(WarningLimiter, 'consume').mockImplementation(() => false)
+
+        await eachBatchIngestionFromOverflow(batch, queue)
+
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
+            1
+        )
+        expect(captureIngestionWarning).not.toHaveBeenCalled()
+        expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+    })
+
+    it('runs the rest of the pipeline', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const consume = jest.spyOn(WarningLimiter, 'consume').mockImplementation(() => false)
+
+        await eachBatchIngestionFromOverflow(batch, queue)
+
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
+            1
+        )
+        // This is "the rest of the pipeline"
+        expect(queue.workerMethods.runEventPipeline).toHaveBeenCalled()
+    })
+
+    it('does not produce the event again', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        jest.spyOn(WarningLimiter, 'consume').mockImplementation(() => false)
+
+        await eachBatchIngestionFromOverflow(batch, queue)
+
+        expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Problem

Some review comments were not addressed in #14211 so we do so here.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Moved OVERFLOW detection logic to batch grouping function. This way we can process them in parallel.
* Moved warning raise to overflow consumer, thus capturing both events coming from capture as well as redirected by plugin server.
* Fixed a bug of a missing return which would have caused events to be processed twice.
* Warning and comment clarifications

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
