### PR TITLE
feat(performance): only load correlation results when asked

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -814,7 +814,7 @@ describe('funnelLogic', () => {
                         funnel_viz_type: FunnelVizType.Trends,
                     } as FunnelsFilterType,
                 })
-            }).toNotHaveDispatchedActions(['loadCorrelations', 'loadPropertyCorrelations'])
+            }).toNotHaveDispatchedActions(['loadEventCorrelations', 'loadPropertyCorrelations'])
         })
 
         it('triggers update to correlation list when property excluded from project', async () => {

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -210,7 +210,7 @@ export const funnelLogic = kea<funnelLogicType>({
         correlations: [
             { events: [] } as Record<'events', FunnelCorrelation[]>,
             {
-                loadCorrelations: async (_, breakpoint) => {
+                loadEventCorrelations: async (_, breakpoint) => {
                     await breakpoint(100)
 
                     try {
@@ -338,8 +338,11 @@ export const funnelLogic = kea<funnelLogicType>({
             },
         ],
         correlationFeedbackHidden: [
-            false,
+            true,
             {
+                // don't load the feedback form until after some results were loaded
+                loadEventCorrelations: () => false,
+                loadPropertyCorrelations: () => false,
                 sendCorrelationAnalysisFeedback: () => true,
                 hideCorrelationAnalysisFeedback: () => true,
             },
@@ -369,7 +372,7 @@ export const funnelLogic = kea<funnelLogicType>({
                     ...eventWithPropertyCorrelations,
                 }
             },
-            loadCorrelationsSuccess: () => {
+            loadEventCorrelationsSuccess: () => {
                 return {}
             },
         },
@@ -391,7 +394,7 @@ export const funnelLogic = kea<funnelLogicType>({
                 addNestedTableExpandedKey: (state, { expandKey }) => {
                     return [...state, expandKey]
                 },
-                loadCorrelationsSuccess: () => {
+                loadEventCorrelationsSuccess: () => {
                     return []
                 },
             },
@@ -443,6 +446,18 @@ export const funnelLogic = kea<funnelLogicType>({
             null as [number, number, number] | null, // x, y, width
             {
                 showTooltip: (_, { origin }) => origin,
+            },
+        ],
+        loadedEventCorrelationsTableOnce: [
+            false,
+            {
+                loadEventCorrelations: () => true,
+            },
+        ],
+        loadedPropertyCorrelationsTableOnce: [
+            false,
+            {
+                loadPropertyCorrelations: () => true,
             },
         ],
     }),

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
@@ -65,6 +65,8 @@ export const FunnelCorrelation = (): JSX.Element | null => {
 
                     <FunnelCorrelationTable />
 
+                    <FunnelPropertyCorrelationTable />
+
                     {/* Feedback Form */}
                     {!correlationFeedbackHidden && (
                         <div className="border rounded p-4 space-y-2 mt-4">
@@ -134,8 +136,6 @@ export const FunnelCorrelation = (): JSX.Element | null => {
                             ) : null}
                         </div>
                     )}
-
-                    <FunnelPropertyCorrelationTable />
                 </div>
             </PayGateMini>
         </>

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTableEmptyState.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTableEmptyState.tsx
@@ -8,7 +8,6 @@ export function FunnelCorrelationTableEmptyState({
     showLoadResultsButton: boolean
     loadResults: () => void
 }): JSX.Element {
-    console.log(showLoadResultsButton)
     return (
         <>
             {showLoadResultsButton ? (

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTableEmptyState.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTableEmptyState.tsx
@@ -1,0 +1,23 @@
+import { LemonButton } from '@posthog/lemon-ui'
+import { Empty } from 'antd'
+
+export function FunnelCorrelationTableEmptyState({
+    showLoadResultsButton,
+    loadResults,
+}: {
+    showLoadResultsButton: boolean
+    loadResults: () => void
+}): JSX.Element {
+    console.log(showLoadResultsButton)
+    return (
+        <>
+            {showLoadResultsButton ? (
+                <LemonButton onClick={loadResults} className="m-auto" type="secondary">
+                    Load results
+                </LemonButton>
+            ) : (
+                <Empty />
+            )}
+        </>
+    )
+}

--- a/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Col, Row, Table } from 'antd'
+import { Col, ConfigProvider, Row, Table } from 'antd'
 import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
 import { RiseOutlined, FallOutlined, EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons'
@@ -18,6 +18,7 @@ import { Popover } from 'lib/lemon-ui/Popover/Popover'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { FunnelCorrelationTableEmptyState } from './FunnelCorrelationTableEmptyState'
 
 export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -35,6 +36,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
         allProperties,
         filters,
         aggregationTargetLabel,
+        loadedPropertyCorrelationsTableOnce,
     } = useValues(logic)
 
     const { setPropertyCorrelationTypes, setPropertyNames, openCorrelationPersonsModal, loadPropertyCorrelations } =
@@ -44,10 +46,14 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
 
     // Load correlations only if this component is mounted, and then reload if filters change
     useEffect(() => {
-        if (propertyNames.length === 0) {
-            setPropertyNames(allProperties)
+        if (loadedPropertyCorrelationsTableOnce) {
+            if (propertyNames.length === 0) {
+                setPropertyNames(allProperties)
+            }
+
+            // We only automatically refresh results when filters change after the user has manually asked for the first results to be loaded
+            loadPropertyCorrelations({})
         }
-        loadPropertyCorrelations({})
     }, [filters])
 
     const onClickCorrelationType = (correlationType: FunnelCorrelationType): void => {
@@ -198,76 +204,89 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                         </Row>
                     </Col>
                 </Row>
-                <Table
-                    dataSource={propertyCorrelationValues}
-                    loading={propertyCorrelationsLoading}
-                    scroll={{ x: 'max-content' }}
-                    size="small"
-                    rowKey={(record: FunnelCorrelation) => record.event.event}
-                    pagination={{
-                        pageSize: 5,
-                        hideOnSinglePage: true,
-                        onChange: (page, page_size) =>
-                            reportCorrelationInteraction(FunnelCorrelationResultsType.Properties, 'pagination change', {
-                                page,
-                                page_size,
-                            }),
-                    }}
+                <ConfigProvider
+                    renderEmpty={() => (
+                        <FunnelCorrelationTableEmptyState
+                            showLoadResultsButton={!loadedPropertyCorrelationsTableOnce}
+                            loadResults={() => loadPropertyCorrelations({})}
+                        />
+                    )}
                 >
-                    <Column
-                        title={`${capitalizeFirstLetter(aggregationTargetLabel.singular)} property`}
-                        key="propertName"
-                        render={(_, record: FunnelCorrelation) => renderOddsRatioTextRecord(record)}
-                        align="left"
-                    />
-                    <Column
-                        title={
-                            <div className="flex items-center">
-                                Completed
-                                <Tooltip
-                                    title={`${capitalizeFirstLetter(aggregationTargetLabel.plural)} ${
-                                        filters.aggregation_group_type_index != undefined ? 'that' : 'who'
-                                    } have this property and completed the entire funnel.`}
-                                >
-                                    <InfoCircleOutlined className="column-info" />
-                                </Tooltip>
-                            </div>
-                        }
-                        key="success_count"
-                        render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
-                        width={90}
-                        align="center"
-                    />
-                    <Column
-                        title={
-                            <div className="flex items-center">
-                                Dropped off
-                                <Tooltip
-                                    title={
-                                        <>
-                                            {capitalizeFirstLetter(aggregationTargetLabel.plural)}{' '}
-                                            {filters.aggregation_group_type_index != undefined ? 'that' : 'who'} have
-                                            this property and did <b>not complete</b> the entire funnel.
-                                        </>
+                    <Table
+                        dataSource={propertyCorrelationValues}
+                        loading={propertyCorrelationsLoading}
+                        scroll={{ x: 'max-content' }}
+                        size="small"
+                        rowKey={(record: FunnelCorrelation) => record.event.event}
+                        pagination={{
+                            pageSize: 5,
+                            hideOnSinglePage: true,
+                            onChange: (page, page_size) =>
+                                reportCorrelationInteraction(
+                                    FunnelCorrelationResultsType.Properties,
+                                    'pagination change',
+                                    {
+                                        page,
+                                        page_size,
                                     }
-                                >
-                                    <InfoCircleOutlined className="column-info" />
-                                </Tooltip>
-                            </div>
-                        }
-                        key="failure_count"
-                        render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
-                        width={120}
-                        align="center"
-                    />
-                    <Column
-                        title=""
-                        key="actions"
-                        render={(_, record: FunnelCorrelation) => <CorrelationActionsCell record={record} />}
-                        align="center"
-                        width={30}
-                    />
-                </Table>
+                                ),
+                        }}
+                    >
+                        <Column
+                            title={`${capitalizeFirstLetter(aggregationTargetLabel.singular)} property`}
+                            key="propertName"
+                            render={(_, record: FunnelCorrelation) => renderOddsRatioTextRecord(record)}
+                            align="left"
+                        />
+                        <Column
+                            title={
+                                <div className="flex items-center">
+                                    Completed
+                                    <Tooltip
+                                        title={`${capitalizeFirstLetter(aggregationTargetLabel.plural)} ${
+                                            filters.aggregation_group_type_index != undefined ? 'that' : 'who'
+                                        } have this property and completed the entire funnel.`}
+                                    >
+                                        <InfoCircleOutlined className="column-info" />
+                                    </Tooltip>
+                                </div>
+                            }
+                            key="success_count"
+                            render={(_, record: FunnelCorrelation) => renderSuccessCount(record)}
+                            width={90}
+                            align="center"
+                        />
+                        <Column
+                            title={
+                                <div className="flex items-center">
+                                    Dropped off
+                                    <Tooltip
+                                        title={
+                                            <>
+                                                {capitalizeFirstLetter(aggregationTargetLabel.plural)}{' '}
+                                                {filters.aggregation_group_type_index != undefined ? 'that' : 'who'}{' '}
+                                                have this property and did <b>not complete</b> the entire funnel.
+                                            </>
+                                        }
+                                    >
+                                        <InfoCircleOutlined className="column-info" />
+                                    </Tooltip>
+                                </div>
+                            }
+                            key="failure_count"
+                            render={(_, record: FunnelCorrelation) => renderFailureCount(record)}
+                            width={120}
+                            align="center"
+                        />
+                        <Column
+                            title=""
+                            key="actions"
+                            render={(_, record: FunnelCorrelation) => <CorrelationActionsCell record={record} />}
+                            align="center"
+                            width={30}
+                        />
+                    </Table>
+                </ConfigProvider>
             </div>
         </VisibilitySensor>
     ) : null

--- a/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
@@ -46,12 +46,12 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
 
     // Load correlations only if this component is mounted, and then reload if filters change
     useEffect(() => {
+        // We only automatically refresh results when filters change after the user has manually asked for the first results to be loaded
         if (loadedPropertyCorrelationsTableOnce) {
             if (propertyNames.length === 0) {
                 setPropertyNames(allProperties)
             }
 
-            // We only automatically refresh results when filters change after the user has manually asked for the first results to be loaded
             loadPropertyCorrelations({})
         }
     }, [filters])


### PR DESCRIPTION
## Problem

Correlation analysis queries are heavy and we currently trigger them automatically on funnel views, meaning we're running 3 heavy queries at once for each funnel, when in reality most users don't need the correlations report most of the time.

## Changes

Make it so that we only load each correlation report when the user asks for it.

Also only show the feedback form once a report was loaded.

Once loaded it will keep updating with filter changes, but we can change that in the future if we like.

<img width="1510" alt="Screenshot 2023-03-03 at 11 39 58" src="https://user-images.githubusercontent.com/38760734/222749352-98008e57-f42e-41fa-ae7a-b1cce5f10da9.png">


## How did you test this code?

Manually tested it locally
