### PR TITLE
chore: Reduce cardinality by only counting team_id/token in prom

### DIFF
--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -127,7 +127,8 @@ export async function eachBatchIngestionWithOverflow(
                 // We don't want to do it here to preserve the kafka offset handling
                 message.key = null
 
-                ingestionPartitionKeyOverflowed.labels(seenKey).inc()
+                // To reduce cardinality, we only use the `team_id` or `token` as label.
+                ingestionPartitionKeyOverflowed.labels(`${pluginEvent.team_id ?? pluginEvent.token}`).inc()
 
                 if (LoggingLimiter.consume(seenKey, 1) === true) {
                     status.warn('🪣', `Partition key ${seenKey} overflowed ingestion capacity`)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -574,7 +574,7 @@ def is_randomly_partitioned(candidate_partition_key: str) -> bool:
                 # Return early if we have logged this key already.
                 return True
 
-            PARTITION_KEY_CAPACITY_EXCEEDED_COUNTER.labels(partition_key=candidate_partition_key).inc()
+            PARTITION_KEY_CAPACITY_EXCEEDED_COUNTER.labels(partition_key=candidate_partition_key.split(":")[0]).inc()
             statsd.incr("partition_key_capacity_exceeded", tags={"partition_key": candidate_partition_key})
             logger.warning(
                 "Partition key %s overridden as bucket capacity of %s tokens exceeded",


### PR DESCRIPTION
## Problem

Prometheus is going OOM with the large cardinality of our overflow metrics.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Let's be more friendly with it by using only the first part of the partition key as our label. This first part corresponds to the `team_id` or `token` (i.e. without the `distinct_id`).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
