### PR TITLE
chore: pycharm run config after updating to 3.10

### DIFF
--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -4,17 +4,18 @@
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
       <env name="CLICKHOUSE_SECURE" value="False" />
       <env name="DATABASE_URL" value="postgres://posthog:posthog@localhost:5432/posthog" />
       <env name="DEBUG" value="1" />
       <env name="DJANGO_SETTINGS_MODULE" value="posthog.settings" />
       <env name="KAFKA_URL" value="kafka://localhost" />
       <env name="PRINT_SQL" value="1" />
-      <env name="PYTHONUNBUFFERED" value="1" />
       <env name="SKIP_SERVICE_VERSION_REQUIREMENTS" value="1" />
       <env name="BILLING_SERVICE_URL" value="https://billing.dev.posthog.dev" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
+    <option name="SDK_NAME" value="Python 3.9 (posthog)" />
     <option name="WORKING_DIRECTORY" value="" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -15,7 +15,7 @@
       <env name="BILLING_SERVICE_URL" value="https://billing.dev.posthog.dev" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
-    <option name="SDK_NAME" value="Python 3.9 (posthog)" />
+    <option name="SDK_NAME" value="Python 3.10 (posthog)" />
     <option name="WORKING_DIRECTORY" value="" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />


### PR DESCRIPTION
## Changes

This is the change PyCharm made while I updated to Python 3.9

Does it break for other pycharm users if we merge this?

