### PR TITLE
chore(kafka): ensure retry on kafkajs produce failure

### DIFF
--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -1,6 +1,14 @@
 import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
-import { CompressionCodecs, CompressionTypes, KafkaJSError, Message, Producer, ProducerRecord } from 'kafkajs'
+import {
+    CompressionCodecs,
+    CompressionTypes,
+    KafkaJSError,
+    KafkaJSNumberOfRetriesExceeded,
+    Message,
+    Producer,
+    ProducerRecord,
+} from 'kafkajs'
 // @ts-expect-error no type definitions
 import SnappyCodec from 'kafkajs-snappy'
 
@@ -148,9 +156,9 @@ export class KafkaProducerWrapper {
                     estimatedSize: batchSize,
                 })
 
-                if (err instanceof KafkaJSError) {
-                    if (err.retriable === true) {
-                        throw new DependencyUnavailableError(err.name, 'Kafka', err)
+                if (err instanceof KafkaJSNumberOfRetriesExceeded && err.cause instanceof KafkaJSError) {
+                    if (err.cause.retriable === true) {
+                        throw new DependencyUnavailableError(err.cause.name, 'Kafka', err.cause)
                     }
                 }
 

--- a/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
@@ -24,9 +24,11 @@ describe('session-recordings-consumer', () => {
         // To ensure we are catching and retrying on the correct error, we make
         // sure to mock deep into the KafkaJS internals, otherwise we can get
         // into inplaced confidence that we have covered this critical path.
-        mockRefreshMetadataIfNecessary = jest.spyOn(Cluster.prototype, 'refreshMetadataIfNecessary')
         producer = kafka.producer({ retry: { retries: 0 } })
         await producer.connect()
+        mockRefreshMetadataIfNecessary = jest
+            .spyOn(Cluster.prototype, 'refreshMetadataIfNecessary')
+            .mockImplementation()
         producerWrapper = new KafkaProducerWrapper(producer, undefined, {
             KAFKA_FLUSH_FREQUENCY_MS: 0,
         } as any)

--- a/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
@@ -18,8 +18,6 @@ describe('session-recordings-consumer', () => {
     let eachBachWithDependencies: any
 
     beforeEach(async () => {
-        jest.useFakeTimers()
-
         kafka = new Kafka({ brokers: ['localhost:9092'] })
         // To ensure we are catching and retrying on the correct error, we make
         // sure to mock deep into the KafkaJS internals, otherwise we can get
@@ -41,7 +39,6 @@ describe('session-recordings-consumer', () => {
 
     afterEach(async () => {
         await producer.disconnect()
-        jest.useRealTimers()
         jest.clearAllMocks()
     })
 


### PR DESCRIPTION
This is a fix to ensure that we do not simply drop events when Kafka is
e.g. down. We were previously catching the KafkaJSError but it seems the
errors are always run using the `retry` function, which means we always
get a KafkaJSNumberOfRetriesExceeded error.

See https://posthog.slack.com/archives/C0185UNBSJZ/p1677846422433139?thread_ts=1677845745.557509&cid=C0185UNBSJZ for context.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
