### PR TITLE
chore: fix flakey session recordings error case test

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
@@ -67,6 +67,9 @@ describe('session-recordings-consumer', () => {
                 heartbeat: jest.fn(),
             })
         ).rejects.toEqual(new DependencyUnavailableError('KafkaJSError', 'Kafka', error))
+
+        // Should _not_ have retried or sent to DLQ.
+        expect(mockProduce).toHaveBeenCalledTimes(1)
     })
 
     test('eachBatch emits to DLQ and returns on unrecoverable KafkaJS errors', async () => {
@@ -86,5 +89,8 @@ describe('session-recordings-consumer', () => {
             } as any,
             heartbeat: jest.fn(),
         })
+
+        // Should have send to the DLQ.
+        expect(mockProduce).toHaveBeenCalledTimes(2)
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
@@ -1,15 +1,22 @@
-import { Kafka, KafkaJSError, Producer } from 'kafkajs'
-import Cluster from 'kafkajs/src/cluster'
-import { Pool } from 'pg'
+import { Kafka, KafkaJSError, Partitioners, Producer } from 'kafkajs'
+import Broker from 'kafkajs/src/broker'
 
+import { defaultConfig } from '../../../src/config/config'
 import { eachBatch } from '../../../src/main/ingestion-queues/session-recordings-consumer'
 import { DB } from '../../../src/utils/db/db'
 import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { KafkaProducerWrapper } from '../../../src/utils/db/kafka-producer-wrapper'
+import { createPostgresPool } from '../../../src/utils/utils'
 import { TeamManager } from '../../../src/worker/ingestion/team-manager'
+import { createOrganization, createTeam } from '../../helpers/sql'
 
 describe('session-recordings-consumer', () => {
-    let mockRefreshMetadataIfNecessary: jest.SpyInstance
+    // NOTE: at the time of adding this comment, the test only checks the case
+    // that we error at the time of producing to the ClickHouse ingestion Kafka
+    // topic. There are also other cases that can fail which we should also
+    // test.
+
+    let mockProduce: jest.SpyInstance
     let kafka: Kafka
     let producer: Producer
     let producerWrapper: KafkaProducerWrapper
@@ -19,22 +26,21 @@ describe('session-recordings-consumer', () => {
 
     beforeEach(async () => {
         kafka = new Kafka({ brokers: ['localhost:9092'] })
+        producer = kafka.producer({ retry: { retries: 0 }, createPartitioner: Partitioners.LegacyPartitioner })
+        await producer.connect()
+
         // To ensure we are catching and retrying on the correct error, we make
         // sure to mock deep into the KafkaJS internals, otherwise we can get
         // into inplaced confidence that we have covered this critical path.
-        producer = kafka.producer({ retry: { retries: 0 } })
-        await producer.connect()
-        mockRefreshMetadataIfNecessary = jest
-            .spyOn(Cluster.prototype, 'refreshMetadataIfNecessary')
-            .mockImplementation()
+        mockProduce = jest.spyOn(Broker.prototype, 'produce')
         producerWrapper = new KafkaProducerWrapper(producer, undefined, {
             KAFKA_FLUSH_FREQUENCY_MS: 0,
         } as any)
         db = {
-            postgres: new Pool(),
+            postgres: createPostgresPool(defaultConfig.DATABASE_URL),
         } as DB
         teamManager = new TeamManager(db.postgres, {} as any)
-        eachBachWithDependencies = eachBatch({ producer: producerWrapper, teamManager })
+        eachBachWithDependencies = eachBatch({ groupId: 'test', producer: producerWrapper, teamManager })
     })
 
     afterEach(async () => {
@@ -43,10 +49,10 @@ describe('session-recordings-consumer', () => {
     })
 
     test('eachBatch throws on recoverable KafkaJS errors', async () => {
+        const organizationId = await createOrganization(db.postgres)
+        const teamId = await createTeam(db.postgres, organizationId)
         const error = new KafkaJSError('test', { retriable: true })
-        mockRefreshMetadataIfNecessary.mockImplementation(() => {
-            throw error
-        })
+        mockProduce.mockRejectedValueOnce(error)
         await expect(
             eachBachWithDependencies({
                 batch: {
@@ -54,7 +60,7 @@ describe('session-recordings-consumer', () => {
                     messages: [
                         {
                             key: 'test',
-                            value: JSON.stringify({ data: { event: '$snapshot' } }),
+                            value: JSON.stringify({ team_id: teamId, data: JSON.stringify({ event: '$snapshot' }) }),
                         },
                     ],
                 } as any,
@@ -64,17 +70,17 @@ describe('session-recordings-consumer', () => {
     })
 
     test('eachBatch emits to DLQ and returns on unrecoverable KafkaJS errors', async () => {
+        const organizationId = await createOrganization(db.postgres)
+        const teamId = await createTeam(db.postgres, organizationId)
         const error = new KafkaJSError('test', { retriable: false })
-        mockRefreshMetadataIfNecessary.mockImplementation(() => {
-            throw error
-        })
+        mockProduce.mockRejectedValueOnce(error)
         await eachBachWithDependencies({
             batch: {
                 topic: 'test',
                 messages: [
                     {
                         key: 'test',
-                        value: JSON.stringify({ data: { event: '$snapshot' } }),
+                        value: JSON.stringify({ team_id: teamId, data: JSON.stringify({ event: '$snapshot' }) }),
                     },
                 ],
             } as any,


### PR DESCRIPTION
We need to make sure that we hit the case where the events are produced
for ClickHouse ingestion. The signature of the `queueMessage` function
is interesting in that it's behaviour depends on some heiuristics as to
if it will flush and therefore reject or not.

I would like to change this behavior but my preference would be to
update to use rdkafka and update to have more sensible behaviour then.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
