### PR TITLE
feat(hedgehog-mode): Add collisions

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -588,7 +588,7 @@ function InsightCardInternal(
 
     return (
         <div
-            className={clsx('InsightCard', highlighted && 'InsightCard--highlighted', className)}
+            className={clsx('InsightCard border', highlighted && 'InsightCard--highlighted', className)}
             data-attr="insight-card"
             {...divProps}
             ref={ref}

--- a/frontend/src/lib/components/CompactList/CompactList.tsx
+++ b/frontend/src/lib/components/CompactList/CompactList.tsx
@@ -22,7 +22,7 @@ export function CompactList({
     renderRow,
 }: CompactListProps): JSX.Element {
     return (
-        <div className="compact-list">
+        <div className="compact-list border">
             <div className="compact-list-header">
                 <h3>{title}</h3>
                 {viewAllURL && <LemonButton to={viewAllURL}>View all</LemonButton>}

--- a/frontend/src/lib/components/HedgehogBuddy/sprites/sprites.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/sprites/sprites.tsx
@@ -12,6 +12,7 @@ import hhWave from 'public/hedgehog/sprites/wave.png'
 // import hhWaveXmas from 'public/hedgehog/sprites/wave-xmas.png'
 
 export const SPRITE_SIZE = 64
+export const SHADOW_HEIGHT = 8
 export const SPRITE_SHEET_WIDTH = 512
 
 type SpriteInfo = {


### PR DESCRIPTION
## Problem

All that our hedgehog buddy could explore was the bottom of the screen. But what a sad life that must be, never being able to experience anything else except that flat expanse.

<img width="92" alt="Screenshot 2023-03-02 at 23 59 58" src="https://user-images.githubusercontent.com/4550621/222579316-e6c11773-7abb-4766-b1f1-810951111112.png">

## Changes

I resisted my urges for a long time but ultimately gave in: the hedgehog can now stand and jump on top of various elements that have a solid border. @mariusandra's [hogsheep dream](https://posthog.slack.com/archives/C0113360FFV/p1630013966020200?thread_ts=1630009170.020100&cid=C0113360FFV) has come true.

<img src="https://user-images.githubusercontent.com/4550621/222579590-b9357eeb-c680-422c-8229-68b2791468d0.gif" alt="Hedgehog horsing around" width="606" height="416">