### PR TITLE
fix(tests): Allow foreign key constraints in migrations

### DIFF
--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -43,9 +43,25 @@ class Command(BaseCommand):
                         )
                         sys.exit(1)
 
-                    if "CONSTRAINT" in operation_sql and "CREATE TABLE" not in operation_sql:
+                    if (
+                        "CONSTRAINT" in operation_sql
+                        and "CREATE TABLE"
+                        not in operation_sql  # you can set any constraint you want when creating a table
+                        and "REFERENCES" not in operation_sql  # Foreign keys are handled in the next if statement
+                    ):
                         print(
                             f"\n\n\033[91mFound a CONSTRAINT command. This locks tables which causes downtime. Please avoid adding constraints to existing tables.\nSource: `{operation_sql}`"
+                        )
+                        sys.exit(1)
+
+                    if (
+                        "CONSTRAINT" in operation_sql
+                        and "CREATE TABLE" not in operation_sql
+                        and "REFERENCES" in operation_sql
+                        and "NOT NULL" in operation_sql
+                    ):
+                        print(
+                            f"\n\n\033[91mIt looks like you're trying to add a foreign key field that is not nullable. This locks tables which causes downtime. Please add `null=True, blank=True` to the field.\nSource: `{operation_sql}`"
                         )
                         sys.exit(1)
 


### PR DESCRIPTION
## Problem

Our safe migrations test complained [if you added a nullable foreign key](https://github.com/PostHog/posthog/actions/runs/4298397572/jobs/7492469059).
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Ignore nullable foreign keys

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
