### PR TITLE
chore(metrics): reduce cardinality of django metrics buckets

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -284,3 +284,9 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
 )
 
 KAFKA_PRODUCE_ACK_TIMEOUT_SECONDS = int(os.getenv("KAFKA_PRODUCE_ACK_TIMEOUT_SECONDS", None) or 10)
+
+# Prometheus Django metrics settings, see
+# https://github.com/korfuri/django-prometheus for more details
+
+# We keep the number of buckets low to reduce resource usage on the Prometheus
+PROMETHEUS_LATENCY_BUCKETS = [0.1, 0.3, 0.9, 2.7, 8.1] + [float("inf")]


### PR DESCRIPTION
This is to reduce a little resource usage on the prom metrics server.

The default is 

```
PROMETHEUS_LATENCY_BUCKETS = (0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 25.0, 50.0, 75.0, float("inf"),)
```

Which I think is a bit much.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
