### PR TITLE
chore: be explicit re. timezones when sending to ClickHouse

### DIFF
--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -571,7 +571,10 @@
          Please note, that server could display time zone alias instead of specified name.
          Example: W-SU is an alias for Europe/Moscow and Zulu is an alias for UTC.
     -->
-    <!-- <timezone>Europe/Moscow</timezone> -->
+    <!-- Note we specifically set the timezone to something other than UTC to
+    test that we are handling timezones appropriately no matter what the server
+    thinks is the time -->
+    <timezone>Europe/Moscow</timezone>
 
     <!-- You can specify umask here (see "man umask"). Server will apply it on startup.
          Number is always parsed as octal. Default umask is 027 (other users cannot read logs, data files, etc; group can only read).

--- a/ee/api/test/__snapshots__/test_time_to_see_data.ambr
+++ b/ee/api/test/__snapshots__/test_time_to_see_data.ambr
@@ -31,7 +31,6 @@
                   "team_id": 2,
                   "user_id": 123,
                   "session_id": "123",
-                  "timestamp": "2022-10-05T10:10:30",
                   "type": "",
                   "context": "",
                   "is_primary_interaction": 1,
@@ -44,11 +43,12 @@
                   "action": "",
                   "insights_fetched": 1,
                   "insights_fetched_cached": 0,
-                  "min_last_refresh": "1970-01-01T00:00:00",
-                  "max_last_refresh": "1970-01-01T00:00:00",
-                  "_timestamp": "1970-01-01T00:00:00",
+                  "_timestamp": "1970-01-01T03:00:00",
                   "_offset": 0,
                   "_partition": 0,
+                  "timestamp": "2022-10-05T10:10:30Z",
+                  "min_last_refresh": "1970-01-01T00:00:00Z",
+                  "max_last_refresh": "1970-01-01T00:00:00Z",
                   "is_frustrating": 0
               },
               "children": [
@@ -61,7 +61,6 @@
                           "team_id": 2,
                           "user_id": 123,
                           "session_id": "123",
-                          "timestamp": "2022-10-05T10:30:25",
                           "type": "",
                           "context": "",
                           "is_primary_interaction": 0,
@@ -74,11 +73,12 @@
                           "action": "",
                           "insights_fetched": 1,
                           "insights_fetched_cached": 0,
-                          "min_last_refresh": "1970-01-01T00:00:00",
-                          "max_last_refresh": "1970-01-01T00:00:00",
-                          "_timestamp": "1970-01-01T00:00:00",
+                          "_timestamp": "1970-01-01T03:00:00",
                           "_offset": 0,
                           "_partition": 0,
+                          "timestamp": "2022-10-05T10:30:25Z",
+                          "min_last_refresh": "1970-01-01T00:00:00Z",
+                          "max_last_refresh": "1970-01-01T00:00:00Z",
                           "is_frustrating": 0
                       },
                       "children": [
@@ -86,7 +86,6 @@
                               "type": "query",
                               "data": {
                                   "host": "",
-                                  "timestamp": "2022-10-05T10:10:30",
                                   "query_duration_ms": 400,
                                   "read_rows": 0,
                                   "read_bytes": 0,
@@ -115,6 +114,7 @@
                                   "columns": [],
                                   "query": "",
                                   "log_comment": "",
+                                  "timestamp": "2022-10-05T10:10:30Z",
                                   "is_frustrating": 0
                               },
                               "children": []
@@ -125,7 +125,6 @@
                       "type": "query",
                       "data": {
                           "host": "",
-                          "timestamp": "2022-10-05T10:10:30",
                           "query_duration_ms": 200,
                           "read_rows": 0,
                           "read_bytes": 0,
@@ -154,6 +153,7 @@
                           "columns": [],
                           "query": "",
                           "log_comment": "",
+                          "timestamp": "2022-10-05T10:10:30Z",
                           "is_frustrating": 0
                       },
                       "children": []
@@ -169,7 +169,6 @@
                   "team_id": 2,
                   "user_id": 123,
                   "session_id": "123",
-                  "timestamp": "2022-10-05T10:30:30",
                   "type": "",
                   "context": "",
                   "is_primary_interaction": 1,
@@ -182,11 +181,12 @@
                   "action": "",
                   "insights_fetched": 1,
                   "insights_fetched_cached": 0,
-                  "min_last_refresh": "1970-01-01T00:00:00",
-                  "max_last_refresh": "1970-01-01T00:00:00",
-                  "_timestamp": "1970-01-01T00:00:00",
+                  "_timestamp": "1970-01-01T03:00:00",
                   "_offset": 0,
                   "_partition": 0,
+                  "timestamp": "2022-10-05T10:30:30Z",
+                  "min_last_refresh": "1970-01-01T00:00:00Z",
+                  "max_last_refresh": "1970-01-01T00:00:00Z",
                   "is_frustrating": 1
               },
               "children": []

--- a/ee/api/test/test_time_to_see_data.py
+++ b/ee/api/test/test_time_to_see_data.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 import json
 from dataclasses import asdict, dataclass, field
-from typing import Any, List
+from typing import Any, List, Optional
 from unittest import mock
 
 import pytest
@@ -39,15 +40,21 @@ class TestTimeToSeeDataApi(APIBaseTest):
         insert(
             "metrics_time_to_see_data",
             [
-                MetricsRow(session_id="456", timestamp="2022-10-05 12:20:30", time_to_see_data_ms=7000),
-                MetricsRow(session_id="123", timestamp="2022-10-05 10:10:30", time_to_see_data_ms=2000),
+                MetricsRow(
+                    session_id="456", timestamp=datetime.fromisoformat("2022-10-05 12:20:30"), time_to_see_data_ms=7000
+                ),
+                MetricsRow(
+                    session_id="123", timestamp=datetime.fromisoformat("2022-10-05 10:10:30"), time_to_see_data_ms=2000
+                ),
                 MetricsRow(
                     session_id="123",
-                    timestamp="2022-10-05 10:30:25",
+                    timestamp=datetime.fromisoformat("2022-10-05 10:30:25"),
                     time_to_see_data_ms=1000,
                     is_primary_interaction=False,
                 ),
-                MetricsRow(session_id="123", timestamp="2022-10-05 10:30:30", time_to_see_data_ms=7000),
+                MetricsRow(
+                    session_id="123", timestamp=datetime.fromisoformat("2022-10-05 10:30:30"), time_to_see_data_ms=7000
+                ),
             ],
         )
 
@@ -90,22 +97,26 @@ class TestTimeToSeeDataApi(APIBaseTest):
         insert(
             "metrics_time_to_see_data",
             [
-                MetricsRow(session_id="456", timestamp="2022-10-05 12:20:30", time_to_see_data_ms=7000),
+                MetricsRow(
+                    session_id="456", timestamp=datetime.fromisoformat("2022-10-05 12:20:30"), time_to_see_data_ms=7000
+                ),
                 MetricsRow(
                     session_id="123",
-                    timestamp="2022-10-05 10:10:30",
+                    timestamp=datetime.fromisoformat("2022-10-05 10:10:30"),
                     time_to_see_data_ms=2000,
                     primary_interaction_id="111-222-333",
                 ),
                 MetricsRow(
                     session_id="123",
-                    timestamp="2022-10-05 10:30:25",
+                    timestamp=datetime.fromisoformat("2022-10-05 10:30:25"),
                     time_to_see_data_ms=1000,
                     is_primary_interaction=False,
                     primary_interaction_id="111-222-333",
                     query_id="777",
                 ),
-                MetricsRow(session_id="123", timestamp="2022-10-05 10:30:30", time_to_see_data_ms=7000),
+                MetricsRow(
+                    session_id="123", timestamp=datetime.fromisoformat("2022-10-05 10:30:30"), time_to_see_data_ms=7000
+                ),
             ],
         )
 
@@ -114,13 +125,13 @@ class TestTimeToSeeDataApi(APIBaseTest):
             [
                 QueryLogRow(
                     session_id="123",
-                    timestamp="2022-10-05 10:10:30",
+                    timestamp=datetime.fromisoformat("2022-10-05 10:10:30"),
                     query_duration_ms=400,
                     client_query_id="111-222-333::777",
                 ),
                 QueryLogRow(
                     session_id="123",
-                    timestamp="2022-10-05 10:10:30",
+                    timestamp=datetime.fromisoformat("2022-10-05 10:10:30"),
                     query_duration_ms=200,
                     client_query_id="111-222-333::999",
                 ),
@@ -148,7 +159,7 @@ class MetricsRow:
     team_id: int = 2
     user_id: int = 123
     session_id: str = ""
-    timestamp: str = "2022-10-05 10:20:00"
+    timestamp: datetime = datetime.fromisoformat("2022-10-05 10:20:00")
     type: str = ""
     context: str = ""
     is_primary_interaction: int = True
@@ -168,7 +179,7 @@ class MetricsRow:
 @dataclass
 class QueryLogRow:
     host: str = ""
-    timestamp: str = ""
+    timestamp: Optional[datetime] = None
     query_duration_ms: int = 555
     read_rows: int = 0
     read_bytes: int = 0

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -21,7 +21,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -84,7 +84,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -140,7 +140,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -200,7 +200,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -263,7 +263,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -319,7 +319,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -393,7 +393,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -481,7 +481,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -683,7 +683,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values
@@ -744,7 +744,7 @@
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toDateTime(toDateTime('2020-06-07 00:00:00', 'UTC') , 0, 'UTC')),
                               toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
                           )
                       ] as breakdown_values

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -20,7 +20,7 @@
                [
                           dateDiff(
                               'Day',
-                              toStartOfDay(toDateTime('2020-01-01 00:00:00' , 'UTC')),
+                              toStartOfDay(toDateTime(toDateTime('2020-01-01 00:00:00', 'UTC') , 'UTC')),
                               toStartOfDay(min(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')))
                           )
                       ] as breakdown_values
@@ -89,7 +89,7 @@
                [
                           dateDiff(
                               'Day',
-                              toStartOfDay(toDateTime('2020-01-01 00:00:00' , 'UTC')),
+                              toStartOfDay(toDateTime(toDateTime('2020-01-01 00:00:00', 'UTC') , 'UTC')),
                               toStartOfDay(min(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')))
                           )
                       ] as breakdown_values
@@ -161,7 +161,7 @@
                [
                           dateDiff(
                               'Day',
-                              toStartOfDay(toDateTime('2020-01-01 00:00:00' , 'UTC')),
+                              toStartOfDay(toDateTime(toDateTime('2020-01-01 00:00:00', 'UTC') , 'UTC')),
                               toStartOfDay(min(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')))
                           )
                       ] as breakdown_values
@@ -242,7 +242,7 @@
                [
                           dateDiff(
                               'Day',
-                              toStartOfDay(toDateTime('2020-01-01 00:00:00' , 'UTC')),
+                              toStartOfDay(toDateTime(toDateTime('2020-01-01 00:00:00', 'UTC') , 'UTC')),
                               toStartOfDay(min(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')))
                           )
                       ] as breakdown_values
@@ -342,7 +342,7 @@
                [
                           dateDiff(
                               'Day',
-                              toStartOfDay(toDateTime('2020-01-01 00:00:00' , 'UTC')),
+                              toStartOfDay(toDateTime(toDateTime('2020-01-01 00:00:00', 'UTC') , 'UTC')),
                               toStartOfDay(min(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')))
                           )
                       ] as breakdown_values
@@ -438,7 +438,7 @@
                [
                           dateDiff(
                               'Day',
-                              toStartOfDay(toDateTime('2020-01-01 00:00:00' , 'UTC')),
+                              toStartOfDay(toDateTime(toDateTime('2020-01-01 00:00:00', 'UTC') , 'UTC')),
                               toStartOfDay(min(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')))
                           )
                       ] as breakdown_values

--- a/posthog/clickhouse/client/escape.py
+++ b/posthog/clickhouse/client/escape.py
@@ -21,6 +21,7 @@
 # https://github.com/mymarilyn/clickhouse-driver/pull/291 for further context.
 
 
+from datetime import datetime
 from typing import Any
 
 from clickhouse_driver.connection import ServerInfo
@@ -91,4 +92,7 @@ def escape_param_for_clickhouse(param: Any) -> str:
         display_name="placeholder server_info value",
         timezone="UTC",
     )
+    if isinstance(param, datetime):
+        # Interpret datetime as UTC
+        return f"toDateTime('{param.strftime('%Y-%m-%d %H:%M:%S')}', 'UTC')"
     return escape_param(param, context=context)

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -85,13 +85,13 @@ def create_event(
 def format_clickhouse_timestamp(
     raw_timestamp: Optional[Union[timezone.datetime, str]],
     default=None,
-) -> str:
+):
     if default is None:
         default = timezone.now()
     parsed_datetime = (
         isoparse(raw_timestamp) if isinstance(raw_timestamp, str) else (raw_timestamp or default).astimezone(pytz.utc)
     )
-    return parsed_datetime.strftime("%Y-%m-%d %H:%M:%S.%f")
+    return parsed_datetime
 
 
 def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Dict[str, Person]] = None) -> None:

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -57,8 +57,8 @@
   WHERE team_id = 2
     AND plugin_config_id = 3
     AND category = 'processEvent'
-    AND timestamp >= '2021-11-28 00:00:00'
-    AND timestamp < '2021-12-05 13:23:00'
+    AND timestamp >= toDateTime('2021-11-28 00:00:00', 'UTC')
+    AND timestamp < toDateTime('2021-12-05 13:23:00', 'UTC')
     AND error_type <> ''
   GROUP BY error_type
   ORDER BY count DESC
@@ -75,8 +75,8 @@
     AND plugin_config_id = 3
     AND category = 'processEvent'
     AND job_id = '1234'
-    AND timestamp >= '2021-11-28 00:00:00'
-    AND timestamp < '2021-12-05 13:23:00'
+    AND timestamp >= toDateTime('2021-11-28 00:00:00', 'UTC')
+    AND timestamp < toDateTime('2021-12-05 13:23:00', 'UTC')
     AND error_type <> ''
   GROUP BY error_type
   ORDER BY count DESC
@@ -92,8 +92,8 @@
   WHERE team_id = 2
     AND plugin_config_id = 3
     AND category = 'processEvent'
-    AND timestamp >= '2021-11-28 00:00:00'
-    AND timestamp < '2021-12-05 13:23:00'
+    AND timestamp >= toDateTime('2021-11-28 00:00:00', 'UTC')
+    AND timestamp < toDateTime('2021-12-05 13:23:00', 'UTC')
     AND error_type <> ''
   GROUP BY error_type
   ORDER BY count DESC
@@ -119,12 +119,12 @@
         WHERE team_id = 2
           AND plugin_config_id = 3
           AND category = 'processEvent'
-          AND timestamp >= '2021-11-28 00:00:00'
-          AND timestamp < '2021-12-05 13:23:00'
+          AND timestamp >= toDateTime('2021-11-28 00:00:00', 'UTC')
+          AND timestamp < toDateTime('2021-12-05 13:23:00', 'UTC')
         GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date WITH FILL
-     FROM dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC') TO dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC') STEP 86400)
+     FROM dateTrunc('day', toDateTime(toDateTime('2021-11-28 00:00:00', 'UTC')), 'UTC') TO dateTrunc('day', toDateTime(toDateTime('2021-12-05 13:23:00', 'UTC')) + toIntervalDay(1), 'UTC') STEP 86400)
   '
 ---
 # name: TestAppMetricsQuery.test_filter_by_hourly_date_range
@@ -147,12 +147,12 @@
         WHERE team_id = 2
           AND plugin_config_id = 3
           AND category = 'processEvent'
-          AND timestamp >= '2021-12-05 00:00:00'
-          AND timestamp < '2021-12-05 08:00:00'
+          AND timestamp >= toDateTime('2021-12-05 00:00:00', 'UTC')
+          AND timestamp < toDateTime('2021-12-05 08:00:00', 'UTC')
         GROUP BY dateTrunc('hour', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date WITH FILL
-     FROM dateTrunc('hour', toDateTime('2021-12-05 00:00:00'), 'UTC') TO dateTrunc('hour', toDateTime('2021-12-05 08:00:00') + toIntervalHour(1), 'UTC') STEP 3600)
+     FROM dateTrunc('hour', toDateTime(toDateTime('2021-12-05 00:00:00', 'UTC')), 'UTC') TO dateTrunc('hour', toDateTime(toDateTime('2021-12-05 08:00:00', 'UTC')) + toIntervalHour(1), 'UTC') STEP 3600)
   '
 ---
 # name: TestAppMetricsQuery.test_filter_by_job_id
@@ -176,12 +176,12 @@
           AND plugin_config_id = 3
           AND category = 'exportEvents'
           AND job_id = '12345'
-          AND timestamp >= '2021-11-28 00:00:00'
-          AND timestamp < '2021-12-05 13:23:00'
+          AND timestamp >= toDateTime('2021-11-28 00:00:00', 'UTC')
+          AND timestamp < toDateTime('2021-12-05 13:23:00', 'UTC')
         GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date WITH FILL
-     FROM dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC') TO dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC') STEP 86400)
+     FROM dateTrunc('day', toDateTime(toDateTime('2021-11-28 00:00:00', 'UTC')), 'UTC') TO dateTrunc('day', toDateTime(toDateTime('2021-12-05 13:23:00', 'UTC')) + toIntervalDay(1), 'UTC') STEP 86400)
   '
 ---
 # name: TestAppMetricsQuery.test_ignores_unrelated_data
@@ -204,12 +204,12 @@
         WHERE team_id = 2
           AND plugin_config_id = 3
           AND category = 'processEvent'
-          AND timestamp >= '2021-11-28 00:00:00'
-          AND timestamp < '2021-12-05 13:23:00'
+          AND timestamp >= toDateTime('2021-11-28 00:00:00', 'UTC')
+          AND timestamp < toDateTime('2021-12-05 13:23:00', 'UTC')
         GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date WITH FILL
-     FROM dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC') TO dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC') STEP 86400)
+     FROM dateTrunc('day', toDateTime(toDateTime('2021-11-28 00:00:00', 'UTC')), 'UTC') TO dateTrunc('day', toDateTime(toDateTime('2021-12-05 13:23:00', 'UTC')) + toIntervalDay(1), 'UTC') STEP 86400)
   '
 ---
 # name: TestTeamPluginsDeliveryRateQuery.test_query_delivery_rate
@@ -223,7 +223,7 @@
             sum(successes) + sum(successes_on_retry) + sum(failures) AS total
      FROM app_metrics
      WHERE team_id = 2
-       AND timestamp > '2021-12-04 13:23:00.000000'
+       AND timestamp > toDateTime('2021-12-04 13:23:00', 'UTC')
      GROUP BY plugin_config_id)
   '
 ---

--- a/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
@@ -19,12 +19,12 @@
           AND plugin_config_id = 3
           AND category = 'exportEvents'
           AND job_id = '1234'
-          AND timestamp >= '2021-08-25 00:00:00'
-          AND timestamp < '2021-08-25 06:00:00'
+          AND timestamp >= toDateTime('2021-08-25 00:00:00', 'UTC')
+          AND timestamp < toDateTime('2021-08-25 06:00:00', 'UTC')
         GROUP BY dateTrunc('hour', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date WITH FILL
-     FROM dateTrunc('hour', toDateTime('2021-08-25 00:00:00'), 'UTC') TO dateTrunc('hour', toDateTime('2021-08-25 06:00:00') + toIntervalHour(1), 'UTC') STEP 3600)
+     FROM dateTrunc('hour', toDateTime(toDateTime('2021-08-25 00:00:00', 'UTC')), 'UTC') TO dateTrunc('hour', toDateTime(toDateTime('2021-08-25 06:00:00', 'UTC')) + toIntervalHour(1), 'UTC') STEP 3600)
   '
 ---
 # name: TestHistoricalExports.test_historical_export_metrics.1
@@ -38,8 +38,8 @@
     AND plugin_config_id = 3
     AND category = 'exportEvents'
     AND job_id = '1234'
-    AND timestamp >= '2021-08-25 00:00:00'
-    AND timestamp < '2021-08-25 06:00:00'
+    AND timestamp >= toDateTime('2021-08-25 00:00:00', 'UTC')
+    AND timestamp < toDateTime('2021-08-25 06:00:00', 'UTC')
     AND error_type <> ''
   GROUP BY error_type
   ORDER BY count DESC

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -37,17 +37,14 @@ PERIOD_TO_INTERVAL_FUNC: Dict[str, str] = {
     "month": "toIntervalMonth",
 }
 
+
 # TODO: refactor since this is only used in one spot now
 def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] = None):
-    if convert_to_timezone:
-        # Here we probably get a timestamp set to the beginning of the day (00:00), in UTC
-        # We need to convert that UTC timestamp to the local timestamp (00:00 in US/Pacific for example)
-        # Then we convert it back to UTC (08:00 in UTC)
-        if timestamp.tzinfo and timestamp.tzinfo != pytz.UTC:
-            raise ValidationError(detail="You must pass a timestamp with no timezone or UTC")
-        timestamp = pytz.timezone(convert_to_timezone).localize(timestamp.replace(tzinfo=None)).astimezone(pytz.UTC)
-
-    return timestamp.strftime("%Y-%m-%d %H:%M:%S")
+    # NOTE: this used to convert to a string, then passed it to the ClickHouse
+    # library as a string. Now we pass it as a datetime object, which allows the
+    # ClickHouse library to handle e.g. ensuring timezones are handled
+    # correctly.
+    return timestamp
 
 
 @cache_for(timedelta(seconds=2))


### PR DESCRIPTION
## Problem

We are not being explicit about timezones when sending date strings to ClickHouse afaict. If we are not explicit, we will end up using the ClickHouse servers specified timezone which unless it is UTC will be incorrect. 

We are already being explicit on the table definition side, specifying DateTime columns to be 'UTC' so this should complete the picture.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
