### PR TITLE
feat(capture): check token shape before team resolution too

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -193,7 +193,7 @@ def _get_sent_at(data, request) -> Tuple[Optional[datetime], Any]:
         )
 
 
-def _check_token_shape(token: str) -> Optional[str]:
+def _check_token_shape(token: Optional[str]) -> Optional[str]:
     if not token:
         return "empty"
     if len(token) > 64:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -70,7 +70,7 @@ PARTITION_KEY_CAPACITY_EXCEEDED_COUNTER = Counter(
 TOKEN_SHAPE_INVALID_COUNTER = Counter(
     "capture_token_shape_invalid_total",
     "Events (soon to be) dropped due to an invalid token shape, per reason.",
-    labelnames=["reason"],
+    labelnames=["stage", "reason"],
 )
 
 
@@ -299,6 +299,16 @@ def get_event(request):
     with start_span(op="request.authenticate"):
         token = get_token(data, request)
 
+        try:
+            invalid_token_reason = _check_token_shape(token)
+        except Exception as e:
+            invalid_token_reason = "exception"
+            logger.warning("capture_token_shape_exception", token=token, reason="exception", exception=e)
+
+        if invalid_token_reason:
+            # TODO: start rejecting requests here if  the after_resolution contexts are empty (no false-positives)
+            TOKEN_SHAPE_INVALID_COUNTER.labels(stage="before_resolution", reason=invalid_token_reason).inc()
+
         if not token:
             return cors_response(
                 request,
@@ -326,16 +336,10 @@ def get_event(request):
             if db_error:
                 send_events_to_dead_letter_queue = True
 
-    try:
-        invalid_token_reason = _check_token_shape(token)
-        if invalid_token_reason:
-            # TODO: check the capture_token_shape_invalid_total metric for false positives,
-            #  then move higher and refuse requests
-            TOKEN_SHAPE_INVALID_COUNTER.labels(reason=invalid_token_reason).inc()
-            logger.warning("capture_token_shape_invalid", token=token, reason=invalid_token_reason)
-    except Exception as e:
-        TOKEN_SHAPE_INVALID_COUNTER.labels(reason="exception").inc()
-        logger.warning("capture_token_shape_invalid", token=token, reason="exception", exception=e)
+    if invalid_token_reason:
+        # TODO: remove after we have proven we don't have false-positives
+        TOKEN_SHAPE_INVALID_COUNTER.labels(stage="after_resolution", reason=invalid_token_reason).inc()
+        logger.warning("capture_token_shape_false_positive", token=token, reason=invalid_token_reason)
 
     team_id = ingestion_context.team_id if ingestion_context else None
     structlog.contextvars.bind_contextvars(team_id=team_id)

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -684,8 +684,8 @@
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND event IN ['$autocapture', 'user signed up', '$autocapture']
-                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-20 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-27 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-21 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-28 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))


### PR DESCRIPTION
## Problem

Around 3% of capture requests on prod-us get a 401 error. Let's run our shape validation earlier to compute how many we'll still catch. Success criteria:

- `capture_token_shape_invalid_total{stage="after_resolution}` is still zero (would be false-positives), no `capture_token_shape_false_positive` logs
- `capture_token_shape_invalid_total{stage="before_resolution}` is close enough to our 401 rate, hopefully most of these are token missing from the body.
- no `capture_token_shape_exception` logs

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
