### PR TITLE
fix(sampling): correct results of sum when query is sampled

### DIFF
--- a/posthog/queries/test/test_util.py
+++ b/posthog/queries/test/test_util.py
@@ -19,3 +19,6 @@ class TestQueriesUtil(TestCase):
 
         res = correct_result_for_sampling(1, 0.01, "p90_count_per_actor")
         self.assertEqual(res, 1)
+
+        res = correct_result_for_sampling(1, 0.01, "sum")
+        self.assertEqual(res, 100)

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -108,8 +108,11 @@ def correct_result_for_sampling(value: int, sampling_factor: Optional[float], en
 
     # We don't adjust results for sampling if:
     # - There's no sampling_factor specified i.e. the query isn't sampled
-    # - The query performs a math operation because math operations on sampled data yield results in the correct format
-    if (not sampling_factor) or (entity_math is not None and entity_math in ALL_SUPPORTED_MATH_FUNCTIONS):
+    # - The query performs a math operation other than 'sum' because statistical math operations
+    # on sampled data yield results in the correct format
+    if (not sampling_factor) or (
+        entity_math is not None and entity_math != "sum" and entity_math in ALL_SUPPORTED_MATH_FUNCTIONS
+    ):
         return value
 
     result: int = round(value * (1 / sampling_factor))

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -15,6 +15,7 @@
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
          "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."session_recording_version",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",


### PR DESCRIPTION
sum is the one math function we should correct sampled results for

