### PR TITLE
feat(data-exploration): add is valid funnel selector

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -69,11 +69,9 @@ export function InsightContainer({
     const { activeView } = useValues(insightNavLogic(insightProps))
 
     // const {
-    //     isValidFunnel,
-    //     areExclusionFiltersValid,
     //     // correlationAnalysisAvailable
     // } = useValues(funnelLogic(insightProps))
-    const { querySource, areFiltersValid } = useValues(funnelDataLogic(insightProps))
+    const { querySource, areFiltersValid, isValidFunnel } = useValues(funnelDataLogic(insightProps))
     // TODO: convert to data exploration with insightLogic
     const { areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
     const {
@@ -87,9 +85,6 @@ export function InsightContainer({
         insightFilter,
         exportContext,
     } = useValues(insightDataLogic(insightProps))
-
-    // TODO: implement in funnelDataLogic
-    const isValidFunnel = true
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -28,7 +28,7 @@ import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 // import { AlertMessage } from 'lib/lemon-ui/AlertMessage'
 import { ComputationTimeWithRefresh } from './ComputationTimeWithRefresh'
 import { FunnelInsightDataExploration } from 'scenes/insights/views/Funnels/FunnelInsight'
-import { FunnelsQuery, StickinessFilter, TrendsFilter } from '~/queries/schema'
+import { StickinessFilter, TrendsFilter } from '~/queries/schema'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -71,7 +71,7 @@ export function InsightContainer({
     // const {
     //     // correlationAnalysisAvailable
     // } = useValues(funnelLogic(insightProps))
-    const { querySource, areFiltersValid, isValidFunnel } = useValues(funnelDataLogic(insightProps))
+    const { areFiltersValid, isValidFunnel } = useValues(funnelDataLogic(insightProps))
     // TODO: convert to data exploration with insightLogic
     const { areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
     const {
@@ -98,7 +98,7 @@ export function InsightContainer({
 
         // Insight specific empty states - note order is important here
         if (activeView === InsightType.FUNNELS) {
-            if (((querySource as FunnelsQuery).series || []).length <= 1) {
+            if (!areFiltersValid) {
                 return <FunnelSingleStepState actionable={insightMode === ItemMode.Edit || disableTable} />
             }
             if (!areExclusionFiltersValid) {

--- a/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
+++ b/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
@@ -304,3 +304,19 @@ export const funnelResultTimeToConvertWithoutConversions: FunnelResult = {
     last_refresh: '2023-03-03T12:02:22.618420Z',
     is_cached: false,
 }
+
+// 1. Add step "Pageview"
+// 2. Select graph type "Trends"
+export const funnelResultTrends = {
+    result: [
+        {
+            count: 31,
+            data: [74.12, 68.67, 71.05, 72.06, 69.33, 70.83, 72.37],
+            days: ['2023-02-01', '2023-02-02', '2023-02-03', '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07'],
+            labels: ['1-Feb-2023', '2-Feb-2023', '3-Feb-2023', '4-Feb-2023', '5-Feb-2023', '6-Feb-2023', '7-Feb-2023'],
+        },
+    ],
+    timezone: 'UTC',
+    last_refresh: '2023-03-03T18:55:57.840129Z',
+    is_cached: false,
+}

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -2,7 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 
 import { teamLogic } from 'scenes/teamLogic'
-import { insightLogic } from 'scenes/insights/insightLogic'
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { funnelDataLogic } from './funnelDataLogic'
 
 import { FunnelVizType, InsightLogicProps, InsightModel, InsightType } from '~/types'
@@ -20,8 +20,8 @@ describe('funnelDataLogic', () => {
     const insightProps: InsightLogicProps = {
         dashboardItemId: undefined,
     }
-    let logic: ReturnType<typeof funnelDataLogic.build>
-    let builtInsightLogic: ReturnType<typeof insightLogic.build>
+    let logic: ReturnType<typeof dataNodeLogic.build>
+    let builtDataNodeLogic: ReturnType<typeof dataNodeLogic.build>
 
     beforeEach(() => {
         initKeaTests(false)
@@ -31,9 +31,9 @@ describe('funnelDataLogic', () => {
         teamLogic.mount()
         await expectLogic(teamLogic).toFinishAllListeners()
 
-        builtInsightLogic = insightLogic(insightProps)
-        builtInsightLogic.mount()
-        await expectLogic(insightLogic).toFinishAllListeners()
+        builtDataNodeLogic = dataNodeLogic({ key: 'InsightViz.new', query: {} })
+        builtDataNodeLogic.mount()
+        await expectLogic(dataNodeLogic).toFinishAllListeners()
 
         logic = funnelDataLogic(insightProps)
         logic.mount()
@@ -164,14 +164,9 @@ describe('funnelDataLogic', () => {
         })
     })
 
-    /**
-     * We set insightLogic.insight via a call to setInsight for data exploration,
-     * in future we should use the response of dataNodeLogic via a connected
-     * insightDataLogic.
-     */
-    describe('based on insightLogic', () => {
+    describe('based on insightDataLogic', () => {
         describe('results', () => {
-            it('with non-funnel insight', async () => {
+            it.skip('with non-funnel insight', async () => {
                 await expectLogic(logic).toMatchValues({
                     insight: expect.objectContaining({ filters: {} }),
                     results: [],
@@ -180,14 +175,11 @@ describe('funnelDataLogic', () => {
 
             it('for standard funnel', async () => {
                 const insight: Partial<InsightModel> = {
-                    filters: {
-                        insight: InsightType.FUNNELS,
-                    },
                     result: funnelResult.result,
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     results: funnelResult.result,
                 })
@@ -195,14 +187,11 @@ describe('funnelDataLogic', () => {
 
             it('with breakdown', async () => {
                 const insight: Partial<InsightModel> = {
-                    filters: {
-                        insight: InsightType.FUNNELS,
-                    },
                     result: funnelResultWithBreakdown.result,
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     results: expect.arrayContaining([
                         expect.arrayContaining([
@@ -217,14 +206,11 @@ describe('funnelDataLogic', () => {
 
             it('with multi breakdown', async () => {
                 const insight: Partial<InsightModel> = {
-                    filters: {
-                        insight: InsightType.FUNNELS,
-                    },
                     result: funnelResultWithMultiBreakdown.result,
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     results: expect.arrayContaining([
                         expect.arrayContaining([
@@ -256,7 +242,7 @@ describe('funnelDataLogic', () => {
 
                 await expectLogic(logic, () => {
                     logic.actions.updateQuerySource(query)
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     steps: [],
                 })
@@ -271,7 +257,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     steps: funnelResult.result,
                 })
@@ -286,7 +272,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     steps: expect.arrayContaining([
                         expect.objectContaining({
@@ -318,7 +304,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     steps: expect.arrayContaining([
                         expect.objectContaining({
@@ -352,7 +338,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     stepsWithConversionMetrics: expect.arrayContaining([
                         expect.objectContaining({
@@ -384,7 +370,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     stepsWithConversionMetrics: expect.arrayContaining([
                         expect.objectContaining({
@@ -432,7 +418,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     stepsWithConversionMetrics: expect.arrayContaining([
                         expect.objectContaining({
@@ -485,7 +471,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     flattenedBreakdowns: [
                         {
@@ -527,7 +513,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     flattenedBreakdowns: [
                         expect.objectContaining({ breakdown: ['baseline'] }),
@@ -573,7 +559,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     flattenedBreakdowns: [
                         expect.objectContaining({ breakdown: ['baseline'] }),
@@ -621,7 +607,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     visibleStepsWithConversionMetrics: [
                         expect.objectContaining({
@@ -656,7 +642,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     visibleStepsWithConversionMetrics: [
                         expect.objectContaining({
@@ -704,7 +690,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     visibleStepsWithConversionMetrics: [
                         expect.objectContaining({
@@ -791,7 +777,7 @@ describe('funnelDataLogic', () => {
 
                 await expectLogic(logic, () => {
                     logic.actions.updateQuerySource(query)
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     timeConversionResults: funnelResultTimeToConvert.result,
                 })
@@ -806,7 +792,7 @@ describe('funnelDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     timeConversionResults: null,
                 })
@@ -834,7 +820,7 @@ describe('funnelDataLogic', () => {
 
                 await expectLogic(logic, () => {
                     logic.actions.updateQuerySource(query)
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     histogramGraphData: null,
                 })
@@ -857,7 +843,7 @@ describe('funnelDataLogic', () => {
 
                 await expectLogic(logic, () => {
                     logic.actions.updateQuerySource(query)
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     histogramGraphData: [],
                 })
@@ -880,7 +866,7 @@ describe('funnelDataLogic', () => {
 
                 await expectLogic(logic, () => {
                     logic.actions.updateQuerySource(query)
-                    builtInsightLogic.actions.setInsight(insight, {})
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     histogramGraphData: [
                         { bin0: 4, bin1: 73591, count: 74, id: 4, label: '54.8%' },
@@ -914,7 +900,7 @@ describe('funnelDataLogic', () => {
             }
 
             await expectLogic(logic, () => {
-                builtInsightLogic.actions.setInsight(insight, {})
+                builtDataNodeLogic.actions.loadDataSuccess(insight)
                 logic.actions.updateQuerySource(query)
             }).toMatchValues({
                 isValidFunnel: true,
@@ -938,7 +924,7 @@ describe('funnelDataLogic', () => {
             }
 
             await expectLogic(logic, () => {
-                builtInsightLogic.actions.setInsight(insight, {})
+                builtDataNodeLogic.actions.loadDataSuccess(insight)
                 logic.actions.updateQuerySource(query)
             }).toMatchValues({
                 isValidFunnel: true,
@@ -962,7 +948,7 @@ describe('funnelDataLogic', () => {
             }
 
             await expectLogic(logic, () => {
-                builtInsightLogic.actions.setInsight(insight, {})
+                builtDataNodeLogic.actions.loadDataSuccess(insight)
                 logic.actions.updateQuerySource(query)
             }).toMatchValues({
                 isValidFunnel: true,

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -13,6 +13,7 @@ import {
     funnelResultWithMultiBreakdown,
     funnelResultTimeToConvert,
     funnelResultTimeToConvertWithoutConversions,
+    funnelResultTrends,
 } from './__mocks__/funnelDataLogicMocks'
 
 describe('funnelDataLogic', () => {
@@ -891,6 +892,80 @@ describe('funnelDataLogic', () => {
                         { bin0: 441526, bin1: 515113, count: 0, id: 441526, label: '' },
                     ],
                 })
+            })
+        })
+    })
+
+    describe('isValidFunnel', () => {
+        it('for steps viz', async () => {
+            const query: FunnelsQuery = {
+                kind: NodeKind.FunnelsQuery,
+                series: [],
+                funnelsFilter: {
+                    funnel_viz_type: FunnelVizType.Steps,
+                },
+            }
+
+            const insight: Partial<InsightModel> = {
+                filters: {
+                    insight: InsightType.FUNNELS,
+                },
+                result: funnelResult.result,
+            }
+
+            await expectLogic(logic, () => {
+                builtInsightLogic.actions.setInsight(insight, {})
+                logic.actions.updateQuerySource(query)
+            }).toMatchValues({
+                isValidFunnel: true,
+            })
+        })
+
+        it('for time to convert viz', async () => {
+            const query: FunnelsQuery = {
+                kind: NodeKind.FunnelsQuery,
+                series: [],
+                funnelsFilter: {
+                    funnel_viz_type: FunnelVizType.TimeToConvert,
+                },
+            }
+
+            const insight: Partial<InsightModel> = {
+                filters: {
+                    insight: InsightType.FUNNELS,
+                },
+                result: funnelResultTimeToConvert.result,
+            }
+
+            await expectLogic(logic, () => {
+                builtInsightLogic.actions.setInsight(insight, {})
+                logic.actions.updateQuerySource(query)
+            }).toMatchValues({
+                isValidFunnel: true,
+            })
+        })
+
+        it('for trends viz', async () => {
+            const query: FunnelsQuery = {
+                kind: NodeKind.FunnelsQuery,
+                series: [],
+                funnelsFilter: {
+                    funnel_viz_type: FunnelVizType.Trends,
+                },
+            }
+
+            const insight: Partial<InsightModel> = {
+                filters: {
+                    insight: InsightType.FUNNELS,
+                },
+                result: funnelResultTrends.result,
+            }
+
+            await expectLogic(logic, () => {
+                builtInsightLogic.actions.setInsight(insight, {})
+                logic.actions.updateQuerySource(query)
+            }).toMatchValues({
+                isValidFunnel: true,
             })
         })
     })

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -217,6 +217,21 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
                 })
             },
         ],
+        isValidFunnel: [
+            (s) => [s.funnelsFilter, s.steps, s.histogramGraphData],
+            (funnelsFilter, steps, histogramGraphData) => {
+                if (funnelsFilter?.funnel_viz_type === FunnelVizType.Steps || !funnelsFilter?.funnel_viz_type) {
+                    return !!(steps && steps[0] && steps[0].count > -1)
+                } else if (funnelsFilter.funnel_viz_type === FunnelVizType.TimeToConvert) {
+                    return (histogramGraphData?.length ?? 0) > 0
+                } else if (funnelsFilter.funnel_viz_type === FunnelVizType.Trends) {
+                    console.log(steps)
+                    return (steps?.length ?? 0) > 0 && !!steps?.[0]?.labels
+                } else {
+                    return false
+                }
+            },
+        ],
 
         /*
          * Advanced options: funnel_order_type, funnel_step_reference, exclusions

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -225,7 +225,6 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
                 } else if (funnelsFilter.funnel_viz_type === FunnelVizType.TimeToConvert) {
                     return (histogramGraphData?.length ?? 0) > 0
                 } else if (funnelsFilter.funnel_viz_type === FunnelVizType.Trends) {
-                    console.log(steps)
                     return (steps?.length ?? 0) > 0 && !!steps?.[0]?.labels
                 } else {
                     return false

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -71,7 +71,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
             ['toggledLifecycles as trendsLifecycles'],
             // TODO: need to pass empty query here, as otherwise dataNodeLogic will throw
             dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
-            ['response'],
+            ['response as insightData'],
         ],
         actions: [
             insightLogic,
@@ -244,7 +244,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
          * This subscription updates the insight for all visualizations
          * that haven't been refactored to use the data exploration yet.
          */
-        response: (response: Record<string, any> | null) => {
+        insightData: (insightData: Record<string, any> | null) => {
             if (!values.isUsingDataExploration) {
                 return
             }
@@ -252,9 +252,9 @@ export const insightDataLogic = kea<insightDataLogicType>([
             actions.setInsight(
                 {
                     ...values.insight,
-                    result: response?.result,
-                    next: response?.next,
-                    // filters: queryNodeToFilter(query.source),
+                    result: insightData?.result,
+                    next: insightData?.next,
+                    filters: queryNodeToFilter(values.querySource),
                 },
                 {}
             )

--- a/frontend/src/scenes/insights/views/Funnels/FunnelInsight.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelInsight.tsx
@@ -7,10 +7,7 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 
 export function FunnelInsightDataExploration(): JSX.Element {
     const { insightLoading, insightProps } = useValues(insightLogic)
-    const { areFiltersValid } = useValues(funnelDataLogic(insightProps))
-
-    // TODO: implement in funnelDataLogic
-    const isValidFunnel = true
+    const { areFiltersValid, isValidFunnel } = useValues(funnelDataLogic(insightProps))
 
     const nonEmptyState = (isValidFunnel && areFiltersValid) || insightLoading
 


### PR DESCRIPTION
## Problem

We need the `isValidFunnel` selector to determine wether we should display the funnel or an empty state. A better name for the selector would be `hasFunnelResults` in my opinion.

## Changes

This PR converts the `isValidFunnel` selector.

## How did you test this code?

Added tests.