### PR TITLE
fix: mark notifications unread

### DIFF
--- a/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
@@ -8,7 +8,7 @@ import type { notificationsLogicType } from './notificationsLogicType'
 import { describerFor } from 'lib/components/ActivityLog/activityLogLogic'
 
 const POLL_TIMEOUT = 5 * 60 * 1000
-const MARK_READ_TIMEOUT = 7500
+const MARK_READ_TIMEOUT = 2500
 
 export const notificationsLogic = kea<notificationsLogicType>([
     path(['layout', 'navigation', 'TopBar', 'notificationsLogic']),
@@ -19,11 +19,15 @@ export const notificationsLogic = kea<notificationsLogicType>([
         setMarkReadTimeout: (markReadTimeout: number) => ({ markReadTimeout }),
         incrementErrorCount: true,
         clearErrorCount: true,
+        markAllAsRead: true,
     }),
     loaders(({ actions, values }) => ({
         importantChanges: [
             [] as HumanizedActivityLogItem[],
             {
+                markAllAsRead: () => {
+                    return values.importantChanges.map((ic) => ({ ...ic, unread: false }))
+                },
                 loadImportantChanges: async (_, breakpoint) => {
                     await breakpoint(1)
 
@@ -95,6 +99,7 @@ export const notificationsLogic = kea<notificationsLogicType>([
                                     bookmark: bookmarkDate,
                                 }
                             )
+                            actions.markAllAsRead()
                         }, MARK_READ_TIMEOUT)
                     )
                 }


### PR DESCRIPTION
## Problem

When we mark notifications are read we don't change the UI.

This was fine when the important changes API was polled very frequently, but now we only poll every five minutes.

So, when notifications have been viewed for 7.5 seconds we would mark them as read. And then 5 minutes later update the UI.

## Changes

Changes, mark as read after 1.5 seconds and update the UI

![2023-03-06 14 27 45](https://user-images.githubusercontent.com/984817/223139201-0838716f-0662-46d8-af89-698427a6969d.gif)

## How did you test this code?

👀 locally
