### PR TITLE
feat(capture): final lightweight capture touch-ups

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -527,7 +527,10 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
     if event["event"] in ("$snapshot", "$performance_event"):
         return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
 
-    candidate_partition_key = f"{team_id}:{distinct_id}"
+    if team_id:
+        candidate_partition_key = f"{team_id}:{distinct_id}"
+    else:
+        candidate_partition_key = f"{token}:{distinct_id}"
 
     if is_randomly_partitioned(candidate_partition_key) is False:
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -69,7 +69,7 @@ PARTITION_KEY_CAPACITY_EXCEEDED_COUNTER = Counter(
 
 TOKEN_SHAPE_INVALID_COUNTER = Counter(
     "capture_token_shape_invalid_total",
-    "Events (soon to be) dropped due to an invalid token shape, per reason.",
+    "Events dropped due to an invalid token shape, per reason.",
     labelnames=["stage", "reason"],
 )
 
@@ -202,8 +202,8 @@ def _check_token_shape(token: Any) -> Optional[str]:
         return "too_long"
     if not token.isascii():  # Legacy tokens were base64, so let's be permissive
         return "not_ascii"
-    if token.startswith("phx_"):  # Used by previous versions of the zapier integration, should not happen now
-        return "personal_token"
+    if token.startswith("phx_"):  # Used by previous versions of the zapier integration, can happen on user error
+        return "personal_api_key"
     return None
 
 
@@ -301,16 +301,6 @@ def get_event(request):
     with start_span(op="request.authenticate"):
         token = get_token(data, request)
 
-        try:
-            invalid_token_reason = _check_token_shape(token)
-        except Exception as e:
-            invalid_token_reason = "exception"
-            logger.warning("capture_token_shape_exception", token=token, reason="exception", exception=e)
-
-        if invalid_token_reason:
-            # TODO: start rejecting requests here if  the after_resolution contexts are empty (no false-positives)
-            TOKEN_SHAPE_INVALID_COUNTER.labels(stage="before_resolution", reason=invalid_token_reason).inc()
-
         if not token:
             return cors_response(
                 request,
@@ -323,10 +313,29 @@ def get_event(request):
                 ),
             )
 
+        try:
+            invalid_token_reason = _check_token_shape(token)
+        except Exception as e:
+            invalid_token_reason = "exception"
+            logger.warning("capture_token_shape_exception", token=token, reason="exception", exception=e)
+
         ingestion_context = None
         send_events_to_dead_letter_queue = False
 
         if settings.LIGHTWEIGHT_CAPTURE_ENDPOINT_ALL or token in settings.LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS:
+            if invalid_token_reason:
+                TOKEN_SHAPE_INVALID_COUNTER.labels(reason=invalid_token_reason).inc()
+                return cors_response(
+                    request,
+                    generate_exception_response(
+                        "capture",
+                        f"Provided API key is not valid: {invalid_token_reason}",
+                        type="authentication_error",
+                        code=invalid_token_reason,
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                    ),
+                )
+
             logger.debug("lightweight_capture_endpoint_hit", token=token)
             statsd.incr("lightweight_capture_endpoint_hit")
         else:
@@ -337,11 +346,6 @@ def get_event(request):
 
             if db_error:
                 send_events_to_dead_letter_queue = True
-
-    if invalid_token_reason:
-        # TODO: remove after we have proven we don't have false-positives
-        TOKEN_SHAPE_INVALID_COUNTER.labels(stage="after_resolution", reason=invalid_token_reason).inc()
-        logger.warning("capture_token_shape_false_positive", token=token, reason=invalid_token_reason)
 
     team_id = ingestion_context.team_id if ingestion_context else None
     structlog.contextvars.bind_contextvars(team_id=team_id)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -325,6 +325,7 @@ def get_event(request):
         if settings.LIGHTWEIGHT_CAPTURE_ENDPOINT_ALL or token in settings.LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS:
             if invalid_token_reason:
                 TOKEN_SHAPE_INVALID_COUNTER.labels(reason=invalid_token_reason).inc()
+                logger.warning("capture_token_shape_invalid", token=token, reason=invalid_token_reason)
                 return cors_response(
                     request,
                     generate_exception_response(

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -15,6 +15,7 @@
          "posthog_team"."session_recording_opt_in",
          "posthog_team"."capture_console_log_opt_in",
          "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."session_recording_version",
          "posthog_team"."signup_token",
          "posthog_team"."is_demo",
          "posthog_team"."access_control",


### PR DESCRIPTION
## Problem

Hopefully closes https://github.com/PostHog/posthog/issues/14328

## Changes

- We have confirmed that `_check_token_shape` does not introduce false-positives, have it reject requests with 401 if false. Only doing so in the `LIGHTWEIGHT_CAPTURE_ENDPOINT_ALL` code path, so that we can disable it quickly if we find a regression
- Use the token instead of the team_id to build `candidate_partition_key` if the team_id is unavailable. @tomasfarias, this means that our current values for `EVENT_PARTITION_KEYS_TO_OVERRIDE` will be ineffective, but I hope the automatic detection will protect us? 🤞 


## How did you test this code?

