### PR TITLE
fix: Remove and re-add constraint in migration 0308

### DIFF
--- a/posthog/migrations/0308_add_indirect_person_override_constraints.py
+++ b/posthog/migrations/0308_add_indirect_person_override_constraints.py
@@ -42,6 +42,10 @@ class Migration(migrations.Migration):
             model_name="personoverride",
             name="old_person_id_is_not_override_person_id",
         ),
+        migrations.RemoveConstraint(
+            model_name="personoverride",
+            name="old_person_id_different_from_override_person_id",
+        ),
         migrations.RunSQL(DROP_FUNCTION_FOR_CONSTRAINT_SQL, CREATE_FUNCTION_FOR_CONSTRAINT_SQL),
         migrations.RemoveField(model_name="personoverride", name="old_person_id"),
         migrations.AddField(
@@ -69,6 +73,15 @@ class Migration(migrations.Migration):
             model_name="personoverride",
             constraint=models.UniqueConstraint(
                 fields=("team", "old_person_id"), name="unique override per old_person_id"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="personoverride",
+            constraint=models.CheckConstraint(
+                check=models.Q(
+                    ("old_person_id__exact", django.db.models.expressions.F("override_person_id")), _negated=True
+                ),
+                name="old_person_id_different_from_override_person_id",
             ),
         ),
         # Provides operator classes for integers (gist_int4_ops)


### PR DESCRIPTION
## Problem

Migration tests `test_migration_0237` and `test_migration_0285` do a rollback at the end. These tests raised issues with migration 0308 failing on rollback. It's unclear why this issue wasn't raised in the PR that introduced migration 0308.

Regardless, the problem is that dropping a field causes Postgres to drop all constraints associated with the field. This causes an inconsistency between model code and database state: code has a constraint that the database already dropped. This inconsistency ultimately leads to Django assuming the constraint is still there when it attempts to roll it back, even though it was dropped on removing the field.

Interestingly, fixing this issue also takes care of a timeout on Kafka command tests.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

These changes are explicit with removing and re-adding the constraint. However, this says nothing about actual database state.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
