### PR TITLE
feat(exports-v2): add retry to exports on ClickHouse failures

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -1,8 +1,10 @@
+import { RetryError } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
 import { Element, RawClickHouseEvent, TimestampFormat } from '../../../../types'
 import { DB } from '../../../../utils/db/db'
 import { parseRawClickHouseEvent } from '../../../../utils/event'
+import { status } from '../../../../utils/status'
 import { castTimestampToClickhouseFormat } from '../../../../utils/utils'
 import { HistoricalExportEvent } from './utils'
 
@@ -48,7 +50,14 @@ export const fetchEventsForInterval = async (
     LIMIT ${eventsPerRun}
     OFFSET ${offset}`
 
-    const clickhouseFetchEventsResult = await db.clickhouseQuery<RawClickHouseEvent>(fetchEventsQuery)
+    let clickhouseFetchEventsResult: { data: RawClickHouseEvent[] }
+
+    try {
+        clickhouseFetchEventsResult = await db.clickhouseQuery<RawClickHouseEvent>(fetchEventsQuery)
+    } catch (error) {
+        status.error('🔥', 'clickhouse_export_fetch_failure', { error })
+        throw new RetryError("Couldn't fetch events from ClickHouse")
+    }
 
     return clickhouseFetchEventsResult.data.map(convertClickhouseEventToPluginEvent)
 }

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -55,6 +55,9 @@ export const fetchEventsForInterval = async (
     try {
         clickhouseFetchEventsResult = await db.clickhouseQuery<RawClickHouseEvent>(fetchEventsQuery)
     } catch (error) {
+        // TODO: add more specific error handling based on the error from
+        // `clickhouseQuery` (e.g. if it's a timeout, we should retry, if it's a
+        // query syntax error, we should not retry)
         status.error('🔥', 'clickhouse_export_fetch_failure', { error })
         throw new RetryError("Couldn't fetch events from ClickHouse")
     }


### PR DESCRIPTION
This is a quick fix to retry exports on ClickHouse failures. Prior to
this if we e.g. failed to connect to ClickHouse for a single fetch, we'd
end up failing the whole export.

Instead, we add a retry to the fetchEventsForInterval function, which
will retry the fetch up to `HISTORICAL_EXPORTS_MAX_RETRY_COUNT` times
before failing, which is 15 times by default.

This is a corresponding retry that is already in place for the failures
of calls to `exportEvents` calls.

For (internal) context, this was triggered by https://posthog.slack.com/archives/C046E3HVAKZ/p1676633534384679

NOTE: I haven't done anything to check this plays well with the export resume logic, but this is the same as for the exportEvents retry logic so I don't think I'd be introducing anything new here by way of concurrency bugs. Might be making it a little worse however.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
