### PR TITLE
ci(e2e): wait for test server before running cypress

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -140,6 +140,11 @@ jobs:
                   $DOCKER_RUN ./bin/docker-worker &> /tmp/logs/worker.txt &
                   $DOCKER_RUN ./bin/docker-server &> /tmp/logs/server.txt &
 
+            - name: Wait for PostHog
+              uses: ifaxity/wait-on-action
+              with:
+                  resource: http://localhost:8000
+
             - name: Cypress run
               uses: cypress-io/github-action@v5
               with:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -141,7 +141,7 @@ jobs:
                   $DOCKER_RUN ./bin/docker-server &> /tmp/logs/server.txt &
 
             - name: Wait for PostHog
-              uses: ifaxity/wait-on-action
+              uses: iFaxity/wait-on-action@v1
               with:
                   resource: http://localhost:8000
 


### PR DESCRIPTION
## Problem

Cypress runs are frequently failing when the test server can't be spun up quickly enough. See e.g.
https://github.com/PostHog/posthog/actions/runs/4323852376/jobs/7547979263.

```
Cypress could not verify that this server is running:

  > http://localhost:8000

We are verifying this server because it has been configured as your baseUrl.

Cypress automatically waits until your server is accessible before running tests.

We will try connecting to it 3 more times...
We will try connecting to it 2 more times...
We will try connecting to it 1 more time...

Cypress failed to verify that your server is running.

Please start this server and then run Cypress again.
```

## Changes

This PR adds a "Wait for PostHog" step that simply waits until the server is ready.

## How did you test this code?

This PR. Since I'm not sure if the server is starting slowly or not starting at all, we'll see if this helps once we merge.