### PR TITLE
fix(ingestion): consider ECONNREFUSED & ETIMEDOUT PG errors retryable

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -139,6 +139,8 @@ export const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'server closed the connection unexpectedly',
     'getaddrinfo EAI_AGAIN',
     'Connection terminated unexpectedly',
+    'ECONNREFUSED',
+    'ETIMEDOUT',
 ]
 
 /** The recommended way of accessing the database. */


### PR DESCRIPTION
## Problem

Tested lightweight capture on dev this morning by scaling-down pgbouncer. While capture behaved as expected, plugin-server sent the events to the DLQ instead of retrying them.

## Changes

Add `ECONNREFUSED` and `ETIMEDOUT` (the errors observed today) in `POSTGRES_UNAVAILABLE_ERROR_MESSAGES` as a quick fix forward.

We should evaluate a nicer way to do this, but that might do it for now.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
