### PR TITLE
fix(insights): Fix quarter option in date range selector

### DIFF
--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
@@ -1,5 +1,5 @@
 import { Input } from 'antd'
-import { rollingDateRangeFilterLogic } from './rollingDateRangeFilterLogic'
+import { DateOption, rollingDateRangeFilterLogic } from './rollingDateRangeFilterLogic'
 import { useActions, useValues } from 'kea'
 import { LemonButton, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -7,11 +7,11 @@ import { dayjs } from 'lib/dayjs'
 import clsx from 'clsx'
 import './RollingDateRangeFilter.scss'
 
-const dateOptions: LemonSelectOptions<'days' | 'weeks' | 'months' | 'quarter'> = [
+const dateOptions: LemonSelectOptions<DateOption> = [
     { value: 'days', label: 'days' },
     { value: 'weeks', label: 'weeks' },
     { value: 'months', label: 'months' },
-    { value: 'quarter', label: 'quarters' },
+    { value: 'quarters', label: 'quarters' },
 ]
 
 type RollingDateRangeFilterProps = {

--- a/frontend/src/lib/components/DateFilter/rollingDateRangeFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/rollingDateRangeFilterLogic.ts
@@ -9,7 +9,9 @@ const dateOptionsMap = {
     m: 'months',
     w: 'weeks',
     d: 'days',
-}
+} as const
+
+export type DateOption = typeof dateOptionsMap[keyof typeof dateOptionsMap]
 
 export type RollingDateFilterLogicPropsType = {
     selected?: boolean

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -941,7 +941,7 @@ export function dateFilterToText(
         if (dateOption && counter) {
             let date = null
             switch (dateOption) {
-                case 'quarter':
+                case 'quarters':
                     date = dayjs().subtract(counter * 3, 'M')
                     break
                 case 'months':


### PR DESCRIPTION
## Problem

Resolves #14585.

## Changes

Looks like the problem was we were mixing up singular and plural versions of the words! The typing was lacking, so this wasn't caught anywhere.

## How did you test this code?

Gonna rely on stricter types now.