### PR TITLE
fix: use plugin's 'auto' setting to avoid overlapping values

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -375,6 +375,8 @@ export function LineGraph_({
                     display: (context) => {
                         const datum = context.dataset.data[context.dataIndex]
                         return filters?.show_values_on_series === true && typeof datum === 'number' && datum !== 0
+                            ? 'auto'
+                            : false
                     },
                     formatter: (value: number) => formatAggregationAxisValue(filters, value),
                     borderWidth: 2,

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -133,11 +133,11 @@ export function PieChart({
                                 0
                             ) as number
                             const percentage = ((context.dataset.data[context.dataIndex] as number) / total) * 100
-                            return (
-                                filters?.show_values_on_series !== false && // show if true or unset
+                            return filters?.show_values_on_series !== false && // show if true or unset
                                 context.dataset.data.length > 1 &&
                                 percentage > 5
-                            )
+                                ? 'auto'
+                                : false
                         },
                         padding: (context) => {
                             // in order to make numbers below 10 look circular we need a little padding


### PR DESCRIPTION
## Problem

On smaller or busier charts showing values on series can lead to overlapping values

## Changes

The plugin we are using lets us return "auto" instead of true for whether to "display" a value. In which case it has some heuristics for whether to show a particular value to avoid overlaps.

|||
|-|-|
|before|<img width="1270" alt="Screenshot 2023-02-22 at 12 18 12" src="https://user-images.githubusercontent.com/984817/220617921-09d6b12f-e4c2-482e-b337-f2147869b42b.png">|
|after|<img width="1272" alt="Screenshot 2023-02-22 at 12 15 03" src="https://user-images.githubusercontent.com/984817/220617953-02ceea6e-cd75-4379-a87c-a3a7063800b7.png">|

## How did you test this code?

👀 