### PR TITLE
feat(ingestion): enable partition statistics on session-recordings and overflow

### DIFF
--- a/posthog/clickhouse/migrations/0041_kafka_partitions_stats.py
+++ b/posthog/clickhouse/migrations/0041_kafka_partitions_stats.py
@@ -7,6 +7,6 @@ from posthog.models.kafka_partition_stats.sql import (
 
 operations = [
     run_sql_with_exceptions(CREATE_KAFKA_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS),
-    run_sql_with_exceptions(EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS),
+    run_sql_with_exceptions(EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS()),
     run_sql_with_exceptions(CREATE_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS_MV),
 ]

--- a/posthog/clickhouse/migrations/0041_kafka_partitions_stats.py
+++ b/posthog/clickhouse/migrations/0041_kafka_partitions_stats.py
@@ -6,7 +6,7 @@ from posthog.models.kafka_partition_stats.sql import (
 )
 
 operations = [
-    run_sql_with_exceptions(CREATE_KAFKA_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS()),
-    run_sql_with_exceptions(EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS()),
-    run_sql_with_exceptions(CREATE_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS_MV()),
+    run_sql_with_exceptions(CREATE_KAFKA_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS),
+    run_sql_with_exceptions(EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS),
+    run_sql_with_exceptions(CREATE_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS_MV),
 ]

--- a/posthog/clickhouse/migrations/0042_kafka_partitions_stats.py
+++ b/posthog/clickhouse/migrations/0042_kafka_partitions_stats.py
@@ -1,0 +1,13 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW, KAFKA_SESSION_RECORDING_EVENTS
+from posthog.models.kafka_partition_stats.sql import (
+    CREATE_PARTITION_STATISTICS_KAFKA_TABLE,
+    CREATE_PARTITION_STATISTICS_MV,
+)
+
+operations = [
+    run_sql_with_exceptions(CREATE_PARTITION_STATISTICS_KAFKA_TABLE(KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW)),
+    run_sql_with_exceptions(CREATE_PARTITION_STATISTICS_MV(KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW)),
+    run_sql_with_exceptions(CREATE_PARTITION_STATISTICS_KAFKA_TABLE(KAFKA_SESSION_RECORDING_EVENTS)),
+    run_sql_with_exceptions(CREATE_PARTITION_STATISTICS_MV(KAFKA_SESSION_RECORDING_EVENTS)),
+]

--- a/posthog/kafka_client/topics.py
+++ b/posthog/kafka_client/topics.py
@@ -4,6 +4,7 @@ from posthog.settings.data_stores import KAFKA_PREFIX, SUFFIX
 
 KAFKA_EVENTS_JSON = f"{KAFKA_PREFIX}clickhouse_events_json{SUFFIX}"
 KAFKA_EVENTS_PLUGIN_INGESTION = f"{KAFKA_PREFIX}events_plugin_ingestion{SUFFIX}"
+KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW = f"{KAFKA_PREFIX}events_plugin_ingestion_overflow{SUFFIX}"
 KAFKA_PERSON = f"{KAFKA_PREFIX}clickhouse_person{SUFFIX}"
 KAFKA_PERSON_UNIQUE_ID = f"{KAFKA_PREFIX}clickhouse_person_unique_id{SUFFIX}"  # DEPRECATED_DO_NOT_USE
 KAFKA_PERSON_DISTINCT_ID = f"{KAFKA_PREFIX}clickhouse_person_distinct_id{SUFFIX}"


### PR DESCRIPTION
## Problem

The `events_plugin_ingestion_partition_statistics` is very useful, but only covers one of our three capture topics.

Let's reuse the same table to monitor them, we'll filter by `_topic` when needed.

## Changes

- make the statements from migration 41 reusable for different topic names
- create the consumer for `session_recording_events` and `events_plugin_ingestion_overflow`

## How did you test this code?

- Tested migration apply from existing state + empty CH state
- Running locally, I see stats for the three topics:
![image](https://user-images.githubusercontent.com/6241083/223509735-e85e97aa-d691-49bb-89ce-415419d4db31.png)

