### PR TITLE
chore(compose): update kafka to latest, to use arm64 image

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -34,7 +34,7 @@ services:
         restart: on-failure
 
     kafka:
-        image: bitnami/kafka:2.8.1-debian-10-r99
+        image: bitnami/kafka:3.4.0-debian-11-r6
         restart: on-failure
         depends_on:
             - zookeeper


### PR DESCRIPTION
## Problem

The kafka container has been the less reliable part of the local devenv for a while now. We suspect it's because it's a amd64 image, running with emulation.

## Changes

Update the kafka image to use the [new arm64 builds](https://blog.bitnami.com/2023/02/bitnami-arm-containers-available-at.html). Because they didn't push an arm64 build for the old 2.8 versions, I'm upgrading to 3.4.0, let's evaluate for a couple of days whether it causes an issue before merging.

## How did you test this code?

Works on my machine ™️ 