### PR TITLE
fix(plugin-server): don't DLQ session recordings with invalid token

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -11,7 +11,7 @@ import { createPerformanceEvent, createSessionRecordingEvent } from '../../worke
 import { TeamManager } from '../../worker/ingestion/team-manager'
 import { parseEventTimestamp } from '../../worker/ingestion/timestamps'
 import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
-import { latestOffsetTimestampGauge } from './metrics'
+import { eventDroppedCounter, latestOffsetTimestampGauge } from './metrics'
 
 export const startSessionRecordingEventsConsumer = async ({
     teamManager,
@@ -149,12 +149,17 @@ export const eachBatch =
                 .observe(message.value.length)
 
             if (messagePayload.team_id == null && !messagePayload.token) {
+                eventDroppedCounter
+                    .labels({
+                        event_type: 'session_recordings',
+                        drop_cause: 'no_token',
+                    })
+                    .inc()
                 status.warn('⚠️', 'invalid_message', {
                     reason: 'no_token',
                     partition: batch.partition,
                     offset: message.offset,
                 })
-                await producer.queueMessage({ topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ, messages: [message] })
                 continue
             }
 
@@ -167,12 +172,17 @@ export const eachBatch =
             }
 
             if (team == null) {
+                eventDroppedCounter
+                    .labels({
+                        event_type: 'session_recordings',
+                        drop_cause: 'invalid_token',
+                    })
+                    .inc()
                 status.warn('⚠️', 'invalid_message', {
                     reason: 'team_not_found',
                     partition: batch.partition,
                     offset: message.offset,
                 })
-                await producer.queueMessage({ topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ, messages: [message] })
                 continue
             }
 


### PR DESCRIPTION
## Problem

With lightweigth capture on, we're ingesting session-recordings with invalid tokens now.

Instead of DLQ-ing them, drop them if team_id resolution fails.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
