### PR TITLE
fix(flags): Match properties in db irrespective of type

### DIFF
--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -251,9 +251,9 @@ class Property:
         return {key: value for key, value in vars(self).items() if value is not None}
 
     @staticmethod
-    def _parse_value(value: ValueT) -> Any:
+    def _parse_value(value: ValueT, convert_to_number: bool = False) -> Any:
         if isinstance(value, list):
-            return [Property._parse_value(v) for v in value]
+            return [Property._parse_value(v, convert_to_number) for v in value]
         if value == "true":
             return True
         if value == "false":
@@ -262,14 +262,15 @@ class Property:
             return value
 
         # `json.loads()` converts strings to numbers if possible
-        # and we don't want this behavior, as if we wanted a number
+        # and we don't want this behavior by default, as if we wanted a number
         # we would have passed it as a number
-        try:
-            # tests if string is a number & returns string if it is a number
-            float(value)
-            return value
-        except (ValueError, TypeError):
-            pass
+        if not convert_to_number:
+            try:
+                # tests if string is a number & returns string if it is a number
+                float(value)
+                return value
+            except (ValueError, TypeError):
+                pass
 
         try:
             return json.loads(value)

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -182,10 +182,10 @@ def empty_or_null_with_value_q(
         value_as_given = Property._parse_value(value)
         value_as_coerced_to_number = Property._parse_value(value, convert_to_number=True)
         if value_as_given == value_as_coerced_to_number:
-            target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value))
+            target_filter = lookup_q(f"{column}__{key}", value_as_given)
         else:
-            target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value)) | lookup_q(
-                f"{column}__{key}", Property._parse_value(value, convert_to_number=True)
+            target_filter = lookup_q(f"{column}__{key}", value_as_given) | lookup_q(
+                f"{column}__{key}", value_as_coerced_to_number
             )
     else:
         target_filter = Q(**{f"{column}__{key}__{operator}": value})

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -179,7 +179,9 @@ def empty_or_null_with_value_q(
 ) -> Q:
 
     if operator == "exact" or operator is None:
-        target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value))
+        target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value)) | lookup_q(
+            f"{column}__{key}", Property._parse_value(value, convert_to_number=True)
+        )
     else:
         target_filter = Q(**{f"{column}__{key}__{operator}": value})
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -179,9 +179,14 @@ def empty_or_null_with_value_q(
 ) -> Q:
 
     if operator == "exact" or operator is None:
-        target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value)) | lookup_q(
-            f"{column}__{key}", Property._parse_value(value, convert_to_number=True)
-        )
+        value_as_given = Property._parse_value(value)
+        value_as_coerced_to_number = Property._parse_value(value, convert_to_number=True)
+        if value_as_given == value_as_coerced_to_number:
+            target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value))
+        else:
+            target_filter = lookup_q(f"{column}__{key}", Property._parse_value(value)) | lookup_q(
+                f"{column}__{key}", Property._parse_value(value, convert_to_number=True)
+            )
     else:
         target_filter = Q(**{f"{column}__{key}__{operator}": value})
 

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -684,8 +684,8 @@
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND event IN ['$autocapture', 'user signed up', '$autocapture']
-                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-17 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-02-21 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-02-28 23:59:59', 'UTC')
                    AND (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 ))

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -12,7 +12,8 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.1
   '
-  SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+  SELECT ((("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+           OR ("posthog_person"."properties" -> 'email') = '"test@posthog.com"')
           AND "posthog_person"."properties" ? 'email'
           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
@@ -38,10 +39,12 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
-  SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
+  SELECT ((("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
+           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"'))
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0",
-         (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
+         ((("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
+           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"'))
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_group"
@@ -64,7 +67,8 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.5
   '
-  SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+  SELECT ((("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+           OR ("posthog_person"."properties" -> 'email') = '"test@posthog.com"')
           AND "posthog_person"."properties" ? 'email'
           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
@@ -80,10 +84,12 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.6
   '
-  SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
+  SELECT ((("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
+           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"'))
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0",
-         (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
+         ((("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
+           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"'))
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_group"

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -1,3 +1,147 @@
+# name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type.1
+  '
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type.2
+  '
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type.3
+  '
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity"
+  FROM "posthog_featureflag"
+  WHERE ("posthog_featureflag"."active"
+         AND NOT "posthog_featureflag"."deleted"
+         AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type.4
+  '
+  SELECT ((("posthog_person"."properties" -> 'Distinct Id') IN ('"307"')
+           OR ("posthog_person"."properties" -> 'Distinct Id') IN ('307'))
+          AND "posthog_person"."properties" ? 'Distinct Id'
+          AND NOT (("posthog_person"."properties" -> 'Distinct Id') = 'null')) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type.5
+  '
+  SELECT (("posthog_person"."properties" -> 'Distinct Id') IN ('307')
+          AND "posthog_person"."properties" ? 'Distinct Id'
+          AND NOT (("posthog_person"."properties" -> 'Distinct Id') = 'null')) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type.6
+  '
+  SELECT (("posthog_person"."properties" -> 'Distinct Id') = '307'
+          AND "posthog_person"."properties" ? 'Distinct Id'
+          AND NOT (("posthog_person"."properties" -> 'Distinct Id') = 'null')) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
 # name: TestFeatureFlagMatcher.test_multiple_flags
   '
   SELECT "posthog_grouptypemapping"."id",
@@ -12,8 +156,7 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.1
   '
-  SELECT ((("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
-           OR ("posthog_person"."properties" -> 'email') = '"test@posthog.com"')
+  SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
           AND "posthog_person"."properties" ? 'email'
           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
@@ -39,12 +182,10 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
-  SELECT ((("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
-           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"'))
+  SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0",
-         ((("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
-           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"'))
+         (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_group"
@@ -67,8 +208,7 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.5
   '
-  SELECT ((("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
-           OR ("posthog_person"."properties" -> 'email') = '"test@posthog.com"')
+  SELECT (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
           AND "posthog_person"."properties" ? 'email'
           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
          (true) AS "flag_X_condition_1",
@@ -84,12 +224,10 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.6
   '
-  SELECT ((("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
-           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"'))
+  SELECT (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0",
-         ((("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
-           OR ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"'))
+         (("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"')
           AND "posthog_group"."group_properties" ? 'name'
           AND NOT (("posthog_group"."group_properties" -> 'name') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_group"

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -22,7 +22,7 @@ from posthog.models.group import Group
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.models.user import User
-from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_postgres_queries_context
+from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_postgres_queries, snapshot_postgres_queries_context
 
 
 class TestFeatureFlagCohortExpansion(BaseTest):
@@ -616,6 +616,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 1),
         )
 
+    @snapshot_postgres_queries
     def test_db_matches_independent_of_string_or_number_type(self):
         Person.objects.create(
             team=self.team,


### PR DESCRIPTION
Instead of worrying about types, and not being able to set numeric types from the UI, make the matching algorithm type insensitive: it tests for both string and number types.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
