### PR TITLE
feat(data-exploration): prep for funnels conversion

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -1,13 +1,7 @@
 import { Card, Col, Row } from 'antd'
 import { InsightDisplayConfig } from './InsightDisplayConfig'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
-import {
-    ChartDisplayType,
-    ExporterFormat,
-    // FunnelVizType,
-    InsightType,
-    ItemMode,
-} from '~/types'
+import { ChartDisplayType, ExporterFormat, FunnelVizType, InsightType, ItemMode } from '~/types'
 import { TrendInsight } from 'scenes/trends/Trends'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { PathsDataExploration } from 'scenes/paths/Paths'
@@ -32,15 +26,9 @@ import { AnimationType } from 'lib/animations/animations'
 // import { FunnelCorrelation } from './views/Funnels/FunnelCorrelation'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 // import { AlertMessage } from 'lib/lemon-ui/AlertMessage'
-import {
-    isFilterWithDisplay,
-    isFunnelsFilter,
-    isPathsFilter,
-    // isTrendsFilter
-} from 'scenes/insights/sharedUtils'
 import { ComputationTimeWithRefresh } from './ComputationTimeWithRefresh'
 import { FunnelInsightDataExploration } from 'scenes/insights/views/Funnels/FunnelInsight'
-import { FunnelsQuery } from '~/queries/schema'
+import { FunnelsQuery, StickinessFilter, TrendsFilter } from '~/queries/schema'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -73,7 +61,6 @@ export function InsightContainer({
         insightLoading,
         activeView,
         loadedView,
-        filters,
         timedOutQueryId,
         erroredQueryId,
         exporterResourceParams,
@@ -88,10 +75,12 @@ export function InsightContainer({
     const { querySource } = useValues(funnelDataLogic(insightProps))
     // TODO: convert to data exploration with insightLogic
     const { areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
-    const { isTrends, display, trendsFilter } = useValues(insightDataLogic(insightProps))
+    const { isTrends, isFunnels, isPaths, display, trendsFilter, funnelsFilter, supportsDisplay, insightFilter } =
+        useValues(insightDataLogic(insightProps))
 
     // TODO: implement in funnelDataLogic
     const isValidFunnel = true
+    const areFiltersValid = true
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {
@@ -128,22 +117,22 @@ export function InsightContainer({
     })()
 
     function renderTable(): JSX.Element | null {
-        //     if (
-        //         isFunnelsFilter(filters) &&
-        //         !showErrorMessage &&
-        //         !showTimeoutMessage &&
-        //         areFiltersValid &&
-        //         isValidFunnel &&
-        //         filters.funnel_viz_type === FunnelVizType.Steps &&
-        //         !disableTable
-        //     ) {
-        //         return (
-        //             <>
-        //                 <h2 className="my-4 mx-0">Detailed results</h2>
-        //                 <FunnelStepsTable />
-        //             </>
-        //         )
-        //     }
+        if (
+            isFunnels &&
+            erroredQueryId === null &&
+            timedOutQueryId === null &&
+            areFiltersValid &&
+            isValidFunnel &&
+            funnelsFilter?.funnel_viz_type === FunnelVizType.Steps &&
+            !disableTable
+        ) {
+            return (
+                <>
+                    {/* <h2 className="my-4 mx-0">Detailed results</h2> */}
+                    {/* <FunnelStepsTable /> */}
+                </>
+            )
+        }
 
         // InsightsTable is loaded for all trend views (except below), plus the sessions view.
         // Exclusions:
@@ -207,7 +196,7 @@ export function InsightContainer({
                 <div>
                     <div
                         className={clsx('flex items-center justify-between insights-graph-header', {
-                            funnels: isFunnelsFilter(filters),
+                            funnels: isFunnels,
                         })}
                     >
                         {/*Don't add more than two columns in this row.*/}
@@ -217,14 +206,14 @@ export function InsightContainer({
                             </div>
                         )}
                         <div>
-                            {isFunnelsFilter(filters) ? <FunnelCanvasLabel /> : null}
-                            {isPathsFilter(filters) ? <PathCanvasLabel /> : null}
+                            {isFunnels ? <FunnelCanvasLabel /> : null}
+                            {isPaths ? <PathCanvasLabel /> : null}
                             <InsightLegendButton />
                         </div>
                     </div>
                     {!!BlockingEmptyState ? (
                         BlockingEmptyState
-                    ) : isFilterWithDisplay(filters) && filters.show_legend ? (
+                    ) : supportsDisplay && (insightFilter as TrendsFilter | StickinessFilter)?.show_legend ? (
                         <Row className="insights-graph-container-row" wrap={false}>
                             <Col className="insights-graph-container-row-left">{VIEW_MAP[activeView]}</Col>
                             <Col className="insights-graph-container-row-right">


### PR DESCRIPTION
## Problem

The funnels table needs to be converted to data exploration. Doing some prep work here to keep the PR small.

## Changes

This PR converts the related parts of the insights container to use data exploration already. 

## How did you test this code?

No testing, as only unused internals change.