### PR TITLE
fix(recordings): keep session_id locality for recording events

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -486,7 +486,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
     kafka_partition_key = None
 
     if event["event"] in ("$snapshot", "$performance_event"):
-        return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
+        return log_event(parsed_event, event["event"], partition_key=event["properties"]["$session_id"])
 
     candidate_partition_key = f"{team_id}:{distinct_id}"
 

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1290,7 +1290,7 @@ class TestCapture(BaseTest):
         self.assertEqual(kafka_produce.call_count, 1)
         self.assertEqual(kafka_produce.call_args_list[0][1]["topic"], KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, None)
+        self.assertEqual(key, session_id)
         data_sent_to_kafka = json.loads(kafka_produce.call_args_list[0][1]["data"]["data"])
 
         # Decompress the data sent to kafka to compare it to the original data

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1231,7 +1231,7 @@ class TestCapture(BaseTest):
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
         self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, None)
+        self.assertEqual(key, "abc123")
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_performance_events_go_to_session_recording_events_topic(self, kafka_produce):
@@ -1264,7 +1264,7 @@ class TestCapture(BaseTest):
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
         self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, None)
+        self.assertEqual(key, "abc123")
 
     @patch("posthog.models.utils.UUIDT", return_value="fake-uuid")
     @patch("posthog.kafka_client.client._KafkaProducer.produce")


### PR DESCRIPTION
Without this, we will process events out of order, and therefore it is
possible that we end up with invalid session recordings in ClickHouse.
This is particuarly important e.g. when we have lag on specific
parttitions.

Note that this doesn't handle ensuring e.g. that we have all chunks of a
multipart snapshot event, it will still be possible to have missing
chunks at any point in time.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
