### PR TITLE
test(plugin-server): use librdkafka for functional tests

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -17,24 +17,35 @@ import { UUIDT } from '../src/utils/utils'
 import { insertRow } from '../tests/helpers/sql'
 import { produce } from './kafka'
 
-export const capture = async (
-    teamId: number | null,
-    distinctId: string,
-    uuid: string,
-    event: string,
-    properties: object = {},
-    token: string | null = null,
-    sentAt: Date = new Date(),
-    eventTime: Date = new Date(),
-    now: Date = new Date(),
-    topic = 'events_plugin_ingestion'
-) => {
+export const capture = async ({
+    teamId,
+    distinctId,
+    uuid,
+    event,
+    properties = {},
+    token = null,
+    sentAt = new Date(),
+    eventTime = new Date(),
+    now = new Date(),
+    topic = 'events_plugin_ingestion',
+}: {
+    teamId: number | null
+    distinctId: string
+    uuid: string
+    event: string
+    properties?: object
+    token?: string | null
+    sentAt?: Date
+    eventTime?: Date
+    now?: Date
+    topic?: string
+}) => {
     // WARNING: this capture method is meant to simulate the ingestion of events
     // from the capture endpoint, but there is no guarantee that is is 100%
     // accurate.
-    return await produce(
+    return await produce({
         topic,
-        Buffer.from(
+        message: Buffer.from(
             JSON.stringify({
                 token,
                 distinct_id: distinctId,
@@ -52,8 +63,8 @@ export const capture = async (
                 }),
             })
         ),
-        teamId ? teamId.toString() : ''
-    )
+        key: teamId ? teamId.toString() : '',
+    })
 }
 
 export const createPlugin = async (pgClient: Pool, plugin: Omit<Plugin, 'id'>) => {

--- a/plugin-server/functional_tests/definitions.test.ts
+++ b/plugin-server/functional_tests/definitions.test.ts
@@ -30,8 +30,14 @@ test.concurrent(`event ingestion: definition for string property %p`, async () =
     const distinctId = 'distinctId'
     const uuid = new UUIDT().toString()
 
-    await capture(teamId, distinctId, uuid, 'custom event', {
-        property: 'hehe',
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: 'custom event',
+        properties: {
+            property: 'hehe',
+        },
     })
 
     await waitForExpect(async () => {
@@ -53,8 +59,14 @@ test.concurrent.each([[2], [2.1234], ['2'], ['2.1234']])(
         const distinctId = 'distinctId'
         const uuid = new UUIDT().toString()
 
-        await capture(teamId, distinctId, uuid, 'custom event', {
-            property: numberValue,
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: 'custom event',
+            properties: {
+                property: numberValue,
+            },
         })
 
         await waitForExpect(async () => {
@@ -82,8 +94,14 @@ test.concurrent.each([
     const distinctId = 'distinctId'
     const uuid = new UUIDT().toString()
 
-    await capture(teamId, distinctId, uuid, 'custom event', {
-        property: dateString,
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: 'custom event',
+        properties: {
+            property: dateString,
+        },
     })
 
     await waitForExpect(async () => {
@@ -105,8 +123,14 @@ test.concurrent.each([[true], ['true']])(
         const distinctId = 'distinctId'
         const uuid = new UUIDT().toString()
 
-        await capture(teamId, distinctId, uuid, 'custom event', {
-            property: booleanValue,
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: 'custom event',
+            properties: {
+                property: booleanValue,
+            },
         })
 
         await waitForExpect(async () => {
@@ -129,8 +153,14 @@ test.concurrent.each([['utm_abc'], ['utm_123']])(
         const distinctId = 'distinctId'
         const uuid = new UUIDT().toString()
 
-        await capture(teamId, distinctId, uuid, 'custom event', {
-            [propertyName]: 1234,
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: 'custom event',
+            properties: {
+                [propertyName]: 1234,
+            },
         })
 
         await waitForExpect(async () => {

--- a/plugin-server/functional_tests/exports-v1.test.ts
+++ b/plugin-server/functional_tests/exports-v1.test.ts
@@ -71,9 +71,15 @@ test.concurrent(`exports: exporting events on ingestion`, async () => {
     const uuid = new UUIDT().toString()
 
     // First let's ingest an event
-    await capture(teamId, distinctId, uuid, 'custom event', {
-        name: 'hehe',
-        uuid: new UUIDT().toString(),
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: 'custom event',
+        properties: {
+            name: 'hehe',
+            uuid: new UUIDT().toString(),
+        },
     })
 
     // Then check that the exportEvents function was called
@@ -125,10 +131,16 @@ test.concurrent(`exports: exporting $autocapture events on ingestion`, async () 
     const uuid = new UUIDT().toString()
 
     // First let's ingest an event
-    await capture(teamId, distinctId, uuid, '$autocapture', {
-        name: 'hehe',
-        uuid: new UUIDT().toString(),
-        $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: '$autocapture',
+        properties: {
+            name: 'hehe',
+            uuid: new UUIDT().toString(),
+            $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
+        },
     })
 
     // Then check that the exportEvents function was called
@@ -191,10 +203,16 @@ test.concurrent(`exports: historical exports`, async () => {
     // First let's capture an event and wait for it to be ingested so
     // so we can check that the historical event is the same as the one
     // passed to processEvent on initial ingestion.
-    await capture(teamId, distinctId, uuid, '$autocapture', {
-        name: 'hehe',
-        uuid: new UUIDT().toString(),
-        $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: '$autocapture',
+        properties: {
+            name: 'hehe',
+            uuid: new UUIDT().toString(),
+            $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
+        },
     })
 
     // Then check that the exportEvents function was called
@@ -212,9 +230,9 @@ test.concurrent(`exports: historical exports`, async () => {
     // adds directly to PostgreSQL using the graphile-worker stored
     // procedure `add_job`. I'd rather keep these tests graphile
     // unaware.
-    await produce(
-        'jobs',
-        Buffer.from(
+    await produce({
+        topic: 'jobs',
+        message: Buffer.from(
             JSON.stringify({
                 type: 'Export historical events',
                 pluginConfigId: pluginConfig.id,
@@ -225,8 +243,8 @@ test.concurrent(`exports: historical exports`, async () => {
                 },
             })
         ),
-        teamId.toString()
-    )
+        key: teamId.toString(),
+    })
 
     // Then check that the exportEvents function was called with the
     // same data that was used with the non-historical export, with the

--- a/plugin-server/functional_tests/exports-v2.test.ts
+++ b/plugin-server/functional_tests/exports-v2.test.ts
@@ -106,7 +106,7 @@ test.concurrent(`exports: historical exports v2`, async () => {
         uuid: new UUIDT().toString(),
         $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
     }
-    await capture(teamId, distinctId, uuid, '$autocapture', properties, null, sentAt, eventTime, now)
+    await capture({ teamId, distinctId, uuid, event: '$autocapture', properties, token: null, sentAt, eventTime, now })
 
     // Then check that the exportEvents function was called
     const [exportedEvent] = await waitForExpect(() => {
@@ -259,10 +259,16 @@ test.concurrent('consumer updates timestamp exported to prometheus', async () =>
         labels: { topic: 'clickhouse_events_json', partition: '0', groupId: 'async_handlers' },
     })
 
-    await capture(teamId, distinctId, uuid, '$autocapture', {
-        name: 'hehe',
-        uuid: new UUIDT().toString(),
-        $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: '$autocapture',
+        properties: {
+            name: 'hehe',
+            uuid: new UUIDT().toString(),
+            $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
+        },
     })
 
     await waitForExpect(async () => {
@@ -285,9 +291,9 @@ const createHistoricalExportJob = async ({ teamId, pluginConfigId, dateRange }) 
     // adds directly to PostgreSQL using the graphile-worker stored
     // procedure `add_job`. I'd rather keep these tests graphile
     // unaware.
-    await produce(
-        'jobs',
-        Buffer.from(
+    await produce({
+        topic: 'jobs',
+        message: Buffer.from(
             JSON.stringify({
                 type: 'Export historical events V2',
                 pluginConfigId: pluginConfigId,
@@ -299,6 +305,6 @@ const createHistoricalExportJob = async ({ teamId, pluginConfigId, dateRange }) 
                 },
             })
         ),
-        teamId.toString()
-    )
+        key: teamId.toString(),
+    })
 }

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -43,19 +43,31 @@ test.concurrent(`event ingestion: can set and update group properties`, async ()
     const distinctId = new UUIDT().toString()
 
     const groupIdentityUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, groupIdentityUuid, '$groupidentify', {
-        distinct_id: distinctId,
-        $group_type: 'organization',
-        $group_key: 'posthog',
-        $group_set: {
-            prop: 'value',
+    await capture({
+        teamId,
+        distinctId,
+        uuid: groupIdentityUuid,
+        event: '$groupidentify',
+        properties: {
+            distinct_id: distinctId,
+            $group_type: 'organization',
+            $group_key: 'posthog',
+            $group_set: {
+                prop: 'value',
+            },
         },
     })
 
     const firstEventUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, firstEventUuid, 'custom event', {
-        name: 'haha',
-        $group_0: 'posthog',
+    await capture({
+        teamId,
+        distinctId,
+        uuid: firstEventUuid,
+        event: 'custom event',
+        properties: {
+            name: 'haha',
+            $group_0: 'posthog',
+        },
     })
 
     await waitForExpect(async () => {
@@ -71,19 +83,31 @@ test.concurrent(`event ingestion: can set and update group properties`, async ()
     })
 
     const secondGroupIdentityUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, secondGroupIdentityUuid, '$groupidentify', {
-        distinct_id: distinctId,
-        $group_type: 'organization',
-        $group_key: 'posthog',
-        $group_set: {
-            prop: 'updated value',
+    await capture({
+        teamId,
+        distinctId,
+        uuid: secondGroupIdentityUuid,
+        event: '$groupidentify',
+        properties: {
+            distinct_id: distinctId,
+            $group_type: 'organization',
+            $group_key: 'posthog',
+            $group_set: {
+                prop: 'updated value',
+            },
         },
     })
 
     const secondEventUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, secondEventUuid, 'custom event', {
-        name: 'haha',
-        $group_0: 'posthog',
+    await capture({
+        teamId,
+        distinctId,
+        uuid: secondEventUuid,
+        event: 'custom event',
+        properties: {
+            name: 'haha',
+            $group_0: 'posthog',
+        },
     })
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, secondEventUuid)
@@ -103,16 +127,28 @@ test.concurrent(`event ingestion: handles $groupidentify with no properties`, as
     const distinctId = new UUIDT().toString()
 
     const groupIdentityUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, groupIdentityUuid, '$groupidentify', {
-        distinct_id: distinctId,
-        $group_type: 'organization',
-        $group_key: 'posthog',
+    await capture({
+        teamId,
+        distinctId,
+        uuid: groupIdentityUuid,
+        event: '$groupidentify',
+        properties: {
+            distinct_id: distinctId,
+            $group_type: 'organization',
+            $group_key: 'posthog',
+        },
     })
 
     const firstEventUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, firstEventUuid, 'custom event', {
-        name: 'haha',
-        $group_0: 'posthog',
+    await capture({
+        teamId,
+        distinctId,
+        uuid: firstEventUuid,
+        event: 'custom event',
+        properties: {
+            name: 'haha',
+            $group_0: 'posthog',
+        },
     })
 
     const event = await waitForExpect(async () => {
@@ -133,13 +169,19 @@ test.concurrent(`event ingestion: can $set and update person properties`, async 
     const teamId = await createTeam(postgres, organizationId)
     const distinctId = new UUIDT().toString()
 
-    await capture(teamId, distinctId, new UUIDT().toString(), '$identify', {
-        distinct_id: distinctId,
-        $set: { prop: 'value' },
+    await capture({
+        teamId,
+        distinctId,
+        uuid: new UUIDT().toString(),
+        event: '$identify',
+        properties: {
+            distinct_id: distinctId,
+            $set: { prop: 'value' },
+        },
     })
 
     const firstUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, firstUuid, 'custom event', {})
+    await capture({ teamId, distinctId, uuid: firstUuid, event: 'custom event', properties: {} })
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, firstUuid)
         expect(event).toEqual(
@@ -151,13 +193,19 @@ test.concurrent(`event ingestion: can $set and update person properties`, async 
         )
     })
 
-    await capture(teamId, distinctId, new UUIDT().toString(), '$identify', {
-        distinct_id: distinctId,
-        $set: { prop: 'updated value' },
+    await capture({
+        teamId,
+        distinctId,
+        uuid: new UUIDT().toString(),
+        event: '$identify',
+        properties: {
+            distinct_id: distinctId,
+            $set: { prop: 'updated value' },
+        },
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, secondUuid, 'custom event', {})
+    await capture({ teamId, distinctId, uuid: secondUuid, event: 'custom event', properties: {} })
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, secondUuid)
         expect(event).toEqual(
@@ -174,18 +222,30 @@ test.concurrent(`event ingestion: person properties are point in event time`, as
     const teamId = await createTeam(postgres, organizationId)
     const distinctId = new UUIDT().toString()
 
-    await capture(teamId, distinctId, new UUIDT().toString(), '$identify', {
-        distinct_id: distinctId,
-        $set: { prop: 'value' },
+    await capture({
+        teamId,
+        distinctId,
+        uuid: new UUIDT().toString(),
+        event: '$identify',
+        properties: {
+            distinct_id: distinctId,
+            $set: { prop: 'value' },
+        },
     })
 
     const firstUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, firstUuid, 'custom event', {})
-    await capture(teamId, distinctId, new UUIDT().toString(), 'custom event', {
-        distinct_id: distinctId,
-        $set: {
-            prop: 'updated value', // This value should not be reflected in the first event
-            new_prop: 'new value', // This new value should be reflected in the first event
+    await capture({ teamId, distinctId, uuid: firstUuid, event: 'custom event', properties: {} })
+    await capture({
+        teamId,
+        distinctId,
+        uuid: new UUIDT().toString(),
+        event: 'custom event',
+        properties: {
+            distinct_id: distinctId,
+            $set: {
+                prop: 'updated value',
+                new_prop: 'new value',
+            },
         },
     })
 
@@ -206,13 +266,19 @@ test.concurrent(`event ingestion: can $set_once person properties but not update
     const distinctId = new UUIDT().toString()
 
     const personEventUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, personEventUuid, '$identify', {
-        distinct_id: distinctId,
-        $set_once: { prop: 'value' },
+    await capture({
+        teamId,
+        distinctId,
+        uuid: personEventUuid,
+        event: '$identify',
+        properties: {
+            distinct_id: distinctId,
+            $set_once: { prop: 'value' },
+        },
     })
 
     const firstUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, firstUuid, 'custom event', {})
+    await capture({ teamId, distinctId, uuid: firstUuid, event: 'custom event', properties: {} })
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, firstUuid)
         expect(event).toEqual(
@@ -225,13 +291,19 @@ test.concurrent(`event ingestion: can $set_once person properties but not update
         )
     })
 
-    await capture(teamId, distinctId, personEventUuid, '$identify', {
-        distinct_id: distinctId,
-        $set_once: { prop: 'updated value' },
+    await capture({
+        teamId,
+        distinctId,
+        uuid: personEventUuid,
+        event: '$identify',
+        properties: {
+            distinct_id: distinctId,
+            $set_once: { prop: 'updated value' },
+        },
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(teamId, distinctId, secondUuid, 'custom event', {})
+    await capture({ teamId, distinctId, uuid: secondUuid, event: 'custom event', properties: {} })
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, secondUuid)
         expect(event).toEqual(
@@ -250,16 +322,16 @@ test.concurrent(`event ingestion: events without a team_id get processed correct
     const teamId = await createTeam(postgres, organizationId, '', token)
     const personIdentifier = 'test@posthog.com'
 
-    await capture(
-        null, // team_id should be added by the plugin server from the token
-        personIdentifier,
-        new UUIDT().toString(),
-        'test event',
-        {
+    await capture({
+        teamId: null,
+        distinctId: personIdentifier,
+        uuid: new UUIDT().toString(),
+        event: 'test event',
+        properties: {
             distinct_id: personIdentifier,
         },
-        token
-    )
+        token,
+    })
 
     await waitForExpect(async () => {
         const events = await fetchEvents(clickHouseClient, teamId)
@@ -281,7 +353,7 @@ test.concurrent('consumer updates timestamp exported to prometheus', async () =>
         labels: { topic: 'events_plugin_ingestion', partition: '0', groupId: 'ingestion' },
     })
 
-    await capture(teamId, distinctId, new UUIDT().toString(), 'custom event', {})
+    await capture({ teamId, distinctId, uuid: new UUIDT().toString(), event: 'custom event', properties: {} })
 
     await waitForExpect(async () => {
         const metricAfter = await getMetric({
@@ -306,7 +378,7 @@ test.concurrent(`event ingestion: initial login flow keeps the same person_id`, 
     // First we emit an anoymous event and wait for the person to be
     // created.
     const initialEventId = new UUIDT().toString()
-    await capture(teamId, initialDistinctId, initialEventId, 'custom event')
+    await capture({ teamId, distinctId: initialDistinctId, uuid: initialEventId, event: 'custom event' })
     await waitForExpect(async () => {
         const persons = await fetchPersons(clickHouseClient, teamId)
         expect(persons).toContainEqual(
@@ -317,9 +389,15 @@ test.concurrent(`event ingestion: initial login flow keeps the same person_id`, 
     }, 10000)
 
     // We then identify the person
-    await capture(teamId, personIdentifier, new UUIDT().toString(), '$identify', {
-        distinct_id: personIdentifier,
-        $anon_distinct_id: initialDistinctId,
+    await capture({
+        teamId,
+        distinctId: personIdentifier,
+        uuid: new UUIDT().toString(),
+        event: '$identify',
+        properties: {
+            distinct_id: personIdentifier,
+            $anon_distinct_id: initialDistinctId,
+        },
     })
 
     await waitForExpect(async () => {
@@ -341,9 +419,9 @@ testIfPoEEmbraceJoinEnabled(`single merge results in all events resolving to the
 
     // First we emit anoymous events and wait for the persons to be created.
     const initialEventId = new UUIDT().toString()
-    await capture(teamId, initialDistinctId, initialEventId, 'custom event')
+    await capture({ teamId, distinctId: initialDistinctId, uuid: initialEventId, event: 'custom event' })
     const secondEventId = new UUIDT().toString()
-    await capture(teamId, secondDistinctId, secondEventId, 'custom event 2')
+    await capture({ teamId, distinctId: secondDistinctId, uuid: secondEventId, event: 'custom event 2' })
     await waitForExpect(async () => {
         const persons = await fetchPersons(clickHouseClient, teamId)
         expect(persons).toEqual(
@@ -360,14 +438,26 @@ testIfPoEEmbraceJoinEnabled(`single merge results in all events resolving to the
 
     // Then we identify both ids
     const uuidOfFirstIdentifyEvent = new UUIDT().toString()
-    await capture(teamId, personIdentifier, uuidOfFirstIdentifyEvent, '$identify', {
-        distinct_id: personIdentifier,
-        $anon_distinct_id: initialDistinctId,
+    await capture({
+        teamId,
+        distinctId: personIdentifier,
+        uuid: uuidOfFirstIdentifyEvent,
+        event: '$identify',
+        properties: {
+            distinct_id: personIdentifier,
+            $anon_distinct_id: initialDistinctId,
+        },
     })
     const uuidOfSecondIdentifyEvent = new UUIDT().toString()
-    await capture(teamId, personIdentifier, uuidOfSecondIdentifyEvent, '$identify', {
-        distinct_id: personIdentifier,
-        $anon_distinct_id: secondEventId,
+    await capture({
+        teamId,
+        distinctId: personIdentifier,
+        uuid: uuidOfSecondIdentifyEvent,
+        event: '$identify',
+        properties: {
+            distinct_id: personIdentifier,
+            $anon_distinct_id: secondEventId,
+        },
     })
 
     await waitForExpect(async () => {
@@ -387,23 +477,35 @@ testIfPoEEmbraceJoinEnabled(`chained merge results in all events resolving to th
     const thirdDistinctId = new UUIDT().toString()
 
     // First we emit anoymous events and wait for the persons to be created.
-    await capture(teamId, initialDistinctId, new UUIDT().toString(), 'custom event')
-    await capture(teamId, secondDistinctId, new UUIDT().toString(), 'custom event 2')
-    await capture(teamId, thirdDistinctId, new UUIDT().toString(), 'custom event 3')
+    await capture({ teamId, distinctId: initialDistinctId, uuid: new UUIDT().toString(), event: 'custom event' })
+    await capture({ teamId, distinctId: secondDistinctId, uuid: new UUIDT().toString(), event: 'custom event 2' })
+    await capture({ teamId, distinctId: thirdDistinctId, uuid: new UUIDT().toString(), event: 'custom event 3' })
     await waitForExpect(async () => {
         const persons = await fetchPersons(clickHouseClient, teamId)
         expect(persons.length).toBe(3)
     }, 10000)
 
     // Then we identify first two together
-    await capture(teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
-        distinct_id: initialDistinctId,
-        $anon_distinct_id: secondDistinctId,
+    await capture({
+        teamId,
+        distinctId: initialDistinctId,
+        uuid: new UUIDT().toString(),
+        event: '$identify',
+        properties: {
+            distinct_id: initialDistinctId,
+            $anon_distinct_id: secondDistinctId,
+        },
     })
     // Then we merge the third person
-    await capture(teamId, secondDistinctId, new UUIDT().toString(), '$identify', {
-        distinct_id: secondDistinctId,
-        $anon_distinct_id: thirdDistinctId,
+    await capture({
+        teamId,
+        distinctId: secondDistinctId,
+        uuid: new UUIDT().toString(),
+        event: '$identify',
+        properties: {
+            distinct_id: secondDistinctId,
+            $anon_distinct_id: thirdDistinctId,
+        },
     })
 
     await waitForExpect(async () => {
@@ -429,23 +531,35 @@ testIfPoEEmbraceJoinEnabled(
         const forthDistinctId = new UUIDT().toString()
 
         // First we emit anoymous events and wait for the persons to be created.
-        await capture(teamId, initialDistinctId, new UUIDT().toString(), 'custom event')
-        await capture(teamId, secondDistinctId, new UUIDT().toString(), 'custom event 2')
-        await capture(teamId, thirdDistinctId, new UUIDT().toString(), 'custom event 3')
-        await capture(teamId, forthDistinctId, new UUIDT().toString(), 'custom event 3')
+        await capture({ teamId, distinctId: initialDistinctId, uuid: new UUIDT().toString(), event: 'custom event' })
+        await capture({ teamId, distinctId: secondDistinctId, uuid: new UUIDT().toString(), event: 'custom event 2' })
+        await capture({ teamId, distinctId: thirdDistinctId, uuid: new UUIDT().toString(), event: 'custom event 3' })
+        await capture({ teamId, distinctId: forthDistinctId, uuid: new UUIDT().toString(), event: 'custom event 3' })
         await waitForExpect(async () => {
             const persons = await fetchPersons(clickHouseClient, teamId)
             expect(persons.length).toBe(4)
         }, 10000)
 
         // Then we identify 1-2 and 3-4
-        await capture(teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
-            distinct_id: initialDistinctId,
-            $anon_distinct_id: secondDistinctId,
+        await capture({
+            teamId,
+            distinctId: initialDistinctId,
+            uuid: new UUIDT().toString(),
+            event: '$identify',
+            properties: {
+                distinct_id: initialDistinctId,
+                $anon_distinct_id: secondDistinctId,
+            },
         })
-        await capture(teamId, thirdDistinctId, new UUIDT().toString(), '$identify', {
-            distinct_id: thirdDistinctId,
-            $anon_distinct_id: forthDistinctId,
+        await capture({
+            teamId,
+            distinctId: thirdDistinctId,
+            uuid: new UUIDT().toString(),
+            event: '$identify',
+            properties: {
+                distinct_id: thirdDistinctId,
+                $anon_distinct_id: forthDistinctId,
+            },
         })
 
         await waitForExpect(async () => {
@@ -455,9 +569,15 @@ testIfPoEEmbraceJoinEnabled(
 
         // Then we merge 2-3
         // TODO: make this a valid merge event instead of $identify
-        await capture(teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
-            distinct_id: secondDistinctId,
-            $anon_distinct_id: thirdDistinctId,
+        await capture({
+            teamId,
+            distinctId: initialDistinctId,
+            uuid: new UUIDT().toString(),
+            event: '$identify',
+            properties: {
+                distinct_id: secondDistinctId,
+                $anon_distinct_id: thirdDistinctId,
+            },
         })
         await waitForExpect(async () => {
             const events = await fetchEvents(clickHouseClient, teamId)
@@ -487,22 +607,34 @@ test.skip(`person properties don't see properties from descendents`, async () =>
     const firstDistinctId = new UUIDT().toString()
 
     const firstUuid = new UUIDT().toString()
-    await capture(teamId, firstDistinctId, firstUuid, 'custom event', {
-        $set: {
-            k: 'v',
-        },
-        $set_once: {
-            set_once_property: 'value',
+    await capture({
+        teamId,
+        distinctId: firstDistinctId,
+        uuid: firstUuid,
+        event: 'custom event',
+        properties: {
+            $set: {
+                k: 'v',
+            },
+            $set_once: {
+                set_once_property: 'value',
+            },
         },
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(teamId, firstDistinctId, secondUuid, 'custom event', {
-        $set: {
-            j: 'w',
-        },
-        $set_once: {
-            set_once_property: 'second value',
+    await capture({
+        teamId,
+        distinctId: firstDistinctId,
+        uuid: secondUuid,
+        event: 'custom event',
+        properties: {
+            $set: {
+                j: 'w',
+            },
+            $set_once: {
+                set_once_property: 'second value',
+            },
         },
     })
 
@@ -561,16 +693,28 @@ test.skip(`person properties can't see properties from merge descendants`, async
     const bobAnonId = new UUIDT().toString()
 
     const firstUuid = new UUIDT().toString()
-    await capture(teamId, aliceAnonId, firstUuid, 'custom event', {
-        $set: {
-            k: 'v',
+    await capture({
+        teamId,
+        distinctId: aliceAnonId,
+        uuid: firstUuid,
+        event: 'custom event',
+        properties: {
+            $set: {
+                k: 'v',
+            },
         },
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(teamId, bobAnonId, secondUuid, 'custom event', {
-        $set: {
-            j: 'w',
+    await capture({
+        teamId,
+        distinctId: bobAnonId,
+        uuid: secondUuid,
+        event: 'custom event',
+        properties: {
+            $set: {
+                j: 'w',
+            },
         },
     })
 
@@ -578,10 +722,16 @@ test.skip(`person properties can't see properties from merge descendants`, async
     // NOTE: $create_alias is not symmetric, so we will currently get different
     // results according to the order of `bobAnonId` and `aliceAnonId`.
     // TODO: make $create_alias symmetric.
-    await capture(teamId, bobAnonId, thirdUuid, '$create_alias', {
-        alias: aliceAnonId,
-        $set: {
-            l: 'x',
+    await capture({
+        teamId,
+        distinctId: bobAnonId,
+        uuid: thirdUuid,
+        event: '$create_alias',
+        properties: {
+            alias: aliceAnonId,
+            $set: {
+                l: 'x',
+            },
         },
     })
 

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -1,6 +1,5 @@
 import ClickHouse from '@posthog/clickhouse'
 import Redis from 'ioredis'
-import { Kafka, Partitioners, Producer } from 'kafkajs'
 import { Pool } from 'pg'
 
 import { defaultConfig } from '../src/config/config'
@@ -8,10 +7,8 @@ import { UUIDT } from '../src/utils/utils'
 import { capture, createOrganization, createTeam, fetchEvents, fetchPersons, getMetric } from './api'
 import { waitForExpect } from './expectations'
 
-let producer: Producer
 let clickHouseClient: ClickHouse
 let postgres: Pool // NOTE: we use a Pool here but it's probably not necessary, but for instance `insertRow` uses a Pool.
-let kafka: Kafka
 let redis: Redis.Redis
 let organizationId: string
 
@@ -32,16 +29,13 @@ beforeAll(async () => {
             output_format_json_quote_64bit_integers: false,
         },
     })
-    kafka = new Kafka({ brokers: [defaultConfig.KAFKA_HOSTS] })
-    producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner })
-    await producer.connect()
     redis = new Redis(defaultConfig.REDIS_URL)
 
     organizationId = await createOrganization(postgres)
 })
 
 afterAll(async () => {
-    await Promise.all([producer.disconnect(), postgres.end(), redis.disconnect()])
+    await Promise.all([postgres.end(), redis.disconnect()])
 })
 
 test.concurrent(`event ingestion: can set and update group properties`, async () => {
@@ -49,7 +43,7 @@ test.concurrent(`event ingestion: can set and update group properties`, async ()
     const distinctId = new UUIDT().toString()
 
     const groupIdentityUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, groupIdentityUuid, '$groupidentify', {
+    await capture(teamId, distinctId, groupIdentityUuid, '$groupidentify', {
         distinct_id: distinctId,
         $group_type: 'organization',
         $group_key: 'posthog',
@@ -59,7 +53,7 @@ test.concurrent(`event ingestion: can set and update group properties`, async ()
     })
 
     const firstEventUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, firstEventUuid, 'custom event', {
+    await capture(teamId, distinctId, firstEventUuid, 'custom event', {
         name: 'haha',
         $group_0: 'posthog',
     })
@@ -77,7 +71,7 @@ test.concurrent(`event ingestion: can set and update group properties`, async ()
     })
 
     const secondGroupIdentityUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, secondGroupIdentityUuid, '$groupidentify', {
+    await capture(teamId, distinctId, secondGroupIdentityUuid, '$groupidentify', {
         distinct_id: distinctId,
         $group_type: 'organization',
         $group_key: 'posthog',
@@ -87,7 +81,7 @@ test.concurrent(`event ingestion: can set and update group properties`, async ()
     })
 
     const secondEventUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, secondEventUuid, 'custom event', {
+    await capture(teamId, distinctId, secondEventUuid, 'custom event', {
         name: 'haha',
         $group_0: 'posthog',
     })
@@ -109,14 +103,14 @@ test.concurrent(`event ingestion: handles $groupidentify with no properties`, as
     const distinctId = new UUIDT().toString()
 
     const groupIdentityUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, groupIdentityUuid, '$groupidentify', {
+    await capture(teamId, distinctId, groupIdentityUuid, '$groupidentify', {
         distinct_id: distinctId,
         $group_type: 'organization',
         $group_key: 'posthog',
     })
 
     const firstEventUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, firstEventUuid, 'custom event', {
+    await capture(teamId, distinctId, firstEventUuid, 'custom event', {
         name: 'haha',
         $group_0: 'posthog',
     })
@@ -139,13 +133,13 @@ test.concurrent(`event ingestion: can $set and update person properties`, async 
     const teamId = await createTeam(postgres, organizationId)
     const distinctId = new UUIDT().toString()
 
-    await capture(producer, teamId, distinctId, new UUIDT().toString(), '$identify', {
+    await capture(teamId, distinctId, new UUIDT().toString(), '$identify', {
         distinct_id: distinctId,
         $set: { prop: 'value' },
     })
 
     const firstUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, firstUuid, 'custom event', {})
+    await capture(teamId, distinctId, firstUuid, 'custom event', {})
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, firstUuid)
         expect(event).toEqual(
@@ -157,13 +151,13 @@ test.concurrent(`event ingestion: can $set and update person properties`, async 
         )
     })
 
-    await capture(producer, teamId, distinctId, new UUIDT().toString(), '$identify', {
+    await capture(teamId, distinctId, new UUIDT().toString(), '$identify', {
         distinct_id: distinctId,
         $set: { prop: 'updated value' },
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, secondUuid, 'custom event', {})
+    await capture(teamId, distinctId, secondUuid, 'custom event', {})
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, secondUuid)
         expect(event).toEqual(
@@ -180,14 +174,14 @@ test.concurrent(`event ingestion: person properties are point in event time`, as
     const teamId = await createTeam(postgres, organizationId)
     const distinctId = new UUIDT().toString()
 
-    await capture(producer, teamId, distinctId, new UUIDT().toString(), '$identify', {
+    await capture(teamId, distinctId, new UUIDT().toString(), '$identify', {
         distinct_id: distinctId,
         $set: { prop: 'value' },
     })
 
     const firstUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, firstUuid, 'custom event', {})
-    await capture(producer, teamId, distinctId, new UUIDT().toString(), 'custom event', {
+    await capture(teamId, distinctId, firstUuid, 'custom event', {})
+    await capture(teamId, distinctId, new UUIDT().toString(), 'custom event', {
         distinct_id: distinctId,
         $set: {
             prop: 'updated value', // This value should not be reflected in the first event
@@ -212,13 +206,13 @@ test.concurrent(`event ingestion: can $set_once person properties but not update
     const distinctId = new UUIDT().toString()
 
     const personEventUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, personEventUuid, '$identify', {
+    await capture(teamId, distinctId, personEventUuid, '$identify', {
         distinct_id: distinctId,
         $set_once: { prop: 'value' },
     })
 
     const firstUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, firstUuid, 'custom event', {})
+    await capture(teamId, distinctId, firstUuid, 'custom event', {})
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, firstUuid)
         expect(event).toEqual(
@@ -231,13 +225,13 @@ test.concurrent(`event ingestion: can $set_once person properties but not update
         )
     })
 
-    await capture(producer, teamId, distinctId, personEventUuid, '$identify', {
+    await capture(teamId, distinctId, personEventUuid, '$identify', {
         distinct_id: distinctId,
         $set_once: { prop: 'updated value' },
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(producer, teamId, distinctId, secondUuid, 'custom event', {})
+    await capture(teamId, distinctId, secondUuid, 'custom event', {})
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, secondUuid)
         expect(event).toEqual(
@@ -257,7 +251,6 @@ test.concurrent(`event ingestion: events without a team_id get processed correct
     const personIdentifier = 'test@posthog.com'
 
     await capture(
-        producer,
         null, // team_id should be added by the plugin server from the token
         personIdentifier,
         new UUIDT().toString(),
@@ -288,7 +281,7 @@ test.concurrent('consumer updates timestamp exported to prometheus', async () =>
         labels: { topic: 'events_plugin_ingestion', partition: '0', groupId: 'ingestion' },
     })
 
-    await capture(producer, teamId, distinctId, new UUIDT().toString(), 'custom event', {})
+    await capture(teamId, distinctId, new UUIDT().toString(), 'custom event', {})
 
     await waitForExpect(async () => {
         const metricAfter = await getMetric({
@@ -313,7 +306,7 @@ test.concurrent(`event ingestion: initial login flow keeps the same person_id`, 
     // First we emit an anoymous event and wait for the person to be
     // created.
     const initialEventId = new UUIDT().toString()
-    await capture(producer, teamId, initialDistinctId, initialEventId, 'custom event')
+    await capture(teamId, initialDistinctId, initialEventId, 'custom event')
     await waitForExpect(async () => {
         const persons = await fetchPersons(clickHouseClient, teamId)
         expect(persons).toContainEqual(
@@ -324,7 +317,7 @@ test.concurrent(`event ingestion: initial login flow keeps the same person_id`, 
     }, 10000)
 
     // We then identify the person
-    await capture(producer, teamId, personIdentifier, new UUIDT().toString(), '$identify', {
+    await capture(teamId, personIdentifier, new UUIDT().toString(), '$identify', {
         distinct_id: personIdentifier,
         $anon_distinct_id: initialDistinctId,
     })
@@ -348,9 +341,9 @@ testIfPoEEmbraceJoinEnabled(`single merge results in all events resolving to the
 
     // First we emit anoymous events and wait for the persons to be created.
     const initialEventId = new UUIDT().toString()
-    await capture(producer, teamId, initialDistinctId, initialEventId, 'custom event')
+    await capture(teamId, initialDistinctId, initialEventId, 'custom event')
     const secondEventId = new UUIDT().toString()
-    await capture(producer, teamId, secondDistinctId, secondEventId, 'custom event 2')
+    await capture(teamId, secondDistinctId, secondEventId, 'custom event 2')
     await waitForExpect(async () => {
         const persons = await fetchPersons(clickHouseClient, teamId)
         expect(persons).toEqual(
@@ -367,12 +360,12 @@ testIfPoEEmbraceJoinEnabled(`single merge results in all events resolving to the
 
     // Then we identify both ids
     const uuidOfFirstIdentifyEvent = new UUIDT().toString()
-    await capture(producer, teamId, personIdentifier, uuidOfFirstIdentifyEvent, '$identify', {
+    await capture(teamId, personIdentifier, uuidOfFirstIdentifyEvent, '$identify', {
         distinct_id: personIdentifier,
         $anon_distinct_id: initialDistinctId,
     })
     const uuidOfSecondIdentifyEvent = new UUIDT().toString()
-    await capture(producer, teamId, personIdentifier, uuidOfSecondIdentifyEvent, '$identify', {
+    await capture(teamId, personIdentifier, uuidOfSecondIdentifyEvent, '$identify', {
         distinct_id: personIdentifier,
         $anon_distinct_id: secondEventId,
     })
@@ -394,21 +387,21 @@ testIfPoEEmbraceJoinEnabled(`chained merge results in all events resolving to th
     const thirdDistinctId = new UUIDT().toString()
 
     // First we emit anoymous events and wait for the persons to be created.
-    await capture(producer, teamId, initialDistinctId, new UUIDT().toString(), 'custom event')
-    await capture(producer, teamId, secondDistinctId, new UUIDT().toString(), 'custom event 2')
-    await capture(producer, teamId, thirdDistinctId, new UUIDT().toString(), 'custom event 3')
+    await capture(teamId, initialDistinctId, new UUIDT().toString(), 'custom event')
+    await capture(teamId, secondDistinctId, new UUIDT().toString(), 'custom event 2')
+    await capture(teamId, thirdDistinctId, new UUIDT().toString(), 'custom event 3')
     await waitForExpect(async () => {
         const persons = await fetchPersons(clickHouseClient, teamId)
         expect(persons.length).toBe(3)
     }, 10000)
 
     // Then we identify first two together
-    await capture(producer, teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
+    await capture(teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
         distinct_id: initialDistinctId,
         $anon_distinct_id: secondDistinctId,
     })
     // Then we merge the third person
-    await capture(producer, teamId, secondDistinctId, new UUIDT().toString(), '$identify', {
+    await capture(teamId, secondDistinctId, new UUIDT().toString(), '$identify', {
         distinct_id: secondDistinctId,
         $anon_distinct_id: thirdDistinctId,
     })
@@ -436,21 +429,21 @@ testIfPoEEmbraceJoinEnabled(
         const forthDistinctId = new UUIDT().toString()
 
         // First we emit anoymous events and wait for the persons to be created.
-        await capture(producer, teamId, initialDistinctId, new UUIDT().toString(), 'custom event')
-        await capture(producer, teamId, secondDistinctId, new UUIDT().toString(), 'custom event 2')
-        await capture(producer, teamId, thirdDistinctId, new UUIDT().toString(), 'custom event 3')
-        await capture(producer, teamId, forthDistinctId, new UUIDT().toString(), 'custom event 3')
+        await capture(teamId, initialDistinctId, new UUIDT().toString(), 'custom event')
+        await capture(teamId, secondDistinctId, new UUIDT().toString(), 'custom event 2')
+        await capture(teamId, thirdDistinctId, new UUIDT().toString(), 'custom event 3')
+        await capture(teamId, forthDistinctId, new UUIDT().toString(), 'custom event 3')
         await waitForExpect(async () => {
             const persons = await fetchPersons(clickHouseClient, teamId)
             expect(persons.length).toBe(4)
         }, 10000)
 
         // Then we identify 1-2 and 3-4
-        await capture(producer, teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
+        await capture(teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
             distinct_id: initialDistinctId,
             $anon_distinct_id: secondDistinctId,
         })
-        await capture(producer, teamId, thirdDistinctId, new UUIDT().toString(), '$identify', {
+        await capture(teamId, thirdDistinctId, new UUIDT().toString(), '$identify', {
             distinct_id: thirdDistinctId,
             $anon_distinct_id: forthDistinctId,
         })
@@ -462,7 +455,7 @@ testIfPoEEmbraceJoinEnabled(
 
         // Then we merge 2-3
         // TODO: make this a valid merge event instead of $identify
-        await capture(producer, teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
+        await capture(teamId, initialDistinctId, new UUIDT().toString(), '$identify', {
             distinct_id: secondDistinctId,
             $anon_distinct_id: thirdDistinctId,
         })
@@ -494,7 +487,7 @@ test.skip(`person properties don't see properties from descendents`, async () =>
     const firstDistinctId = new UUIDT().toString()
 
     const firstUuid = new UUIDT().toString()
-    await capture(producer, teamId, firstDistinctId, firstUuid, 'custom event', {
+    await capture(teamId, firstDistinctId, firstUuid, 'custom event', {
         $set: {
             k: 'v',
         },
@@ -504,7 +497,7 @@ test.skip(`person properties don't see properties from descendents`, async () =>
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(producer, teamId, firstDistinctId, secondUuid, 'custom event', {
+    await capture(teamId, firstDistinctId, secondUuid, 'custom event', {
         $set: {
             j: 'w',
         },
@@ -568,14 +561,14 @@ test.skip(`person properties can't see properties from merge descendants`, async
     const bobAnonId = new UUIDT().toString()
 
     const firstUuid = new UUIDT().toString()
-    await capture(producer, teamId, aliceAnonId, firstUuid, 'custom event', {
+    await capture(teamId, aliceAnonId, firstUuid, 'custom event', {
         $set: {
             k: 'v',
         },
     })
 
     const secondUuid = new UUIDT().toString()
-    await capture(producer, teamId, bobAnonId, secondUuid, 'custom event', {
+    await capture(teamId, bobAnonId, secondUuid, 'custom event', {
         $set: {
             j: 'w',
         },
@@ -585,7 +578,7 @@ test.skip(`person properties can't see properties from merge descendants`, async
     // NOTE: $create_alias is not symmetric, so we will currently get different
     // results according to the order of `bobAnonId` and `aliceAnonId`.
     // TODO: make $create_alias symmetric.
-    await capture(producer, teamId, bobAnonId, thirdUuid, '$create_alias', {
+    await capture(teamId, bobAnonId, thirdUuid, '$create_alias', {
         alias: aliceAnonId,
         $set: {
             l: 'x',

--- a/plugin-server/functional_tests/jobs-consumer.test.ts
+++ b/plugin-server/functional_tests/jobs-consumer.test.ts
@@ -54,7 +54,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles empty messages`, async () => {
         const key = uuidv4()
 
-        await produce('jobs', null, key)
+        await produce({ topic: 'jobs', message: null, key })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -65,7 +65,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles invalid JSON`, async () => {
         const key = uuidv4()
 
-        await produce('jobs', Buffer.from('invalid json'), key)
+        await produce({ topic: 'jobs', message: Buffer.from('invalid json'), key })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -83,7 +83,7 @@ describe('dlq handling', () => {
             labels: { topic: 'jobs', partition: '0', groupId: 'jobs-inserter' },
         })
 
-        await produce('jobs', Buffer.from(''), '')
+        await produce({ topic: 'jobs', message: Buffer.from(''), key: '' })
 
         await waitForExpect(async () => {
             const metricAfter = await getMetric({

--- a/plugin-server/functional_tests/jobs-consumer.test.ts
+++ b/plugin-server/functional_tests/jobs-consumer.test.ts
@@ -1,18 +1,18 @@
 import Redis from 'ioredis'
-import { Consumer, Kafka, KafkaMessage, logLevel, Partitioners, Producer } from 'kafkajs'
+import { Consumer, Kafka, KafkaMessage, logLevel } from 'kafkajs'
 import { Pool } from 'pg'
 import { v4 as uuidv4 } from 'uuid'
 
 import { defaultConfig } from '../src/config/config'
 import { getMetric } from './api'
 import { waitForExpect } from './expectations'
+import { produce } from './kafka'
 
-let producer: Producer
 let postgres: Pool // NOTE: we use a Pool here but it's probably not necessary, but for instance `insertRow` uses a Pool.
 let kafka: Kafka
 let redis: Redis.Redis
 
-beforeAll(async () => {
+beforeAll(() => {
     // Setup connections to kafka, clickhouse, and postgres
     postgres = new Pool({
         connectionString: defaultConfig.DATABASE_URL!,
@@ -21,100 +21,79 @@ beforeAll(async () => {
         max: 1,
     })
     kafka = new Kafka({ brokers: [defaultConfig.KAFKA_HOSTS], logLevel: logLevel.NOTHING })
-    producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner })
-    await producer.connect()
     redis = new Redis(defaultConfig.REDIS_URL)
 })
 
 afterAll(async () => {
-    await Promise.all([producer.disconnect(), postgres.end(), redis.disconnect()])
+    await Promise.all([postgres.end(), redis.disconnect()])
 })
 
-// Test out some error cases that we wouldn't be able to handle without
-// producing to the jobs queue directly.
+describe('dlq handling', () => {
+    // Test out some error cases that we wouldn't be able to handle without
+    // producing to the jobs queue directly.
 
-let dlq: KafkaMessage[]
-let dlqConsumer: Consumer
+    let dlq: KafkaMessage[]
+    let dlqConsumer: Consumer
 
-beforeAll(async () => {
-    dlq = []
-    dlqConsumer = kafka.consumer({ groupId: 'jobs-consumer-test' })
-    await dlqConsumer.subscribe({ topic: 'jobs_dlq' })
-    await dlqConsumer.run({
-        eachMessage: ({ message }) => {
-            dlq.push(message)
-            return Promise.resolve()
-        },
-    })
-})
-
-afterAll(async () => {
-    await dlqConsumer.disconnect()
-})
-
-test.concurrent(`handles empty messages`, async () => {
-    const key = uuidv4()
-
-    await producer.send({
-        topic: 'jobs',
-        messages: [
-            {
-                key: key,
-                value: null,
+    beforeAll(async () => {
+        dlq = []
+        dlqConsumer = kafka.consumer({ groupId: 'jobs-consumer-test' })
+        await dlqConsumer.subscribe({ topic: 'jobs_dlq' })
+        await dlqConsumer.run({
+            eachMessage: ({ message }) => {
+                dlq.push(message)
+                return Promise.resolve()
             },
-        ],
+        })
     })
 
-    await waitForExpect(() => {
-        const messages = dlq.filter((message) => message.key?.toString() === key)
-        expect(messages.length).toBe(1)
-    })
-})
-
-test.concurrent(`handles invalid JSON`, async () => {
-    const key = uuidv4()
-
-    await producer.send({
-        topic: 'jobs',
-        messages: [
-            {
-                key: key,
-                value: 'invalid json',
-            },
-        ],
+    afterAll(async () => {
+        await dlqConsumer.disconnect()
     })
 
-    await waitForExpect(() => {
-        const messages = dlq.filter((message) => message.key?.toString() === key)
-        expect(messages.length).toBe(1)
-    })
-})
+    test.concurrent(`handles empty messages`, async () => {
+        const key = uuidv4()
 
-test.concurrent('consumer updates timestamp exported to prometheus', async () => {
-    // NOTE: it may be another event other than the one we emit here that causes
-    // the gauge to increase, but pushing this event through should at least
-    // ensure that the gauge is updated.
-    const metricBefore = await getMetric({
-        name: 'latest_processed_timestamp_ms',
-        type: 'GAUGE',
-        labels: { topic: 'jobs', partition: '0', groupId: 'jobs-inserter' },
+        await produce('jobs', null, key)
+
+        await waitForExpect(() => {
+            const messages = dlq.filter((message) => message.key?.toString() === key)
+            expect(messages.length).toBe(1)
+        })
     })
 
-    await producer.send({
-        topic: 'jobs',
-        // NOTE: we don't actually care too much about the contents of the
-        // message, just that it triggeres the consumer to try to process it.
-        messages: [{ key: '', value: '' }],
+    test.concurrent(`handles invalid JSON`, async () => {
+        const key = uuidv4()
+
+        await produce('jobs', Buffer.from('invalid json'), key)
+
+        await waitForExpect(() => {
+            const messages = dlq.filter((message) => message.key?.toString() === key)
+            expect(messages.length).toBe(1)
+        })
     })
 
-    await waitForExpect(async () => {
-        const metricAfter = await getMetric({
+    test.concurrent('consumer updates timestamp exported to prometheus', async () => {
+        // NOTE: it may be another event other than the one we emit here that causes
+        // the gauge to increase, but pushing this event through should at least
+        // ensure that the gauge is updated.
+        const metricBefore = await getMetric({
             name: 'latest_processed_timestamp_ms',
             type: 'GAUGE',
             labels: { topic: 'jobs', partition: '0', groupId: 'jobs-inserter' },
         })
-        expect(metricAfter).toBeGreaterThan(metricBefore)
-        expect(metricAfter).toBeLessThan(Date.now()) // Make sure, e.g. we're not setting micro seconds
-        expect(metricAfter).toBeGreaterThan(Date.now() - 60_000) // Make sure, e.g. we're not setting seconds
-    }, 10_000)
+
+        await produce('jobs', Buffer.from(''), '')
+
+        await waitForExpect(async () => {
+            const metricAfter = await getMetric({
+                name: 'latest_processed_timestamp_ms',
+                type: 'GAUGE',
+                labels: { topic: 'jobs', partition: '0', groupId: 'jobs-inserter' },
+            })
+            expect(metricAfter).toBeGreaterThan(metricBefore)
+            expect(metricAfter).toBeLessThan(Date.now()) // Make sure, e.g. we're not setting micro seconds
+            expect(metricAfter).toBeGreaterThan(Date.now() - 60_000) // Make sure, e.g. we're not setting seconds
+        }, 10_000)
+    })
 })

--- a/plugin-server/functional_tests/kafka.ts
+++ b/plugin-server/functional_tests/kafka.ts
@@ -30,7 +30,7 @@ export async function createKafkaProducer() {
     return producer
 }
 
-export async function produce(topic: string, message: Buffer | null, key: string) {
+export async function produce({ topic, message, key }: { topic: string; message: Buffer | null; key: string }) {
     producer = producer ?? (await createKafkaProducer())
     await new Promise((resolve, reject) =>
         producer.produce(topic, undefined, message, Buffer.from(key), Date.now(), (err, offset) => {

--- a/plugin-server/functional_tests/kafka.ts
+++ b/plugin-server/functional_tests/kafka.ts
@@ -1,0 +1,53 @@
+import { HighLevelProducer } from 'node-rdkafka'
+
+import { defaultConfig } from '../src/config/config'
+
+let producer: HighLevelProducer
+
+beforeAll(async () => {
+    producer = await createKafkaProducer()
+})
+
+afterAll(async () => {
+    await new Promise((resolve, reject) =>
+        producer?.disconnect((error, data) => {
+            return error ? reject(error) : resolve(data)
+        })
+    )
+})
+
+export async function createKafkaProducer() {
+    producer = new HighLevelProducer({
+        'metadata.broker.list': defaultConfig.KAFKA_HOSTS,
+    })
+
+    await new Promise((resolve, reject) =>
+        producer.connect(undefined, (error, data) => {
+            return error ? reject(error) : resolve(data)
+        })
+    )
+
+    return producer
+}
+
+export async function produce(topic: string, message: Buffer | null, key: string) {
+    producer = producer ?? (await createKafkaProducer())
+    await new Promise((resolve, reject) =>
+        producer.produce(topic, undefined, message, Buffer.from(key), Date.now(), (err, offset) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve(offset)
+            }
+        })
+    )
+    await new Promise((resolve, reject) =>
+        producer.flush(10000, (err) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve(null)
+            }
+        })
+    )
+}

--- a/plugin-server/functional_tests/plugins.test.ts
+++ b/plugin-server/functional_tests/plugins.test.ts
@@ -85,7 +85,7 @@ test.concurrent(`plugin method tests: event captured, processed, ingested`, asyn
         properties: { name: 'haha' },
     }
 
-    await capture(teamId, distinctId, uuid, event.event, event.properties)
+    await capture({ teamId, distinctId, uuid, event: event.event, properties: event.properties })
 
     await waitForExpect(async () => {
         const events = await fetchEvents(clickHouseClient, teamId)
@@ -133,7 +133,7 @@ test.concurrent(`plugin method tests: can update distinct_id via processEvent`, 
     const distinctId = new UUIDT().toString()
     const uuid = new UUIDT().toString()
 
-    await capture(teamId, distinctId, uuid, 'custom event')
+    await capture({ teamId, distinctId, uuid, event: 'custom event' })
 
     await waitForExpect(async () => {
         const events = await fetchEvents(clickHouseClient, teamId, uuid)
@@ -166,13 +166,13 @@ test.concurrent(`plugin method tests: can drop events via processEvent`, async (
 
     // First capture the event we want to drop
     const dropMeUuid = new UUIDT().toString()
-    await capture(teamId, aliceId, dropMeUuid, 'drop me')
+    await capture({ teamId, distinctId: aliceId, uuid: dropMeUuid, event: 'drop me' })
 
     // Then capture a custom event that will not be dropped. We capture this
     // second such that if we have ingested this event, we can be reasonably
     // confident that the drop me event was also completely processed.
     const customEventUuid = uuid4()
-    await capture(teamId, bobId, customEventUuid, 'custom event')
+    await capture({ teamId, distinctId: bobId, uuid: customEventUuid, event: 'custom event' })
 
     await waitForExpect(async () => {
         const [event] = await fetchEvents(clickHouseClient, teamId, customEventUuid)
@@ -233,7 +233,7 @@ test.concurrent(
             properties: properties,
         }
 
-        await capture(teamId, distinctId, uuid, event.event, event.properties)
+        await capture({ teamId, distinctId, uuid, event: event.event, properties: event.properties })
 
         await waitForExpect(async () => {
             const logEntries = await fetchPluginLogEntries(clickHouseClient, pluginConfig.id)
@@ -282,9 +282,15 @@ test.concurrent(`plugin jobs: can call runNow from onEvent`, async () => {
     const uuid = new UUIDT().toString()
 
     // First let's ingest an event
-    await capture(teamId, distinctId, uuid, 'custom event', {
-        name: 'hehe',
-        uuid: new UUIDT().toString(),
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: 'custom event',
+        properties: {
+            name: 'hehe',
+            uuid: new UUIDT().toString(),
+        },
     })
 
     await waitForExpect(async () => {
@@ -328,9 +334,15 @@ test.concurrent(`plugin jobs: can call runNow from processEvent`, async () => {
     const uuid = new UUIDT().toString()
 
     // First let's ingest an event
-    await capture(teamId, distinctId, uuid, 'custom event', {
-        name: 'hehe',
-        uuid: new UUIDT().toString(),
+    await capture({
+        teamId,
+        distinctId,
+        uuid,
+        event: 'custom event',
+        properties: {
+            name: 'hehe',
+            uuid: new UUIDT().toString(),
+        },
     })
 
     await waitForExpect(async () => {

--- a/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
+++ b/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
@@ -54,7 +54,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles empty messages`, async () => {
         const key = uuidv4()
 
-        await produce('scheduled_tasks', null, key)
+        await produce({ topic: 'scheduled_tasks', message: null, key })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -65,7 +65,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles invalid JSON`, async () => {
         const key = uuidv4()
 
-        await produce('scheduled_tasks', Buffer.from('invalid json'), key)
+        await produce({ topic: 'scheduled_tasks', message: Buffer.from('invalid json'), key })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -76,11 +76,11 @@ describe('dlq handling', () => {
     test.concurrent(`handles invalid taskType`, async () => {
         const key = uuidv4()
 
-        await produce(
-            'scheduled_tasks',
-            Buffer.from(JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 1 })),
-            key
-        )
+        await produce({
+            topic: 'scheduled_tasks',
+            message: Buffer.from(JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 1 })),
+            key,
+        })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -91,11 +91,11 @@ describe('dlq handling', () => {
     test.concurrent(`handles invalid pluginConfigId`, async () => {
         const key = uuidv4()
 
-        await produce(
-            'scheduled_tasks',
-            Buffer.from(JSON.stringify({ taskType: 'runEveryMinute', pluginConfigId: 'asdf' })),
-            key
-        )
+        await produce({
+            topic: 'scheduled_tasks',
+            message: Buffer.from(JSON.stringify({ taskType: 'runEveryMinute', pluginConfigId: 'asdf' })),
+            key,
+        })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -115,7 +115,7 @@ describe('dlq handling', () => {
 
         // NOTE: we don't actually care too much about the contents of the
         // message, just that it triggeres the consumer to try to process it.
-        await produce('scheduled_tasks', Buffer.from(''), '')
+        await produce({ topic: 'scheduled_tasks', message: Buffer.from(''), key: '' })
 
         await waitForExpect(async () => {
             const metricAfter = await getMetric({

--- a/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
+++ b/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
@@ -1,18 +1,18 @@
 import Redis from 'ioredis'
-import { Consumer, Kafka, KafkaMessage, logLevel, Partitioners, Producer } from 'kafkajs'
+import { Consumer, Kafka, KafkaMessage, logLevel } from 'kafkajs'
 import { Pool } from 'pg'
 import { v4 as uuidv4 } from 'uuid'
 
 import { defaultConfig } from '../src/config/config'
 import { getMetric } from './api'
 import { waitForExpect } from './expectations'
+import { produce } from './kafka'
 
-let producer: Producer
 let postgres: Pool // NOTE: we use a Pool here but it's probably not necessary, but for instance `insertRow` uses a Pool.
 let kafka: Kafka
 let redis: Redis.Redis
 
-beforeAll(async () => {
+beforeAll(() => {
     // Setup connections to kafka, clickhouse, and postgres
     postgres = new Pool({
         connectionString: defaultConfig.DATABASE_URL!,
@@ -21,138 +21,111 @@ beforeAll(async () => {
         max: 1,
     })
     kafka = new Kafka({ brokers: [defaultConfig.KAFKA_HOSTS], logLevel: logLevel.NOTHING })
-    producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner })
-    await producer.connect()
     redis = new Redis(defaultConfig.REDIS_URL)
 })
 
 afterAll(async () => {
-    await Promise.all([producer.disconnect(), postgres.end(), redis.disconnect()])
+    await Promise.all([postgres.end(), redis.disconnect()])
 })
 
-// Test out some error cases that we wouldn't be able to handle without
-// producing to the jobs queue directly.
+describe('dlq handling', () => {
+    // Test out some error cases that we wouldn't be able to handle without
+    // producing to the jobs queue directly.
 
-let dlq: KafkaMessage[]
-let dlqConsumer: Consumer
+    let dlq: KafkaMessage[]
+    let dlqConsumer: Consumer
 
-beforeAll(async () => {
-    dlq = []
-    dlqConsumer = kafka.consumer({ groupId: 'scheduled-tasks-consumer-test' })
-    await dlqConsumer.subscribe({ topic: 'scheduled_tasks_dlq' })
-    await dlqConsumer.run({
-        eachMessage: ({ message }) => {
-            dlq.push(message)
-            return Promise.resolve()
-        },
-    })
-})
-
-afterAll(async () => {
-    await dlqConsumer.disconnect()
-})
-
-test.concurrent(`handles empty messages`, async () => {
-    const key = uuidv4()
-
-    await producer.send({
-        topic: 'scheduled_tasks',
-        messages: [
-            {
-                key: key,
-                value: null,
+    beforeAll(async () => {
+        dlq = []
+        dlqConsumer = kafka.consumer({ groupId: 'scheduled-tasks-consumer-test' })
+        await dlqConsumer.subscribe({ topic: 'scheduled_tasks_dlq' })
+        await dlqConsumer.run({
+            eachMessage: ({ message }) => {
+                dlq.push(message)
+                return Promise.resolve()
             },
-        ],
+        })
     })
 
-    await waitForExpect(() => {
-        const messages = dlq.filter((message) => message.key?.toString() === key)
-        expect(messages.length).toBe(1)
-    })
-})
-
-test.concurrent(`handles invalid JSON`, async () => {
-    const key = uuidv4()
-
-    await producer.send({
-        topic: 'scheduled_tasks',
-        messages: [
-            {
-                key: key,
-                value: 'invalid json',
-            },
-        ],
+    afterAll(async () => {
+        await dlqConsumer.disconnect()
     })
 
-    await waitForExpect(() => {
-        const messages = dlq.filter((message) => message.key?.toString() === key)
-        expect(messages.length).toBe(1)
-    })
-})
+    test.concurrent(`handles empty messages`, async () => {
+        const key = uuidv4()
 
-test.concurrent(`handles invalid taskType`, async () => {
-    const key = uuidv4()
+        await produce('scheduled_tasks', null, key)
 
-    await producer.send({
-        topic: 'scheduled_tasks',
-        messages: [
-            {
-                key: key,
-                value: JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 1 }),
-            },
-        ],
+        await waitForExpect(() => {
+            const messages = dlq.filter((message) => message.key?.toString() === key)
+            expect(messages.length).toBe(1)
+        })
     })
 
-    await waitForExpect(() => {
-        const messages = dlq.filter((message) => message.key?.toString() === key)
-        expect(messages.length).toBe(1)
-    })
-})
+    test.concurrent(`handles invalid JSON`, async () => {
+        const key = uuidv4()
 
-test.concurrent(`handles invalid pluginConfigId`, async () => {
-    const key = uuidv4()
+        await produce('scheduled_tasks', Buffer.from('invalid json'), key)
 
-    await producer.send({
-        topic: 'scheduled_tasks',
-        messages: [
-            {
-                key: key,
-                value: JSON.stringify({ taskType: 'runEveryMinute', pluginConfigId: 'asdf' }),
-            },
-        ],
+        await waitForExpect(() => {
+            const messages = dlq.filter((message) => message.key?.toString() === key)
+            expect(messages.length).toBe(1)
+        })
     })
 
-    await waitForExpect(() => {
-        const messages = dlq.filter((message) => message.key?.toString() === key)
-        expect(messages.length).toBe(1)
-    })
-})
+    test.concurrent(`handles invalid taskType`, async () => {
+        const key = uuidv4()
 
-test.concurrent('consumer updates timestamp exported to prometheus', async () => {
-    // NOTE: it may be another event other than the one we emit here that causes
-    // the gauge to increase, but pushing this event through should at least
-    // ensure that the gauge is updated.
-    const metricBefore = await getMetric({
-        name: 'latest_processed_timestamp_ms',
-        type: 'GAUGE',
-        labels: { topic: 'scheduled_tasks', partition: '0', groupId: 'scheduled-tasks-runner' },
-    })
+        await produce(
+            'scheduled_tasks',
+            Buffer.from(JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 1 })),
+            key
+        )
 
-    await producer.send({
-        topic: 'scheduled_tasks',
-        // NOTE: we don't actually care too much about the contents of the
-        // message, just that it triggeres the consumer to try to process it.
-        messages: [{ key: '', value: '' }],
+        await waitForExpect(() => {
+            const messages = dlq.filter((message) => message.key?.toString() === key)
+            expect(messages.length).toBe(1)
+        })
     })
 
-    await waitForExpect(async () => {
-        const metricAfter = await getMetric({
+    test.concurrent(`handles invalid pluginConfigId`, async () => {
+        const key = uuidv4()
+
+        await produce(
+            'scheduled_tasks',
+            Buffer.from(JSON.stringify({ taskType: 'runEveryMinute', pluginConfigId: 'asdf' })),
+            key
+        )
+
+        await waitForExpect(() => {
+            const messages = dlq.filter((message) => message.key?.toString() === key)
+            expect(messages.length).toBe(1)
+        })
+    })
+
+    test.concurrent('consumer updates timestamp exported to prometheus', async () => {
+        // NOTE: it may be another event other than the one we emit here that causes
+        // the gauge to increase, but pushing this event through should at least
+        // ensure that the gauge is updated.
+        const metricBefore = await getMetric({
             name: 'latest_processed_timestamp_ms',
             type: 'GAUGE',
             labels: { topic: 'scheduled_tasks', partition: '0', groupId: 'scheduled-tasks-runner' },
         })
-        expect(metricAfter).toBeGreaterThan(metricBefore)
-        expect(metricAfter).toBeLessThan(Date.now()) // Make sure, e.g. we're not setting micro seconds
-        expect(metricAfter).toBeGreaterThan(Date.now() - 60_000) // Make sure, e.g. we're not setting seconds
-    }, 10_000)
+
+        // NOTE: we don't actually care too much about the contents of the
+        // message, just that it triggeres the consumer to try to process it.
+        await produce('scheduled_tasks', Buffer.from(''), '')
+
+        await waitForExpect(async () => {
+            const metricAfter = await getMetric({
+                name: 'latest_processed_timestamp_ms',
+                type: 'GAUGE',
+                labels: { topic: 'scheduled_tasks', partition: '0', groupId: 'scheduled-tasks-runner' },
+            })
+            expect(metricAfter).toBeGreaterThan(metricBefore)
+            expect(metricAfter).toBeLessThan(Date.now()) // Make sure, e.g. we're not setting micro seconds
+            expect(metricAfter).toBeGreaterThan(Date.now() - 60_000) // Make sure, e.g. we're not setting seconds
+        }, 10_000)
+    })
 })

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -83,10 +83,16 @@ test.concurrent(
         const distinctId = new UUIDT().toString()
         const uuid = new UUIDT().toString()
 
-        await capture(teamId, distinctId, uuid, '$snapshot', {
-            $session_id: '1234abc',
-            $window_id: 'abc1234',
-            $snapshot_data: 'yes way',
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: '$snapshot',
+            properties: {
+                $session_id: '1234abc',
+                $window_id: 'abc1234',
+                $snapshot_data: 'yes way',
+            },
         })
 
         const events = await waitForExpect(async () => {
@@ -131,21 +137,21 @@ test.concurrent(
         const distinctId = new UUIDT().toString()
         const uuid = new UUIDT().toString()
 
-        await capture(
-            null,
+        await capture({
+            teamId: null,
             distinctId,
             uuid,
-            '$snapshot',
-            {
+            event: '$snapshot',
+            properties: {
                 $session_id: '1234abc',
                 $snapshot_data: 'yes way',
             },
             token,
-            new Date(),
-            new Date(),
-            new Date(),
-            'session_recording_events'
-        )
+            sentAt: new Date(),
+            eventTime: new Date(),
+            now: new Date(),
+            topic: 'session_recording_events',
+        })
 
         await waitForExpect(async () => {
             const events = await fetchSessionRecordingsEvents(clickHouseClient, teamId)
@@ -170,41 +176,41 @@ test.concurrent(`recording events not ingested to ClickHouse if team is opted ou
     const teamOptedOutId = await createTeam(postgres, organizationId, undefined, tokenOptedOut, false)
     const uuidOptedOut = new UUIDT().toString()
 
-    await capture(
-        null,
-        new UUIDT().toString(),
-        uuidOptedOut,
-        '$snapshot',
-        {
+    await capture({
+        teamId: null,
+        distinctId: new UUIDT().toString(),
+        uuid: uuidOptedOut,
+        event: '$snapshot',
+        properties: {
             $session_id: '1234abc',
             $snapshot_data: 'yes way',
         },
-        tokenOptedOut,
-        new Date(),
-        new Date(),
-        new Date(),
-        'session_recording_events'
-    )
+        token: tokenOptedOut,
+        sentAt: new Date(),
+        eventTime: new Date(),
+        now: new Date(),
+        topic: 'session_recording_events',
+    })
 
     const tokenOptedIn = uuidv4()
     const teamOptedInId = await createTeam(postgres, organizationId, undefined, tokenOptedIn)
     const uuidOptedIn = new UUIDT().toString()
 
-    await capture(
-        null,
-        new UUIDT().toString(),
-        uuidOptedIn,
-        '$snapshot',
-        {
+    await capture({
+        teamId: null,
+        distinctId: new UUIDT().toString(),
+        uuid: uuidOptedIn,
+        event: '$snapshot',
+        properties: {
             $session_id: '1234abc',
             $snapshot_data: 'yes way',
         },
-        tokenOptedIn,
-        new Date(),
-        new Date(),
-        new Date(),
-        'session_recording_events'
-    )
+        token: tokenOptedIn,
+        sentAt: new Date(),
+        eventTime: new Date(),
+        now: new Date(),
+        topic: 'session_recording_events',
+    })
 
     await waitForExpect(async () => {
         const events = await fetchSessionRecordingsEvents(clickHouseClient, teamOptedInId)
@@ -229,9 +235,15 @@ test.concurrent(
         const distinctId = new UUIDT().toString()
         const uuid = new UUIDT().toString()
 
-        await capture(teamId, distinctId, uuid, '$snapshot', {
-            $session_id: '1234abc',
-            $snapshot_data: 'yes way',
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: '$snapshot',
+            properties: {
+                $session_id: '1234abc',
+                $snapshot_data: 'yes way',
+            },
         })
 
         await waitForExpect(async () => {
@@ -240,21 +252,21 @@ test.concurrent(
             return events
         })
 
-        await capture(
+        await capture({
             teamId,
             distinctId,
             uuid,
-            '$snapshot',
-            {
+            event: '$snapshot',
+            properties: {
                 $session_id: '1234abc',
                 $snapshot_data: 'yes way',
             },
-            null,
-            new Date(),
-            new Date(),
-            new Date(),
-            'session_recording_events'
-        )
+            token: null,
+            sentAt: new Date(),
+            eventTime: new Date(),
+            now: new Date(),
+            topic: 'session_recording_events',
+        })
 
         const eventsThroughNewTopic = await waitForExpect(async () => {
             const eventsThroughNewTopic = await fetchSessionRecordingsEvents(clickHouseClient, teamId)
@@ -324,7 +336,17 @@ test.concurrent(
             $current_url: 'http://localhost:8000/recordings/recent',
         }
 
-        await capture(teamId, distinctId, uuid, '$performance_event', properties, null, now, now, now)
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: '$performance_event',
+            properties,
+            token: null,
+            sentAt: now,
+            eventTime: now,
+            now,
+        })
 
         const events = await waitForExpect(async () => {
             const events = await fetchPerformanceEvents(clickHouseClient, teamId)
@@ -399,12 +421,18 @@ test.concurrent(
         const uuid = new UUIDT().toString()
         const now = new Date()
 
-        await capture(teamId, distinctId, uuid, '$performance_event', {
-            '0': 'resource',
-            '1': now.getTime(),
-            '40': now.getTime() + 1000,
-            $session_id: '1234abc',
-            $snapshot_data: 'yes way',
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: '$performance_event',
+            properties: {
+                '0': 'resource',
+                '1': now.getTime(),
+                '40': now.getTime() + 1000,
+                $session_id: '1234abc',
+                $snapshot_data: 'yes way',
+            },
         })
 
         await waitForExpect(async () => {
@@ -413,24 +441,24 @@ test.concurrent(
             return events
         })
 
-        await capture(
+        await capture({
             teamId,
             distinctId,
             uuid,
-            '$performance_event',
-            {
+            event: '$performance_event',
+            properties: {
                 '0': 'resource',
                 '1': now.getTime(),
                 '40': now.getTime() + 1000,
                 $session_id: '1234abc',
                 $snapshot_data: 'yes way',
             },
-            null,
+            token: null,
+            sentAt: now,
+            eventTime: now,
             now,
-            now,
-            now,
-            'session_recording_events'
-        )
+            topic: 'session_recording_events',
+        })
 
         const eventsThroughNewTopic = await waitForExpect(async () => {
             const eventsThroughNewTopic = await fetchPerformanceEvents(clickHouseClient, teamId)
@@ -467,7 +495,7 @@ test.concurrent(
     async () => {
         const key = uuidv4()
 
-        await produce('session_recording_events', null, key)
+        await produce({ topic: 'session_recording_events', message: null, key })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -487,7 +515,7 @@ test.concurrent('consumer updates timestamp exported to prometheus', async () =>
         labels: { topic: 'session_recording_events', partition: '0', groupId: 'session-recordings' },
     })
 
-    await produce('session_recording_events', Buffer.from(''), '')
+    await produce({ topic: 'session_recording_events', message: Buffer.from(''), key: '' })
 
     await waitForExpect(async () => {
         const metricAfter = await getMetric({
@@ -504,7 +532,7 @@ test.concurrent('consumer updates timestamp exported to prometheus', async () =>
 test.concurrent(`handles invalid JSON`, async () => {
     const key = uuidv4()
 
-    await produce('session_recording_events', Buffer.from('invalid json'), key)
+    await produce({ topic: 'session_recording_events', message: Buffer.from('invalid json'), key })
 
     await waitForExpect(() => {
         const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -515,7 +543,7 @@ test.concurrent(`handles invalid JSON`, async () => {
 test.concurrent(`handles message with no token`, async () => {
     const key = uuidv4()
 
-    await produce('session_recording_events', Buffer.from(JSON.stringify({})), key)
+    await produce({ topic: 'session_recording_events', message: Buffer.from(JSON.stringify({})), key })
 
     await waitForExpect(() => {
         const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -527,15 +555,15 @@ test.concurrent(`handles message with token and no associated team_id`, async ()
     const key = uuidv4()
     const token = uuidv4()
 
-    await produce(
-        'session_recording_events',
-        Buffer.from(
+    await produce({
+        topic: 'session_recording_events',
+        message: Buffer.from(
             JSON.stringify({
                 token: token,
             })
         ),
-        key
-    )
+        key,
+    })
 
     await waitForExpect(() => {
         const messages = dlq.filter((message) => message.key?.toString() === key)

--- a/plugin-server/functional_tests/web-performance-events.test.ts
+++ b/plugin-server/functional_tests/web-performance-events.test.ts
@@ -45,12 +45,18 @@ test.concurrent(
         const distinctId = new UUIDT().toString()
         const uuid = new UUIDT().toString()
 
-        await capture(teamId, distinctId, uuid, '$performance_event', {
-            '0': 'resource',
-            $session_id: '$session_id_1',
-            $window_id: '$window_id_1',
-            $pageview_id: '$pageview_id_1',
-            $current_url: '$current_url_1',
+        await capture({
+            teamId,
+            distinctId,
+            uuid,
+            event: '$performance_event',
+            properties: {
+                '0': 'resource',
+                $session_id: '$session_id_1',
+                $window_id: '$window_id_1',
+                $pageview_id: '$pageview_id_1',
+                $current_url: '$current_url_1',
+            },
         })
 
         await delayUntilEventIngested(() => fetchPerformanceEvents(clickHouseClient, teamId), 1, 500, 40)

--- a/plugin-server/functional_tests/webhooks.test.ts
+++ b/plugin-server/functional_tests/webhooks.test.ts
@@ -1,15 +1,12 @@
 import { createServer } from 'http'
 import Redis from 'ioredis'
-import { Kafka, Partitioners, Producer } from 'kafkajs'
 import { Pool } from 'pg'
 
 import { defaultConfig } from '../src/config/config'
 import { UUIDT } from '../src/utils/utils'
 import { capture, createAction, createOrganization, createTeam, createUser, reloadAction } from './api'
 
-let producer: Producer
 let postgres: Pool // NOTE: we use a Pool here but it's probably not necessary, but for instance `insertRow` uses a Pool.
-let kafka: Kafka
 let redis: Redis.Redis
 let organizationId: string
 
@@ -21,16 +18,13 @@ beforeAll(async () => {
         // so set max connections to 1.
         max: 1,
     })
-    kafka = new Kafka({ brokers: [defaultConfig.KAFKA_HOSTS] })
-    producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner })
-    await producer.connect()
     redis = new Redis(defaultConfig.REDIS_URL)
 
     organizationId = await createOrganization(postgres)
 })
 
 afterAll(async () => {
-    await Promise.all([producer.disconnect(), postgres.end(), redis.disconnect()])
+    await Promise.all([postgres.end(), redis.disconnect()])
 })
 
 test.concurrent(`webhooks: fires slack webhook`, async () => {
@@ -93,7 +87,7 @@ test.concurrent(`webhooks: fires slack webhook`, async () => {
 
         await reloadAction(redis, teamId, action.id)
 
-        await capture(producer, teamId, distinctId, new UUIDT().toString(), '$autocapture', {
+        await capture(teamId, distinctId, new UUIDT().toString(), '$autocapture', {
             name: 'hehe',
             uuid: new UUIDT().toString(),
             $current_url: 'http://localhost:8000',

--- a/plugin-server/functional_tests/webhooks.test.ts
+++ b/plugin-server/functional_tests/webhooks.test.ts
@@ -87,11 +87,17 @@ test.concurrent(`webhooks: fires slack webhook`, async () => {
 
         await reloadAction(redis, teamId, action.id)
 
-        await capture(teamId, distinctId, new UUIDT().toString(), '$autocapture', {
-            name: 'hehe',
+        await capture({
+            teamId,
+            distinctId,
             uuid: new UUIDT().toString(),
-            $current_url: 'http://localhost:8000',
-            $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: 'text' }],
+            event: '$autocapture',
+            properties: {
+                name: 'hehe',
+                uuid: new UUIDT().toString(),
+                $current_url: 'http://localhost:8000',
+                $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: 'text' }],
+            },
         })
 
         for (const _ in Array.from(Array(20).keys())) {

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -68,6 +68,7 @@
         "lru-cache": "^6.0.0",
         "luxon": "^1.27.0",
         "node-fetch": "^2.6.1",
+        "node-rdkafka": "^2.15.0",
         "node-schedule": "^2.1.0",
         "pg": "^8.6.0",
         "pino": "^8.6.0",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -73,6 +73,7 @@ specifiers:
   lru-cache: ^6.0.0
   luxon: ^1.27.0
   node-fetch: ^2.6.1
+  node-rdkafka: ^2.15.0
   node-schedule: ^2.1.0
   parse-prometheus-text-format: ^1.1.1
   pg: ^8.6.0
@@ -125,6 +126,7 @@ dependencies:
   lru-cache: 6.0.0
   luxon: 1.28.0
   node-fetch: 2.6.7
+  node-rdkafka: 2.15.0
   node-schedule: 2.1.0
   pg: 8.8.0
   pino: 8.7.0
@@ -3484,7 +3486,6 @@ packages:
     dependencies:
       file-uri-to-path: 1.0.0
     dev: false
-    optional: true
 
   /bintrees/1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
@@ -4689,7 +4690,6 @@ packages:
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
     dev: false
-    optional: true
 
   /file-uri-to-path/2.0.0:
     resolution: {integrity: sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==}
@@ -6777,6 +6777,15 @@ packages:
   /node-int64/0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
+
+  /node-rdkafka/2.15.0:
+    resolution: {integrity: sha512-LXeliPuuWC9QaeQL48RWbXz1AUl6M0JAbZJN800VHYMXO+jO7GBc97rtClBau+fMj2qxFiPw+d0IovIIcgaVdw==}
+    engines: {node: '>=6.0.0'}
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.17.0
+    dev: false
 
   /node-releases/2.0.6:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}


### PR DESCRIPTION
While trying to port the session recordings to use node-librdkafka I
found it useful to first implement it in the functional tests.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
