### PR TITLE
fix(plugin-server): default to 1 concurrency for Piscina

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -1,5 +1,3 @@
-import os from 'os'
-
 import { LogLevel, PluginsServerConfig } from '../types'
 import { isDevEnv, isTestEnv, stringToBoolean } from '../utils/env-utils'
 import { KAFKAJS_LOG_LEVEL_MAPPING } from './constants'
@@ -13,8 +11,6 @@ export const defaultConfig = overrideWithEnv(getDefaultConfig())
 export const configHelp = getConfigHelp()
 
 export function getDefaultConfig(): PluginsServerConfig {
-    const coreCount = os.cpus().length
-
     return {
         DATABASE_URL: isTestEnv()
             ? 'postgres://posthog:posthog@localhost:5432/test_posthog'
@@ -56,7 +52,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         POSTHOG_REDIS_PORT: 6379,
         BASE_DIR: '.',
         PLUGINS_RELOAD_PUBSUB_CHANNEL: 'reload-plugins',
-        WORKER_CONCURRENCY: isDevEnv() ? 1 : coreCount,
+        WORKER_CONCURRENCY: 1,
         TASK_TIMEOUT: 30,
         TASKS_PER_WORKER: 10,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,


### PR DESCRIPTION
We're defaulting to the number of cores, which is particularly dangerous
on e.g. K8s where we'll end up thinking we have, like, 64 cores but
that's shared with 100 pods.

It also makes it highly likely that you'll get OOM'd and makes it hard
to set sensible K8s resource limits.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
