### PR TITLE
fix(experiments): prevent experiments call if feature not available

### DIFF
--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -11,7 +11,7 @@ import { loaders } from 'kea-loaders'
 
 export const experimentsLogic = kea<experimentsLogicType>([
     path(['scenes', 'experiments', 'experimentsLogic']),
-    connect({ values: [teamLogic, ['currentTeamId'], userLogic, ['user']] }),
+    connect({ values: [teamLogic, ['currentTeamId'], userLogic, ['user', 'hasAvailableFeature']] }),
     actions({
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setSearchStatus: (status: ExperimentStatus | 'all') => ({ status }),
@@ -36,7 +36,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
             [] as Experiment[],
             {
                 loadExperiments: async () => {
-                    if (!values.hasAvailableFeature(AvailableFeature.EXPERIMENTATION)) {
+                    if (!values.hasExperimentAvailableFeature) {
                         return []
                     }
                     const response = await api.get(`api/projects/${values.currentTeamId}/experiments`)


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/25164963/219728497-2e395c22-c2d6-470a-b9fd-1626a66d0e10.png)

Adding experiments to storybook broke the logic for checking if the feature is available before loading experiments

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
