### PR TITLE
chore(kafka): add util for moving topics between clusters

### DIFF
--- a/posthog/management/commands/migrate_kafka_data.py
+++ b/posthog/management/commands/migrate_kafka_data.py
@@ -18,13 +18,13 @@
 # Django settings.
 
 from typing import List
+
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer
 from kafka.errors import KafkaError
-from kafka.structs import TopicPartition
 from kafka.producer.future import FutureRecordMetadata
-
-from django.conf import settings
+from kafka.structs import TopicPartition
 
 
 class Command(BaseCommand):

--- a/posthog/management/commands/migrate_kafka_data.py
+++ b/posthog/management/commands/migrate_kafka_data.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
         consumer = KafkaConsumer(
             from_topic,
             bootstrap_servers=from_cluster,
-            auto_offset_reset="earliest",
+            auto_offset_reset="latest",
             enable_auto_commit=False,
             group_id=consumer_group_id,
             consumer_timeout_ms=1000,

--- a/posthog/management/commands/migrate_kafka_data.py
+++ b/posthog/management/commands/migrate_kafka_data.py
@@ -1,0 +1,111 @@
+# This management command is intended to be used to migrate data from one Kafka
+# cluster to another. It is intended for the use case where the Kafka cluster
+# has suffered some catastrophic failure that causes us to migrate to a new
+# cluster. The old cluster may well come back up, and in which case we would
+# want to ensure that if there is any data in the old cluster that wasn't
+# consumed by the PostHog app when it was pointing at it, then that data is
+# transferred to the new cluster.
+#
+# We do not make any attempt at validation, so it's important to ensure that you
+# move data to and from the corresponding topics.
+#
+# We also do not validate that you use the correct consumer group ID, so it's
+# important that you use the same consumer group ID that the PostHog app is
+# using when consuming from the old cluster, otherwise you risk migrating data
+# that has already been consumed.
+#
+# By default the target Kafka cluster is the currently configured cluster in
+# Django settings.
+
+from django.core.management.base import BaseCommand
+from kafka import KafkaConsumer, KafkaProducer
+from kafka.errors import KafkaError
+from kafka.structs import TopicPartition
+from typing import Any, Dict, List, Optional, Tuple
+
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    help = "Migrate data from one Kafka cluster to another"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--from-topic",
+            required=True,
+            help="The topic to migrate data from",
+        )
+        parser.add_argument(
+            "--to-topic",
+            required=True,
+            help="The topic to migrate data to",
+        )
+        parser.add_argument(
+            "--from-cluster",
+            default=settings.KAFKA_URL,
+            help="The Kafka cluster to migrate data from",
+        )
+        parser.add_argument(
+            "--to-cluster",
+            default=settings.KAFKA_URL,
+            help="The Kafka cluster to migrate data to",
+        )
+        parser.add_argument(
+            "--consumer-group-id",
+            default="posthog",
+            help="The consumer group ID to use when consuming from the old cluster",
+        )
+
+    def handle(self, *args, **options):
+        from_topic = options["from_topic"]
+        to_topic = options["to_topic"]
+        from_cluster = options["from_cluster"]
+        to_cluster = options["to_cluster"]
+        consumer_group_id = options["consumer_group_id"]
+
+        # Validate that we don't push messages back into the same cluster and
+        # topic.
+        if from_cluster == to_cluster and from_topic == to_topic:
+            raise ValueError("You must specify a different topic and cluster to migrate data to")
+
+        self.stdout.write(
+            f"Migrating data from topic {from_topic} on cluster {from_cluster} to topic {to_topic} on cluster {to_cluster} using consumer group ID {consumer_group_id}"
+        )
+
+        # Create a Kafka consumer to consume from the old topic.
+        consumer = KafkaConsumer(
+            from_topic,
+            bootstrap_servers=from_cluster,
+            enable_auto_commit=True,
+            group_id=consumer_group_id,
+            consumer_timeout_ms=1000,  # If we have no more messages, just stop.
+        )
+
+        # Create a Kafka producer to produce to the new topic.
+        producer = KafkaProducer(bootstrap_servers=to_cluster)
+
+        # Now consume from the consumer, and produce to the producer.
+        while True:
+            messages_by_topic = consumer.poll(timeout_ms=1000)
+
+            if not messages_by_topic:
+                break
+
+            # Output progress of data migration
+            for topic, messages in messages_by_topic.items():
+                self.stdout.write(f"Migrating {len(messages)} messages from topic {topic}")
+
+            # Send the messages to the new topic. Note that messages may not be
+            # send immediately, but rather batched by the Kafka Producer
+            # according to e.g. linger_ms etc.
+            for _, messages in messages_by_topic.items():
+                for message in messages:
+                    producer.send(
+                        to_topic,
+                        message.value,
+                        key=message.key,
+                    )
+
+        producer.flush()
+
+        self.stdout.write("Done migrating data")

--- a/posthog/management/commands/migrate_kafka_data.py
+++ b/posthog/management/commands/migrate_kafka_data.py
@@ -51,7 +51,6 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--consumer-group-id",
-            default="posthog",
             help="The consumer group ID to use when consuming from the old cluster",
         )
 

--- a/posthog/management/commands/test/test_migrate_kafka_data.py
+++ b/posthog/management/commands/test/test_migrate_kafka_data.py
@@ -29,11 +29,8 @@ def test_can_migrate_data_from_one_topic_to_another_on_a_different_cluster():
     # offsets first.
     _commit_offsets_for_topic(old_events_topic, consumer_group_id)
 
-    old_kafka = KafkaProducer(bootstrap_servers="localhost:9092")
-
     # Put some data to the old topic
-    old_kafka.send(old_events_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"), headers=[("foo", b"bar")])
-    old_kafka.flush()
+    _send_message(old_events_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"), headers=[("foo", b"bar")])
 
     call_command(
         "migrate_kafka_data",
@@ -49,38 +46,29 @@ def test_can_migrate_data_from_one_topic_to_another_on_a_different_cluster():
         consumer_group_id,
     )
 
-    # Now create a kafka consumer to consumer data from the new topic, and
-    # verify it is the same as from the old topic.
-    new_kafka_consumer = KafkaConsumer(
-        new_events_topic,
-        bootstrap_servers="localhost:9092",
-        auto_offset_reset="earliest",
-        group_id="test",
-    )
-
-    # Poll the consumer for messages until we find a message with the same
-    # message_key we send to the old topic, failing the test if we don't find
-    # it within 10 seconds.
-    found_message = None
-    for _ in range(10):
-        messages_by_topic = new_kafka_consumer.poll(timeout_ms=1000)
-
-        if not messages_by_topic:
-            continue
-
-        for _, messages in messages_by_topic.items():
-            for message in messages:
-                if message.key.decode("utf-8") == message_key:
-                    found_message = message
-                    break
-
-            if found_message:
-                break
-        if found_message:
-            break
+    # We should have produced a message to the new topic
+    found_message = _wait_for_message(new_events_topic, message_key)
 
     assert found_message and found_message.value == b'{ "event": "test" }', "Did not find message in new topic"
     assert found_message and found_message.headers == [("foo", b"bar")], "Did not find headers in new topic"
+
+    # Try running the command again, and we should't see a new message produced
+    call_command(
+        "migrate_kafka_data",
+        "--from-topic",
+        old_events_topic,
+        "--to-topic",
+        new_events_topic,
+        "--from-cluster",
+        "localhost:9092",
+        "--to-cluster",
+        "localhost:9092",
+        "--consumer-group-id",
+        consumer_group_id,
+    )
+
+    found_message = _wait_for_message(new_events_topic, message_key)
+    assert not found_message
 
 
 def test_cannot_send_data_back_into_same_topic_on_same_cluster():
@@ -90,14 +78,12 @@ def test_cannot_send_data_back_into_same_topic_on_same_cluster():
     """
     topic = "events_topic"
     consumer_group_id = "events-ingestion-consumer"
-    kafka = KafkaProducer(bootstrap_servers="localhost:9092")
     message_key = str(uuid4())
 
     _commit_offsets_for_topic(topic, consumer_group_id)
 
     # Put some data to the topic
-    kafka.send(topic, b'{ "event": "test" }', key=message_key.encode("utf-8"))
-    kafka.flush()
+    _send_message(topic, b'{ "event": "test" }', key=message_key.encode("utf-8"), headers=[("foo", b"bar")])
 
     try:
         call_command(
@@ -126,12 +112,10 @@ def test_that_the_command_fails_if_the_specified_consumer_group_does_not_exist()
     """
     old_topic = "events_topic"
     new_topic = "new_events_topic"
-    kafka = KafkaProducer(bootstrap_servers="localhost:9092")
     message_key = str(uuid4())
 
     # Put some data to the topic
-    kafka.send(old_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"))
-    kafka.flush()
+    _send_message(old_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"), headers=[("foo", b"bar")])
 
     try:
         call_command(
@@ -161,14 +145,12 @@ def test_that_we_error_if_the_target_topic_doesnt_exist():
     old_topic = "events_topic"
     new_topic = str(uuid4())
     consumer_group_id = "events-ingestion-consumer"
-    kafka = KafkaProducer(bootstrap_servers="localhost:9092")
     message_key = str(uuid4())
 
     _commit_offsets_for_topic(old_topic, consumer_group_id)
 
     # Put some data to the topic
-    kafka.send(old_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"))
-    kafka.flush()
+    _send_message(old_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"), headers=[("foo", b"bar")])
 
     try:
         call_command(
@@ -185,7 +167,7 @@ def test_that_we_error_if_the_target_topic_doesnt_exist():
             consumer_group_id,
         )
     except ValueError as e:
-        assert str(e) == "Topic new_events_topic does not exist"
+        assert str(e) == f"Topic {new_topic} does not exist"
     else:
         assert False, "Expected ValueError to be raised"
 
@@ -198,14 +180,12 @@ def test_we_fail_on_send_errors_to_new_topic():
     old_topic = "events_topic"
     new_topic = "new_events_topic"
     consumer_group_id = "events-ingestion-consumer"
-    kafka = KafkaProducer(bootstrap_servers="localhost:9092")
     message_key = str(uuid4())
 
     _commit_offsets_for_topic(old_topic, consumer_group_id)
 
     # Put some data to the topic
-    kafka.send(old_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"))
-    kafka.flush()
+    _send_message(old_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"), headers=[("foo", b"bar")])
 
     with mock.patch("kafka.KafkaProducer.send") as mock_send:
         produce_future = FutureProduceResult(topic_partition=TopicPartition(new_topic, 1))
@@ -236,9 +216,29 @@ def test_we_fail_on_send_errors_to_new_topic():
                 consumer_group_id,
             )
         except KafkaError as e:
-            assert str(e) == "Error sending message to new topic"
+            assert str(e) == "KafkaError: Failed to produce"
         else:
             assert False, "Expected KafkaError to be raised"
+
+    # Ensure that if we run the command again, it will not fail
+    # and will re-consume and produce the message to the new topic.
+    call_command(
+        "migrate_kafka_data",
+        "--from-topic",
+        old_topic,
+        "--to-topic",
+        new_topic,
+        "--from-cluster",
+        "localhost:9092",
+        "--to-cluster",
+        "localhost:9092",
+        "--consumer-group-id",
+        consumer_group_id,
+    )
+
+    found_message = _wait_for_message(new_topic, message_key)
+
+    assert found_message, "Did not find message in new topic"
 
 
 def _commit_offsets_for_topic(topic, consumer_group_id):
@@ -248,6 +248,46 @@ def _commit_offsets_for_topic(topic, consumer_group_id):
         auto_offset_reset="latest",
         group_id=consumer_group_id,
     )
-    kafka_consumer.poll(timeout_ms=1000)
-    kafka_consumer.commit()
-    kafka_consumer.close()
+
+    try:
+        kafka_consumer.poll(timeout_ms=1000)
+        kafka_consumer.commit()
+
+    finally:
+        kafka_consumer.close()
+
+
+def _wait_for_message(topic: str, key: str):
+    """
+    Wait for a message to appear in the topic with the specified key.
+    """
+    new_kafka_consumer = KafkaConsumer(
+        topic,
+        bootstrap_servers="localhost:9092",
+        auto_offset_reset="earliest",
+        group_id="test",
+    )
+
+    try:
+        messages_by_topic = new_kafka_consumer.poll(timeout_ms=1000)
+
+        if not messages_by_topic:
+            return
+
+        for _, messages in messages_by_topic.items():
+            for message in messages:
+                if message.key.decode("utf-8") == key:
+                    return message
+
+    finally:
+        new_kafka_consumer.close()
+
+
+def _send_message(topic, value, key, headers):
+    producer = KafkaProducer(bootstrap_servers="localhost:9092")
+
+    try:
+        producer.send(topic, value, key, headers).get()
+
+    finally:
+        producer.close()

--- a/posthog/management/commands/test/test_migrate_kafka_data.py
+++ b/posthog/management/commands/test/test_migrate_kafka_data.py
@@ -1,8 +1,8 @@
 from unittest import mock
 from uuid import uuid4
+
 from django.core.management import call_command
 from kafka import KafkaConsumer, KafkaProducer
-
 from kafka.errors import KafkaError
 from kafka.producer.future import FutureProduceResult, FutureRecordMetadata
 from kafka.structs import TopicPartition

--- a/posthog/management/commands/test/test_migrate_kafka_data.py
+++ b/posthog/management/commands/test/test_migrate_kafka_data.py
@@ -30,11 +30,12 @@ def test_can_migrate_data_from_one_topic_to_another_on_a_different_cluster():
     )
     old_kafka_consumer.poll(timeout_ms=1000)
     old_kafka_consumer.commit()
+    old_kafka_consumer.close()
 
     old_kafka = KafkaProducer(bootstrap_servers="localhost:9092")
 
     # Put some data to the old topic
-    old_kafka.send(old_events_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"))
+    old_kafka.send(old_events_topic, b'{ "event": "test" }', key=message_key.encode("utf-8"), headers=[("foo", b"bar")])
     old_kafka.flush()
 
     call_command(
@@ -82,6 +83,7 @@ def test_can_migrate_data_from_one_topic_to_another_on_a_different_cluster():
             break
 
     assert found_message and found_message.value == b'{ "event": "test" }', "Did not find message in new topic"
+    assert found_message and found_message.headers == [("foo", b"bar")], "Did not find headers in new topic"
 
 
 def test_cannot_send_data_back_into_same_topic_on_same_cluster():

--- a/posthog/management/commands/test/test_migrate_kafka_data.py
+++ b/posthog/management/commands/test/test_migrate_kafka_data.py
@@ -1,0 +1,85 @@
+from django.core.management import call_command
+from kafka import KafkaConsumer, KafkaProducer
+
+
+def test_can_migrate_data_from_one_topic_to_another_on_a_different_cluster():
+    """
+    Importantly, we want to make sure:
+
+        1. we commit offsets to the old cluster, such that we do not produce
+           duplicates on e.g. multiple runs
+        2. we do not commit offsets to the new cluster
+        3. we do not produce to the old cluster
+        4. we copy over not just the values of the messages, but also the keys
+
+    """
+    old_events_topic = "old_events_topic"
+    new_events_topic = "new_events_topic"
+
+    old_kafka = KafkaProducer(bootstrap_servers="localhost:9092")
+
+    # Put some data to the old topic
+    old_kafka.send(old_events_topic, b'{ "event": "test" }', key=b"key")
+    old_kafka.flush()
+
+    call_command(
+        "migrate_kafka_data",
+        "--from-topic",
+        old_events_topic,
+        "--to-topic",
+        new_events_topic,
+        "--from-cluster",
+        "localhost:9092",
+        "--to-cluster",
+        "localhost:9092",
+        "--consumer-group-id",
+        "events-ingestion-consumer",
+    )
+
+    # Now create a kafka consumer to consumer data from the new topic, and
+    # verify it is the same as from the old topic.
+    new_kafka_consumer = KafkaConsumer(
+        new_events_topic,
+        bootstrap_servers="localhost:9092",
+        group_id="test",
+    )
+
+    new_kafka_consumer.subscribe([new_events_topic])
+
+    # Now consume from the consumer, collect all messages and verify they are
+    # the same.
+    messages = new_kafka_consumer.poll(timeout_ms=1000)
+
+    assert len(messages) == 1
+
+
+def test_cannot_send_data_back_into_same_topic_on_same_cluster():
+    """
+    We want to make sure that we do not send data back into the same topic on
+    the same cluster, as that would cause duplicates.
+    """
+    topic = "events_topic"
+    kafka = KafkaProducer(bootstrap_servers="localhost:9092")
+
+    # Put some data to the topic
+    kafka.send(topic, b'{ "event": "test" }', key=b"key")
+    kafka.flush()
+
+    try:
+        call_command(
+            "migrate_kafka_data",
+            "--from-topic",
+            topic,
+            "--to-topic",
+            topic,
+            "--from-cluster",
+            "localhost:9092",
+            "--to-cluster",
+            "localhost:9092",
+            "--consumer-group-id",
+            "events-ingestion-consumer",
+        )
+    except ValueError as e:
+        assert str(e) == "You must specify a different topic and cluster to migrate data to"
+    else:
+        assert False, "Expected ValueError to be raised"


### PR DESCRIPTION
This is a utility script that can be used to move topics between Kafka
clusters. It's not a perfect solution, but it's better than nothing. It
is intended to be used in the case that you have an old cluster that is
no longer being written to of consumed from, but has data that was not
processed by a consumer, and you want to transfer this data to the new
cluster so that it will be picked up by the running consumers in the
PostHog app.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
