### PR TITLE
fix: make 0305 a no-op migration

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -5,7 +5,7 @@ contenttypes: 0002_remove_content_type_name
 ee: 0014_roles_memberships_and_resource_access
 otp_static: 0002_throttling
 otp_totp: 0002_auto_20190420_0723
-posthog: 0304_store_dashboard_template_in_db
+posthog: 0305_rework_person_overrides
 sessions: 0001_initial
 social_django: 0010_uid_db_index
 two_factor: 0007_auto_20201201_1019

--- a/posthog/migrations/0305_rework_person_overrides.py
+++ b/posthog/migrations/0305_rework_person_overrides.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("posthog", "0304_store_dashboard_template_in_db"),
+    ]
+
+    operations = []  # type: ignore


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
On top of https://github.com/PostHog/posthog/pull/14445
Making the migration a no-op

will merge this into the below one, but for easier review created separately


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
