### PR TITLE
feat(hogql): intervals

### DIFF
--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -298,6 +298,7 @@ const HogQL: HogQLQuery = {
         '          properties.$geoip_country_name as `Country Name`,\n' +
         '          count() as `Event count`\n' +
         '     from events\n' +
+        '    where timestamp > now() - interval 1 month\n' +
         ' group by event,\n' +
         '          properties.$geoip_country_name\n' +
         ' order by count() desc\n' +

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -408,7 +408,26 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return ast.CompareOperation(left=self.visit(ctx.left), right=self.visit(ctx.right), op=op)
 
     def visitColumnExprInterval(self, ctx: HogQLParser.ColumnExprIntervalContext):
-        raise NotImplementedError(f"Unsupported node: ColumnExprInterval")
+        if ctx.interval().SECOND():
+            name = "toIntervalSecond"
+        elif ctx.interval().MINUTE():
+            name = "toIntervalMinute"
+        elif ctx.interval().HOUR():
+            name = "toIntervalHour"
+        elif ctx.interval().DAY():
+            name = "toIntervalDay"
+        elif ctx.interval().WEEK():
+            name = "toIntervalWeek"
+        elif ctx.interval().MONTH():
+            name = "toIntervalMonth"
+        elif ctx.interval().QUARTER():
+            name = "toIntervalQuarter"
+        elif ctx.interval().YEAR():
+            name = "toIntervalYear"
+        else:
+            raise NotImplementedError(f"Unsupported interval type: {ctx.interval().getText()}")
+
+        return ast.Call(name=name, args=[self.visit(ctx.columnExpr())])
 
     def visitColumnExprIsNull(self, ctx: HogQLParser.ColumnExprIsNullContext):
         return ast.CompareOperation(

--- a/posthog/hogql/test/test_parser.py
+++ b/posthog/hogql/test/test_parser.py
@@ -355,6 +355,24 @@ class TestParser(BaseTest):
             ),
         )
 
+    def test_intervals(self):
+        self.assertEqual(
+            parse_expr("interval 1 month"),
+            ast.Call(name="toIntervalMonth", args=[ast.Constant(value=1)]),
+        )
+        self.assertEqual(
+            parse_expr("now() - interval 1 week"),
+            ast.BinaryOperation(
+                op=ast.BinaryOperationType.Sub,
+                left=ast.Call(name="now", args=[]),
+                right=ast.Call(name="toIntervalWeek", args=[ast.Constant(value=1)]),
+            ),
+        )
+        self.assertEqual(
+            parse_expr("interval event year"),
+            ast.Call(name="toIntervalYear", args=[ast.Field(chain=["event"])]),
+        )
+
     def test_select_columns(self):
         self.assertEqual(parse_select("select 1"), ast.SelectQuery(select=[ast.Constant(value=1)]))
         self.assertEqual(


### PR DESCRIPTION
## Changes

Support syntax like `interval 1 month` to be able to make queries like:

```mysql
   select event,
          properties.$geoip_country_name as `Country Name`,
          count() as `Event count`
     from events
    where timestamp > now() - interval 1 month
 group by event,
          properties.$geoip_country_name
 order by count() desc
    limit 100
```

Currently you'd have to write `toIntervalMonth(1)`, which _is_ supported, but does not look that good.

## How did you test this code?

Added tests. Tested in the browser.