### PR TITLE
fix(recordings): start at specific time from url param

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -324,7 +324,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             const initialSegment = values.sessionPlayerData?.metadata?.segments[0]
             if (initialSegment) {
                 actions.setCurrentSegment(initialSegment)
-                actions.setCurrentPlayerPosition(initialSegment.startPlayerPosition)
+
+                // Ensure seek time initialized from url doesn't get overwritten
+                if (!cache.initializedFromUrl) {
+                    actions.setCurrentPlayerPosition(initialSegment.startPlayerPosition)
+                }
 
                 if (!values.player) {
                     actions.tryInitReplayer()


### PR DESCRIPTION
## Problem

Seeking to a specific time from a single recording was broken because of a logic timing issue.

https://posthog.slack.com/archives/C02KGGDCA6Q/p1677259197493809

https://posthoghelp.zendesk.com/agent/tickets/1882 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/4897)

## Changes

- [x] Add cache.initializedFromURL check to make sure the seek time doesn't get overwritten on initializing the player again.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally
