### PR TITLE
fix: debump posthog-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "kea-window-values": "^3.0.0",
         "md5": "^2.3.0",
         "monaco-editor": "^0.23.0",
-        "posthog-js": "1.50.3",
+        "posthog-js": "1.50.2",
         "posthog-js-lite": "2.0.0-alpha5",
         "prettier": "^2.3.1",
         "prop-types": "^15.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ specifiers:
   pngjs: ^6.0.0
   postcss: ^8.4.14
   postcss-loader: ^4.3.0
-  posthog-js: 1.50.3
+  posthog-js: 1.50.2
   posthog-js-lite: 2.0.0-alpha5
   prettier: ^2.3.1
   prop-types: ^15.7.2
@@ -238,7 +238,7 @@ dependencies:
   kea-window-values: 3.0.0_kea@3.1.0
   md5: 2.3.0
   monaco-editor: 0.23.0
-  posthog-js: 1.50.3
+  posthog-js: 1.50.2
   posthog-js-lite: 2.0.0-alpha5
   prettier: 2.7.1
   prop-types: 15.8.1
@@ -14677,8 +14677,8 @@ packages:
     resolution: {integrity: sha512-tlkBdypJuvK/s00n4EiQjwYVfuuZv6vt8BF3g1ooIQa2Gz9Vz80p8q3qsPLZ0V5ErGRy6i3Q4fWC9TDzR7GNRQ==}
     dev: false
 
-  /posthog-js/1.50.3:
-    resolution: {integrity: sha512-QWEQ1bvKKsHUBLYGGIgwC2t9Lsivoi5gkQ/QgzAQrK9bMHQgexAx5CCTgdQ2ael9o88i9eIExWQId6+/RpALsw==}
+  /posthog-js/1.50.2:
+    resolution: {integrity: sha512-9iQU9tdsPa6q2+wgdeKK2jxJhPN5VeV3L3bdUEietF24z5UlCtVOkXRhNWiPp2+KfRW5S8ismUl+BUOcz5aD9A==}
     dependencies:
       fflate: 0.4.8
       rrweb-snapshot: 1.1.14


### PR DESCRIPTION
## Problem

Started receiving [errors](https://posthog.sentry.io/issues/3971473553/events/oldest/?project=6423401) about text being null after merging [autocapture change](https://github.com/PostHog/posthog-js/pull/563) that captured span text inside buttons. We'll see if reverting to previous version stops the errors. [internal [slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1677853782695289) for more detail/discussion]

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Unbumps posthog-js to 1.50.2

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
