### PR TITLE
fix(hogql): better error for no json support

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -205,6 +205,12 @@ class PropertySymbol(Symbol):
     name: str
     parent: FieldSymbol
 
+    def get_child(self, name: str) -> "Symbol":
+        raise NotImplementedError("JSON property traversal is not yet supported")
+
+    def has_child(self, name: str) -> bool:
+        return False
+
 
 class Expr(AST):
     symbol: Optional[Symbol]

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -161,6 +161,7 @@ class TestPrinter(TestCase):
             "avg(avg(properties.bla))", "Aggregation 'avg' cannot be nested inside another aggregation 'avg'."
         )
         self._assert_expr_error("person.chipotle", "Field not found: chipotle")
+        self._assert_expr_error("properties.no.json.yet", "JSON property traversal is not yet supported")
 
     def test_expr_syntax_errors(self):
         self._assert_expr_error("(", "line 1, column 1: no viable alternative at input '('")


### PR DESCRIPTION
## Problem

Using `properties.go.into.the.json` gave a undefined error.

## Changes

It's a slightly better error now. It won't show up in insights yet, but at least it'll 

## How did you test this code?

Added a test for the error.