### PR TITLE
fix(recordings): fix escaping of property values in session recordings

### DIFF
--- a/posthog/clickhouse/client/escape.py
+++ b/posthog/clickhouse/client/escape.py
@@ -39,6 +39,10 @@ def substitute_params(query, params):
     It seems somewhat unusual that you need to connect to the server before
     you can escape params, so we're just going to copy the function here
     and remove that dependency.
+
+    See
+    https://github.com/mymarilyn/clickhouse-driver/blob/87090902f0270ed51a0b6754d5cbf0dc8544ec4b/clickhouse_driver/client.py#L593
+    for the original function.
     """
     if not isinstance(params, dict):
         raise ValueError("Parameters are expected in dict form")
@@ -52,6 +56,10 @@ def escape_params(params):
     This is a copy of clickhouse-driver's `escape_params` function without the
     dependency that you need to connect to the server before you can escape
     params.
+
+    See
+    https://github.com/mymarilyn/clickhouse-driver/blob/87090902f0270ed51a0b6754d5cbf0dc8544ec4b/clickhouse_driver/util/escape.py#L60
+    for the original function.
     """
     escaped = {}
 
@@ -68,6 +76,10 @@ def escape_param_for_clickhouse(param: Any) -> str:
     just such that it can run. The only value that the real `escape_param` uses
     from the context is the server timezone. We assume that the server timezone
     is UTC.
+
+    See
+    https://github.com/mymarilyn/clickhouse-driver/blob/87090902f0270ed51a0b6754d5cbf0dc8544ec4b/clickhouse_driver/util/escape.py#L31
+    for the wrapped function.
     """
     context = Context()
     context.server_info = ServerInfo(

--- a/posthog/clickhouse/client/escape.py
+++ b/posthog/clickhouse/client/escape.py
@@ -66,8 +66,8 @@ def escape_param_for_clickhouse(param: Any) -> str:
     This is a wrapper around the `escape_param` function from the
     `clickhouse-driver` package, but passes a placeholder `Context` object to it
     just such that it can run. The only value that the real `escape_param` uses
-    from the context is the server timezone, which we don't care about here so
-    we set it to None.
+    from the context is the server timezone. We assume that the server timezone
+    is UTC.
     """
     context = Context()
     context.server_info = ServerInfo(
@@ -77,6 +77,6 @@ def escape_param_for_clickhouse(param: Any) -> str:
         version_patch="placeholder server_info value",
         revision="placeholder server_info value",
         display_name="placeholder server_info value",
-        timezone=None,
+        timezone="UTC",
     )
     return escape_param(param, context=context)

--- a/posthog/clickhouse/client/escape.py
+++ b/posthog/clickhouse/client/escape.py
@@ -1,0 +1,82 @@
+# Methods used for rendering a ClickHouse query, given a template string and a
+# set of parameters.
+#
+# This uses the `escape_param` function from the `clickhouse-driver` package,
+# but passes an empty `Context` object to it. Prior to
+# https://github.com/mymarilyn/clickhouse-driver/commit/87090902f0270ed51a0b6754d5cbf0dc8544ec4b
+# the `escape_param` function didn't take a `Context` object. As of
+# `clickhouse-driver` 0.2.4 all it uses the context for is to determine the
+# "server" timezone, so passing an empty context maintains the existing
+# behaviour of `clickhouse-driver` 0.2.1, the version we were previously using.
+#
+# This is of course a bit of a hack but we want to be able to render queries
+# without the need of having a connection, which seems like a reasonable thing
+# to be able to do. Having a dependency on a connection to render a query is a
+# little over the top.
+#
+# NOTE: this change is necessary because the `clickhouse-driver` package up to
+# 0.2.3 uses an invalid `python_requires` in it's `setup.py` at least for
+# recent versions of setuptools. This was highlighted as a consequence of
+# upgrading to Python 3.10. See
+# https://github.com/mymarilyn/clickhouse-driver/pull/291 for further context.
+
+
+from typing import Any
+
+from clickhouse_driver.connection import ServerInfo
+from clickhouse_driver.context import Context
+from clickhouse_driver.util.escape import escape_param
+
+
+def substitute_params(query, params):
+    """
+    This is a copy of clickhouse-driver's `substitute_params` function without
+    the dependency that you need to connect to the server before you can escape
+    params. There was a bug in which we were trying to substitute params before
+    the connection was established, which caused the query to fail. Presumably
+    this was on initial worker startup only.
+
+    It seems somewhat unusual that you need to connect to the server before
+    you can escape params, so we're just going to copy the function here
+    and remove that dependency.
+    """
+    if not isinstance(params, dict):
+        raise ValueError("Parameters are expected in dict form")
+
+    escaped = escape_params(params)
+    return query % escaped
+
+
+def escape_params(params):
+    """
+    This is a copy of clickhouse-driver's `escape_params` function without the
+    dependency that you need to connect to the server before you can escape
+    params.
+    """
+    escaped = {}
+
+    for key, value in params.items():
+        escaped[key] = escape_param_for_clickhouse(value)
+
+    return escaped
+
+
+def escape_param_for_clickhouse(param: Any) -> str:
+    """
+    This is a wrapper around the `escape_param` function from the
+    `clickhouse-driver` package, but passes a placeholder `Context` object to it
+    just such that it can run. The only value that the real `escape_param` uses
+    from the context is the server timezone, which we don't care about here so
+    we set it to None.
+    """
+    context = Context()
+    context.server_info = ServerInfo(
+        name="placeholder server_info value",
+        version_major="placeholder server_info value",
+        version_minor="placeholder server_info value",
+        version_patch="placeholder server_info value",
+        revision="placeholder server_info value",
+        display_name="placeholder server_info value",
+        timezone=None,
+    )
+    return escape_param(param, context=context)

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -12,6 +12,7 @@ from django.conf import settings as app_settings
 from statshog.defaults.django import statsd
 
 from posthog.clickhouse.client.connection import Workload, get_pool
+from posthog.clickhouse.client.escape import substitute_params
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags
 from posthog.errors import wrap_query_error
 from posthog.settings import TEST
@@ -187,7 +188,7 @@ def _prepare_query(client: SyncClient, query: str, args: QueryArgs, workload: Wo
     else:
         # Else perform the substitution so we can perform operations on the raw
         # non-templated SQL
-        rendered_sql = client.substitute_params(query, args, client.connection.context)
+        rendered_sql = substitute_params(query, args)
         prepared_args = None
 
     formatted_sql = sqlparse.format(rendered_sql, strip_comments=True)

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -13,10 +13,9 @@ from typing import (
     cast,
 )
 
-from clickhouse_driver.context import Context
-from clickhouse_driver.util.escape import escape_param
 from rest_framework import exceptions
 
+from posthog.clickhouse.client.escape import escape_param_for_clickhouse
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.materialized_columns import TableWithProperties, get_materialized_columns
 from posthog.constants import PropertyOperatorType
@@ -552,27 +551,6 @@ def property_table(property: Property) -> TableWithProperties:
         return "groups"
     else:
         raise ValueError(f"Property type does not have a table: {property.type}")
-
-
-def escape_param_for_clickhouse(param: Any) -> str:
-    """
-    Escape a parameter for ClickHouse. This uses the `escape_param` function
-    from the `clickhouse-driver` package, but passes an empty `Context` object
-    to it. Prior to
-    https://github.com/mymarilyn/clickhouse-driver/commit/87090902f0270ed51a0b6754d5cbf0dc8544ec4b
-    the `escape_param` function didn't take a `Context` object. As of
-    `clickhouse-driver` 0.2.4 all it uses the context for is to determine the
-    "server" timezone, so passing an empty context maintains the existing
-    behaviour of `clickhouse-driver` 0.2.1, the version we were previously
-    using.
-
-    NOTE: this change is necessary because the `clickhouse-driver` package up to
-    0.2.3 uses an invalid `python_requires` in it's `setup.py` at least for
-    recent versions of setuptools. This was highlighted as a consequence of
-    upgrading to Python 3.10. See
-    https://github.com/mymarilyn/clickhouse-driver/pull/291 for further context.
-    """
-    return escape_param(param, Context())
 
 
 def get_single_or_multi_property_string_expr(


### PR DESCRIPTION
With the merging of https://github.com/PostHog/posthog/pull/14405 due to
the introduction of
https://github.com/mymarilyn/clickhouse-driver/issues/268 in
`clickhouse-driver` we ended up passing the `Context` object to the
`substitute_params` function _before_ the connection had been
established. This meant that the `context.server_info` property for
`None`, which results in the `substitute_params` function raising an
error on trying to access the servers timezone information.

Here I simply remove the functionality of using the server timezone
info, and instead pass in a timezone of `None`. This reflects the
functionality that was in place before
https://github.com/mymarilyn/clickhouse-driver/issues/268 was merged.

It seems this only affects the session recordings snapshots endpoint.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
