### PR TITLE
fix: update language on attribution type info tooltip

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -173,7 +173,8 @@ export function EditorFilters({ query, setQuery, showing }: EditorFiltersProps):
                           position: 'right',
                           tooltip: (
                               <div>
-                                  Attribution type determines which property value to use for the entire funnel.
+                                  Attribution type determines which property value to use for filtering or breakdowns.
+                                  That value is then used for the entire funnel.
                                   <ul className="list-disc pl-4">
                                       <li>First step: the first property value seen from all steps is chosen.</li>
                                       <li>Last step: last property value seen from all steps is chosen.</li>

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -195,7 +195,8 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
 
                           tooltip: (
                               <div>
-                                  Attribution type determines which property value to use for the entire funnel.
+                                  Attribution type determines which property value to use for filtering or breakdowns.
+                                  That value is then used for the entire funnel.
                                   <ul className="list-disc pl-4">
                                       <li>First step: the first property value seen from all steps is chosen.</li>
                                       <li>Last step: last property value seen from all steps is chosen.</li>


### PR DESCRIPTION
## Problem

The Attribution type description didn't say that it was specific to whole-funnel filters and breakdowns, so it was confusing why property values mattered. Hoping this updated description helps 🤷‍♀️ 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
