### PR TITLE
test(data-exploration): add more funnel data logic tests

### DIFF
--- a/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
+++ b/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
@@ -268,3 +268,23 @@ export const funnelResultWithMultiBreakdown: FunnelResult = {
     last_refresh: '2023-02-22T15:57:24.684263Z',
     is_cached: true,
 }
+
+// 1. Add step "Pageview"
+// 2. Select graph type "Time to convert"
+export const funnelResultTimeToConvert: FunnelResult = {
+    result: {
+        bins: [
+            [4.0, 74],
+            [73591.0, 24],
+            [147178.0, 24],
+            [220765.0, 10],
+            [294352.0, 2],
+            [367939.0, 1],
+            [441526.0, 0],
+        ],
+        average_conversion_time: 86456.76,
+    },
+    timezone: 'UTC',
+    last_refresh: '2023-02-22T17:32:24.245364Z',
+    is_cached: false,
+}

--- a/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
+++ b/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
@@ -1,0 +1,270 @@
+import { FunnelResult } from '~/types'
+
+// 1. Add step "Pageview"
+export const funnelResult: FunnelResult = {
+    result: [
+        {
+            action_id: '$pageview',
+            name: '$pageview',
+            custom_name: null,
+            order: 0,
+            people: [],
+            count: 291,
+            type: 'events',
+            average_conversion_time: null,
+            median_conversion_time: null,
+            converted_people_url:
+                '/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+            dropped_people_url: null,
+        },
+        {
+            action_id: '$pageview',
+            name: '$pageview',
+            custom_name: null,
+            order: 1,
+            people: [],
+            count: 134,
+            type: 'events',
+            average_conversion_time: 87098.67529697785,
+            median_conversion_time: 208.75,
+            converted_people_url:
+                '/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+            dropped_people_url:
+                '/api/person/funnel/?breakdown_attribution_type=first_touch&breakdown_normalize_url=False&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+        },
+    ],
+    timezone: 'UTC',
+    last_refresh: '2023-02-22T08:24:07.710763Z',
+    is_cached: true,
+}
+
+// 1. Add step "Pageview"
+// 2. Add breakdown "Browser"
+export const funnelResultWithBreakdown: FunnelResult = {
+    result: [
+        [
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 0,
+                people: [],
+                count: 136,
+                type: 'events',
+                average_conversion_time: null,
+                median_conversion_time: null,
+                breakdown_value: ['Chrome'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url: null,
+                breakdowns: ['Chrome'],
+            },
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 1,
+                people: [],
+                count: 66,
+                type: 'events',
+                average_conversion_time: 73028.08440653938,
+                median_conversion_time: 112.0,
+                breakdown_value: ['Chrome'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                breakdowns: ['Chrome'],
+            },
+        ],
+        [
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 0,
+                people: [],
+                count: 12,
+                type: 'events',
+                average_conversion_time: null,
+                median_conversion_time: null,
+                breakdown_value: ['Safari'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Safari%22%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url: null,
+                breakdowns: ['Safari'],
+            },
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 1,
+                people: [],
+                count: 6,
+                type: 'events',
+                average_conversion_time: 132776.4872685185,
+                median_conversion_time: 62513.5,
+                breakdown_value: ['Safari'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Safari%22%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Safari%22%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                breakdowns: ['Safari'],
+            },
+        ],
+        [
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 0,
+                people: [],
+                count: 53,
+                type: 'events',
+                average_conversion_time: null,
+                median_conversion_time: null,
+                breakdown_value: ['Firefox'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Firefox%22%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url: null,
+                breakdowns: ['Firefox'],
+            },
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 1,
+                people: [],
+                count: 27,
+                type: 'events',
+                average_conversion_time: 68104.22259380294,
+                median_conversion_time: 112.0,
+                breakdown_value: ['Firefox'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Firefox%22%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Firefox%22%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                breakdowns: ['Firefox'],
+            },
+        ],
+    ],
+    timezone: 'UTC',
+    last_refresh: '2023-02-22T08:29:29.281842Z',
+    is_cached: true,
+}
+
+// 1. Add step "Pageview"
+// 2. Add breakdown "Browser"
+// 3. Add breakdown "OS"
+export const funnelResultWithMultiBreakdown: FunnelResult = {
+    result: [
+        [
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 0,
+                people: [],
+                count: 15,
+                type: 'events',
+                average_conversion_time: null,
+                median_conversion_time: null,
+                breakdown_value: ['Chrome', 'Linux'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%2C+%22Linux%22%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url: null,
+                breakdowns: ['Chrome', 'Linux'],
+            },
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 1,
+                people: [],
+                count: 8,
+                type: 'events',
+                average_conversion_time: 74799.17588141025,
+                median_conversion_time: 18617.0,
+                breakdown_value: ['Chrome', 'Linux'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%2C+%22Linux%22%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%2C+%22Linux%22%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                breakdowns: ['Chrome', 'Linux'],
+            },
+        ],
+        [
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 0,
+                people: [],
+                count: 49,
+                type: 'events',
+                average_conversion_time: null,
+                median_conversion_time: null,
+                breakdown_value: ['Chrome', 'Mac OS X'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%2C+%22Mac+OS+X%22%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url: null,
+                breakdowns: ['Chrome', 'Mac OS X'],
+            },
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 1,
+                people: [],
+                count: 26,
+                type: 'events',
+                average_conversion_time: 81295.60927113237,
+                median_conversion_time: 145.5,
+                breakdown_value: ['Chrome', 'Mac OS X'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%2C+%22Mac+OS+X%22%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Chrome%22%2C+%22Mac+OS+X%22%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                breakdowns: ['Chrome', 'Mac OS X'],
+            },
+        ],
+        [
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 0,
+                people: [],
+                count: 5,
+                type: 'events',
+                average_conversion_time: null,
+                median_conversion_time: null,
+                breakdown_value: ['Internet Explorer', 'Windows'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Internet+Explorer%22%2C+%22Windows%22%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url: null,
+                breakdowns: ['Internet Explorer', 'Windows'],
+            },
+            {
+                action_id: '$pageview',
+                name: '$pageview',
+                custom_name: null,
+                order: 1,
+                people: [],
+                count: 3,
+                type: 'events',
+                average_conversion_time: 105313.06349206349,
+                median_conversion_time: 130763.0,
+                breakdown_value: ['Internet Explorer', 'Windows'],
+                converted_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Internet+Explorer%22%2C+%22Windows%22%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                dropped_people_url:
+                    '/api/person/funnel/?breakdown=%5B%22%24browser%22%2C+%22%24os%22%5D&breakdowns=%5B%7B%22property%22%3A+%22%24browser%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%2C+%7B%22property%22%3A+%22%24os%22%2C+%22type%22%3A+%22event%22%2C+%22normalize_url%22%3A+false%7D%5D&breakdown_attribution_type=first_touch&breakdown_normalize_url=False&breakdown_type=event&date_from=2023-02-15T00%3A00%3A00%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step_breakdown=%5B%22Internet+Explorer%22%2C+%22Windows%22%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100&properties=%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22id%22%2C+%22type%22%3A+%22precalculated-cohort%22%2C+%22value%22%3A+2%7D%5D%7D&sample_factor=&smoothing_intervals=1',
+                breakdowns: ['Internet Explorer', 'Windows'],
+            },
+        ],
+    ],
+    timezone: 'UTC',
+    last_refresh: '2023-02-22T15:57:24.684263Z',
+    is_cached: true,
+}

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -5,8 +5,13 @@ import { teamLogic } from 'scenes/teamLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { funnelDataLogic } from './funnelDataLogic'
 
-import { FunnelVizType, InsightLogicProps, InsightModel } from '~/types'
+import { FunnelVizType, InsightLogicProps, InsightModel, InsightType } from '~/types'
 import { FunnelsQuery, NodeKind } from '~/queries/schema'
+import {
+    funnelResult,
+    funnelResultWithBreakdown,
+    funnelResultWithMultiBreakdown,
+} from './__mocks__/funnelDataLogicMocks'
 
 describe('funnelDataLogic', () => {
     const insightProps: InsightLogicProps = {
@@ -179,15 +184,62 @@ describe('funnelDataLogic', () => {
                 })
             })
 
-            it('with breakdown', async () => {
+            it('for standard funnel', async () => {
                 const insight: Partial<InsightModel> = {
-                    result: { a: 1 },
+                    filters: {
+                        insight: InsightType.FUNNELS,
+                    },
+                    result: funnelResult.result,
                 }
 
                 await expectLogic(logic, () => {
                     builtInsightLogic.actions.setInsight(insight, {})
                 }).toMatchValues({
-                    insight: { b: 5 },
+                    results: funnelResult.result,
+                })
+            })
+
+            it('with breakdown', async () => {
+                const insight: Partial<InsightModel> = {
+                    filters: {
+                        insight: InsightType.FUNNELS,
+                    },
+                    result: funnelResultWithBreakdown.result,
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightLogic.actions.setInsight(insight, {})
+                }).toMatchValues({
+                    results: expect.arrayContaining([
+                        expect.arrayContaining([
+                            expect.objectContaining({
+                                breakdown_value: ['Chrome'],
+                                breakdown: ['Chrome'],
+                            }),
+                        ]),
+                    ]),
+                })
+            })
+
+            it('with multi breakdown', async () => {
+                const insight: Partial<InsightModel> = {
+                    filters: {
+                        insight: InsightType.FUNNELS,
+                    },
+                    result: funnelResultWithMultiBreakdown.result,
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightLogic.actions.setInsight(insight, {})
+                }).toMatchValues({
+                    results: expect.arrayContaining([
+                        expect.arrayContaining([
+                            expect.objectContaining({
+                                breakdown_value: ['Chrome', 'Mac OS X'],
+                                breakdown: ['Chrome', 'Mac OS X'],
+                            }),
+                        ]),
+                    ]),
                 })
             })
         })

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -1,4 +1,4 @@
-import { expectLogic, truth } from 'kea-test-utils'
+import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 
 import { teamLogic } from 'scenes/teamLogic'

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -10,6 +10,7 @@ import {
     InsightLogicProps,
     StepOrderValue,
     InsightType,
+    FunnelsFilterType,
 } from '~/types'
 import { FunnelsQuery, NodeKind } from '~/queries/schema'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -19,6 +20,7 @@ import { groupsModel, Noun } from '~/models/groupsModel'
 import type { funnelDataLogicType } from './funnelDataLogicType'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { isFunnelsQuery } from '~/queries/utils'
+import { isBreakdownFunnelResults } from './funnelUtils'
 
 const DEFAULT_FUNNEL_LOGIC_KEY = 'default_funnel_key'
 
@@ -86,16 +88,21 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
 
         results: [
             (s) => [s.insight],
-            ({ filters, result }): FunnelResultType => {
+            ({
+                filters,
+                result,
+            }: {
+                filters: Partial<FunnelsFilterType>
+                result: FunnelResultType
+            }): FunnelResultType => {
                 if (filters?.insight === InsightType.FUNNELS) {
-                    if (Array.isArray(result) && Array.isArray(result[0]) && result[0][0].breakdowns) {
+                    if (isBreakdownFunnelResults(result) && result[0][0].breakdowns) {
                         // in order to stop the UI having to check breakdowns and breakdown
                         // this collapses breakdowns onto the breakdown property
                         return result.map((series) =>
-                            series.map((r: { [x: string]: any; breakdowns: any; breakdown_value: any }) => {
+                            series.map((r) => {
                                 const { breakdowns, breakdown_value, ...singlePropertyClone } = r
-                                singlePropertyClone.breakdown = breakdowns
-                                singlePropertyClone.breakdown_value = breakdown_value
+                                singlePropertyClone.breakdown = breakdowns as (string | number)[]
                                 return singlePropertyClone
                             })
                         )

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -100,10 +100,10 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
                         // in order to stop the UI having to check breakdowns and breakdown
                         // this collapses breakdowns onto the breakdown property
                         return result.map((series) =>
-                            series.map((r) => {
-                                const { breakdowns, breakdown_value, ...singlePropertyClone } = r
-                                singlePropertyClone.breakdown = breakdowns as (string | number)[]
-                                return singlePropertyClone
+                            series.map((step) => {
+                                const { breakdowns, ...clone } = step
+                                clone.breakdown = breakdowns as (string | number)[]
+                                return clone
                             })
                         )
                     }

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import {
     FilterType,
-    FunnelAPIResponse,
+    FunnelResultType,
     FunnelVizType,
     FunnelStep,
     FunnelStepRangeEntityFilter,
@@ -86,7 +86,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
 
         results: [
             (s) => [s.insight],
-            ({ filters, result }): FunnelAPIResponse => {
+            ({ filters, result }): FunnelResultType => {
                 if (filters?.insight === InsightType.FUNNELS) {
                     if (Array.isArray(result) && Array.isArray(result[0]) && result[0][0].breakdowns) {
                         // in order to stop the UI having to check breakdowns and breakdown
@@ -108,7 +108,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
         ],
         steps: [
             (s) => [s.funnelsFilter, s.results],
-            (funnelsFilter, results: FunnelAPIResponse): FunnelStepWithNestedBreakdown[] => {
+            (funnelsFilter, results: FunnelResultType): FunnelStepWithNestedBreakdown[] => {
                 const stepResults =
                     funnelsFilter?.funnel_viz_type !== FunnelVizType.TimeToConvert
                         ? (results as FunnelStep[] | FunnelStep[][])

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -16,7 +16,7 @@ import {
     FilterType,
     FlattenedFunnelStep,
     FlattenedFunnelStepByBreakdown,
-    FunnelAPIResponse,
+    FunnelResultType,
     FunnelConversionWindowTimeUnit,
     FunnelCorrelation,
     FunnelCorrelationResultsType,
@@ -470,7 +470,7 @@ export const funnelLogic = kea<funnelLogicType>({
         ],
         results: [
             (s) => [s.insight],
-            ({ filters, result }): FunnelAPIResponse => {
+            ({ filters, result }): FunnelResultType => {
                 if (filters?.insight === InsightType.FUNNELS) {
                     if (Array.isArray(result) && Array.isArray(result[0]) && result[0][0].breakdowns) {
                         // in order to stop the UI having to check breakdowns and breakdown
@@ -639,7 +639,7 @@ export const funnelLogic = kea<funnelLogicType>({
             (s) => [s.filters, s.results, s.apiParams],
             (
                 filters: Partial<FunnelsFilterType>,
-                results: FunnelAPIResponse,
+                results: FunnelResultType,
                 apiParams
             ): FunnelStepWithNestedBreakdown[] => {
                 const stepResults =

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -131,7 +131,10 @@ export function isBreakdownFunnelResults(results: FunnelResultType): results is 
 }
 
 // breakdown parameter could be a string (property breakdown) or object/number (list of cohort ids)
-export function isValidBreakdownParameter(breakdown: BreakdownKeyType, breakdowns: Breakdown[]): boolean {
+export function isValidBreakdownParameter(
+    breakdown: BreakdownKeyType | undefined,
+    breakdowns: Breakdown[] | undefined
+): boolean {
     return (
         (Array.isArray(breakdowns) && breakdowns.length > 0) ||
         ['string', 'null', 'undefined', 'number'].includes(typeof breakdown) ||

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -4,7 +4,7 @@ import {
     FunnelStep,
     FunnelStepWithNestedBreakdown,
     BreakdownKeyType,
-    FunnelAPIResponse,
+    FunnelResultType,
     FunnelStepReference,
     FunnelConversionWindow,
     FunnelsFilterType,
@@ -126,7 +126,7 @@ export function aggregateBreakdownResult(
     return []
 }
 
-export function isBreakdownFunnelResults(results: FunnelAPIResponse): results is FunnelStep[][] {
+export function isBreakdownFunnelResults(results: FunnelResultType): results is FunnelStep[][] {
     return Array.isArray(results) && (results.length === 0 || Array.isArray(results[0]))
 }
 

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -1,7 +1,6 @@
 import { clamp } from 'lib/utils'
 import {
     FunnelStepRangeEntityFilter,
-    FunnelRequestParams,
     FunnelStep,
     FunnelStepWithNestedBreakdown,
     BreakdownKeyType,
@@ -9,6 +8,7 @@ import {
     FunnelStepReference,
     FunnelConversionWindow,
     FunnelsFilterType,
+    Breakdown,
 } from '~/types'
 import { dayjs } from 'lib/dayjs'
 import { combineUrl } from 'kea-router'
@@ -131,10 +131,7 @@ export function isBreakdownFunnelResults(results: FunnelAPIResponse): results is
 }
 
 // breakdown parameter could be a string (property breakdown) or object/number (list of cohort ids)
-export function isValidBreakdownParameter(
-    breakdown: FunnelRequestParams['breakdown'],
-    breakdowns: FunnelRequestParams['breakdowns']
-): boolean {
+export function isValidBreakdownParameter(breakdown: BreakdownKeyType, breakdowns: Breakdown[]): boolean {
     return (
         (Array.isArray(breakdowns) && breakdowns.length > 0) ||
         ['string', 'null', 'undefined', 'number'].includes(typeof breakdown) ||

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1747,10 +1747,10 @@ export interface FunnelStep {
     data?: number[]
     days?: string[]
 
-    // Url that you can GET to retrieve the people that converted in this step
+    /** Url that you can GET to retrieve the people that converted in this step */
     converted_people_url: string
 
-    // Url that you can GET to retrieve the people that dropped in this step
+    /** Url that you can GET to retrieve the people that dropped in this step  */
     dropped_people_url: string | null
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1754,28 +1754,33 @@ export interface FunnelStep {
     dropped_people_url: string | null
 }
 
-export interface FunnelStepWithNestedBreakdown extends FunnelStep {
-    nested_breakdown?: FunnelStep[]
+export interface FunnelsTimeConversionBins {
+    bins: [number, number][]
+    average_conversion_time: number
 }
 
 export interface FunnelResult<ResultType = FunnelStep[] | FunnelsTimeConversionBins> {
     is_cached: boolean
     last_refresh: string | null
     result: ResultType
-    type: 'Funnel'
+    timezone: string
 }
 
-export interface FunnelsTimeConversionBins {
-    bins: [number, number][]
-    average_conversion_time: number
+export interface FunnelRequestParams extends FilterType {
+    refresh?: boolean
+    from_dashboard?: boolean | number
+    funnel_window_days?: number
 }
 
-export interface HistogramGraphDatum {
-    id: number
-    bin0: number
-    bin1: number
-    count: number
-    label: string
+export type FunnelAPIResponse = FunnelStep[] | FunnelStep[][] | FunnelsTimeConversionBins
+
+export interface LoadedRawFunnelResults {
+    results: FunnelAPIResponse
+    filters: Partial<FilterType>
+}
+
+export interface FunnelStepWithNestedBreakdown extends FunnelStep {
+    nested_breakdown?: FunnelStep[]
 }
 
 export interface FunnelTimeConversionMetrics {
@@ -1796,19 +1801,6 @@ export enum FunnelConversionWindowTimeUnit {
     Day = 'day',
     Week = 'week',
     Month = 'month',
-}
-
-export interface FunnelRequestParams extends FilterType {
-    refresh?: boolean
-    from_dashboard?: boolean | number
-    funnel_window_days?: number
-}
-
-export type FunnelAPIResponse = FunnelStep[] | FunnelStep[][] | FunnelsTimeConversionBins
-
-export interface LoadedRawFunnelResults {
-    results: FunnelAPIResponse
-    filters: Partial<FilterType>
 }
 
 export enum FunnelStepReference {
@@ -1853,6 +1845,31 @@ export interface FlattenedFunnelStepByBreakdown {
     significant?: boolean
 }
 
+export interface FunnelCorrelation {
+    event: Pick<EventType, 'elements' | 'event' | 'properties'>
+    odds_ratio: number
+    success_count: number
+    success_people_url: string
+    failure_count: number
+    failure_people_url: string
+    correlation_type: FunnelCorrelationType.Failure | FunnelCorrelationType.Success
+    result_type:
+        | FunnelCorrelationResultsType.Events
+        | FunnelCorrelationResultsType.Properties
+        | FunnelCorrelationResultsType.EventWithProperties
+}
+
+export enum FunnelCorrelationType {
+    Success = 'success',
+    Failure = 'failure',
+}
+
+export enum FunnelCorrelationResultsType {
+    Events = 'events',
+    Properties = 'properties',
+    EventWithProperties = 'event_with_properties',
+}
+
 export enum BreakdownAttributionType {
     FirstTouch = 'first_touch',
     LastTouch = 'last_touch',
@@ -1864,6 +1881,14 @@ export interface ChartParams {
     inCardView?: boolean
     inSharedMode?: boolean
     showPersonsModal?: boolean
+}
+
+export interface HistogramGraphDatum {
+    id: number
+    bin0: number
+    bin1: number
+    count: number
+    label: string
 }
 
 // Shared between insightLogic, dashboardItemLogic, trendsLogic, funnelLogic, pathsLogic, retentionLogic
@@ -2279,37 +2304,12 @@ export interface PathEdgeParameters {
     max_edge_weight?: number | undefined
 }
 
-export interface FunnelCorrelation {
-    event: Pick<EventType, 'elements' | 'event' | 'properties'>
-    odds_ratio: number
-    success_count: number
-    success_people_url: string
-    failure_count: number
-    failure_people_url: string
-    correlation_type: FunnelCorrelationType.Failure | FunnelCorrelationType.Success
-    result_type:
-        | FunnelCorrelationResultsType.Events
-        | FunnelCorrelationResultsType.Properties
-        | FunnelCorrelationResultsType.EventWithProperties
-}
-
 export enum SignificanceCode {
     Significant = 'significant',
     NotEnoughExposure = 'not_enough_exposure',
     LowWinProbability = 'low_win_probability',
     HighLoss = 'high_loss',
     HighPValue = 'high_p_value',
-}
-
-export enum FunnelCorrelationType {
-    Success = 'success',
-    Failure = 'failure',
-}
-
-export enum FunnelCorrelationResultsType {
-    Events = 'events',
-    Properties = 'properties',
-    EventWithProperties = 'event_with_properties',
 }
 
 export enum HelpType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1742,7 +1742,7 @@ export interface FunnelStep {
     type: EntityType
     labels?: string[]
     breakdown?: BreakdownKeyType
-    breakdowns?: Breakdown[]
+    breakdowns?: BreakdownKeyType[]
     breakdown_value?: BreakdownKeyType
     data?: number[]
     days?: string[]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1768,11 +1768,6 @@ export interface FunnelResult<ResultType = FunnelStep[] | FunnelsTimeConversionB
 
 export type FunnelAPIResponse = FunnelStep[] | FunnelStep[][] | FunnelsTimeConversionBins
 
-export interface LoadedRawFunnelResults {
-    results: FunnelAPIResponse
-    filters: Partial<FilterType>
-}
-
 export interface FunnelStepWithNestedBreakdown extends FunnelStep {
     nested_breakdown?: FunnelStep[]
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1766,12 +1766,6 @@ export interface FunnelResult<ResultType = FunnelStep[] | FunnelsTimeConversionB
     timezone: string
 }
 
-export interface FunnelRequestParams extends FilterType {
-    refresh?: boolean
-    from_dashboard?: boolean | number
-    funnel_window_days?: number
-}
-
 export type FunnelAPIResponse = FunnelStep[] | FunnelStep[][] | FunnelsTimeConversionBins
 
 export interface LoadedRawFunnelResults {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1759,14 +1759,14 @@ export interface FunnelsTimeConversionBins {
     average_conversion_time: number
 }
 
-export interface FunnelResult<ResultType = FunnelStep[] | FunnelsTimeConversionBins> {
+export type FunnelResultType = FunnelStep[] | FunnelStep[][] | FunnelsTimeConversionBins
+
+export interface FunnelResult<ResultType = FunnelResultType> {
     is_cached: boolean
     last_refresh: string | null
     result: ResultType
     timezone: string
 }
-
-export type FunnelAPIResponse = FunnelStep[] | FunnelStep[][] | FunnelsTimeConversionBins
 
 export interface FunnelStepWithNestedBreakdown extends FunnelStep {
     nested_breakdown?: FunnelStep[]


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/14339.

## Changes

This PR adds tests for `insightsDataLogic` selectors `results` and `steps`. While doing so, it also cleans up funnel related types and adds breakdown support to the `steps` selector.

## How did you test this code?

`pnpm jest funnelD`