### PR TITLE
fix(tests): Safer migrations

### DIFF
--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -13,27 +13,42 @@ class Command(BaseCommand):
             try:
                 results = re.findall(r"([a-z]+)\/migrations\/([a-zA-Z_0-9]+)\.py", variable)[0]
                 sql = call_command("sqlmigrate", results[0], results[1])
-                if (
-                    re.findall(r"(?<!DROP) (NOT NULL|DEFAULT)", sql, re.M & re.I)
-                    and "Create model" not in sql
-                    and "-- not-null-ignore" not in sql
-                ):
-                    print(
-                        f"\n\n\033[91mFound a non-null field or default added to an existing model. This will lock up the table while migrating. Please add 'null=True, blank=True' to the field"
-                    )
-                    sys.exit(1)
+                operations = sql.split("\n")
+                for operation_sql in operations:
+                    if (
+                        re.findall(r"(?<!DROP) (NOT NULL|DEFAULT)", operation_sql, re.M & re.I)
+                        and "CREATE TABLE" not in operation_sql
+                        and "-- not-null-ignore" not in operation_sql
+                    ):
+                        print(
+                            f"\n\n\033[91mFound a non-null field or default added to an existing model. This will lock up the table while migrating. Please add 'null=True, blank=True' to the field.\nSource: `{operation_sql}`"
+                        )
+                        sys.exit(1)
 
-                if "RENAME" in sql and "-- rename-ignore" not in sql:
-                    print(
-                        f"\n\n\033[91mFound a rename command. This will lock up the table while migrating. Please create a new column and provide alternative method for swapping columns"
-                    )
-                    sys.exit(1)
+                    if "RENAME" in operation_sql and "-- rename-ignore" not in operation_sql:
+                        print(
+                            f"\n\n\033[91mFound a rename command. This will lock up the table while migrating. Please create a new column and provide alternative method for swapping columns.\nSource: `{operation_sql}`"
+                        )
+                        sys.exit(1)
 
-                if "DROP COLUMN" in sql and "-- drop-column-ignore" not in sql:
-                    print(
-                        f"\n\n\033[91mFound a drop command. This could lead to unsafe states for the app. Please avoid dropping columns"
-                    )
-                    sys.exit(1)
+                    if "DROP COLUMN" in operation_sql and "-- drop-column-ignore" not in operation_sql:
+                        print(
+                            f"\n\n\033[91mFound a drop command. This could lead to unsafe states for the app. Please avoid dropping columns.\nSource: `{operation_sql}`"
+                        )
+                        sys.exit(1)
+
+                    if "DROP TABLE" in operation_sql:
+                        print(
+                            f"\n\n\033[91mFound a DROP TABLE command. This could lead to unsafe states for the app. Please avoid dropping tables.\nSource: `{operation_sql}`"
+                        )
+                        sys.exit(1)
+
+                    if "CONSTRAINT" in operation_sql and "CREATE TABLE" not in operation_sql:
+                        print(
+                            f"\n\n\033[91mFound a CONSTRAINT command. This locks tables which causes downtime. Please avoid adding constraints to existing tables.\nSource: `{operation_sql}`"
+                        )
+                        sys.exit(1)
+
             except (IndexError, CommandError):
                 pass
 


### PR DESCRIPTION
## Problem

#14277 caused an outage by doing 3 things we shouldn't be doing in migrations
- Adding a constraint
- Adding a non-nullable field
- Dropping tables

All of which cause locks
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Only allow constraints when creating a table
- Don't allow dropping a table
- Check for non-nullable fields per statement instead of the entire migration (the test thought it was creating a model b/c that's what we were doing earlier in the migration)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
