### PR TITLE
feat: Track info about quota limiting to posthog

### DIFF
--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -6,7 +6,7 @@ from django.utils.timezone import now
 from freezegun import freeze_time
 
 from ee.billing.quota_limiting import (
-    RATE_LIMITER_CACHE_KEY,
+    QUOTA_LIMITER_CACHE_KEY,
     QuotaResource,
     list_limited_team_tokens,
     org_quota_limited_until,
@@ -47,8 +47,8 @@ class TestQuotaLimiting(BaseTest):
         assert result["events"] == {}
         assert result["recordings"] == {}
 
-        assert self.redis_client.zrange(f"{RATE_LIMITER_CACHE_KEY}events", 0, -1) == []
-        assert self.redis_client.zrange(f"{RATE_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
+        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
 
     def test_billing_rate_limit(self) -> None:
         with self.settings(USE_TZ=False):
@@ -77,10 +77,10 @@ class TestQuotaLimiting(BaseTest):
         assert result["events"] == {org_id: 1612137599}
         assert result["recordings"] == {}
 
-        assert self.redis_client.zrange(f"{RATE_LIMITER_CACHE_KEY}events", 0, -1) == [
+        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == [
             self.team.api_token.encode("UTF-8")
         ]
-        assert self.redis_client.zrange(f"{RATE_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
 
         self.organization.refresh_from_db()
         assert self.organization.usage == {

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -102,7 +102,7 @@ class UserChangeForm(DjangoUserChangeForm):
 class OrganizationMemberInline(admin.TabularInline):
     extra = 0
     model = OrganizationMembership
-    readonly_fields = ("joined_at", "updated_at")
+    readonly_fields = ("user", "joined_at", "updated_at")
     autocomplete_fields = ("user", "organization")
 
 

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -589,7 +589,9 @@
 ---
 # name: TestDecide.test_flag_with_regular_cohorts.5
   '
-  SELECT ("posthog_person"."properties" -> '$some_prop_1') = '"something_1"' AS "flag_X_condition_0"
+  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'
+          AND "posthog_person"."properties" ? '$some_prop_1'
+          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id_1'
@@ -666,7 +668,9 @@
 ---
 # name: TestDecide.test_flag_with_regular_cohorts.8
   '
-  SELECT ("posthog_person"."properties" -> '$some_prop_1') = '"something_1"' AS "flag_X_condition_0"
+  SELECT (("posthog_person"."properties" -> '$some_prop_1') = '"something_1"'
+          AND "posthog_person"."properties" ? '$some_prop_1'
+          AND NOT (("posthog_person"."properties" -> '$some_prop_1') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'another_id'

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -405,7 +405,9 @@
   '
   SELECT pg_sleep(1);
   
-  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
+  SELECT (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
+          AND "posthog_person"."properties" ? 'email'
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
@@ -443,7 +445,9 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.3
   '
-  SELECT ("posthog_person"."properties" -> 'email') = '"tim@posthog.com"' AS "flag_X_condition_0",
+  SELECT (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
+          AND "posthog_person"."properties" ? 'email'
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -790,7 +790,7 @@
          "posthog_insightcachingstate"."created_at",
          "posthog_insightcachingstate"."updated_at"
   FROM "posthog_insightcachingstate"
-  WHERE ("posthog_insightcachingstate"."cache_key" = 'cache_8927b6bdeed5f8af7eeba3673259bf59'
+  WHERE ("posthog_insightcachingstate"."cache_key" = 'cache_2dfd15f76fb6ac02f0972f7b0203a789'
          AND "posthog_insightcachingstate"."insight_id" = 2
          AND "posthog_insightcachingstate"."team_id" = 2) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -205,8 +205,25 @@ def groups(organization: Optional[Organization] = None, team: Optional[Team] = N
     return result
 
 
-def report_team_action(team: Team, event: str, properties: Dict = {}):
+def report_team_action(team: Team, event: str, properties: Dict = {}, group_properties: Optional[Dict] = None):
     """
     For capturing events where it is unclear which user was the core actor we can use the team instead
     """
     posthoganalytics.capture(str(team.uuid), event, properties=properties, groups=groups(team=team))
+
+    if group_properties:
+        posthoganalytics.group_identify("team", str(team.id), properties=group_properties)
+
+
+def report_organization_action(
+    organization: Organization, event: str, properties: Dict = {}, group_properties: Optional[Dict] = None
+):
+    """
+    For capturing events where it is unclear which user was the core actor we can use the organization instead
+    """
+    posthoganalytics.capture(
+        str(organization.id), event, properties=properties, groups=groups(organization=organization)
+    )
+
+    if group_properties:
+        posthoganalytics.group_identify("organization", str(organization.id), properties=group_properties)

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -153,7 +153,7 @@
               CROSS JOIN
                 (SELECT breakdown_value
                  FROM
-                   (SELECT [37, 0] as breakdown_value) ARRAY
+                   (SELECT [36, 0] as breakdown_value) ARRAY
                  JOIN breakdown_value) as sec
               ORDER BY breakdown_value,
                        day_start
@@ -163,7 +163,7 @@
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
-                        37 as value
+                        36 as value
                  FROM
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
@@ -222,7 +222,7 @@
               CROSS JOIN
                 (SELECT breakdown_value
                  FROM
-                   (SELECT [37, 0] as breakdown_value) ARRAY
+                   (SELECT [36, 0] as breakdown_value) ARRAY
                  JOIN breakdown_value) as sec
               ORDER BY breakdown_value,
                        day_start
@@ -232,7 +232,7 @@
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
-                        37 as value
+                        36 as value
                  FROM
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id


### PR DESCRIPTION
## Problem

We'd like to have better reporting when an org gets quota limited.

## Changes

* Track the diff of teams being rate limited so we can report an event and group properties
* Makes the "user" in the admin portal noneditable so it is quicker to click from an org to a user (for internal debugging)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
