### PR TITLE
feat(ingestion): run all analytic events through populateTeamDataStep

### DIFF
--- a/plugin-server/src/main/ingestion-queues/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/metrics.ts
@@ -1,9 +1,15 @@
 // Metrics that make sense across all Kafka consumers
 
-import { Gauge } from 'prom-client'
+import { Counter, Gauge } from 'prom-client'
 
 export const latestOffsetTimestampGauge = new Gauge({
     name: 'latest_processed_timestamp_ms',
     help: 'Timestamp of the latest offset that has been committed.',
     labelNames: ['topic', 'partition', 'groupId'],
+})
+
+export const eventDroppedCounter = new Counter({
+    name: 'ingestion_event_dropped_total',
+    help: 'Count of events dropped by the ingestion pipeline, by type and cause.',
+    labelNames: ['event_type', 'drop_cause'],
 })

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -11,17 +11,18 @@ export const inconsistentTeamCounter = new Counter({
     labelNames: ['token', 'captured_team_id', 'resolved_team_id'],
 })
 
-/*
-This step populates event.team_id and deletes event.ip if needed.
-If the event already has a team_id we will not run this step and
-the capture endpoint will have handled this process. This is
-temporary as this step will become the default for all events
-when we fully remove this functionality from the capture endpoint.
-*/
 export async function populateTeamDataStep(
     runner: EventPipelineRunner,
     event: PipelineEvent
 ): Promise<PluginEvent | null> {
+    /**
+     * Implements team_id resolution and applies the team's ingestion settings (dropping event.ip if requested).
+     *
+     * If the event already has a team_id field set by capture, it is used, but plugin-server still runs
+     * the resolution logic to confirm no inconsistency exists. Once team_id resolution is fully removed
+     * from capture, that section should be resolved, and team_id not trusted anymore.
+     */
+
     // Events ingested with no token are dropped, they should be blocked by capture
     if (!event.token) {
         eventDroppedCounter

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -1,12 +1,20 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
+import { Counter } from 'prom-client'
 
+import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
 import { PipelineEvent } from '../../../types'
 import { EventPipelineRunner } from './runner'
 
-/* 
+export const inconsistentTeamCounter = new Counter({
+    name: 'ingestion_inconsistent_team_resolution_total',
+    help: 'Count of events with an inconsistent team resolution between capture and plugin-server, should be zero.',
+    labelNames: ['token', 'captured_team_id', 'resolved_team_id'],
+})
+
+/*
 This step populates event.team_id and deletes event.ip if needed.
-If the event already has a team_id we will not run this step and 
-the capture endpoint will have handled this process. This is 
+If the event already has a team_id we will not run this step and
+the capture endpoint will have handled this process. This is
 temporary as this step will become the default for all events
 when we fully remove this functionality from the capture endpoint.
 */
@@ -14,15 +22,47 @@ export async function populateTeamDataStep(
     runner: EventPipelineRunner,
     event: PipelineEvent
 ): Promise<PluginEvent | null> {
+    // Events ingested with no token are dropped, they should be blocked by capture
     if (!event.token) {
+        eventDroppedCounter
+            .labels({
+                event_type: 'analytics',
+                drop_cause: 'no_token',
+            })
+            .inc()
         runner.hub.statsd?.increment('dropped_event_with_no_team', { token_set: 'false' })
         return null
     }
 
+    // Team lookup is cached, but will fail if PG is unavailable and the key expired.
+    // We should retry processing this event.
     const team = await runner.hub.teamManager.getTeamByToken(event.token)
 
-    // should we actually throw here?
+    // Short-circuit the logic if capture already resolved the team ID,
+    // just compare the lookup result to confirm data quality.
+    // TODO: remove after lightweight capture is fully rolled-out
+    if (event.team_id) {
+        if (team?.id || event.team_id) {
+            inconsistentTeamCounter
+                .labels({
+                    token: event.token,
+                    captured_team_id: event.team_id,
+                    resolved_team_id: team?.id,
+                })
+                .inc()
+            runner.hub.statsd?.increment('ingestion_inconsistent_team_resolution_total')
+        }
+        return event as PluginEvent
+    }
+
+    // If the token does not resolve to an existing team, drop the events.
     if (!team) {
+        eventDroppedCounter
+            .labels({
+                event_type: 'analytics',
+                drop_cause: 'invalid_token',
+            })
+            .inc()
         runner.hub.statsd?.increment('dropped_event_with_no_team', { token_set: 'true' })
         return null
     }
@@ -33,6 +73,5 @@ export async function populateTeamDataStep(
         ip: team.anonymize_ips ? null : event.ip,
     }
 
-    delete event['token']
     return event as PluginEvent
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -8,7 +8,6 @@ import { EventPipelineRunner } from './runner'
 export const inconsistentTeamCounter = new Counter({
     name: 'ingestion_inconsistent_team_resolution_total',
     help: 'Count of events with an inconsistent team resolution between capture and plugin-server, should be zero.',
-    labelNames: ['token', 'captured_team_id', 'resolved_team_id'],
 })
 
 export async function populateTeamDataStep(
@@ -44,13 +43,7 @@ export async function populateTeamDataStep(
     // TODO: remove after lightweight capture is fully rolled-out
     if (event.team_id) {
         if (team?.id || event.team_id) {
-            inconsistentTeamCounter
-                .labels({
-                    token: event.token,
-                    captured_team_id: event.team_id,
-                    resolved_team_id: team?.id,
-                })
-                .inc()
+            inconsistentTeamCounter.inc()
             runner.hub.statsd?.increment('ingestion_inconsistent_team_resolution_total')
         }
         return event as PluginEvent

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -53,16 +53,16 @@ export class TeamManager {
          * Validates and resolves the api token from an incoming event.
          *
          * Caching is added to reduce the load on Postgres, not to be resilient
-         * to failures. If PG is unavailable, this function will trow and the
-         * lookup must be retried later.
+         * to failures. If PG is unavailable and the cache expired, this function
+         * will trow and the lookup must be retried later.
          *
          * Returns null if the token is invalid.
          */
 
         const cachedTeamId = this.tokenToTeamIdCache.get(token)
 
-        // Negative lookups (`null` instead of `undefined`) return fast,
-        // but will be retried after that cache key expires.
+        // LRU.get returns `undefined` if the key is not found, so `null`s will
+        // only be returned when caching a negative lookup (invalid token).
         // A new token can potentially get caught here for up to 5 minutes
         // if a bad request in the past used that token.
         if (cachedTeamId === null) {

--- a/plugin-server/tests/helpers/metrics.ts
+++ b/plugin-server/tests/helpers/metrics.ts
@@ -1,0 +1,15 @@
+import { register } from 'prom-client'
+
+export function resetMetrics() {
+    register.resetMetrics()
+}
+
+export async function getMetricValues(metricName: string): Promise<any> {
+    const metrics = await register.getMetricsAsJSON()
+    for (const metric of metrics) {
+        if (metric.name === metricName) {
+            return (metric as any).values
+        }
+    }
+    throw Error(`Metric not found: ${metricName}`)
+}

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -64,6 +64,7 @@ describe('eachBatchIngestionWithOverflow', () => {
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(),
+                runLightweightCaptureEndpointEventPipeline: jest.fn(),
                 runBufferEventPipeline: jest.fn(),
             },
         }

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -63,6 +63,7 @@ describe('eachBatchIngestionWithOverflow', () => {
             },
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),
+                runLightweightCaptureEndpointEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(),
                 runBufferEventPipeline: jest.fn(),
             },
@@ -114,7 +115,7 @@ describe('eachBatchIngestionWithOverflow', () => {
             1
         )
         // This is "the rest of the pipeline"
-        expect(queue.workerMethods.runEventPipeline).toHaveBeenCalled()
+        expect(queue.workerMethods.runLightweightCaptureEndpointEventPipeline).toHaveBeenCalled()
     })
 
     it('does not produce the event again', async () => {

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -2,8 +2,7 @@ import { KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW }
 import { eachBatch } from '../../../src/main/ingestion-queues/batch-processing/each-batch'
 import { eachBatchAsyncHandlers } from '../../../src/main/ingestion-queues/batch-processing/each-batch-async-handlers'
 import { eachBatchIngestion } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
-import { ClickHouseTimestamp, ISOTimestamp } from '../../../src/types'
-import { PostIngestionEvent, RawClickHouseEvent } from '../../../src/types'
+import { ClickHouseTimestamp, ISOTimestamp, PostIngestionEvent, RawClickHouseEvent } from '../../../src/types'
 import { ConfiguredLimiter } from '../../../src/utils/token-bucket'
 import { groupIntoBatches } from '../../../src/utils/utils'
 import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
@@ -114,6 +113,7 @@ describe('eachBatchX', () => {
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(),
+                runLightweightCaptureEndpointEventPipeline: jest.fn(),
                 runBufferEventPipeline: jest.fn(),
             },
         }
@@ -157,11 +157,11 @@ describe('eachBatchX', () => {
     })
 
     describe('eachBatchIngestion', () => {
-        it('calls runEventPipeline', async () => {
+        it('calls runLightweightCaptureEndpointEventPipeline', async () => {
             const batch = createBatch(captureEndpointEvent)
             await eachBatchIngestion(batch, queue)
 
-            expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledWith({
+            expect(queue.workerMethods.runLightweightCaptureEndpointEventPipeline).toHaveBeenCalledWith({
                 distinct_id: 'id',
                 event: 'event',
                 properties: {},

--- a/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
@@ -92,9 +92,9 @@ describe('populateTeamDataStep()', () => {
         jest.mocked(runner.hub.teamManager.getTeamByToken).mockReturnValue({ ...team, anonymize_ips: true })
         const response = await populateTeamDataStep(runner, { ...pipelineEvent, team_id: 43, token: 'unknown' })
         expect(response.team_id).toEqual(43)
-        expect(await getMetricValues('ingestion_inconsistent_team_resolution_total')).toEqual([
+        expect(await getMetricValues('ingestion_team_resolution_checks_total')).toEqual([
             {
-                labels: {},
+                labels: { check_ok: 'false' },
                 value: 1,
             },
         ])

--- a/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
@@ -94,11 +94,7 @@ describe('populateTeamDataStep()', () => {
         expect(response.team_id).toEqual(43)
         expect(await getMetricValues('ingestion_inconsistent_team_resolution_total')).toEqual([
             {
-                labels: {
-                    captured_team_id: 43,
-                    resolved_team_id: 2,
-                    token: 'unknown',
-                },
+                labels: {},
                 value: 1,
             },
         ])


### PR DESCRIPTION
## Problem

Closes #14327, part of removing the Postgres dependency from capture.py

## Changes

- Run all events through the `populateTeamDataStep`, not just events without a team_id. This allows us to:
  - confirm that the Postgres load will be OK once we fully roll it out (and rollback without getting in a pickle)
  - control the rollout from a single point (dropping the team_id field in capture)
- If a `team_id` field is present, trust it but report inconsistencies with the new `ingestion_team_resolution_checks_total` counter
- Emit a new `ingestion_event_dropped_total` counter, that could be used by other parts of the pipeline (dropping events from apps)
- Tune the team cache settings, only cache negative lookups for 5 minutes
- Don't drop the token from the event, mirroring previous behaviour


## How did you test this code?

unit and end2end tests