### PR TITLE
test(unit): fix running only files of given chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "copy-scripts": "mkdir -p frontend/dist/ && ./bin/copy-posthog-js",
         "test": "pnpm test:unit && pnpm test:visual-regression",
-        "test:unit": "jest --testPathPattern=frontend/",
+        "test:unit": "jest",
         "test:visual-regression": "docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual-regression:legacy:docker && pnpm test:visual-regression:stories:docker",
         "test:visual-regression:legacy": "docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual-regression:legacy:docker",
         "test:visual-regression:legacy:docker": "STORYBOOK_URL=http://host.docker.internal:6006 playwright test -u",


### PR DESCRIPTION
## Problem

The current `test:unit` script ignores file patterns, which causes CI to run all tests for all 3 chunks. See e.g. https://github.com/PostHog/posthog/actions/runs/4306146697/jobs/7509591280.

## Changes

- This PR removes the `testPathPattern` option from the script - seems it wasn't necessary as the exact same number of tests are run with and without the option.

## How did you test this code?

This PR.