### PR TITLE
fix(billing): Handle non-billable events

### DIFF
--- a/plugin-server/src/worker/ingestion/property-definitions-manager.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-manager.ts
@@ -22,7 +22,7 @@ import { PropertyDefinitionsCache } from './property-definitions-cache'
 import { TeamManager } from './team-manager'
 
 // for e.g. internal events we don't want to be available for users in the UI
-const EVENTS_WITHOUT_EVENT_DEFINITION = ['$$plugin_metrics']
+const EVENTS_WITHOUT_EVENT_DEFINITION_PREFIX = '$$'
 // These are used internally for manipulating person/group properties
 const NOT_SYNCED_PROPERTIES = new Set([
     '$set',
@@ -86,7 +86,7 @@ export class PropertyDefinitionsManager {
     }
 
     public async updateEventNamesAndProperties(teamId: number, event: string, properties: Properties): Promise<void> {
-        if (EVENTS_WITHOUT_EVENT_DEFINITION.includes(event)) {
+        if (event.indexOf(EVENTS_WITHOUT_EVENT_DEFINITION_PREFIX) === 0) {
             return
         }
 

--- a/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
@@ -267,6 +267,12 @@ describe('PropertyDefinitionsManager()', () => {
                 // extra query for `cacheEventNamesAndProperties` that we did manually before
                 expect(hub.db.postgresQuery).toHaveBeenCalledTimes(2)
             })
+
+            it('ignores non-billable events', async () => {
+                await manager.updateEventNamesAndProperties(teamId, '$$non_billable_event', {})
+                const results = await hub.db.postgresQuery('select * from posthog_eventdefinition', [])
+                expect(results.rows[0]).toEqual(0)
+            })
         })
 
         it('saves person property definitions', async () => {

--- a/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
@@ -270,8 +270,8 @@ describe('PropertyDefinitionsManager()', () => {
 
             it('ignores non-billable events', async () => {
                 await manager.updateEventNamesAndProperties(teamId, '$$non_billable_event', {})
-                const results = await hub.db.postgresQuery('select * from posthog_eventdefinition', [])
-                expect(results.rows[0]).toEqual(0)
+                const results = await hub.db.postgresQuery('select count(1) as c from posthog_eventdefinition', [])
+                expect(results.rows[0].c).toEqual(2)
             })
         })
 

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -684,8 +684,8 @@
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND event IN ['$autocapture', 'user signed up', '$autocapture']
-                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-17 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-20 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-27 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -110,6 +110,14 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     team=self.org_1_team_1,
                 )
 
+            _create_event(
+                distinct_id=distinct_id,
+                event="$$non_billable_event",
+                properties={"$lib": "$web"},
+                timestamp=now() - relativedelta(hours=12),
+                team=self.org_1_team_1,
+            )
+
             # Events before the period
             for _ in range(0, 10):
                 _create_event(

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -292,6 +292,7 @@ def get_teams_with_event_count_lifetime() -> List[Tuple[int, int]]:
         """
         SELECT team_id, count(1) as count
         FROM events
+        WHERE not startsWith(event, '$$')
         GROUP BY team_id
     """
     )
@@ -304,6 +305,7 @@ def get_teams_with_event_count_in_period(begin: datetime, end: datetime) -> List
         SELECT team_id, count(1) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s
+        AND not startsWith(event, '$$')
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},
@@ -318,6 +320,7 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s
         AND ($group_0 != '' OR $group_1 != '' OR $group_2 != '' OR $group_3 != '' OR $group_4 != '')
+        AND not startsWith(event, '$$')
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},
@@ -331,6 +334,7 @@ def get_teams_with_event_count_by_lib(begin: datetime, end: datetime) -> List[Tu
         SELECT team_id, JSONExtractString(properties, '$lib') as lib, COUNT(1) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s
+        AND not startsWith(event, '$$')
         GROUP BY lib, team_id
     """,
         {"begin": begin, "end": end},
@@ -344,6 +348,7 @@ def get_teams_with_event_count_by_name(begin: datetime, end: datetime) -> List[T
         SELECT team_id, event, COUNT(1) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s
+        AND not startsWith(event, '$$')
         GROUP BY event, team_id
     """,
         {"begin": begin, "end": end},


### PR DESCRIPTION
## Problem

Events starting with `$$` are internal events and shouldn't be billed or shown in the interface.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Filter out events starting with `$$` from the interface and billing.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
