### PR TITLE
fix(ingestion): use the token for the overflow logic not just team_id

### DIFF
--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -112,7 +112,10 @@ export async function eachBatchIngestionWithOverflow(
 
         for (const message of kafkaMessages) {
             const pluginEvent = formPipelineEvent(message)
-            const seenKey = `${pluginEvent.team_id}:${pluginEvent.distinct_id}`
+            // NOTE: we need to ensure that we either use the team_id or the
+            // token whilst we haven't fully rolled out lightweight capture i.e.
+            // we can't rely on token being set.
+            const seenKey = `${pluginEvent.team_id ?? pluginEvent.token}:${pluginEvent.distinct_id}`
 
             // Events with a null key should have been produced to the the
             // KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW topic, so we shouldn't see them here as this consumer's

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
@@ -66,6 +66,8 @@ export async function eachBatchIngestionFromOverflow(
 export async function eachMessageIngestionFromOverflow(message: KafkaMessage, queue: IngestionConsumer): Promise<void> {
     const pluginEvent = formPipelineEvent(message)
     // Warnings are limited to 1/key/hour to avoid spamming.
+    // TODO: now that we use lightweight capture, we need to ensure that we
+    // resolve the team_id, as at the moment it will always be null.
     if (pluginEvent.team_id && WarningLimiter.consume(`${pluginEvent.team_id}:${pluginEvent.distinct_id}`, 1)) {
         captureIngestionWarning(queue.pluginsServer.db, pluginEvent.team_id, 'ingestion_capacity_overflow', {
             overflowDistinctId: pluginEvent.distinct_id,


### PR DESCRIPTION
For lightweight capture we do not have the team_id at this point.
Lightweight capture isn't rolled out completely so we also need to use
the team_id if we are given it.

Note that at the moment we will not be sending the ingestion warning for
events that are from the lightweight capture endpoint.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
