### PR TITLE
fix: Tooltip displaying incorrectly 

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -144,6 +144,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         displayRefreshButtonChangedNotice ? `The 'Refresh' button has moved here.` : ''
                                     }
                                     visible={displayRefreshButtonChangedNotice}
+                                    zIndex={940}
                                 >
                                     <More
                                         onClick={


### PR DESCRIPTION
## Problem

Resolves #14432

## Changes
Add z-index prop to be lower than main toolbar `948`
❓ is there a better way than to hardcode a z-index value?

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Ran locally to verify
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
