### PR TITLE
feat(capture): check the token for obviously invalid shapes

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -334,7 +334,8 @@ def get_event(request):
             TOKEN_SHAPE_INVALID_COUNTER.labels(reason=invalid_token_reason).inc()
             logger.warning("capture_token_shape_invalid", token=token, reason=invalid_token_reason)
     except Exception as e:
-        logger.warning("capture_token_shape_invalid", token=token, exception=e)
+        TOKEN_SHAPE_INVALID_COUNTER.labels(reason="exception").inc()
+        logger.warning("capture_token_shape_invalid", token=token, reason="exception", exception=e)
 
     team_id = ingestion_context.team_id if ingestion_context else None
     structlog.contextvars.bind_contextvars(team_id=team_id)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -196,12 +196,12 @@ def _get_sent_at(data, request) -> Tuple[Optional[datetime], Any]:
 def _check_token_shape(token: str) -> Optional[str]:
     if not token:
         return "empty"
-    if token.startswith("phx_"):  # Used by previous versions of the zapier integration, should not happen now
-        return "personal_token"
     if len(token) > 64:
         return "too_long"
     if not token.isascii():  # Legacy tokens were base64, so let's be permissive
         return "not_ascii"
+    if token.startswith("phx_"):  # Used by previous versions of the zapier integration, should not happen now
+        return "personal_token"
     return None
 
 

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -684,8 +684,8 @@
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND event IN ['$autocapture', 'user signed up', '$autocapture']
-                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-17 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-20 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-27 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/issues/14328

## Changes

- After the token is successfully resolved to a team_id, check it for obviously bad shapes. We are reporting a metric and logs, with the hope to have zero trigger on prod.

If that's the case, we'll use that code to reject tokens in lightweigth intake mode.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
