### PR TITLE
fix(roles): do not create role on update save

### DIFF
--- a/frontend/src/scenes/organization/Settings/Permissions/Roles/CreateRoleModal.tsx
+++ b/frontend/src/scenes/organization/Settings/Permissions/Roles/CreateRoleModal.tsx
@@ -37,12 +37,8 @@ export function CreateRoleModal(): JSX.Element {
     }
 
     const handleSubmit = (): void => {
-        if (isNewRole) {
-            createRole(roleName)
-            setRoleName('')
-        } else {
-            setCreateRoleModalShown(false)
-        }
+        createRole(roleName)
+        setRoleName('')
     }
 
     return (
@@ -74,9 +70,11 @@ export function CreateRoleModal(): JSX.Element {
                                 </LemonButton>
                             )}
                         </div>
-                        <LemonButton type="primary" onClick={handleSubmit}>
-                            Save
-                        </LemonButton>
+                        {isNewRole && (
+                            <LemonButton type="primary" onClick={handleSubmit}>
+                                Save
+                            </LemonButton>
+                        )}
                     </div>
                 ) : undefined
             }

--- a/frontend/src/scenes/organization/Settings/Permissions/Roles/CreateRoleModal.tsx
+++ b/frontend/src/scenes/organization/Settings/Permissions/Roles/CreateRoleModal.tsx
@@ -29,17 +29,21 @@ export function CreateRoleModal(): JSX.Element {
 
     const [roleName, setRoleName] = useState('')
 
+    const isNewRole = !roleInFocus
+
     const handleClose = (): void => {
         setCreateRoleModalShown(false)
         setRoleMembersToAdd([])
     }
 
     const handleSubmit = (): void => {
-        createRole(roleName)
-        setRoleName('')
+        if (isNewRole) {
+            createRole(roleName)
+            setRoleName('')
+        } else {
+            setCreateRoleModalShown(false)
+        }
     }
-
-    const isNewRole = !roleInFocus
 
     return (
         <LemonModal


### PR DESCRIPTION
## Problem

An error was being thrown because on the role modal, the "save" button for updates to existing roles was calling the create endpoint

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
