### PR TITLE
chore(overflow): Instrument on capacity overflow in plugin-server

### DIFF
--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -1,6 +1,7 @@
 import Piscina from '@posthog/piscina'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 import * as schedule from 'node-schedule'
+import { Counter } from 'prom-client'
 
 import {
     KAFKA_EVENTS_PLUGIN_INGESTION,
@@ -11,10 +12,16 @@ import { Hub } from '../../types'
 import { isIngestionOverflowEnabled } from '../../utils/env-utils'
 import { formPipelineEvent } from '../../utils/event'
 import { status } from '../../utils/status'
-import { ConfiguredLimiter } from '../../utils/token-bucket'
+import { ConfiguredLimiter, LoggingLimiter } from '../../utils/token-bucket'
 import { eachBatch } from './batch-processing/each-batch'
 import { eachBatchIngestion, eachMessageIngestion } from './batch-processing/each-batch-ingestion'
 import { IngestionConsumer } from './kafka-queue'
+
+export const ingestionPartitionKeyOverflowed = new Counter({
+    name: 'ingestion_partition_key_overflowed',
+    help: 'Indicates that a given key has overflowed capacity and been redirected to a different topic. Value incremented once a minute.',
+    labelNames: ['partition_key'],
+})
 
 export const startAnalyticsEventsIngestionConsumer = async ({
     hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
@@ -91,6 +98,11 @@ export async function eachBatchIngestionWithOverflow(
                 // Set message key to be null so we know to send it to overflow topic.
                 // We don't want to do it here to preserve the kafka offset handling
                 message.key = null
+
+                if (LoggingLimiter.consume(seenKey, 1) === true) {
+                    ingestionPartitionKeyOverflowed.labels(seenKey).inc()
+                    status.warn('🪣', `Partition key ${seenKey} overflowed ingestion capacity`)
+                }
             }
 
             if (currentBatch.length >= batchSize || (message.key != null && seenIds.has(seenKey))) {

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -99,8 +99,9 @@ export async function eachBatchIngestionWithOverflow(
                 // We don't want to do it here to preserve the kafka offset handling
                 message.key = null
 
+                ingestionPartitionKeyOverflowed.labels(seenKey).inc()
+
                 if (LoggingLimiter.consume(seenKey, 1) === true) {
-                    ingestionPartitionKeyOverflowed.labels(seenKey).inc()
                     status.warn('🪣', `Partition key ${seenKey} overflowed ingestion capacity`)
                 }
             }

--- a/plugin-server/src/utils/token-bucket.ts
+++ b/plugin-server/src/utils/token-bucket.ts
@@ -75,3 +75,5 @@ export const ConfiguredLimiter: Limiter = new Limiter(
 )
 
 export const WarningLimiter: Limiter = new Limiter(1, 1.0 / 3600)
+
+export const LoggingLimiter: Limiter = new Limiter(1, 1.0 / 60)


### PR DESCRIPTION
## Problem

Ingestion capacity overflow detection is deployed on the Plugin Server but we have little visilibity on how this is working.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds logging and a counter to track overflows. Important that both fire off only once a minute to avoid overflowing metric servers. This is the same behavior we have in the capture endpoint.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
