### PR TITLE
feat(data-exploration): convert trends export

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -76,7 +76,6 @@ export function InsightContainer({
         filters,
         timedOutQueryId,
         erroredQueryId,
-        exporterResourceParams,
         // isUsingSessionAnalysis,
     } = useValues(insightLogic)
     // const {
@@ -88,7 +87,7 @@ export function InsightContainer({
     const { querySource } = useValues(funnelDataLogic(insightProps))
     // TODO: convert to data exploration with insightLogic
     const { areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
-    const { isTrends, display, trendsFilter } = useValues(insightDataLogic(insightProps))
+    const { isTrends, display, trendsFilter, exportContext } = useValues(insightDataLogic(insightProps))
 
     // TODO: implement in funnelDataLogic
     const isValidFunnel = true
@@ -156,7 +155,7 @@ export function InsightContainer({
         ) {
             return (
                 <>
-                    {exporterResourceParams && (
+                    {exportContext && (
                         <div className="flex items-center justify-between my-4 mx-0">
                             <h2 className="m-0">Detailed results</h2>
                             <Tooltip title="Export this table in CSV format" placement="left">
@@ -166,7 +165,7 @@ export function InsightContainer({
                                     items={[
                                         {
                                             export_format: ExporterFormat.CSV,
-                                            export_context: exporterResourceParams,
+                                            export_context: exportContext,
                                         },
                                     ]}
                                 />

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -3,7 +3,7 @@ import { InsightDisplayConfig } from './InsightDisplayConfig'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import {
     ChartDisplayType,
-    // ExporterFormat,
+    ExporterFormat,
     // FunnelVizType,
     InsightType,
     ItemMode,
@@ -25,12 +25,12 @@ import {
 import clsx from 'clsx'
 import { PathCanvasLabel } from 'scenes/paths/PathsLabel'
 import { InsightLegend, InsightLegendButton } from 'lib/components/InsightLegend/InsightLegend'
-// import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 // import { FunnelStepsTable } from './views/Funnels/FunnelStepsTable'
 import { Animation } from 'lib/components/Animation/Animation'
 import { AnimationType } from 'lib/animations/animations'
 // import { FunnelCorrelation } from './views/Funnels/FunnelCorrelation'
-// import { ExportButton } from 'lib/components/ExportButton/ExportButton'
+import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 // import { AlertMessage } from 'lib/lemon-ui/AlertMessage'
 import {
     isFilterWithDisplay,
@@ -76,7 +76,7 @@ export function InsightContainer({
         filters,
         timedOutQueryId,
         erroredQueryId,
-        // exporterResourceParams,
+        exporterResourceParams,
         // isUsingSessionAnalysis,
     } = useValues(insightLogic)
     // const {
@@ -156,23 +156,23 @@ export function InsightContainer({
         ) {
             return (
                 <>
-                    {/* {exporterResourceParams && (
-                                 <div className="flex items-center justify-between my-4 mx-0">
-                                     <h2 className="m-0">Detailed results</h2>
-                                     <Tooltip title="Export this table in CSV format" placement="left">
-                                         <ExportButton
-                                             type="secondary"
-                                             status="primary"
-                                             items={[
-                                                 {
-                                                     export_format: ExporterFormat.CSV,
-                                                     export_context: exporterResourceParams,
-                                                 },
-                                             ]}
-                                         />
-                                     </Tooltip>
-                                 </div>
-                             )} */}
+                    {exporterResourceParams && (
+                        <div className="flex items-center justify-between my-4 mx-0">
+                            <h2 className="m-0">Detailed results</h2>
+                            <Tooltip title="Export this table in CSV format" placement="left">
+                                <ExportButton
+                                    type="secondary"
+                                    status="primary"
+                                    items={[
+                                        {
+                                            export_format: ExporterFormat.CSV,
+                                            export_context: exporterResourceParams,
+                                        },
+                                    ]}
+                                />
+                            </Tooltip>
+                        </div>
+                    )}
 
                     <InsightsTableDataExploration
                         isLegend

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -32,6 +32,7 @@ import { cleanFilters } from './utils/cleanFilters'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { getBreakdown, getDisplay, getCompare, getSeries, getInterval } from '~/queries/nodes/InsightViz/utils'
 import { nodeKindToDefaultQuery } from '~/queries/nodes/InsightQuery/defaults'
+import { queryExportContext } from '~/queries/query'
 
 const defaultQuery = (insightProps: InsightLogicProps): InsightVizNode => {
     const filters = insightProps.cachedInsight?.filters
@@ -54,7 +55,14 @@ export const insightDataLogic = kea<insightDataLogicType>([
     path((key) => ['scenes', 'insights', 'insightDataLogic', key]),
 
     connect((props: InsightLogicProps) => ({
-        values: [featureFlagLogic, ['featureFlags'], trendsLogic, ['toggledLifecycles as trendsLifecycles']],
+        values: [
+            insightLogic,
+            ['insight'],
+            featureFlagLogic,
+            ['featureFlags'],
+            trendsLogic,
+            ['toggledLifecycles as trendsLifecycles'],
+        ],
         actions: [
             insightLogic,
             ['setFilters', 'setActiveView', 'setInsight', 'loadInsightSuccess', 'loadResultsSuccess'],
@@ -111,6 +119,14 @@ export const insightDataLogic = kea<insightDataLogicType>([
         isNonTimeSeriesDisplay: [
             (s) => [s.display],
             (display) => !!display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display),
+        ],
+
+        exportContext: [
+            (s) => [s.query, s.insight],
+            (query, insight) => {
+                const filename = ['export', insight.name || insight.derived_name].join('-')
+                return { ...queryExportContext(query), filename }
+            },
         ],
     }),
 


### PR DESCRIPTION
## Problem

Trends exports need to be converted to data exploration

## Changes

This PR converts the query to an export context and passes it to the button. Closes #14275 ([see here for commit](https://github.com/PostHog/posthog/pull/14275/commits/4cfe23c40d50982aaf97501a84a054a27e038e5d), PR would need to be rebased), as simply using the `exporterResourceParams` of insightLogic doesn't work.

## How did you test this code?

Manual testing. Make sure Celery is running to test the exports here.