### PR TITLE
feat(capture): gracefully catch non-string tokens

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -196,6 +196,8 @@ def _get_sent_at(data, request) -> Tuple[Optional[datetime], Any]:
 def _check_token_shape(token: Optional[str]) -> Optional[str]:
     if not token:
         return "empty"
+    if not isinstance(token, str):
+        return "not_string"
     if len(token) > 64:
         return "too_long"
     if not token.isascii():  # Legacy tokens were base64, so let's be permissive

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -193,7 +193,7 @@ def _get_sent_at(data, request) -> Tuple[Optional[datetime], Any]:
         )
 
 
-def _check_token_shape(token: Optional[str]) -> Optional[str]:
+def _check_token_shape(token: Any) -> Optional[str]:
     if not token:
         return "empty"
     if not isinstance(token, str):


### PR DESCRIPTION
## Problem

We get some requests with `token: 123` in the body. `_check_token_shape` is currently throwing `"TypeError(\"object of type 'int' has no len()\")"`, let's gracefully detect this case.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
