### PR TITLE
chore: refactor insight logic to depend on active view less

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -1353,7 +1353,7 @@ describe('insightLogic', () => {
             logic.actions.setLastRefresh('123')
             await expectLogic(logic).toMatchValues({ lastRefresh: '123' })
             logic.actions.setActiveView(InsightType.FUNNELS)
-            await expectLogic(logic).toMatchValues({ lastRefresh: null })
+            await expectLogic(logic).toFinishAllListeners().toMatchValues({ lastRefresh: null })
         })
 
         it('clears erroredQueryId when setting active view', async () => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -513,7 +513,7 @@ export const insightLogic = kea<insightLogicType>([
         ],
         timedOutQueryId: [
             null as string | null,
-            { markInsightTimedOut: (_, { timedOutQueryId }) => timedOutQueryId, setActiveView: () => null },
+            { markInsightTimedOut: (_, { timedOutQueryId }) => timedOutQueryId, loadResult: () => null },
         ],
         maybeShowTimeoutMessage: [
             false,
@@ -522,12 +522,12 @@ export const insightLogic = kea<insightLogicType>([
                 markInsightTimedOut: (_, { timedOutQueryId }) => !!timedOutQueryId,
                 endQuery: (_, { exception }) => !!exception && exception.status !== 500,
                 startQuery: () => false,
-                setActiveView: () => false,
+                loadResult: () => false,
             },
         ],
         erroredQueryId: [
             null as string | null,
-            { markInsightErrored: (_, { erroredQueryId }) => erroredQueryId, setActiveView: () => null },
+            { markInsightErrored: (_, { erroredQueryId }) => erroredQueryId, loadResult: () => null },
         ],
         maybeShowErrorMessage: [
             false,
@@ -540,7 +540,7 @@ export const insightLogic = kea<insightLogicType>([
                 loadInsightFailure: (_, { errorObject }) => errorObject?.status === 0,
                 loadResultsFailure: (_, { errorObject }) => errorObject?.status === 0,
                 startQuery: () => false,
-                setActiveView: () => false,
+                loadResult: () => false,
             },
         ],
         timeout: [null as number | null, { setTimeout: (_, { timeout }) => timeout }],
@@ -549,7 +549,7 @@ export const insightLogic = kea<insightLogicType>([
             {
                 setLastRefresh: (_, { lastRefresh }) => lastRefresh,
                 loadInsightSuccess: (_, { insight }) => insight.last_refresh || null,
-                setActiveView: () => null,
+                loadResult: () => null,
             },
         ],
         nextAllowedRefresh: [
@@ -557,7 +557,7 @@ export const insightLogic = kea<insightLogicType>([
             {
                 setNextAllowedRefresh: (_, { nextAllowedRefresh }) => nextAllowedRefresh,
                 loadInsightSuccess: (_, { insight }) => insight.next_allowed_client_refresh || null,
-                setActiveView: () => null,
+                loadResult: () => null,
             },
         ],
         insightLoading: [
@@ -999,6 +999,8 @@ export const insightLogic = kea<insightLogicType>([
         },
         setActiveView: ({ type }) => {
             actions.setFilters(cleanFilters({ ...values.filters, insight: type as InsightType }, values.filters))
+        },
+        loadResult: () => {
             if (values.timeout) {
                 clearTimeout(values.timeout)
             }


### PR DESCRIPTION
## Problem

The `insightLogic` is super-hyper coupled to `setActiveView` which makes changing the `InsightNav` to support data exploration several shades of tricky

You can see here how many reducers are altered by a call to `insightLogic.setActiveView` in `InsightNav`

![Screenshot 2023-02-21 at 17 18 02](https://user-images.githubusercontent.com/984817/220414911-061d8f0b-a1e1-4e22-84af-ba0420e5afbb.png)

But logically we can remove the need for `setActiveView` as it is being used as a proxy for "filters will have changed so much that you can reset state"

![Screenshot 2023-02-21 at 17 19 14](https://user-images.githubusercontent.com/984817/220415180-0f1f948e-0fff-41df-bf39-51f9d6328a53.png)

We can use `loadResults` instead which is triggered when "filters have changed so much"

## Changes

* replace reactions to `setActiveView` with reactions to `loadResults`

## How did you test this code?

* checking developer tests
* 🧠 