### PR TITLE
fix(roles): validation for role names is per organization

### DIFF
--- a/ee/api/role.py
+++ b/ee/api/role.py
@@ -46,7 +46,7 @@ class RoleSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "created_at", "created_by"]
 
     def validate_name(self, name):
-        if Role.objects.filter(name__iexact=name).exists():
+        if Role.objects.filter(name__iexact=name, organization=self.context["request"].user.organization).exists():
             raise serializers.ValidationError("There is already a role with this name.", code="unique")
         return name
 

--- a/ee/api/test/test_role.py
+++ b/ee/api/test/test_role.py
@@ -1,4 +1,3 @@
-from django.db import IntegrityError
 from rest_framework import status
 
 from ee.api.test.base import APILicensedTest
@@ -82,8 +81,8 @@ class TestRoleAPI(APILicensedTest):
         Role.objects.create(name="Marketing", organization=other_org)
         self.assertEqual(Role.objects.count(), 2)
         self.assertEqual(Role.objects.filter(organization=other_org).exists(), True)
-        with self.assertRaises(IntegrityError):
-            Role.objects.create(name="Marketing", organization=self.organization)
+        Role.objects.create(name="Marketing", organization=self.organization)
+        self.assertEqual(Role.objects.count(), 3)
 
     def test_updating_feature_flags_access_level_for_a_role(self):
         role = Role.objects.create(organization=self.organization, name="Engineering")

--- a/ee/api/test/test_role.py
+++ b/ee/api/test/test_role.py
@@ -1,3 +1,4 @@
+from django.db import IntegrityError
 from rest_framework import status
 
 from ee.api.test.base import APILicensedTest
@@ -81,8 +82,8 @@ class TestRoleAPI(APILicensedTest):
         Role.objects.create(name="Marketing", organization=other_org)
         self.assertEqual(Role.objects.count(), 2)
         self.assertEqual(Role.objects.filter(organization=other_org).exists(), True)
-        Role.objects.create(name="Marketing", organization=self.organization)
-        self.assertEqual(Role.objects.count(), 3)
+        with self.assertRaises(IntegrityError):
+            Role.objects.create(name="Marketing", organization=self.organization)
 
     def test_updating_feature_flags_access_level_for_a_role(self):
         role = Role.objects.create(organization=self.organization, name="Engineering")


### PR DESCRIPTION
## Problem

API validation for unique role names was searching across all roles but should only be within the organization's roles

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
