### PR TITLE
fix(cohort-expansion): add key lookup for exact/is_equal prop

### DIFF
--- a/posthog/models/filters/test/__snapshots__/test_filter.ambr
+++ b/posthog/models/filters/test/__snapshots__/test_filter.ambr
@@ -232,6 +232,8 @@
          "posthog_person"."version"
   FROM "posthog_person"
   WHERE (UPPER(("posthog_person"."properties" ->> 'urls')::text) LIKE UPPER('%["abcd"]%')
+         AND "posthog_person"."properties" ? 'urls'
+         AND NOT (("posthog_person"."properties" -> 'urls') = 'null')
          AND "posthog_person"."team_id" = 2)
   '
 ---
@@ -325,10 +327,20 @@
          "posthog_person"."version"
   FROM "posthog_person"
   WHERE (((("posthog_person"."properties" -> 'url') = '"https://whatever.com"'
+           AND "posthog_person"."properties" ? 'url'
+           AND NOT (("posthog_person"."properties" -> 'url') = 'null')
            AND ("posthog_person"."properties" -> 'bla') = '1'
-           AND (("posthog_person"."properties" -> 'bla') = '1'
-                OR ("posthog_person"."properties" -> 'bla') = '2'))
-          OR ("posthog_person"."properties" -> 'bla') = '3')
+           AND "posthog_person"."properties" ? 'bla'
+           AND NOT (("posthog_person"."properties" -> 'bla') = 'null')
+           AND ((("posthog_person"."properties" -> 'bla') = '1'
+                 AND "posthog_person"."properties" ? 'bla'
+                 AND NOT (("posthog_person"."properties" -> 'bla') = 'null'))
+                OR (("posthog_person"."properties" -> 'bla') = '2'
+                    AND "posthog_person"."properties" ? 'bla'
+                    AND NOT (("posthog_person"."properties" -> 'bla') = 'null'))))
+          OR (("posthog_person"."properties" -> 'bla') = '3'
+              AND "posthog_person"."properties" ? 'bla'
+              AND NOT (("posthog_person"."properties" -> 'bla') = 'null')))
          AND "posthog_person"."team_id" = 2)
   '
 ---
@@ -431,10 +443,20 @@
          "posthog_person"."version"
   FROM "posthog_person"
   WHERE (((("posthog_person"."properties" -> 'url') = '"https://whatever.com"'
+           AND "posthog_person"."properties" ? 'url'
+           AND NOT (("posthog_person"."properties" -> 'url') = 'null')
            AND ("posthog_person"."properties" -> 'bla') = '1'
+           AND "posthog_person"."properties" ? 'bla'
+           AND NOT (("posthog_person"."properties" -> 'bla') = 'null')
            AND ("posthog_person"."properties" -> 'bla') = '1'
-           AND ("posthog_person"."properties" -> 'bla') = '2')
-          OR ("posthog_person"."properties" -> 'bla') = '3')
+           AND "posthog_person"."properties" ? 'bla'
+           AND NOT (("posthog_person"."properties" -> 'bla') = 'null')
+           AND ("posthog_person"."properties" -> 'bla') = '2'
+           AND "posthog_person"."properties" ? 'bla'
+           AND NOT (("posthog_person"."properties" -> 'bla') = 'null'))
+          OR (("posthog_person"."properties" -> 'bla') = '3'
+              AND "posthog_person"."properties" ? 'bla'
+              AND NOT (("posthog_person"."properties" -> 'bla') = 'null')))
          AND "posthog_person"."team_id" = 2)
   '
 ---
@@ -737,11 +759,21 @@
          "posthog_person"."uuid",
          "posthog_person"."version"
   FROM "posthog_person"
-  WHERE (NOT ((("posthog_person"."properties" -> 'bla') = '1'
-               OR ("posthog_person"."properties" -> 'bla') = '2'))
-         AND NOT ((("posthog_person"."properties" -> 'bla') = '3'
-                   OR ("posthog_person"."properties" -> 'bla') = '4'))
+  WHERE (NOT (((("posthog_person"."properties" -> 'bla') = '1'
+                AND "posthog_person"."properties" ? 'bla'
+                AND NOT (("posthog_person"."properties" -> 'bla') = 'null'))
+               OR (("posthog_person"."properties" -> 'bla') = '2'
+                   AND "posthog_person"."properties" ? 'bla'
+                   AND NOT (("posthog_person"."properties" -> 'bla') = 'null'))))
+         AND NOT (((("posthog_person"."properties" -> 'bla') = '3'
+                    AND "posthog_person"."properties" ? 'bla'
+                    AND NOT (("posthog_person"."properties" -> 'bla') = 'null'))
+                   OR (("posthog_person"."properties" -> 'bla') = '4'
+                       AND "posthog_person"."properties" ? 'bla'
+                       AND NOT (("posthog_person"."properties" -> 'bla') = 'null'))))
          AND ("posthog_person"."properties" -> 'other') = '1'
+         AND "posthog_person"."properties" ? 'other'
+         AND NOT (("posthog_person"."properties" -> 'other') = 'null')
          AND "posthog_person"."team_id" = 2)
   '
 ---

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -494,8 +494,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
     def test_group_property_filters_direct(self):
         filter = Filter(data={"properties": [{"key": "some_prop", "value": 5, "type": "group", "group_type_index": 1}]})
         query_filter = properties_to_Q(filter.property_groups.flat)
-
-        self.assertEqual(query_filter, Q(group_properties__some_prop=5))
+        self.assertEqual(query_filter, Q(Q(group_properties__some_prop=5) & Q(group_properties__has_key="some_prop")))
 
     def _filter_with_date_range(
         self, date_from: datetime.datetime, date_to: Optional[datetime.datetime] = None

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -436,7 +436,6 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
             },
             name="user_in_this_cohort",
         )
-        user_in.calculate_people_ch(pending_version=0)
         not_in_1_cohort = Cohort.objects.create(
             team=self.team,
             filters={
@@ -454,7 +453,6 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
             },
             name="user_not_in_1",
         )
-        not_in_1_cohort.calculate_people_ch(pending_version=0)
 
         cohort1 = Cohort.objects.create(
             team=self.team,
@@ -479,7 +477,6 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
             },
             name="overall_cohort",
         )
-        cohort1.calculate_people_ch(pending_version=0)
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}]})
 
@@ -494,7 +491,14 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
     def test_group_property_filters_direct(self):
         filter = Filter(data={"properties": [{"key": "some_prop", "value": 5, "type": "group", "group_type_index": 1}]})
         query_filter = properties_to_Q(filter.property_groups.flat)
-        self.assertEqual(query_filter, Q(Q(group_properties__some_prop=5) & Q(group_properties__has_key="some_prop")))
+        self.assertEqual(
+            query_filter,
+            Q(
+                Q(group_properties__some_prop=5)
+                & Q(group_properties__has_key="some_prop")
+                & ~Q(group_properties__some_prop=None)
+            ),
+        )
 
     def _filter_with_date_range(
         self, date_from: datetime.datetime, date_to: Optional[datetime.datetime] = None

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -250,9 +250,10 @@ class Property:
     def to_dict(self) -> Dict[str, Any]:
         return {key: value for key, value in vars(self).items() if value is not None}
 
-    def _parse_value(self, value: ValueT) -> Any:
+    @staticmethod
+    def _parse_value(value: ValueT) -> Any:
         if isinstance(value, list):
-            return [self._parse_value(v) for v in value]
+            return [Property._parse_value(v) for v in value]
         if value == "true":
             return True
         if value == "false":

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -228,7 +228,7 @@ def property_to_Q(property: Property, override_property_values: Dict[str, Any] =
         return Q(**{f"{column}__{property.key}__{effective_operator}": value})
 
     if property.operator == "exact" or property.operator is None:
-        return lookup_q(f"{column}__{property.key}", value)
+        return Q(lookup_q(f"{column}__{property.key}", value)) & Q(**{f"{column}__has_key": property.key})
     else:
         return Q(**{f"{column}__{property.key}__{property.operator}": property.value})
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -232,7 +232,7 @@ def property_to_Q(property: Property, override_property_values: Dict[str, Any] =
         return Q(lookup_q(f"{column}__{property.key}", value)) & Q(**{f"{column}__has_key": property.key})
     else:
         return Q(**{f"{column}__{property.key}__{property.operator}": property.value}) & Q(
-            **{f"{column}__has_key": property.key}
+            **{f"{column}__has_key": property.key}) & ~Q(**{f"{column}__{property.key}": None}
         )
 
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -227,12 +227,13 @@ def property_to_Q(property: Property, override_property_values: Dict[str, Any] =
         effective_operator = "gt" if property.operator == "is_date_after" else "lt"
         return Q(**{f"{column}__{property.key}__{effective_operator}": value})
 
+    # NOTE: existence clause necessary when overall clause is negated
     if property.operator == "exact" or property.operator is None:
-        return Q(lookup_q(f"{column}__{property.key}", value)) & Q(
-            **{f"{column}__has_key": property.key}
-        )  # NOTE: existence clause necessary when overall clause is negated
+        return Q(lookup_q(f"{column}__{property.key}", value)) & Q(**{f"{column}__has_key": property.key})
     else:
-        return Q(**{f"{column}__{property.key}__{property.operator}": property.value})
+        return Q(**{f"{column}__{property.key}__{property.operator}": property.value}) & Q(
+            **{f"{column}__has_key": property.key}
+        )
 
 
 def property_group_to_Q(property_group: PropertyGroup, override_property_values: Dict[str, Any] = {}) -> Q:

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -1,6 +1,15 @@
 import datetime
 import re
-from typing import Any, Callable, Dict, List, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from dateutil import parser
 from django.db.models import Exists, OuterRef, Q
@@ -11,6 +20,7 @@ from posthog.models.cohort import Cohort, CohortPeople
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.property import CLICKHOUSE_ONLY_PROPERTY_TYPES, Property, PropertyGroup
+from posthog.models.property.property import OperatorType, ValueT
 from posthog.models.team import Team
 from posthog.queries.util import convert_to_datetime_aware
 from posthog.utils import get_compare_period_dates, is_valid_regex
@@ -164,6 +174,22 @@ def match_property(property: Property, override_property_values: Dict[str, Any])
     return False
 
 
+def empty_or_null_with_value_q(
+    column: str, key: str, operator: Optional[OperatorType], value: ValueT, negated: bool = False
+) -> Q:
+
+    if operator == "exact" or operator is None:
+        target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value))
+    else:
+        target_filter = Q(**{f"{column}__{key}__{operator}": value})
+
+    query_filter = Q(target_filter & Q(**{f"{column}__has_key": key}) & ~Q(**{f"{column}__{key}": None}))
+
+    if negated:
+        return ~query_filter
+    return query_filter
+
+
 def lookup_q(key: str, value: Any) -> Q:
     # exact and is_not operators can pass lists as arguments. Handle those lookups!
     if isinstance(value, list):
@@ -217,10 +243,8 @@ def property_to_Q(property: Property, override_property_values: Dict[str, Any] =
         # Return no data for invalid regexes
         return Q(pk=-1)
     if isinstance(property.operator, str) and property.operator.startswith("not_"):
-        return Q(
-            ~Q(**{f"{column}__{property.key}__{property.operator[4:]}": value})
-            | ~Q(**{f"{column}__has_key": property.key})
-            | Q(**{f"{column}__{property.key}": None})
+        return empty_or_null_with_value_q(
+            column, property.key, cast(OperatorType, property.operator[4:]), value, negated=True
         )
 
     if property.operator in ("is_date_after", "is_date_before"):
@@ -228,12 +252,7 @@ def property_to_Q(property: Property, override_property_values: Dict[str, Any] =
         return Q(**{f"{column}__{property.key}__{effective_operator}": value})
 
     # NOTE: existence clause necessary when overall clause is negated
-    if property.operator == "exact" or property.operator is None:
-        return Q(lookup_q(f"{column}__{property.key}", value)) & Q(**{f"{column}__has_key": property.key})
-    else:
-        return Q(**{f"{column}__{property.key}__{property.operator}": property.value}) & Q(
-            **{f"{column}__has_key": property.key}) & ~Q(**{f"{column}__{property.key}": None}
-        )
+    return empty_or_null_with_value_q(column, property.key, property.operator, property.value)
 
 
 def property_group_to_Q(property_group: PropertyGroup, override_property_values: Dict[str, Any] = {}) -> Q:

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -228,7 +228,9 @@ def property_to_Q(property: Property, override_property_values: Dict[str, Any] =
         return Q(**{f"{column}__{property.key}__{effective_operator}": value})
 
     if property.operator == "exact" or property.operator is None:
-        return Q(lookup_q(f"{column}__{property.key}", value)) & Q(**{f"{column}__has_key": property.key})
+        return Q(lookup_q(f"{column}__{property.key}", value)) & Q(
+            **{f"{column}__has_key": property.key}
+        )  # NOTE: existence clause necessary when overall clause is negated
     else:
         return Q(**{f"{column}__{property.key}__{property.operator}": property.value})
 

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -12,7 +12,8 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.1
   '
-  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_X_condition_0",
+  SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+          AND "posthog_person"."properties" ? 'email') AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
          (true) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0",
@@ -36,8 +37,10 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
-  SELECT ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"') AS "flag_X_condition_0",
-         ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"') AS "flag_X_condition_0"
+  SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
+          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0",
+         (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
+          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0"
   FROM "posthog_group"
   WHERE ("posthog_group"."team_id" = 2
          AND "posthog_group"."group_key" = 'foo'
@@ -58,7 +61,8 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.5
   '
-  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_X_condition_0",
+  SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+          AND "posthog_person"."properties" ? 'email') AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
          (true) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0",
@@ -72,8 +76,10 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.6
   '
-  SELECT ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"') AS "flag_X_condition_0",
-         ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"') AS "flag_X_condition_0"
+  SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
+          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0",
+         (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
+          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0"
   FROM "posthog_group"
   WHERE ("posthog_group"."team_id" = 2
          AND "posthog_group"."group_key" = 'foo2'

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -13,7 +13,8 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags.1
   '
   SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
-          AND "posthog_person"."properties" ? 'email') AS "flag_X_condition_0",
+          AND "posthog_person"."properties" ? 'email'
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
          (true) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0",
@@ -38,9 +39,11 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
   SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
-          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0",
+          AND "posthog_group"."group_properties" ? 'name'
+          AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0",
          (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
-          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0"
+          AND "posthog_group"."group_properties" ? 'name'
+          AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_group"
   WHERE ("posthog_group"."team_id" = 2
          AND "posthog_group"."group_key" = 'foo'
@@ -62,7 +65,8 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags.5
   '
   SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
-          AND "posthog_person"."properties" ? 'email') AS "flag_X_condition_0",
+          AND "posthog_person"."properties" ? 'email'
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
          (true) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0",
@@ -77,9 +81,11 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags.6
   '
   SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
-          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0",
+          AND "posthog_group"."group_properties" ? 'name'
+          AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0",
          (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
-          AND "posthog_group"."group_properties" ? 'name') AS "flag_X_condition_0"
+          AND "posthog_group"."group_properties" ? 'name'
+          AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_group"
   WHERE ("posthog_group"."team_id" = 2
          AND "posthog_group"."group_key" = 'foo2'


### PR DESCRIPTION
## Problem

- https://github.com/PostHog/posthog/pull/14187 added negation handling to cohort expansion. This fails when a cohort has a positive property and the cohort is negated. For example, "NOT IN cohort X" where cohort X is defined has `$some_prop = B`. Expansion will convert this to `NOT ($some_prop = B)`. We want this to evaluate as true even if $some_prop doesn't exist in properties but this null safety is not guaranteed in postgres.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- added a clause for the positive equality statement that checks for key existence. This will be trivial in positive cases but important when the overall clause is negated

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
