### PR TITLE
fix: turbo mode persist dashboard filters

### DIFF
--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -34,6 +34,25 @@ describe('Dashboard', () => {
         cy.get('.CardMeta h4').should('have.text', insightName)
     })
 
+    it('Adding new insight to dashboard does not clear filters', () => {
+        const dashboardName = randomString('to add an insight to')
+        const firstInsight = randomString('insight to add to dashboard')
+        const secondInsight = randomString('another insight to add to dashboard')
+
+        // create and visit a dashboard to get it into turbomode cache
+        dashboards.createAndGoToEmptyDashboard(dashboardName)
+        dashboard.addInsightToEmptyDashboard(firstInsight)
+
+        dashboard.addAnyFilter()
+
+        dashboard.addInsightToEmptyDashboard(secondInsight)
+
+        cy.get('.PropertyFilterButton').should('have.length', 1)
+
+        cy.get('.CardMeta h4').should('contain.text', firstInsight)
+        cy.get('.CardMeta h4').should('contain.text', secondInsight)
+    })
+
     it('Cannot see tags or description (non-FOSS feature)', () => {
         cy.get('h1').should('contain', 'Dashboards')
         cy.get('th').contains('Description').should('not.exist')

--- a/cypress/productAnalytics/index.ts
+++ b/cypress/productAnalytics/index.ts
@@ -105,6 +105,15 @@ export const dashboard = {
         cy.get('[data-attr=insight-save-button]').contains('Save & add to dashboard').click()
         cy.wait('@postInsight')
     },
+    addAnyFilter(): void {
+        cy.get('.PropertyFilterButton').should('have.length', 0)
+        cy.get('[data-attr="property-filter-0"]').click()
+        cy.get('[data-attr="taxonomic-filter-searchfield"]').click()
+        cy.get('[data-attr="prop-filter-event_properties-1"]').click({ force: true })
+        cy.get('[data-attr="prop-val"]').click()
+        cy.get('[data-attr="prop-val-0"]').click({ force: true })
+        cy.get('.PropertyFilterButton').should('have.length', 1)
+    },
 }
 
 export function createInsight(insightName: string): void {

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -45,7 +45,8 @@ export function Dashboard({ id, dashboard, placement }: Props = {}): JSX.Element
 function DashboardScene(): JSX.Element {
     const {
         placement,
-        dashboard,
+        // dashboard on dashboardLogic isn't the dashboard on dashboardLogic (╯°□°)╯︵ ┻━┻
+        allItems: dashboard,
         canEditDashboard,
         tiles,
         itemsLoading,


### PR DESCRIPTION
## Problem

see this private slack thread https://posthog.slack.com/archives/C045L1VEG87/p1677065308974459

A customer reported dashboard filters not persisting.

The `dashboard` that we expose on the `dashboardLogic` is actually the `dashboard` on the `dashboardsModel` and the `dashboard` on the `dashboardLogic` is called `allItems`. So, while the `dashboardLogic` was patching its in-memory state internally that state wasn't also patched on the `dashboardsModel` so navigating away (to add an insight) and coming back made it appear that the filter hadn't persisted (it had)

## Changes

use `allItems`

## How did you test this code?

👀  and adding a cypress test
