### PR TITLE
chore: add beta tag to ff usage tab

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -460,7 +460,17 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         </Row>
                                     </Tabs.TabPane>
                                     {featureFlags[FEATURE_FLAGS.EXPOSURES_ON_FEATURE_FLAGS] && featureFlag.key && id && (
-                                        <Tabs.TabPane tab="Usage" key="usage">
+                                        <Tabs.TabPane
+                                            tab={
+                                                <div>
+                                                    Usage
+                                                    <LemonTag type="warning" className="uppercase ml-2">
+                                                        Beta
+                                                    </LemonTag>
+                                                </div>
+                                            }
+                                            key="usage"
+                                        >
                                             <UsageTab id={id} featureFlagKey={featureFlag.key} />
                                         </Tabs.TabPane>
                                     )}


### PR DESCRIPTION
## Problem

- usage tab is in testing
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<img width="402" alt="Screen Shot 2023-02-23 at 11 31 11 AM" src="https://user-images.githubusercontent.com/13127476/221010969-afe7f60a-a042-41f3-8c39-8472317b4435.png">

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
