### PR TITLE
fix(recordings): add state to player metadata

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -121,15 +121,21 @@ export function PlayerMeta(props: SessionRecordingPlayerLogicProps): JSX.Element
                                     />
                                     {!isFullScreen ? iconProperties['$os'] : null}
                                 </span>
-                                <span className="flex items-center gap-1 whitespace-nowrap">
-                                    <PropertyIcon
-                                        noTooltip={!isFullScreen}
-                                        property="$geoip_country_code"
-                                        value={iconProperties['$geoip_country_code']}
-                                    />
-                                    {!isFullScreen ? iconProperties['$geoip_city_name'] : null}
-                                    {!isFullScreen && iconProperties['$geoip_subdivision_1_code'] ? ', ' + iconProperties['$geoip_subdivision_1_code'] : null}
-                                </span>
+                                {iconProperties['$geoip_country_code'] && (
+                                    <span className="flex items-center gap-1 whitespace-nowrap">
+                                        <PropertyIcon
+                                            noTooltip={!isFullScreen}
+                                            property="$geoip_country_code"
+                                            value={iconProperties['$geoip_country_code']}
+                                        />
+                                        {!isFullScreen &&
+                                            `${iconProperties['$geoip_city_name'] || null}${
+                                                iconProperties['$geoip_subdivision_1_code'] &&
+                                                iconProperties['$geoip_city_name'] &&
+                                                ', '
+                                            }${iconProperties['$geoip_subdivision_1_code'] || null}`}
+                                    </span>
+                                )}
                             </div>
                         ) : null}
                     </div>

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -128,6 +128,7 @@ export function PlayerMeta(props: SessionRecordingPlayerLogicProps): JSX.Element
                                         value={iconProperties['$geoip_country_code']}
                                     />
                                     {!isFullScreen ? iconProperties['$geoip_city_name'] : null}
+                                    {!isFullScreen && iconProperties['$geoip_subdivision_1_code'] ? ', ' + iconProperties['$geoip_subdivision_1_code'] : null}
                                 </span>
                             </div>
                         ) : null}

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -129,11 +129,12 @@ export function PlayerMeta(props: SessionRecordingPlayerLogicProps): JSX.Element
                                             value={iconProperties['$geoip_country_code']}
                                         />
                                         {!isFullScreen &&
-                                            `${iconProperties['$geoip_city_name'] || null}${
+                                            `${iconProperties['$geoip_city_name'] || ''}${
                                                 iconProperties['$geoip_subdivision_1_code'] &&
-                                                iconProperties['$geoip_city_name'] &&
-                                                ', '
-                                            }${iconProperties['$geoip_subdivision_1_code'] || null}`}
+                                                iconProperties['$geoip_city_name']
+                                                    ? ', '
+                                                    : ''
+                                            }${iconProperties['$geoip_subdivision_1_code'] || ''}`}
                                     </span>
                                 )}
                             </div>

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -128,13 +128,15 @@ export function PlayerMeta(props: SessionRecordingPlayerLogicProps): JSX.Element
                                             property="$geoip_country_code"
                                             value={iconProperties['$geoip_country_code']}
                                         />
-                                        {!isFullScreen &&
-                                            `${iconProperties['$geoip_city_name'] || ''}${
-                                                iconProperties['$geoip_subdivision_1_code'] &&
-                                                iconProperties['$geoip_city_name']
-                                                    ? ', '
-                                                    : ''
-                                            }${iconProperties['$geoip_subdivision_1_code'] || ''}`}
+                                        {
+                                            isFullScreen &&
+                                                [
+                                                    iconProperties['$geoip_city_name'],
+                                                    iconProperties['$geoip_subdivision_1_code'],
+                                                ]
+                                                    .filter((x) => x)
+                                                    .join(', ') /* [city, state] */
+                                        }
                                     </span>
                                 )}
                             </div>


### PR DESCRIPTION
## Problem

Most of my users are not in major cities, so seeing the city name without the state isn't useful.

## Changes

Adds the users's state to the recording player metadata.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't.... I don't have a ph dev env set up, but I think it should work 🙃
