### PR TITLE
fix(slowlane-ingestion): Access db attribute instead of hub

### DIFF
--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
@@ -67,7 +67,7 @@ export async function eachMessageIngestionFromOverflow(message: KafkaMessage, qu
     const pluginEvent = formPipelineEvent(message)
     // Warnings are limited to 1/key/hour to avoid spamming.
     if (pluginEvent.team_id && WarningLimiter.consume(`${pluginEvent.team_id}:${pluginEvent.distinct_id}`, 1)) {
-        captureIngestionWarning(queue.pluginsServer.hub.db, pluginEvent.team_id, 'ingestion_capacity_overflow', {
+        captureIngestionWarning(queue.pluginsServer.db, pluginEvent.team_id, 'ingestion_capacity_overflow', {
             overflowDistinctId: pluginEvent.distinct_id,
         })
     }

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -59,9 +59,7 @@ describe('eachBatchIngestionWithOverflow', () => {
                 kafkaProducer: {
                     queueMessage: jest.fn(),
                 },
-                hub: {
-                    db: 'database',
-                },
+                db: 'database',
             },
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -59,9 +59,7 @@ describe('eachBatchIngestionWithOverflow', () => {
                 kafkaProducer: {
                     queueMessage: jest.fn(),
                 },
-                hub: {
-                    db: 'database',
-                },
+                db: 'database',
             },
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),
@@ -82,7 +80,7 @@ describe('eachBatchIngestionWithOverflow', () => {
             1
         )
         expect(captureIngestionWarning).toHaveBeenCalledWith(
-            queue.pluginsServer.hub.db,
+            queue.pluginsServer.db,
             captureEndpointEvent['team_id'],
             'ingestion_capacity_overflow',
             {


### PR DESCRIPTION
## Problem

We were accesing an unknown property in `Hub` when raising an ingestion warning. This was not caught by the type checker because `Hub` extends from `Record<string, any>`. A follow up PR could address this.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

The `pluginsServer` is the `Hub` already, we don't access the `hub` property but instead access `db` directly.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

By requesting to dev.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
