### PR TITLE
test(unit): don't use test chunks

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -70,6 +70,6 @@ jobs:
 
             - name: Test with Jest
               # set maxWorkers or Jest only uses 1 CPU in GitHub Actions
-              run: pnpm test:unit --maxWorkers=1
+              run: pnpm test:unit --runInBand
               env:
                   NODE_OPTIONS: --max-old-space-size=6144

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -70,6 +70,6 @@ jobs:
 
             - name: Test with Jest
               # set maxWorkers or Jest only uses 1 CPU in GitHub Actions
-              run: pnpm test:unit --maxWorkers=2
+              run: pnpm test:unit --maxWorkers=1
               env:
                   NODE_OPTIONS: --max-old-space-size=6144

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -47,48 +47,9 @@ jobs:
             - name: Check if "schema.json" is up to date
               run: pnpm schema:build:json && git diff --exit-code
 
-    jest-setup:
-        # Split the tests into multiple chunks
-        runs-on: ubuntu-latest
-        outputs:
-            test-chunks: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
-            test-chunk-ids: ${{ steps['set-test-chunk-ids'].outputs['test-chunk-ids'] }}
-        steps:
-            - uses: actions/checkout@v3
-            - name: Install pnpm
-              uses: pnpm/action-setup@v2
-              with:
-                  version: 7.x.x
-
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-                  cache: pnpm
-
-            - run: pnpm install --frozen-lockfile
-            - id: set-test-chunks
-              name: Set Chunks
-              # Looks at the output of 'pnpm test:unit -- --listTests --json'
-              # Take the 5th line of the output (the first two are pnpm non-sense)
-              # Split the test into 3 parts. To increase the number split change the denominator in `length / 3`
-              run: echo "test-chunks=$(pnpm test:unit --listTests --json | sed -n 5p | jq -cM '[_nwise(length / 3 | ceil)]')" >> $GITHUB_OUTPUT
-            - id: set-test-chunk-ids
-              name: Set Chunk IDs
-              run: echo "test-chunk-ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
-              env:
-                  CHUNKS: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
-
     jest:
         runs-on: ubuntu-20.04
-        name: Jest test (${{ matrix.chunk }})
-        needs: [jest-setup]
-
-        strategy:
-            # If one test fails, still run the others
-            fail-fast: false
-            matrix:
-                chunk: ${{fromJson(needs.jest-setup.outputs['test-chunk-ids'])}}
+        name: Jest tests
 
         steps:
             - uses: actions/checkout@v3
@@ -109,7 +70,6 @@ jobs:
 
             - name: Test with Jest
               # set maxWorkers or Jest only uses 1 CPU in GitHub Actions
-              run: pnpm test:unit --maxWorkers=2 $(echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text')
+              run: pnpm test:unit --maxWorkers=2
               env:
                   NODE_OPTIONS: --max-old-space-size=6144
-                  CHUNKS: ${{ needs.jest-setup.outputs['test-chunks'] }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "copy-scripts": "mkdir -p frontend/dist/ && ./bin/copy-posthog-js",
         "test": "pnpm test:unit && pnpm test:visual-regression",
-        "test:unit": "jest --testPathPattern=frontend/",
+        "test:unit": "jest",
         "test:visual-regression": "docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual-regression:legacy:docker && pnpm test:visual-regression:stories:docker",
         "test:visual-regression:legacy": "docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual-regression:legacy:docker",
         "test:visual-regression:legacy:docker": "STORYBOOK_URL=http://host.docker.internal:6006 playwright test -u",


### PR DESCRIPTION
## Problem

Supposedly jest can run faster with one worker / no workers at all in CI, as it has limited resources. See e.g. here https://ivantanev.com/make-jest-faster/. Quick testing in the PR denies this hypothesis and running with two workers is faster.

## Changes

This PR tries running the tests
- A: in a single step (hypothesis: setup and launching a runner take time; running setup is brittle e.g. pnpm install) - 3m 31s
  https://github.com/PostHog/posthog/actions/runs/4308670420/jobs/7515195503
- B: in a single step, with only one worker (hypothesis: this is faster due to limited resources in ci) - 7m 29s
  https://github.com/PostHog/posthog/actions/runs/4308716127/jobs/7515290739
- C: in a single step, disabling workers using `--runInBand` (hypothesis: this is even faster due to limited resources in ci) - 5m 42s


## How did you test this code?

See above.