### PR TITLE
fix: improve usage report task handling

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -687,7 +687,7 @@ def clickhouse_mark_all_materialized():
 def send_org_usage_reports():
     from posthog.tasks.usage_report import send_all_org_usage_reports
 
-    send_all_org_usage_reports()
+    send_all_org_usage_reports.delay()
 
 
 @app.task(ignore_result=True)

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -274,7 +274,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "organization_user_count": 1,
                     "team_count": 2,
                     "teams": {
-                        self.org_1_team_1.id: {
+                        str(self.org_1_team_1.id): {
                             "event_count_lifetime": 32,
                             "event_count_in_period": 12,
                             "event_count_in_month": 22,
@@ -289,7 +289,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "ff_count": 2,
                             "ff_active_count": 1,
                         },
-                        self.org_1_team_2.id: {
+                        str(self.org_1_team_2.id): {
                             "event_count_lifetime": 10,
                             "event_count_in_period": 10,
                             "event_count_in_month": 10,
@@ -346,7 +346,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "organization_user_count": 0,
                     "team_count": 1,
                     "teams": {
-                        self.org_2_team_3.id: {
+                        str(self.org_2_team_3.id): {
                             "event_count_lifetime": 10,
                             "event_count_in_period": 10,
                             "event_count_in_month": 10,
@@ -412,6 +412,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
             ),
         ]
 
+        assert mock_posthog.capture.call_count == 2
         mock_posthog.capture.assert_has_calls(calls, any_order=True)
 
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -386,7 +386,7 @@ def find_count_for_team_in_rows(team_id: int, rows: list) -> int:
 
 
 @app.task(ignore_result=True, retries=0)
-def capture_report(capture_event_name: str, org_id: str, full_report_dict: dict, at_date=Optional[datetime]):
+def capture_report(capture_event_name: str, org_id: str, full_report_dict: dict, at_date=Optional[datetime]) -> None:
     pha_client = Client("sTMFPsFhdP1Ssg")
     try:
         capture_event(pha_client, capture_event_name, org_id, full_report_dict, timestamp=at_date)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -386,7 +386,9 @@ def find_count_for_team_in_rows(team_id: int, rows: list) -> int:
 
 
 @app.task(ignore_result=True, retries=0)
-def capture_report(capture_event_name: str, org_id: str, full_report_dict: dict, at_date=Optional[datetime]) -> None:
+def capture_report(
+    capture_event_name: str, org_id: str, full_report_dict: Dict[str, Any], at_date: Optional[datetime] = None
+) -> None:
     pha_client = Client("sTMFPsFhdP1Ssg")
     try:
         capture_event(pha_client, capture_event_name, org_id, full_report_dict, timestamp=at_date)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -99,7 +99,7 @@ class OrgReport(UsageReportCounters):
     organization_created_at: str
     organization_user_count: int
     team_count: int
-    teams: Dict[int, UsageReportCounters]
+    teams: Dict[str, UsageReportCounters]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Problem
Usage reports are failing due to a long running task on celery without appropriate retries and task splitting.

## Changes
- Add retry to main `send_usage_report` task
- Splits events capturing and sending report to the billing service in its own tasks

## How did you test this code?
- Fixed tests
- Note: `team.id` used for indexing team reports, is now a string key, it was an int, this shouldn't have any effective change
