### PR TITLE
fix(ci): Bump Ubuntu to fix GH runner in CI Plugin Server

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
     code-quality:
         name: Code quality
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         defaults:
             run:
                 working-directory: 'plugin-server'
@@ -71,7 +71,7 @@ jobs:
 
     tests:
         name: Tests (${{matrix.shard}})
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Problem

As of today we started seeing errors in CI Plugin Server builds related to invalid versions of an xml library. See for example CI Plugin Server in https://github.com/PostHog/posthog/pull/13999

We tested this out, and apparently none of our changes caused this issue, but instead it was the release of a new GH Actions runner. We confirmed this by reverting all commits since the latest success and re-running CI, which failed.  

During our testing we noticed that CI Backend was working perfectly fine, and we noticed it's using a newer version of the Ubuntu runner, so...

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

We bumped Ubuntu to 22.04 in CI Plugin Server.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Running CI Plugin Server on the new runner and confirming "Set up databases" step works fine.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
