### PR TITLE
refactor(logics): use new kea format for insight logics

### DIFF
--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, props, key, connect, selectors } from 'kea'
 import {
     FilterType,
     FunnelResultType,
@@ -34,12 +34,12 @@ import {
 
 const DEFAULT_FUNNEL_LOGIC_KEY = 'default_funnel_key'
 
-export const funnelDataLogic = kea<funnelDataLogicType>({
-    path: (key) => ['scenes', 'funnels', 'funnelDataLogic', key],
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps(DEFAULT_FUNNEL_LOGIC_KEY),
+export const funnelDataLogic = kea<funnelDataLogicType>([
+    path((key) => ['scenes', 'funnels', 'funnelDataLogic', key]),
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_FUNNEL_LOGIC_KEY)),
 
-    connect: (props: InsightLogicProps) => ({
+    connect((props: InsightLogicProps) => ({
         values: [
             insightDataLogic(props),
             ['querySource', 'insightFilter', 'funnelsFilter', 'breakdown', 'series', 'insightData'],
@@ -49,9 +49,9 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
             ['hiddenLegendKeys'],
         ],
         actions: [insightDataLogic(props), ['updateInsightFilter', 'updateQuerySource']],
-    }),
+    })),
 
-    selectors: ({ props }) => ({
+    selectors(({ props }) => ({
         isStepsFunnel: [
             (s) => [s.funnelsFilter],
             (funnelsFilter): boolean | null => {
@@ -263,5 +263,5 @@ export const funnelDataLogic = kea<funnelDataLogicType>({
                 events: funnelsFilter?.exclusions,
             }),
         ],
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/insights/filters/ActionFilter/renameModalLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/renameModalLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, reducers } from 'kea'
 import type { renameModalLogicType } from './renameModalLogicType'
 import { EntityFilterTypes } from '~/types'
 import { getDisplayNameFromEntityFilter } from 'scenes/insights/utils'
@@ -9,17 +9,17 @@ export interface RenameModalProps {
     typeKey: string
 }
 
-export const renameModalLogic = kea<renameModalLogicType>({
-    props: {} as RenameModalProps,
-    key: (props) => props.typeKey,
-    path: (key) => ['scenes', 'insights', 'ActionFilter', 'renameModalLogic', key],
-    connect: {
+export const renameModalLogic = kea<renameModalLogicType>([
+    props({} as RenameModalProps),
+    key((props) => props.typeKey),
+    path((key) => ['scenes', 'insights', 'ActionFilter', 'renameModalLogic', key]),
+    connect({
         actions: [entityFilterLogic, ['selectFilter']],
-    },
-    actions: () => ({
-        setName: (name: string) => ({ name }),
     }),
-    reducers: ({ props }) => ({
+    actions(() => ({
+        setName: (name: string) => ({ name }),
+    })),
+    reducers(({ props }) => ({
         name: [
             getDisplayNameFromEntityFilter(props.filter) ?? '',
             {
@@ -27,5 +27,5 @@ export const renameModalLogic = kea<renameModalLogicType>({
                 selectFilter: (_, { filter }) => getDisplayNameFromEntityFilter(filter) ?? '',
             },
         ],
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterLogic.ts
@@ -1,31 +1,31 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, selectors, listeners } from 'kea'
 import type { insightDateFilterLogicType } from './insightDateFilterLogicType'
 import { InsightLogicProps } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
-export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps('new'),
-    path: (key) => ['scenes', 'insights', 'InsightDateFilter', 'insightDateFilterLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const insightDateFilterLogic = kea<insightDateFilterLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['scenes', 'insights', 'InsightDateFilter', 'insightDateFilterLogic', key]),
+    connect((props: InsightLogicProps) => ({
         actions: [insightLogic(props), ['setFilters'], insightDataLogic(props), ['updateQuerySource']],
         values: [insightLogic(props), ['filters']],
-    }),
-    actions: () => ({
+    })),
+    actions(() => ({
         setDates: (dateFrom: string | undefined | null, dateTo: string | undefined | null) => ({
             dateFrom,
             dateTo,
         }),
-    }),
-    selectors: {
+    })),
+    selectors({
         dates: [
             (s) => [s.filters],
             (filters) => ({ dateFrom: filters?.date_from || null, dateTo: filters?.date_to || null }),
         ],
-    },
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         setDates: ({ dateFrom, dateTo }) => {
             actions.setFilters({
                 ...values.filters,
@@ -39,5 +39,5 @@ export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
                 },
             })
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/insights/insightCommandLogic.ts
+++ b/frontend/src/scenes/insights/insightCommandLogic.ts
@@ -1,5 +1,5 @@
 import { Command, commandPaletteLogic } from 'lib/components/CommandPalette/commandPaletteLogic'
-import { kea } from 'kea'
+import { kea, props, key, path, connect, events } from 'kea'
 import type { insightCommandLogicType } from './insightCommandLogicType'
 import { compareFilterLogic } from 'lib/components/CompareFilter/compareFilterLogic'
 import { RiseOutlined } from '@ant-design/icons'
@@ -10,17 +10,17 @@ import { insightDateFilterLogic } from 'scenes/insights/filters/InsightDateFilte
 
 const INSIGHT_COMMAND_SCOPE = 'insights'
 
-export const insightCommandLogic = kea<insightCommandLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps('new'),
-    path: (key) => ['scenes', 'insights', 'insightCommandLogic', key],
+export const insightCommandLogic = kea<insightCommandLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['scenes', 'insights', 'insightCommandLogic', key]),
 
-    connect: (props: InsightLogicProps) => [
+    connect((props: InsightLogicProps) => [
         commandPaletteLogic,
         compareFilterLogic(props),
         insightDateFilterLogic(props),
-    ],
-    events: ({ props }) => ({
+    ]),
+    events(({ props }) => ({
         afterMount: () => {
             const funnelCommands: Command[] = [
                 {
@@ -51,5 +51,5 @@ export const insightCommandLogic = kea<insightCommandLogicType>({
         beforeUnmount: () => {
             commandPaletteLogic.actions.deregisterScope(INSIGHT_COMMAND_SCOPE)
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/insights/views/Funnels/funnelCommandLogic.ts
+++ b/frontend/src/scenes/insights/views/Funnels/funnelCommandLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect, events } from 'kea'
 import { Command, commandPaletteLogic, CommandResultTemplate } from 'lib/components/CommandPalette/commandPaletteLogic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelPlotOutlined } from '@ant-design/icons'
@@ -7,10 +7,10 @@ import type { funnelCommandLogicType } from './funnelCommandLogicType'
 
 const FUNNEL_COMMAND_SCOPE = 'funnels'
 
-export const funnelCommandLogic = kea<funnelCommandLogicType>({
-    path: ['scenes', 'insights', 'InsightTabs', 'FunnelTab', 'funnelCommandLogic'],
-    connect: [commandPaletteLogic],
-    events: {
+export const funnelCommandLogic = kea<funnelCommandLogicType>([
+    path(['scenes', 'insights', 'InsightTabs', 'FunnelTab', 'funnelCommandLogic']),
+    connect([commandPaletteLogic]),
+    events({
         afterMount: () => {
             const results: CommandResultTemplate[] = [
                 {
@@ -36,5 +36,5 @@ export const funnelCommandLogic = kea<funnelCommandLogicType>({
         beforeUnmount: () => {
             commandPaletteLogic.actions.deregisterScope(FUNNEL_COMMAND_SCOPE)
         },
-    },
-})
+    }),
+])

--- a/frontend/src/scenes/insights/views/Trends/funnelsCueLogic.tsx
+++ b/frontend/src/scenes/insights/views/Trends/funnelsCueLogic.tsx
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, reducers, listeners, selectors, events } from 'kea'
 import { InsightLogicProps, InsightType } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -7,20 +7,20 @@ import posthog from 'posthog-js'
 import { FEATURE_FLAGS } from 'lib/constants'
 import type { funnelsCueLogicType } from './funnelsCueLogicType'
 
-export const funnelsCueLogic = kea<funnelsCueLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps('new'),
-    path: (key) => ['scenes', 'insights', 'InsightTabs', 'TrendTab', 'FunnelsCue', key],
-    connect: (props: InsightLogicProps) => ({
+export const funnelsCueLogic = kea<funnelsCueLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['scenes', 'insights', 'InsightTabs', 'TrendTab', 'FunnelsCue', key]),
+    connect((props: InsightLogicProps) => ({
         values: [insightLogic(props), ['filters', 'isFirstLoad'], featureFlagLogic, ['featureFlags']],
         actions: [insightLogic(props), ['setFilters'], featureFlagLogic, ['setFeatureFlags']],
-    }),
-    actions: {
+    })),
+    actions({
         optOut: (userOptedOut: boolean) => ({ userOptedOut }),
         setShouldShow: (show: boolean) => ({ show }),
         setPermanentOptOut: true,
-    },
-    reducers: {
+    }),
+    reducers({
         _shouldShow: [
             false,
             {
@@ -33,8 +33,8 @@ export const funnelsCueLogic = kea<funnelsCueLogicType>({
                 setPermanentOptOut: () => true,
             },
         ],
-    },
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         optOut: async ({ userOptedOut }) => {
             posthog.capture('funnel cue 7301 - terminated', { user_opted_out: userOptedOut })
             posthog.people.set({ funnels_cue_3701_opt_out: true })
@@ -57,18 +57,18 @@ export const funnelsCueLogic = kea<funnelsCueLogicType>({
                 actions.setPermanentOptOut()
             }
         },
-    }),
-    selectors: {
+    })),
+    selectors({
         shown: [
             (s) => [s._shouldShow, s.permanentOptOut],
             (shouldShow, permanentOptout): boolean => shouldShow && !permanentOptout,
         ],
-    },
-    events: ({ actions, values }) => ({
+    }),
+    events(({ actions, values }) => ({
         afterMount: async () => {
             if (values.featureFlags[FEATURE_FLAGS.FUNNELS_CUE_OPT_OUT]) {
                 actions.setPermanentOptOut()
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
@@ -1,22 +1,22 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, reducers, selectors } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightLogicProps, TrendResult } from '~/types'
 import { keyForInsightLogicProps } from '../../sharedUtils'
 import type { worldMapLogicType } from './worldMapLogicType'
 
-export const worldMapLogic = kea<worldMapLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps('new'),
-    path: (key) => ['scenes', 'insights', 'WorldMap', 'worldMapLogic', key],
-    connect: () => ({
+export const worldMapLogic = kea<worldMapLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['scenes', 'insights', 'WorldMap', 'worldMapLogic', key]),
+    connect(() => ({
         values: [insightLogic, ['insight', 'filters']],
-    }),
-    actions: {
+    })),
+    actions({
         showTooltip: (countryCode: string, countrySeries: TrendResult | null) => ({ countryCode, countrySeries }),
         hideTooltip: true,
         updateTooltipCoordinates: (x: number, y: number) => ({ x, y }),
-    },
-    reducers: {
+    }),
+    reducers({
         isTooltipShown: [
             false,
             {
@@ -36,8 +36,8 @@ export const worldMapLogic = kea<worldMapLogicType>({
                 updateTooltipCoordinates: (_, { x, y }) => [x, y],
             },
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         countryCodeToSeries: [
             (s) => [s.insight],
             (insight): Record<string, TrendResult> =>
@@ -54,5 +54,5 @@ export const worldMapLogic = kea<worldMapLogicType>({
                     ? Math.max(...insight.result.map((series: TrendResult) => series.aggregated_value))
                     : 0,
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, props, key, connect, selectors } from 'kea'
 import { InsightLogicProps, FilterType, PathType } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -34,17 +34,17 @@ export interface PathNode {
     value: number
 }
 
-export const pathsDataLogic = kea<pathsDataLogicType>({
-    path: (key) => ['scenes', 'paths', 'pathsDataLogic', key],
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps(DEFAULT_PATH_LOGIC_KEY),
+export const pathsDataLogic = kea<pathsDataLogicType>([
+    path((key) => ['scenes', 'paths', 'pathsDataLogic', key]),
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_PATH_LOGIC_KEY)),
 
-    connect: (props: InsightLogicProps) => ({
+    connect((props: InsightLogicProps) => ({
         values: [insightDataLogic(props), ['insightFilter']],
         actions: [insightDataLogic(props), ['updateInsightFilter']],
-    }),
+    })),
 
-    selectors: {
+    selectors({
         taxonomicGroupTypes: [
             (s) => [s.insightFilter],
             (insightFilter: PathsFilter | undefined) => {
@@ -64,5 +64,5 @@ export const pathsDataLogic = kea<pathsDataLogicType>({
                 return taxonomicGroupTypes
             },
         ],
-    },
-})
+    }),
+])


### PR DESCRIPTION
## Problem

Saw that I accidentally used the old kea format for two `...DataLogics`.

## Changes

This PR refactors these and a couple of other logics to the kea v3 `kea([...])` format, as per https://github.com/PostHog/posthog/issues/10471. I thought I had already converted all missing ones, but seems I searched with the wrong regex..

## How did you test this code?

CI run.