### PR TITLE
chore(ingestion): have populateTeamDataStep log team resolution mismatches

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -3,6 +3,7 @@ import { Counter } from 'prom-client'
 
 import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
 import { PipelineEvent } from '../../../types'
+import { status } from '../../../utils/status'
 import { EventPipelineRunner } from './runner'
 
 export const teamResolutionChecksCounter = new Counter({
@@ -53,6 +54,13 @@ export async function populateTeamDataStep(
             teamResolutionChecksCounter.labels({ check_ok: checkOk }).inc()
             // statsd copy as prometheus is currently not supported in worker threads.
             runner.hub.statsd?.increment('ingestion_team_resolution_checks', { check_ok: checkOk })
+            if (!checkOk) {
+                status.warn(
+                    '🔍',
+                    `Team resolution mismatch for event ${event.uuid}: token "${event.token}" ` +
+                        `resolves to team "${team?.id}" instead of "${event.team_id}"`
+                )
+            }
         }
         return event as PluginEvent
     }

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -50,17 +50,20 @@ export async function populateTeamDataStep(
     if (event.team_id) {
         if (event.token) {
             const team = await runner.hub.teamManager.getTeamByToken(event.token)
-            const checkOk = team?.id === event.team_id ? 'true' : 'false'
-            teamResolutionChecksCounter.labels({ check_ok: checkOk }).inc()
-            // statsd copy as prometheus is currently not supported in worker threads.
-            runner.hub.statsd?.increment('ingestion_team_resolution_checks', { check_ok: checkOk })
-            if (!checkOk) {
+            let checkOk: string
+            if (team?.id === event.team_id) {
+                checkOk = 'true'
+            } else {
+                checkOk = 'false'
                 status.warn(
                     '🔍',
                     `Team resolution mismatch for event ${event.uuid}: token "${event.token}" ` +
                         `resolves to team "${team?.id}" instead of "${event.team_id}"`
                 )
             }
+            teamResolutionChecksCounter.labels({ check_ok: checkOk }).inc()
+            // statsd copy as prometheus is currently not supported in worker threads.
+            runner.hub.statsd?.increment('ingestion_team_resolution_checks', { check_ok: checkOk })
         }
         return event as PluginEvent
     }


### PR DESCRIPTION
## Problem

Follow-up to https://github.com/PostHog/posthog/pull/14341, we do see some points on the `ingestion_team_resolution_checks` counter, indicating mismatches between the team_id
set by capture and the one resolved by plugin-server.

![image](https://user-images.githubusercontent.com/6241083/220871638-a2a76786-7e3d-444d-8be1-2df035fc7620.png)


## Changes

Log these occurrences so that we can determine what is happening. Now that we have confirmed it's a few dozen cases a day, we can be verbose about them.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
