### PR TITLE
fix: Autoplay removing routing params

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
@@ -38,6 +38,7 @@ export function PlayerUpNext({
     const goToRecording = (automatic: boolean): void => {
         reportNextRecordingTriggered(automatic)
         router.actions.push(router.values.currentLocation.pathname, router.values.currentLocation.searchParams, {
+            ...router.values.currentLocation.hashParams,
             sessionRecordingId: nextSessionRecording?.id,
         })
     }


### PR DESCRIPTION
## Problem

We weren't keeping the hashParams when autoplaying. Persons page uses this for tab navigation

## Changes

* Fixes this by extending the hashparams
  
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
