### PR TITLE
fix(sampling): make sure cache keys for sampled and non-sampled results are different

### DIFF
--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -790,7 +790,7 @@
          "posthog_insightcachingstate"."created_at",
          "posthog_insightcachingstate"."updated_at"
   FROM "posthog_insightcachingstate"
-  WHERE ("posthog_insightcachingstate"."cache_key" = 'cache_a17dac7be3bef5663cdfd90e50ff5aa3'
+  WHERE ("posthog_insightcachingstate"."cache_key" = 'cache_8927b6bdeed5f8af7eeba3673259bf59'
          AND "posthog_insightcachingstate"."insight_id" = 2
          AND "posthog_insightcachingstate"."team_id" = 2) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -790,7 +790,7 @@
          "posthog_insightcachingstate"."created_at",
          "posthog_insightcachingstate"."updated_at"
   FROM "posthog_insightcachingstate"
-  WHERE ("posthog_insightcachingstate"."cache_key" = 'cache_2ef34d59030b5380a5819b53e427cb31'
+  WHERE ("posthog_insightcachingstate"."cache_key" = 'cache_a17dac7be3bef5663cdfd90e50ff5aa3'
          AND "posthog_insightcachingstate"."insight_id" = 2
          AND "posthog_insightcachingstate"."team_id" = 2) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -192,6 +192,8 @@ PATH_MAX_EDGE_WEIGHT = "max_edge_weight"
 AGGREGATION_GROUP_TYPE_INDEX = "aggregation_group_type_index"
 BREAKDOWN_HISTOGRAM_BIN_COUNT = "breakdown_histogram_bin_count"
 BREAKDOWN_NORMALIZE_URL = "breakdown_normalize_url"
+SAMPLE_FACTOR = "sample_factor"
+
 
 BREAKDOWN_TYPES = Literal["event", "person", "cohort", "group", "session", "hogql"]
 

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -574,4 +574,4 @@ class SampleMixin(BaseParamMixin):
 
     @include_dict
     def sample_factor_to_dict(self):
-        return {SAMPLE_FACTOR: self.sample_factor}
+        return {SAMPLE_FACTOR: self.sample_factor or ""}

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -39,6 +39,7 @@ from posthog.constants import (
     INSIGHT_TRENDS,
     LIMIT,
     OFFSET,
+    SAMPLE_FACTOR,
     SELECTOR,
     SHOWN_AS,
     SMOOTHING_INTERVALS,
@@ -563,10 +564,14 @@ class SampleMixin(BaseParamMixin):
 
     default_sample_factor = 0.1
 
-    @include_dict
+    @cached_property
     def sample_factor(self) -> Optional[float]:
         factor = None
-        if self._data.get("sample_results", False):
+        if process_bool(self._data.get("sample_results", False)):
             factor = self.default_sample_factor
 
         return factor
+
+    @include_dict
+    def sample_factor_to_dict(self):
+        return {SAMPLE_FACTOR: self.sample_factor}

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -563,7 +563,7 @@ class SampleMixin(BaseParamMixin):
 
     default_sample_factor = 0.1
 
-    @cached_property
+    @include_dict
     def sample_factor(self) -> Optional[float]:
         factor = None
         if self._data.get("sample_results", False):

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -52,6 +52,7 @@ class TestFilter(BaseTest):
                 "interval",
                 "smoothing_intervals",
                 "breakdown_attribution_type",
+                "sample_factor",
                 "search",
                 "breakdown_normalize_url",
             ],

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -430,7 +430,6 @@ class TrendsFilter(BaseModel):
     show_legend: Optional[bool] = None
     shown_as: Optional[ShownAsValue] = None
     smoothing_intervals: Optional[float] = None
-    sample_factor: Optional[float] = None
 
 
 class Breakdown(BaseModel):
@@ -1007,7 +1006,6 @@ class AnyPartialFilterTypeItem(BaseModel):
     show_legend: Optional[bool] = None
     shown_as: Optional[ShownAsValue] = None
     smoothing_intervals: Optional[float] = None
-    sample_factor: Optional[float] = None
 
 
 class AnyPartialFilterTypeItem1(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -430,6 +430,7 @@ class TrendsFilter(BaseModel):
     show_legend: Optional[bool] = None
     shown_as: Optional[ShownAsValue] = None
     smoothing_intervals: Optional[float] = None
+    sample_factor: Optional[float] = None
 
 
 class Breakdown(BaseModel):
@@ -1006,6 +1007,7 @@ class AnyPartialFilterTypeItem(BaseModel):
     show_legend: Optional[bool] = None
     shown_as: Optional[ShownAsValue] = None
     smoothing_intervals: Optional[float] = None
+    sample_factor: Optional[float] = None
 
 
 class AnyPartialFilterTypeItem1(BaseModel):


### PR DESCRIPTION
This is maybe a point for discussion but it's at least needed right now otherwise toggling between sampled and non-sampled doesn't do anything, leaving the users a bit confused.