### PR TITLE
fix: hide verification pending tag in org settings behind feature flag

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -11,6 +11,7 @@ import type { navigationLogicType } from './navigationLogicType'
 import { membersLogic } from 'scenes/organization/Settings/membersLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export type ProjectNoticeVariant =
     | 'demo_project'
@@ -219,7 +220,10 @@ export const navigationLogic = kea<navigationLogicType>({
                     // Don't show this project-level warning in the PostHog demo environemnt though,
                     // as then Announcement is shown instance-wide
                     return ['demo_project', false]
-                } else if (!user?.is_email_verified && featureFlags['require-email-verification'] === true) {
+                } else if (
+                    !user?.is_email_verified &&
+                    featureFlags[FEATURE_FLAGS.REQUIRE_EMAIL_VERIFICATION] === true
+                ) {
                     return ['unverified_email', false]
                 } else if (
                     !projectNoticesAcknowledged['real_project_with_no_events'] &&

--- a/frontend/src/scenes/organization/Settings/Members.tsx
+++ b/frontend/src/scenes/organization/Settings/Members.tsx
@@ -1,6 +1,6 @@
 import { useValues, useActions } from 'kea'
 import { membersLogic } from './membersLogic'
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
 import { OrganizationMemberType, UserType } from '~/types'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -22,6 +22,7 @@ import { Row } from 'antd'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { useState } from 'react'
 import { Setup2FA } from 'scenes/authentication/Setup2FA'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 function ActionsComponent(_: any, member: OrganizationMemberType): JSX.Element | null {
     const { user } = useValues(userLogic)
@@ -143,6 +144,7 @@ export function Members({ user }: MembersProps): JSX.Element {
     const { setSearch } = useActions(membersLogic)
     const { updateOrganization } = useActions(organizationLogic)
     const [is2FAModalVisible, set2FAModalVisible] = useState(false)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const columns: LemonTableColumns<OrganizationMemberType> = [
         {
@@ -166,14 +168,15 @@ export function Members({ user }: MembersProps): JSX.Element {
                 return (
                     <>
                         {member.user.email}
-                        {!member.user.is_email_verified && (
-                            <>
-                                {' '}
-                                <LemonTag type={'highlight'} data-attr="pending-email-verification">
-                                    pending email verification
-                                </LemonTag>
-                            </>
-                        )}
+                        {!member.user.is_email_verified &&
+                            featureFlags[FEATURE_FLAGS.REQUIRE_EMAIL_VERIFICATION] === true && (
+                                <>
+                                    {' '}
+                                    <LemonTag type={'highlight'} data-attr="pending-email-verification">
+                                        pending email verification
+                                    </LemonTag>
+                                </>
+                            )}
                     </>
                 )
             },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

I forgot to hide the tag in the org settings behind the feature flag for email verification: 

![image](https://user-images.githubusercontent.com/18598166/221258119-2a45c80c-26df-471a-a2f2-3950fee2673d.png)


## Changes

Only shows the tag if the person/org has the flag enabled. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
