### PR TITLE
ci: Fix email render artifact uploads

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -292,7 +292,7 @@ jobs:
 
             - name: Archive email renders
               uses: actions/upload-artifact@v3
-              if: matrix.foss
+              if: matrix.segment == 'FOSS' && matrix.person-on-events == false
               with:
                   name: email_renders
                   path: posthog/tasks/test/__emails__

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -296,6 +296,7 @@ jobs:
               with:
                   name: email_renders
                   path: posthog/tasks/test/__emails__
+                  retention-days: 5
 
     cloud:
         needs: changes


### PR DESCRIPTION
## Problem

Looks like we haven't been able to preview email renders from backend CI for a while (since #13007 I believe). Clearly we haven't missed them very much… but now we could use those previews for #14560.

## Changes

Makes it so that email renders are uploaded as Actions artifacts again.
