### PR TITLE
chore(recordings): remove hub dependency on recordings ingestion

### DIFF
--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -462,6 +462,20 @@ test.concurrent(
     20000
 )
 
+test.concurrent(`liveness check endpoint works`, async () => {
+    await waitForExpect(async () => {
+        const response = await fetch('http://localhost:6738/_health')
+        expect(response.status).toBe(200)
+
+        const body = await response.json()
+        expect(body).toEqual(
+            expect.objectContaining({
+                checks: expect.objectContaining({ 'session-recordings': 'ok' }),
+            })
+        )
+    })
+})
+
 test.concurrent(
     `consumer handles empty messages`,
     async () => {

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -8,6 +8,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
     switch (mode) {
         case null:
             return {
+                mmdb: true,
                 ingestion: true,
                 ingestionOverflow: true,
                 pluginScheduledTasks: true,
@@ -19,22 +20,34 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case 'ingestion':
             // NOTE: this mode will be removed in the future and replaced with
             // `analytics-ingestion` and `recordings-ingestion` modes.
-            return { ingestion: true, sessionRecordingIngestion: true, ...sharedCapabilities }
+            return {
+                mmdb: true,
+                ingestion: true,
+                sessionRecordingIngestion: true,
+                ...sharedCapabilities,
+            }
         case 'ingestion-overflow':
-            return { ingestionOverflow: true, ...sharedCapabilities }
+            return {
+                mmdb: true,
+                ingestionOverflow: true,
+                ...sharedCapabilities,
+            }
         case 'analytics-ingestion':
             return {
+                mmdb: true,
                 ingestion: true,
                 ...sharedCapabilities,
             }
         case 'recordings-ingestion':
             return {
+                mmdb: false,
                 sessionRecordingIngestion: true,
                 ...sharedCapabilities,
             }
 
         case 'async':
             return {
+                mmdb: true,
                 processPluginJobs: true,
                 processAsyncHandlers: true,
                 pluginScheduledTasks: true,
@@ -42,17 +55,20 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             }
         case 'exports':
             return {
+                mmdb: true,
                 processAsyncHandlers: true,
                 ...sharedCapabilities,
             }
         case 'jobs': {
             return {
+                mmdb: true,
                 processPluginJobs: true,
                 ...sharedCapabilities,
             }
         }
         case 'scheduler':
             return {
+                mmdb: true,
                 pluginScheduledTasks: true,
                 ...sharedCapabilities,
             }

--- a/plugin-server/src/index.ts
+++ b/plugin-server/src/index.ts
@@ -1,4 +1,5 @@
 import { Hub } from '../src/types'
+import { getPluginServerCapabilities } from './capabilities'
 import { defaultConfig, formatConfigHelp } from './config/config'
 import { healthcheckWithExit } from './healthcheck'
 import { initApp } from './init'
@@ -62,6 +63,7 @@ switch (alternativeMode) {
     default:
         // void the returned promise
         initApp(defaultConfig)
-        void startPluginsServer(defaultConfig, makePiscina)
+        const capabilities = getPluginServerCapabilities(defaultConfig)
+        void startPluginsServer(defaultConfig, makePiscina, capabilities)
         break
 }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -49,7 +49,7 @@ export async function startPluginsServer(
     config: Partial<PluginsServerConfig>,
     makePiscina: (config: PluginsServerConfig) => Piscina = defaultMakePiscina,
     capabilities: PluginServerCapabilities | undefined
-): Promise<Partial<ServerInstance> | undefined> {
+): Promise<Partial<ServerInstance>> {
     const timer = new Date()
 
     const serverConfig: PluginsServerConfig = {
@@ -436,7 +436,7 @@ export async function startPluginsServer(
             httpServer = createHttpServer(healthChecks, analyticsEventsIngestionConsumer)
         }
 
-        return serverInstance
+        return serverInstance ?? { stop: closeJobs }
     } catch (error) {
         Sentry.captureException(error)
         status.error('💥', 'Launchpad failure!', { error: error.stack ?? error })

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -9,13 +9,14 @@ import { Counter } from 'prom-client'
 
 import { defaultConfig } from '../config/config'
 import { Hub, PluginServerCapabilities, PluginsServerConfig } from '../types'
-import { createHub } from '../utils/db/hub'
+import { createHub, createKafkaClient, KafkaConfig } from '../utils/db/hub'
 import { killProcess } from '../utils/kill'
 import { captureEventLoopMetrics } from '../utils/metrics'
 import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
-import { delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
+import { createPostgresPool, delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
+import { TeamManager } from '../worker/ingestion/team-manager'
 import { makePiscina as defaultMakePiscina } from '../worker/piscina'
 import { GraphileWorker } from './graphile-worker/graphile-worker'
 import { loadPluginSchedule } from './graphile-worker/schedule'
@@ -46,8 +47,8 @@ export type ServerInstance = {
 export async function startPluginsServer(
     config: Partial<PluginsServerConfig>,
     makePiscina: (config: PluginsServerConfig) => Piscina = defaultMakePiscina,
-    capabilities: PluginServerCapabilities | null = null
-): Promise<ServerInstance> {
+    capabilities: PluginServerCapabilities
+): Promise<Partial<ServerInstance> | undefined> {
     const timer = new Date()
 
     const serverConfig: PluginsServerConfig = {
@@ -98,7 +99,7 @@ export async function startPluginsServer(
 
     let graphileWorker: GraphileWorker | undefined
 
-    let closeHub: () => Promise<void> | undefined
+    let closeHub: (() => Promise<void>) | undefined
 
     let lastActivityCheck: NodeJS.Timeout | undefined
     let stopEventLoopMetrics: (() => void) | undefined
@@ -208,18 +209,16 @@ export async function startPluginsServer(
         process.exit(1)
     })
 
+    let serverInstance: (Partial<ServerInstance> & Pick<ServerInstance, 'hub'>) | undefined
+
     try {
-        ;[hub, closeHub] = await createHub(serverConfig, null, capabilities)
+        if (!serverConfig.DISABLE_MMDB && capabilities.mmdb) {
+            ;[hub, closeHub] = await createHub(serverConfig, null, capabilities)
+            serverInstance = { hub }
 
-        const serverInstance: Partial<ServerInstance> & Pick<ServerInstance, 'hub'> = {
-            hub,
-        }
-
-        if (!serverConfig.DISABLE_MMDB) {
             serverInstance.mmdb = (await prepareMmdb(serverInstance)) ?? undefined
-            serverInstance.mmdbUpdateJob = schedule.scheduleJob(
-                '0 */4 * * *',
-                async () => await performMmdbStalenessCheck(serverInstance)
+            serverInstance.mmdbUpdateJob = schedule.scheduleJob('0 */4 * * *', async () =>
+                serverInstance ? await performMmdbStalenessCheck(serverInstance) : null
             )
             mmdbServer = await createMmdbServer(serverInstance)
             serverConfig.INTERNAL_MMDB_SERVER_PORT = (mmdbServer.address() as AddressInfo).port
@@ -237,7 +236,10 @@ export async function startPluginsServer(
         // 3. clickhouse_events_json and plugin_events_ingestion
         // 4. conversion_events_buffer
         //
-        if (hub.capabilities.processPluginJobs || hub.capabilities.pluginScheduledTasks) {
+        if (capabilities.processPluginJobs || capabilities.pluginScheduledTasks) {
+            ;[hub, closeHub] = hub ? [hub, closeHub] : await createHub(serverConfig, null, capabilities)
+            serverInstance = serverInstance ? serverInstance : { hub }
+
             graphileWorker = new GraphileWorker(hub)
             // `connectProducer` just runs the PostgreSQL migrations. Ideally it
             // would be great to move the migration to bin/migrate and ensure we
@@ -250,7 +252,7 @@ export async function startPluginsServer(
             piscina = piscina ?? makePiscina(serverConfig)
             await startGraphileWorker(hub, graphileWorker, piscina)
 
-            if (hub.capabilities.pluginScheduledTasks) {
+            if (capabilities.pluginScheduledTasks) {
                 schedulerTasksConsumer = await startScheduledTasksConsumer({
                     piscina: piscina,
                     kafka: hub.kafka,
@@ -260,7 +262,7 @@ export async function startPluginsServer(
                 })
             }
 
-            if (hub.capabilities.processPluginJobs) {
+            if (capabilities.processPluginJobs) {
                 jobsConsumer = await startJobsConsumer({
                     kafka: hub.kafka,
                     producer: hub.kafkaProducer.producer,
@@ -270,16 +272,10 @@ export async function startPluginsServer(
             }
         }
 
-        if (hub.capabilities.sessionRecordingIngestion) {
-            sessionRecordingEventsConsumer = await startSessionRecordingEventsConsumer({
-                teamManager: hub.teamManager,
-                kafka: hub.kafka,
-                partitionsConsumedConcurrently: serverConfig.RECORDING_PARTITIONS_CONSUMED_CONCURRENTLY,
-                statsd: hub.statsd,
-            })
-        }
+        if (capabilities.ingestion) {
+            ;[hub, closeHub] = hub ? [hub, closeHub] : await createHub(serverConfig, null, capabilities)
+            serverInstance = serverInstance ? serverInstance : { hub }
 
-        if (hub.capabilities.ingestion) {
             piscina = piscina ?? makePiscina(serverConfig)
             analyticsEventsIngestionConsumer = await startAnalyticsEventsIngestionConsumer({
                 hub: hub,
@@ -295,7 +291,10 @@ export async function startPluginsServer(
             })
         }
 
-        if (hub.capabilities.ingestionOverflow) {
+        if (capabilities.ingestionOverflow) {
+            ;[hub, closeHub] = hub ? [hub, closeHub] : await createHub(serverConfig, null, capabilities)
+            serverInstance = serverInstance ? serverInstance : { hub }
+
             piscina = piscina ?? makePiscina(serverConfig)
             analyticsEventsIngestionOverflowConsumer = await startAnalyticsEventsIngestionOverflowConsumer({
                 hub: hub,
@@ -303,7 +302,10 @@ export async function startPluginsServer(
             })
         }
 
-        if (hub.capabilities.processAsyncHandlers) {
+        if (capabilities.processAsyncHandlers) {
+            ;[hub, closeHub] = hub ? [hub, closeHub] : await createHub(serverConfig, null, capabilities)
+            serverInstance = serverInstance ? serverInstance : { hub }
+
             piscina = piscina ?? makePiscina(serverConfig)
             onEventHandlerConsumer = await startOnEventHandlerConsumer({
                 hub: hub,
@@ -311,11 +313,8 @@ export async function startPluginsServer(
             })
         }
 
-        if (config.PLUGIN_SERVER_MODE !== 'recordings-ingestion') {
-            // If we are only running the recording ingestion, we don't need to
-            // start any pubsub or schedules.
-
-            // use one extra Redis connection for pub-sub
+        // If we have
+        if (hub && serverInstance) {
             pubSub = new PubSub(hub, {
                 [hub.PLUGINS_RELOAD_PUBSUB_CHANNEL]: async () => {
                     status.info('⚡', 'Reloading plugins!')
@@ -329,7 +328,7 @@ export async function startPluginsServer(
                 'reset-available-features-cache': async (message) => {
                     await piscina?.broadcastTask({ task: 'resetAvailableFeaturesCache', args: JSON.parse(message) })
                 },
-                ...(hub.capabilities.processAsyncHandlers
+                ...(capabilities.processAsyncHandlers
                     ? {
                           'reload-action': async (message) =>
                               await piscina?.broadcastTask({ task: 'reloadAction', args: JSON.parse(message) }),
@@ -362,63 +361,80 @@ export async function startPluginsServer(
                     }
                 }
             })
-        }
 
-        if (hub.statsd) {
-            stopEventLoopMetrics = captureEventLoopMetrics(hub.statsd, hub.instanceId)
-        }
+            if (hub.statsd) {
+                stopEventLoopMetrics = captureEventLoopMetrics(hub.statsd, hub.instanceId)
+            }
 
-        if (serverConfig.STALENESS_RESTART_SECONDS > 0) {
-            // check every 10 sec how long it has been since the last activity
+            if (serverConfig.STALENESS_RESTART_SECONDS > 0) {
+                // check every 10 sec how long it has been since the last activity
 
-            let lastFoundActivity: number
-            lastActivityCheck = setInterval(() => {
-                const stalenessCheckResult = stalenessCheck(hub, serverConfig.STALENESS_RESTART_SECONDS)
+                let lastFoundActivity: number
+                lastActivityCheck = setInterval(() => {
+                    const stalenessCheckResult = stalenessCheck(hub, serverConfig.STALENESS_RESTART_SECONDS)
 
-                if (
-                    hub?.lastActivity &&
-                    stalenessCheckResult.isServerStale &&
-                    lastFoundActivity !== hub?.lastActivity
-                ) {
-                    lastFoundActivity = hub?.lastActivity
-                    const extra = {
-                        piscina: piscina ? JSON.stringify(getPiscinaStats(piscina)) : null,
-                        ...stalenessCheckResult,
-                    }
-                    Sentry.captureMessage(
-                        `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
-                        {
-                            extra,
+                    if (
+                        hub?.lastActivity &&
+                        stalenessCheckResult.isServerStale &&
+                        lastFoundActivity !== hub?.lastActivity
+                    ) {
+                        lastFoundActivity = hub?.lastActivity
+                        const extra = {
+                            piscina: piscina ? JSON.stringify(getPiscinaStats(piscina)) : null,
+                            ...stalenessCheckResult,
                         }
-                    )
-                    console.log(
-                        `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
-                        extra
-                    )
-                    hub?.statsd?.increment(`alerts.stale_plugin_server_restarted`)
+                        Sentry.captureMessage(
+                            `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
+                            {
+                                extra,
+                            }
+                        )
+                        console.log(
+                            `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
+                            extra
+                        )
+                        hub?.statsd?.increment(`alerts.stale_plugin_server_restarted`)
 
-                    killProcess()
-                }
-            }, Math.min(serverConfig.STALENESS_RESTART_SECONDS, 10000))
+                        killProcess()
+                    }
+                }, Math.min(serverConfig.STALENESS_RESTART_SECONDS, 10000))
+            }
+
+            serverInstance.piscina = piscina
+            serverInstance.queue = analyticsEventsIngestionConsumer
+            serverInstance.stop = closeJobs
+
+            hub.statsd?.timing('total_setup_time', timer)
+            status.info('🚀', 'All systems go')
+
+            hub.lastActivity = new Date().valueOf()
+            hub.lastActivityType = 'serverStart'
         }
 
-        serverInstance.piscina = piscina
-        serverInstance.queue = analyticsEventsIngestionConsumer
-        serverInstance.stop = closeJobs
+        // A collection of healthchecks that should be used to validate the
+        // health of the plugin-server. These are used by the /_health endpoint
+        // to determine if we should trigger a restart of the pod. These should
+        // be super lightweight and ideally not do any IO.
+        const healthChecks: { [service: string]: () => Promise<boolean> } = {}
 
-        hub.statsd?.timing('total_setup_time', timer)
-        status.info('🚀', 'All systems go')
-
-        hub.lastActivity = new Date().valueOf()
-        hub.lastActivityType = 'serverStart'
-
-        if (hub.capabilities.http) {
-            // start http server used for the healthcheck
-            // TODO: include bufferConsumer in healthcheck
-            httpServer = createHttpServer(analyticsEventsIngestionConsumer)
+        if (capabilities.sessionRecordingIngestion) {
+            const kafka = createKafkaClient(serverConfig as KafkaConfig)
+            const postgres = createPostgresPool(serverConfig.DATABASE_URL)
+            const teamManager = new TeamManager(postgres, serverConfig)
+            const { consumer, isHealthy: isSessionRecordingsHealthy } = await startSessionRecordingEventsConsumer({
+                teamManager: teamManager,
+                kafka: kafka,
+                partitionsConsumedConcurrently: serverConfig.RECORDING_PARTITIONS_CONSUMED_CONCURRENTLY,
+            })
+            sessionRecordingEventsConsumer = consumer
+            healthChecks.sessionRecordings = isSessionRecordingsHealthy
         }
 
-        return serverInstance as ServerInstance
+        if (capabilities.http) {
+            httpServer = createHttpServer(healthChecks, analyticsEventsIngestionConsumer)
+        }
+
+        return serverInstance
     } catch (error) {
         Sentry.captureException(error)
         status.error('💥', 'Launchpad failure!', { error: error.stack ?? error })

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -7,6 +7,7 @@ import net, { AddressInfo } from 'net'
 import * as schedule from 'node-schedule'
 import { Counter } from 'prom-client'
 
+import { getPluginServerCapabilities } from '../capabilities'
 import { defaultConfig } from '../config/config'
 import { Hub, PluginServerCapabilities, PluginsServerConfig } from '../types'
 import { createHub, createKafkaClient, KafkaConfig } from '../utils/db/hub'
@@ -47,7 +48,7 @@ export type ServerInstance = {
 export async function startPluginsServer(
     config: Partial<PluginsServerConfig>,
     makePiscina: (config: PluginsServerConfig) => Piscina = defaultMakePiscina,
-    capabilities: PluginServerCapabilities
+    capabilities: PluginServerCapabilities | undefined
 ): Promise<Partial<ServerInstance> | undefined> {
     const timer = new Date()
 
@@ -209,6 +210,7 @@ export async function startPluginsServer(
         process.exit(1)
     })
 
+    capabilities = capabilities ?? getPluginServerCapabilities(serverConfig)
     let serverInstance: (Partial<ServerInstance> & Pick<ServerInstance, 'hub'>) | undefined
 
     try {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -429,7 +429,7 @@ export async function startPluginsServer(
                 partitionsConsumedConcurrently: serverConfig.RECORDING_PARTITIONS_CONSUMED_CONCURRENTLY,
             })
             sessionRecordingEventsConsumer = consumer
-            healthChecks.sessionRecordings = isSessionRecordingsHealthy
+            healthChecks['session-recordings'] = isSessionRecordingsHealthy
         }
 
         if (capabilities.http) {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -420,9 +420,9 @@ export async function startPluginsServer(
         const healthChecks: { [service: string]: () => Promise<boolean> } = {}
 
         if (capabilities.sessionRecordingIngestion) {
-            const kafka = createKafkaClient(serverConfig as KafkaConfig)
-            const postgres = createPostgresPool(serverConfig.DATABASE_URL)
-            const teamManager = new TeamManager(postgres, serverConfig)
+            const kafka = hub?.kafka ?? createKafkaClient(serverConfig as KafkaConfig)
+            const postgres = hub?.postgres ?? createPostgresPool(serverConfig.DATABASE_URL)
+            const teamManager = hub?.teamManager ?? new TeamManager(postgres, serverConfig)
             const { consumer, isHealthy: isSessionRecordingsHealthy } = await startSessionRecordingEventsConsumer({
                 teamManager: teamManager,
                 kafka: kafka,

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -15,7 +15,35 @@ export function createHttpServer(
     const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
         if (req.url === '/_health' && req.method === 'GET') {
             status.info('💚', 'Server liveness check succeeded')
-            const checkResults = await Promise.allSettled(
+            // Check that all health checks pass. Note that a failure of these
+            // _may_ result in the process being terminated by e.g. Kubernetes
+            // so the stakes are high.
+            //
+            // Also, Kubernetes will call this endpoint frequently, on each pod,
+            // so we want to make sure it's fast and doesn't put any stress on
+            // other services. Ideally it shouldn't make any calls to other
+            // services.
+            //
+            // Here we take all of the health checks we are given, run them in
+            // parallel, and return the results. If any of the checks fail, we
+            // return a 503 status code, otherwise we return a 200 status code.
+            //
+            // In all cases we should return a JSON object with the following
+            // structure:
+            //
+            // {
+            //   "status": "ok" | "error",
+            //   "checks": {
+            //     "service1": "ok" | "error",
+            //     "service2": "ok" | "error",
+            //     ...
+            //   }
+            // }
+            const checkResults = await Promise.all(
+                // Note that we do not ues `Promise.allSettled` here so we can
+                // assume that all promises have resolved. If there was a
+                // rejected promise, the http server should catch it and return
+                // a 500 status code.
                 Object.entries(healthChecks).map(async ([service, check]) => {
                     try {
                         return { service, status: (await check()) ? 'ok' : 'error' }
@@ -24,13 +52,15 @@ export function createHttpServer(
                     }
                 })
             )
-            const statusCode = checkResults.every(
-                (result) => result.status === 'fulfilled' && result.value.status === 'ok'
+
+            const statusCode = checkResults.every((result) => result.status === 'ok') ? 200 : 503
+
+            const checkResultsMapping = Object.fromEntries(
+                checkResults.map((result) => [result.service, result.status])
             )
-                ? 200
-                : 503
+
             res.statusCode = statusCode
-            res.end(JSON.stringify({ status: statusCode === 200 ? 'ok' : 'error', checks: checkResults }))
+            res.end(JSON.stringify({ status: statusCode === 200 ? 'ok' : 'error', checks: checkResultsMapping }))
         } else if (req.url === '/_ready' && req.method === 'GET') {
             // Check that, if the server should have a kafka queue,
             // the Kafka consumer is ready to consume messages

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -226,6 +226,7 @@ export interface PluginServerCapabilities {
     processAsyncHandlers?: boolean
     sessionRecordingIngestion?: boolean
     http?: boolean
+    mmdb?: boolean
 }
 
 export type EnqueuedJob = EnqueuedPluginJob | GraphileWorkerCronScheduleJob

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -130,7 +130,7 @@ export interface CachedGroupData {
     created_at: ClickHouseTimestamp
 }
 
-const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
+export const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'connection to server at',
     'could not translate host',
     'server conn crashed',
@@ -1459,53 +1459,6 @@ export class DB {
             'fetchOrganization'
         )
         return selectResult.rows[0]
-    }
-
-    // Team
-
-    public async fetchTeam(teamId: Team['id']): Promise<Team | null> {
-        const selectResult = await this.postgresQuery<Team>(
-            `
-            SELECT
-                id,
-                uuid,
-                organization_id,
-                name,
-                anonymize_ips,
-                api_token,
-                slack_incoming_webhook,
-                session_recording_opt_in,
-                ingested_event
-            FROM posthog_team
-            WHERE id = $1
-            `,
-            [teamId],
-            'fetchTeam'
-        )
-        return selectResult.rows[0] ?? null
-    }
-
-    public async fetchTeamByToken(token: string): Promise<Team | null> {
-        const selectResult = await this.postgresQuery<Team>(
-            `
-            SELECT
-                id,
-                uuid,
-                organization_id,
-                name,
-                anonymize_ips,
-                api_token,
-                slack_incoming_webhook,
-                session_recording_opt_in,
-                ingested_event
-            FROM posthog_team
-            WHERE api_token = $1
-            LIMIT 1
-                `,
-            [token],
-            'fetchTeamByToken'
-        )
-        return selectResult.rows[0] ?? null
     }
 
     // Hook (EE)

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -53,6 +53,7 @@ import {
     TeamId,
     TimestampFormat,
 } from '../../types'
+import { fetchTeam, fetchTeamByToken } from '../../worker/ingestion/team-manager'
 import { parseRawClickHouseEvent } from '../event'
 import { instrumentQuery } from '../metrics'
 import { status } from '../status'
@@ -70,9 +71,9 @@ import { OrganizationPluginsAccessLevel } from './../../types'
 import { PromiseManager } from './../../worker/vm/promise-manager'
 import { DependencyUnavailableError } from './error'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
+import { postgresQuery } from './postgres'
 import {
     generateKafkaPersonUpdateMessage,
-    getFinalPostgresQuery,
     safeClickhouseString,
     shouldStoreLog,
     timeoutGuard,
@@ -193,37 +194,7 @@ export class DB {
         tag: string,
         client?: PoolClient
     ): Promise<QueryResult<R>> {
-        return instrumentQuery(this.statsd, 'query.postgres', tag, async () => {
-            let fullQuery = ''
-            try {
-                fullQuery = getFinalPostgresQuery(queryString, values as any[])
-            } catch {}
-            const timeout = timeoutGuard('Postgres slow query warning after 30 sec', {
-                queryString,
-                values,
-                fullQuery,
-            })
-
-            // Annotate query string to give context when looking at DB logs
-            queryString = `/* plugin-server:${tag} */ ${queryString}`
-            try {
-                if (client) {
-                    return await client.query(queryString, values)
-                } else {
-                    return await this.postgres.query(queryString, values)
-                }
-            } catch (error) {
-                if (
-                    error.message &&
-                    POSTGRES_UNAVAILABLE_ERROR_MESSAGES.some((message) => error.message.includes(message))
-                ) {
-                    throw new DependencyUnavailableError(error.message, 'Postgres', error)
-                }
-                throw error
-            } finally {
-                clearTimeout(timeout)
-            }
-        })
+        return postgresQuery(client ?? this.postgres, queryString, values, tag, this.statsd)
     }
 
     public postgresTransaction<ReturnType>(
@@ -1459,6 +1430,16 @@ export class DB {
             'fetchOrganization'
         )
         return selectResult.rows[0]
+    }
+
+    // Team
+
+    public async fetchTeam(teamId: Team['id']): Promise<Team | null> {
+        return await fetchTeam(this.postgres, teamId)
+    }
+
+    public async fetchTeamByToken(token: string): Promise<Team | null> {
+        return await fetchTeamByToken(this.postgres, token)
     }
 
     // Hook (EE)

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -19,6 +19,7 @@ import { connectObjectStorage } from '../../main/services/object_storage'
 import {
     EnqueuedPluginJob,
     Hub,
+    KafkaSaslMechanism,
     KafkaSecurityProtocol,
     PluginServerCapabilities,
     PluginsServerConfig,
@@ -104,39 +105,6 @@ export async function createHub(
         status.info('👍', `StatsD ready`)
     }
 
-    let kafkaSsl: ConnectionOptions | boolean | undefined
-    if (
-        serverConfig.KAFKA_CLIENT_CERT_B64 &&
-        serverConfig.KAFKA_CLIENT_CERT_KEY_B64 &&
-        serverConfig.KAFKA_TRUSTED_CERT_B64
-    ) {
-        kafkaSsl = {
-            cert: Buffer.from(serverConfig.KAFKA_CLIENT_CERT_B64, 'base64'),
-            key: Buffer.from(serverConfig.KAFKA_CLIENT_CERT_KEY_B64, 'base64'),
-            ca: Buffer.from(serverConfig.KAFKA_TRUSTED_CERT_B64, 'base64'),
-
-            /* Intentionally disabling hostname checking. The Kafka cluster runs in the cloud and Apache
-            Kafka on Heroku doesn't currently provide stable hostnames. We're pinned to a specific certificate
-            #for this connection even though the certificate doesn't include host information. We rely
-            on the ca trust_cert for this purpose. */
-            rejectUnauthorized: false,
-        }
-    } else if (
-        serverConfig.KAFKA_SECURITY_PROTOCOL === KafkaSecurityProtocol.Ssl ||
-        serverConfig.KAFKA_SECURITY_PROTOCOL === KafkaSecurityProtocol.SaslSsl
-    ) {
-        kafkaSsl = true
-    }
-
-    let kafkaSasl: SASLOptions | undefined
-    if (serverConfig.KAFKA_SASL_MECHANISM && serverConfig.KAFKA_SASL_USER && serverConfig.KAFKA_SASL_PASSWORD) {
-        kafkaSasl = {
-            mechanism: serverConfig.KAFKA_SASL_MECHANISM,
-            username: serverConfig.KAFKA_SASL_USER,
-            password: serverConfig.KAFKA_SASL_PASSWORD,
-        }
-    }
-
     status.info('🤔', `Connecting to ClickHouse...`)
     const clickhouse = new ClickHouse({
         // We prefer to run queries on the offline cluster.
@@ -159,18 +127,9 @@ export async function createHub(
     status.info('👍', `ClickHouse ready`)
 
     status.info('🤔', `Connecting to Kafka...`)
-    const kafka = new Kafka({
-        /* clientId does not need to be unique, and is used in Kafka logs and quota accounting.
-           os.hostname() returns the pod name in k8s and the container ID in compose stacks.
-           This allows us to quickly find what pod is consuming a given partition */
-        clientId: hostname(),
-        brokers: serverConfig.KAFKA_HOSTS.split(','),
-        logLevel: KAFKAJS_LOG_LEVEL_MAPPING[serverConfig.KAFKAJS_LOG_LEVEL],
-        ssl: kafkaSsl,
-        sasl: kafkaSasl,
-        connectionTimeout: 7000, // default: 1000
-        authenticationTimeout: 7000, // default: 1000
-    })
+
+    const kafka = createKafkaClient(serverConfig as KafkaConfig)
+
     const producer = kafka.producer({
         retry: { retries: 10, initialRetryTime: 1000, maxRetryTime: 30 },
         createPartitioner: Partitioners.LegacyPartitioner,
@@ -219,7 +178,7 @@ export async function createHub(
         promiseManager,
         serverConfig.PERSON_INFO_CACHE_TTL
     )
-    const teamManager = new TeamManager(db, serverConfig, statsd)
+    const teamManager = new TeamManager(postgres, serverConfig, statsd)
     const organizationManager = new OrganizationManager(db, teamManager)
     const pluginsApiKeyManager = new PluginsApiKeyManager(db)
     const rootAccessManager = new RootAccessManager(db)
@@ -307,4 +266,71 @@ export async function createHub(
     }
 
     return [hub as Hub, closeHub]
+}
+
+export type KafkaConfig = {
+    KAFKA_HOSTS: string
+    KAFKAJS_LOG_LEVEL: keyof typeof KAFKAJS_LOG_LEVEL_MAPPING
+    KAFKA_SECURITY_PROTOCOL: string
+    KAFKA_CLIENT_CERT_B64?: string
+    KAFKA_CLIENT_CERT_KEY_B64?: string
+    KAFKA_TRUSTED_CERT_B64?: string
+    KAFKA_SASL_MECHANISM?: KafkaSaslMechanism
+    KAFKA_SASL_USER?: string
+    KAFKA_SASL_PASSWORD?: string
+}
+
+export function createKafkaClient({
+    KAFKA_HOSTS,
+    KAFKAJS_LOG_LEVEL,
+    KAFKA_SECURITY_PROTOCOL,
+    KAFKA_CLIENT_CERT_B64,
+    KAFKA_CLIENT_CERT_KEY_B64,
+    KAFKA_TRUSTED_CERT_B64,
+    KAFKA_SASL_MECHANISM,
+    KAFKA_SASL_USER,
+    KAFKA_SASL_PASSWORD,
+}: KafkaConfig) {
+    let kafkaSsl: ConnectionOptions | boolean | undefined
+    if (KAFKA_CLIENT_CERT_B64 && KAFKA_CLIENT_CERT_KEY_B64 && KAFKA_TRUSTED_CERT_B64) {
+        kafkaSsl = {
+            cert: Buffer.from(KAFKA_CLIENT_CERT_B64, 'base64'),
+            key: Buffer.from(KAFKA_CLIENT_CERT_KEY_B64, 'base64'),
+            ca: Buffer.from(KAFKA_TRUSTED_CERT_B64, 'base64'),
+
+            /* Intentionally disabling hostname checking. The Kafka cluster runs in the cloud and Apache
+            Kafka on Heroku doesn't currently provide stable hostnames. We're pinned to a specific certificate
+            #for this connection even though the certificate doesn't include host information. We rely
+            on the ca trust_cert for this purpose. */
+            rejectUnauthorized: false,
+        }
+    } else if (
+        KAFKA_SECURITY_PROTOCOL === KafkaSecurityProtocol.Ssl ||
+        KAFKA_SECURITY_PROTOCOL === KafkaSecurityProtocol.SaslSsl
+    ) {
+        kafkaSsl = true
+    }
+
+    let kafkaSasl: SASLOptions | undefined
+    if (KAFKA_SASL_MECHANISM && KAFKA_SASL_USER && KAFKA_SASL_PASSWORD) {
+        kafkaSasl = {
+            mechanism: KAFKA_SASL_MECHANISM,
+            username: KAFKA_SASL_USER,
+            password: KAFKA_SASL_PASSWORD,
+        }
+    }
+
+    const kafka = new Kafka({
+        /* clientId does not need to be unique, and is used in Kafka logs and quota accounting.
+           os.hostname() returns the pod name in k8s and the container ID in compose stacks.
+           This allows us to quickly find what pod is consuming a given partition */
+        clientId: hostname(),
+        brokers: KAFKA_HOSTS.split(','),
+        logLevel: KAFKAJS_LOG_LEVEL_MAPPING[KAFKAJS_LOG_LEVEL],
+        ssl: kafkaSsl,
+        sasl: kafkaSasl,
+        connectionTimeout: 7000,
+        authenticationTimeout: 7000, // default: 1000
+    })
+    return kafka
 }

--- a/plugin-server/src/utils/db/postgres.ts
+++ b/plugin-server/src/utils/db/postgres.ts
@@ -1,0 +1,45 @@
+// Postgres
+
+import { StatsD } from 'hot-shots'
+import { Client, Pool, QueryResult, QueryResultRow } from 'pg'
+
+import { instrumentQuery } from '../../utils/metrics'
+import { POSTGRES_UNAVAILABLE_ERROR_MESSAGES } from './db'
+import { DependencyUnavailableError } from './error'
+import { getFinalPostgresQuery, timeoutGuard } from './utils'
+
+export function postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
+    client: Client | Pool,
+    queryString: string,
+    values: I | undefined,
+    tag: string,
+    statsd?: StatsD
+): Promise<QueryResult<R>> {
+    return instrumentQuery(statsd, 'query.postgres', tag, async () => {
+        let fullQuery = ''
+        try {
+            fullQuery = getFinalPostgresQuery(queryString, values as any[])
+        } catch {}
+        const timeout = timeoutGuard('Postgres slow query warning after 30 sec', {
+            queryString,
+            values,
+            fullQuery,
+        })
+
+        // Annotate query string to give context when looking at DB logs
+        queryString = `/* plugin-server:${tag} */ ${queryString}`
+        try {
+            return await client.query(queryString, values)
+        } catch (error) {
+            if (
+                error.message &&
+                POSTGRES_UNAVAILABLE_ERROR_MESSAGES.some((message) => error.message.includes(message))
+            ) {
+                throw new DependencyUnavailableError(error.message, 'Postgres', error)
+            }
+            throw error
+        } finally {
+            clearTimeout(timeout)
+        }
+    })
+}

--- a/plugin-server/src/utils/db/postgres.ts
+++ b/plugin-server/src/utils/db/postgres.ts
@@ -1,7 +1,7 @@
 // Postgres
 
 import { StatsD } from 'hot-shots'
-import { Client, Pool, QueryResult, QueryResultRow } from 'pg'
+import { Client, Pool, PoolClient, QueryResult, QueryResultRow } from 'pg'
 
 import { instrumentQuery } from '../../utils/metrics'
 import { POSTGRES_UNAVAILABLE_ERROR_MESSAGES } from './db'
@@ -9,7 +9,7 @@ import { DependencyUnavailableError } from './error'
 import { getFinalPostgresQuery, timeoutGuard } from './utils'
 
 export function postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
-    client: Client | Pool,
+    client: Client | Pool | PoolClient,
     queryString: string,
     values: I | undefined,
     tag: string,

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -1,22 +1,23 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import { StatsD } from 'hot-shots'
 import LRU from 'lru-cache'
+import { Client, Pool } from 'pg'
 
 import { ONE_MINUTE } from '../../config/constants'
 import { PluginsServerConfig, Team, TeamId } from '../../types'
-import { DB } from '../../utils/db/db'
+import { postgresQuery } from '../../utils/db/postgres'
 import { timeoutGuard } from '../../utils/db/utils'
 import { posthog } from '../../utils/posthog'
 
 export class TeamManager {
-    db: DB
+    postgres: Pool
     teamCache: LRU<TeamId, Team | null>
     tokenToTeamIdCache: LRU<string, TeamId | null>
     statsd?: StatsD
     instanceSiteUrl: string
 
-    constructor(db: DB, serverConfig: PluginsServerConfig, statsd?: StatsD) {
-        this.db = db
+    constructor(postgres: Pool, serverConfig: PluginsServerConfig, statsd?: StatsD) {
+        this.postgres = postgres
         this.statsd = statsd
 
         this.teamCache = new LRU({
@@ -40,7 +41,7 @@ export class TeamManager {
 
         const timeout = timeoutGuard(`Still running "fetchTeam". Timeout warning after 30 sec!`)
         try {
-            const team: Team | null = await this.db.fetchTeam(teamId)
+            const team: Team | null = await fetchTeam(this.postgres, teamId)
             this.teamCache.set(teamId, team)
             return team
         } finally {
@@ -81,7 +82,7 @@ export class TeamManager {
         // Query PG if token is not in cache. This will throw if PG is unavailable.
         const timeout = timeoutGuard(`Still running "fetchTeamByToken". Timeout warning after 30 sec!`)
         try {
-            const team = await this.db.fetchTeamByToken(token)
+            const team = await fetchTeamByToken(this.postgres, token)
             if (!team) {
                 // Cache `null` for unknown tokens to reduce PG load, cache TTL will lead to retries later.
                 this.tokenToTeamIdCache.set(token, null)
@@ -98,14 +99,16 @@ export class TeamManager {
 
     public async setTeamIngestedEvent(team: Team, properties: Properties) {
         if (team && !team.ingested_event) {
-            await this.db.postgresQuery(
+            await postgresQuery(
+                this.postgres,
                 `UPDATE posthog_team SET ingested_event = $1 WHERE id = $2`,
                 [true, team.id],
                 'setTeamIngestedEvent'
             )
 
             // First event for the team captured
-            const organizationMembers = await this.db.postgresQuery(
+            const organizationMembers = await postgresQuery(
+                this.postgres,
                 'SELECT distinct_id FROM posthog_user JOIN posthog_organizationmembership ON posthog_user.id = posthog_organizationmembership.user_id WHERE organization_id = $1',
                 [team.organization_id],
                 'posthog_organizationmembership'
@@ -130,4 +133,53 @@ export class TeamManager {
             }
         }
     }
+}
+
+// Team
+
+async function fetchTeam(client: Client | Pool, teamId: Team['id']): Promise<Team | null> {
+    const selectResult = await postgresQuery<Team>(
+        client,
+        `
+            SELECT
+                id,
+                uuid,
+                organization_id,
+                name,
+                anonymize_ips,
+                api_token,
+                slack_incoming_webhook,
+                session_recording_opt_in,
+                ingested_event
+            FROM posthog_team
+            WHERE id = $1
+            `,
+        [teamId],
+        'fetchTeam'
+    )
+    return selectResult.rows[0] ?? null
+}
+
+async function fetchTeamByToken(client: Client | Pool, token: string): Promise<Team | null> {
+    const selectResult = await postgresQuery<Team>(
+        client,
+        `
+            SELECT
+                id,
+                uuid,
+                organization_id,
+                name,
+                anonymize_ips,
+                api_token,
+                slack_incoming_webhook,
+                session_recording_opt_in,
+                ingested_event
+            FROM posthog_team
+            WHERE api_token = $1
+            LIMIT 1
+                `,
+        [token],
+        'fetchTeamByToken'
+    )
+    return selectResult.rows[0] ?? null
 }

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -135,9 +135,7 @@ export class TeamManager {
     }
 }
 
-// Team
-
-async function fetchTeam(client: Client | Pool, teamId: Team['id']): Promise<Team | null> {
+export async function fetchTeam(client: Client | Pool, teamId: Team['id']): Promise<Team | null> {
     const selectResult = await postgresQuery<Team>(
         client,
         `
@@ -160,7 +158,7 @@ async function fetchTeam(client: Client | Pool, teamId: Team['id']): Promise<Tea
     return selectResult.rows[0] ?? null
 }
 
-async function fetchTeamByToken(client: Client | Pool, token: string): Promise<Team | null> {
+export async function fetchTeamByToken(client: Client | Pool, token: string): Promise<Team | null> {
     const selectResult = await postgresQuery<Team>(
         client,
         `

--- a/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
@@ -24,7 +24,7 @@ describe('session-recordings-consumer', () => {
         db = {
             postgres: new Pool(),
         } as DB
-        teamManager = new TeamManager(db, {} as any)
+        teamManager = new TeamManager(db.postgres, {} as any)
         eachBachWithDependencies = eachBatch({ producer: producerWrapper, teamManager })
     })
 

--- a/plugin-server/tests/worker/ingestion/group-type-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/group-type-manager.test.ts
@@ -22,7 +22,7 @@ describe('GroupTypeManager()', () => {
         await resetTestDatabase()
         groupTypeManager = new GroupTypeManager(hub.db, hub.teamManager)
 
-        jest.spyOn(hub.db, 'postgresQuery')
+        jest.spyOn(hub.db.postgres, 'query')
         jest.spyOn(hub.db, 'insertGroupType')
     })
     afterEach(async () => {
@@ -40,12 +40,12 @@ describe('GroupTypeManager()', () => {
             await hub.db.insertGroupType(2, 'foo', 0)
             await hub.db.insertGroupType(2, 'bar', 1)
 
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(hub.db.postgres.query).mockClear()
 
             groupTypes = await groupTypeManager.fetchGroupTypes(2)
 
             expect(groupTypes).toEqual({})
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
+            expect(hub.db.postgres.query).toHaveBeenCalledTimes(0)
 
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:36').getTime())
 
@@ -55,7 +55,7 @@ describe('GroupTypeManager()', () => {
                 foo: 0,
                 bar: 1,
             })
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(hub.db.postgres.query).toHaveBeenCalledTimes(1)
         })
 
         it('returns empty object if no groups are set up yet', async () => {
@@ -68,13 +68,13 @@ describe('GroupTypeManager()', () => {
             await hub.db.insertGroupType(2, 'foo', 0)
             await hub.db.insertGroupType(2, 'bar', 1)
 
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(hub.db.postgres.query).mockClear()
             jest.mocked(hub.db.insertGroupType).mockClear()
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 'foo')).toEqual(0)
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 'bar')).toEqual(1)
 
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(hub.db.postgres.query).toHaveBeenCalledTimes(1)
             expect(hub.db.insertGroupType).toHaveBeenCalledTimes(0)
             expect(posthog.capture).not.toHaveBeenCalled()
         })
@@ -83,12 +83,12 @@ describe('GroupTypeManager()', () => {
             await hub.db.insertGroupType(2, 'foo', 0)
 
             jest.mocked(hub.db.insertGroupType).mockClear()
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(hub.db.postgres.query).mockClear()
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 'second')).toEqual(1)
 
             expect(hub.db.insertGroupType).toHaveBeenCalledTimes(1)
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(3) // FETCH + INSERT + Team lookup
+            expect(hub.db.postgres.query).toHaveBeenCalledTimes(3) // FETCH + INSERT + Team lookup
 
             const team = await hub.db.fetchTeam(2)
             expect(posthog.capture).toHaveBeenCalledWith({
@@ -107,7 +107,7 @@ describe('GroupTypeManager()', () => {
             })
 
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 'third')).toEqual(2)
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(hub.db.postgres.query).mockClear()
 
             expect(await groupTypeManager.fetchGroupTypes(2)).toEqual({
                 foo: 0,
@@ -117,7 +117,7 @@ describe('GroupTypeManager()', () => {
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 'second')).toEqual(1)
             expect(await groupTypeManager.fetchGroupTypeIndex(2, 'third')).toEqual(2)
 
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(hub.db.postgres.query).toHaveBeenCalledTimes(1)
         })
 
         it('handles raciness for inserting a new group', async () => {

--- a/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
@@ -786,7 +786,7 @@ describe('PropertyDefinitionsManager()', () => {
             })
 
             it('does not keep trying to set a property type when it cannot', async () => {
-                const postgresQuery = jest.spyOn(hub.db, 'postgresQuery')
+                const postgresQuery = jest.spyOn(hub.db.postgres, 'query')
 
                 const properties = {
                     a_prop_with_a_type_we_do_not_set: { a: 1234567890 },

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -1,7 +1,8 @@
 import { Settings } from 'luxon'
 
-import { Hub } from '../../../src/types'
-import { createHub } from '../../../src/utils/db/hub'
+import { defaultConfig } from '../../../src/config/config'
+import { postgresQuery } from '../../../src/utils/db/postgres'
+import { createPostgresPool } from '../../../src/utils/utils'
 import { TeamManager } from '../../../src/worker/ingestion/team-manager'
 import { resetTestDatabase } from '../../helpers/sql'
 
@@ -14,39 +15,38 @@ jest.mock('../../../src/utils/posthog', () => ({
 }))
 
 describe('TeamManager()', () => {
-    let hub: Hub
-    let closeHub: () => Promise<void>
     let teamManager: TeamManager
+    let postgres: ReturnType<typeof createPostgresPool>
 
     beforeEach(async () => {
-        ;[hub, closeHub] = await createHub()
         await resetTestDatabase()
-        teamManager = hub.teamManager
+        postgres = createPostgresPool(defaultConfig.DATABASE_URL)
+        teamManager = new TeamManager(postgres, defaultConfig)
         Settings.defaultZoneName = 'utc'
     })
 
     afterEach(async () => {
-        await closeHub()
+        await postgres.end()
     })
 
     describe('fetchTeam()', () => {
         it('fetches and caches the team', async () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:05Z').getTime())
-            jest.spyOn(hub.db, 'postgresQuery')
+            jest.spyOn(postgres, 'query')
 
             let team = await teamManager.fetchTeam(2)
             expect(team!.name).toEqual('TEST PROJECT')
             // expect(team!.__fetch_event_uuid).toEqual('uuid1')
 
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:55Z').getTime())
-            await hub.db.postgresQuery("UPDATE posthog_team SET name = 'Updated Name!'", undefined, 'testTag')
+            await postgresQuery(postgres, "UPDATE posthog_team SET name = 'Updated Name!'", undefined, 'testTag')
 
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(postgres.query).mockClear()
 
             team = await teamManager.fetchTeam(2)
             expect(team!.name).toEqual('TEST PROJECT')
             // expect(team!.__fetch_event_uuid).toEqual('uuid1')
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
+            expect(postgres.query).toHaveBeenCalledTimes(0)
 
             // 2min have passed i.e. the cache should have expired
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:02:06Z').getTime())
@@ -54,7 +54,7 @@ describe('TeamManager()', () => {
             team = await teamManager.fetchTeam(2)
             expect(team!.name).toEqual('Updated Name!')
 
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(postgres.query).toHaveBeenCalledTimes(1)
         })
 
         it('returns null when no such team', async () => {
@@ -65,31 +65,31 @@ describe('TeamManager()', () => {
     describe('getTeamByToken()', () => {
         it('caches positive lookups for 2 minutes', async () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:05Z').getTime())
-            await hub.db.postgresQuery("UPDATE posthog_team SET api_token = 'my_token'", undefined, 'testTag')
+            await postgresQuery(postgres, "UPDATE posthog_team SET api_token = 'my_token'", undefined, 'testTag')
 
             // Initial lookup hits the DB and returns null
-            jest.spyOn(hub.db, 'postgresQuery')
+            jest.spyOn(postgres, 'query')
             let team = await teamManager.getTeamByToken('my_token')
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(postgres.query).toHaveBeenCalledTimes(1)
             expect(team!.id).toEqual(2)
             expect(team!.anonymize_ips).toEqual(false)
 
             // Settings are updated
-            await hub.db.postgresQuery('UPDATE posthog_team SET anonymize_ips = true', undefined, 'testTag')
+            await postgresQuery(postgres, 'UPDATE posthog_team SET anonymize_ips = true', undefined, 'testTag')
 
             // Second lookup hits the cache and skips the DB lookup, setting is stale
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:01:56Z').getTime())
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(postgres.query).mockClear()
             team = await teamManager.getTeamByToken('my_token')
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
+            expect(postgres.query).toHaveBeenCalledTimes(0)
             expect(team!.id).toEqual(2)
             expect(team!.anonymize_ips).toEqual(false)
 
             // Setting change take effect after cache expiration
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:25:06Z').getTime())
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(postgres.query).mockClear()
             team = await teamManager.getTeamByToken('my_token')
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(postgres.query).toHaveBeenCalledTimes(1)
             expect(team!.id).toEqual(2)
             expect(team!.anonymize_ips).toEqual(true)
         })
@@ -98,25 +98,25 @@ describe('TeamManager()', () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:05Z').getTime())
 
             // Initial lookup hits the DB and returns null
-            jest.spyOn(hub.db, 'postgresQuery')
+            jest.spyOn(postgres, 'query')
             expect(await teamManager.getTeamByToken('unknown')).toEqual(null)
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(postgres.query).toHaveBeenCalledTimes(1)
 
             // Second lookup hits the cache and skips the DB lookup
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:03:06Z').getTime())
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(postgres.query).mockClear()
             expect(await teamManager.getTeamByToken('unknown')).toEqual(null)
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
+            expect(postgres.query).toHaveBeenCalledTimes(0)
 
             // Hit the DB on cache expiration
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:05:06Z').getTime())
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(postgres.query).mockClear()
             expect(await teamManager.getTeamByToken('unknown')).toEqual(null)
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(postgres.query).toHaveBeenCalledTimes(1)
         })
 
         it('throws on postgres errors', async () => {
-            hub.db.postgresQuery = jest.fn().mockRejectedValue(new Error('PG unavailable'))
+            postgres.query = jest.fn().mockRejectedValue(new Error('PG unavailable'))
             await expect(async () => {
                 await teamManager.getTeamByToken('another')
             }).rejects.toThrow('PG unavailable')


### PR DESCRIPTION
Hub is a grab bag of depencencies that are not all required for
recordings ingestion. To keep the recordings ingestion lean, we
remove the hub dependency and use the postgres and kafka client
directly.

This should increase the availability of the session recordings
workload, e.g. it should not go down it Redis or ClickHouse is down.

The driver behind this is that we're doing a whole load of things on the
recording ingestion pods that we don't need to. It hurts startup times 
and as a result autoscaling. And it hurts e.g. resources on ClickHouse 
and Redis. It hurts availability of the recordings ingestion.

I've also added a healthcheck for session recordings that will mean that
recordings pods are restarted if they get into trouble ingesting.

Note that I have refactored some of the db.ts to call out to specific calls
in e.g. teamManager, which should have the most knowledge of what teams
look like in the database, rather than including it in the catch all db. there 
isn't much benefit to decoupling that from the teamManager and just means
that it is confusing to follow the code paths related to it.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
