### PR TITLE
test(insights): Use `mockDate` in `SavedInsights.stories.tsx`

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.stories.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.stories.tsx
@@ -21,6 +21,7 @@ export default {
         options: { showPanel: false },
         testOptions: {
             excludeNavigationFromSnapshot: true,
+            waitForLoadersToDisappear: 1000,
         },
         viewMode: 'story',
         mockDate: '2023-02-18',

--- a/frontend/src/scenes/saved-insights/SavedInsights.stories.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.stories.tsx
@@ -23,6 +23,7 @@ export default {
             excludeNavigationFromSnapshot: true,
         },
         viewMode: 'story',
+        mockDate: '2023-02-18',
     },
     decorators: [
         mswDecorator({


### PR DESCRIPTION
## Changes

Looks like relative dates have cause Saved Insights snapshots to be updated on other PRs. Let's set the date in stone to prevent this.