### PR TITLE
chore: Use the PostHog Deployer app key instead of a PAT for deploys

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -118,15 +118,19 @@ jobs:
                   build-args: |
                       BASE_IMAGE=posthog/posthog:latest
 
+            - name: Get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@v2
+              with:
+                  app_id: ${{ secrets.DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
+
             - name: Trigger PostHog Cloud deployment
               # TODO: switch to https://github.com/marketplace/actions/repository-dispatch
               # as this action is now deprecated.
               uses: mvasigh/dispatch-action@main
               with:
-                  # TODO: find a way to avoid using a personal access token. An
-                  # option: push something to SQS (using WebIdentity) -> lambda
-                  # function to trigger the workflow via webhook
-                  token: ${{ secrets.POSTHOG_CLOUD_ACCESS_TOKEN }}
+                  token: ${{ steps.deployer.outputs.token }}
                   repo: posthog-cloud-infra
                   owner: PostHog
                   event_type: posthog_cloud_build


### PR DESCRIPTION
## Problem
Currently we're using hazzadous's personal access token for deploys Update this to use a github app installed in the org instead

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tried out on another (internal) repo first