### PR TITLE
fix: Update 0009 async migration error handling

### DIFF
--- a/posthog/async_migrations/migrations/0009_minmax_indexes_for_materialized_columns.py
+++ b/posthog/async_migrations/migrations/0009_minmax_indexes_for_materialized_columns.py
@@ -60,7 +60,12 @@ class Migration(AsyncMigrationDefinition):
                 {execute_on_cluster}
                 MATERIALIZE INDEX {index_name}
                 """,
-                {"mutations_sync": 2},
+                {
+                    "mutations_sync": 2,
+                    "max_execution_time": 2 * 24 * 60 * 60,  # two days
+                    "send_timeout": 2 * 24 * 60 * 60,  # two days,
+                    "receive_timeout": 2 * 24 * 60 * 60,  # two days,
+                },
             )
         except ServerException as err:
             # We ignore indexes that already exist (due to being added before this migration runs)

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple
 
 import structlog
 from semantic_version.base import SimpleSpec
+from sentry_sdk.api import capture_exception
 
 from posthog.async_migrations.definition import AsyncMigrationDefinition
 from posthog.async_migrations.setup import (
@@ -186,6 +187,7 @@ def run_async_migration_next_op(migration_name: str, migration_instance: Optiona
             current_operation_index=migration_instance.current_operation_index,
             error=e,
         )
+        capture_exception(e)
         process_error(migration_instance, error, alert=True)
 
     if error:


### PR DESCRIPTION
0009 failed on cloud due to a timeout. Bumping timeouts + updating to report to sentry