### PR TITLE
feat: use autocapture augment

### DIFF
--- a/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
+++ b/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
@@ -55,6 +55,7 @@ export function NotificationBell(): JSX.Element {
                 className={clsx('h-10 items-center cursor-pointer flex text-primary-alt text-2xl')}
                 onClick={toggleNotificationsPopover}
                 data-attr="notifications-button"
+                data-ph-augment-autocapture-unread-notifications-count={unreadCount}
             >
                 <IconWithCount count={unreadCount} showZero={true} status={hasUnread ? 'primary' : 'muted'}>
                     <IconNotification />


### PR DESCRIPTION
## Problem

When instrumenting the notification button I wanted to know how many unread notifications were visible that (maybe) caused someone to click on the buton.

But to do that I would have had to add a custom event.

## Changes

https://github.com/PostHog/posthog-js/pull/551 will add ability to augment autocapture events. This shows an example of using that feature

## How did you test this code?

Running it locally and seeing it work
