### PR TITLE
chore(plugin-server): add analytics consumer liveness check

### DIFF
--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -104,6 +104,20 @@ test.concurrent(`event ingestion: can set and update group properties`, async ()
     })
 })
 
+test.concurrent(`liveness check endpoint works`, async () => {
+    await waitForExpect(async () => {
+        const response = await fetch('http://localhost:6738/_health')
+        expect(response.status).toBe(200)
+
+        const body = await response.json()
+        expect(body).toEqual(
+            expect.objectContaining({
+                checks: expect.objectContaining({ 'analytics-ingestion': 'ok' }),
+            })
+        )
+    })
+})
+
 test.concurrent(`event ingestion: handles $groupidentify with no properties`, async () => {
     const teamId = await createTeam(postgres, organizationId)
     const distinctId = new UUIDT().toString()

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -72,7 +72,32 @@ export const startAnalyticsEventsIngestionConsumer = async ({
         await queue.emitConsumerGroupMetrics()
     })
 
-    return queue
+    // Subscribe to the heatbeat event to track when the consumer has last
+    // successfully consumed a message. This is used to determine if the
+    // consumer is healthy.
+    const sessionTimeout = 30000
+    const { HEARTBEAT } = queue.consumer.events
+    let lastHeartbeat: number = Date.now()
+    queue.consumer.on(HEARTBEAT, ({ timestamp }) => (lastHeartbeat = timestamp))
+
+    const isHealthy = async () => {
+        // Consumer has heartbeat within the session timeout, so it is healthy.
+        if (Date.now() - lastHeartbeat < sessionTimeout) {
+            return true
+        }
+
+        // Consumer has not heartbeat, but maybe it's because the group is
+        // currently rebalancing.
+        try {
+            const { state } = await queue.consumer.describeGroup()
+
+            return ['CompletingRebalance', 'PreparingRebalance'].includes(state)
+        } catch (error) {
+            return false
+        }
+    }
+
+    return { queue, isHealthy }
 }
 
 export async function eachBatchIngestionWithOverflow(

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -22,8 +22,8 @@ export class IngestionConsumer {
     public topic: string
     public consumerGroupId: string
     public eachBatch: EachBatchFunction
+    public consumer: Consumer
     private kafka: Kafka
-    private consumer: Consumer
     private consumerGroupMemberId: string | null
     private wasConsumerRan: boolean
 


### PR DESCRIPTION
For some reason analytics pods were not joining the consumer group
propertly. This is a hammer to try to, in those cases, kill the pods and
hopefully get them to restart and rejoin the group.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
