### PR TITLE
fix: Improved wrapping of console to ensure we don't get suck in a loop

### DIFF
--- a/frontend/src/lib/utils/wrapConsole.ts
+++ b/frontend/src/lib/utils/wrapConsole.ts
@@ -1,0 +1,24 @@
+export function wrapConsole(level: 'log' | 'warn' | 'error', fn: (args: Array<unknown>) => void): () => void {
+    // Flag the handler to prevent max call stack errors (any code in this execution might retrigger the log)
+    const wrappedFn = console[level]
+    let inWrap = false
+
+    console[level] = function (...args: Array<unknown>) {
+        try {
+            if (inWrap) {
+                wrappedFn(...args)
+                return
+            }
+            inWrap = true
+
+            fn(args)
+            wrappedFn(...args)
+        } finally {
+            inWrap = false
+        }
+    }
+
+    return () => {
+        console[level] = wrappedFn
+    }
+}


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/14599

We wrap console warns so we can better detect when the rrweb player has issues. Similar to my fix for the RRweb console plugin, we need to detect if we accidentally trigger another console.warn whilst handling the first one otherwise we can get stuck in an infinite loop

## Changes

* Adds a util function for wrapping console methods that takes care of detecting this loop.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't as my local env isn't setup... @alexkim205 if you happen to be able to test it out that would be great until I get my setup working again