### PR TITLE
fix: adjust attribution type language again

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -173,9 +173,10 @@ export function EditorFilters({ query, setQuery, showing }: EditorFiltersProps):
                           position: 'right',
                           tooltip: (
                               <div>
-                                  Attribution type determines which property value to use for filtering or breakdowns.
-                                  That value is then used for the entire funnel.
-                                  <ul className="list-disc pl-4">
+                                  When breaking funnels down by a property, you can choose how to assign users to the
+                                  various property values. This is useful because property values can change for a
+                                  user/group as someone travels through the funnel.
+                                  <ul className="list-disc pl-4 pt-4">
                                       <li>First step: the first property value seen from all steps is chosen.</li>
                                       <li>Last step: last property value seen from all steps is chosen.</li>
                                       <li>Specific step: the property value seen at that specific step is chosen.</li>

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -195,9 +195,10 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
 
                           tooltip: (
                               <div>
-                                  Attribution type determines which property value to use for filtering or breakdowns.
-                                  That value is then used for the entire funnel.
-                                  <ul className="list-disc pl-4">
+                                  When breaking funnels down by a property, you can choose how to assign users to the
+                                  various property values. This is useful because property values can change for a
+                                  user/group as someone travels through the funnel.
+                                  <ul className="list-disc pl-4 pt-4">
                                       <li>First step: the first property value seen from all steps is chosen.</li>
                                       <li>Last step: last property value seen from all steps is chosen.</li>
                                       <li>Specific step: the property value seen at that specific step is chosen.</li>


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/14318 I said it worked for whole-funnel filters as well, but it doesn't. I also felt like it was still confusing so I reworded things a bit more.

## Changes

![image](https://user-images.githubusercontent.com/18598166/220456160-342c5350-89d5-42da-9bd1-909007bc06b7.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
