### PR TITLE
feat: Add merge_dangerously event

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -234,6 +234,10 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Alias',
             description: 'An alias ID has been added to a user',
         },
+        $merge_dangerously: {
+            label: 'Merge',
+            description: 'An alias ID has been added to a user',
+        },
         $groupidentify: {
             label: 'Group Identify',
             description: 'A group has been identified with properties',

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -703,9 +703,8 @@ test.skip(`person properties can't see properties from merge descendants`, async
     })
 
     const thirdUuid = new UUIDT().toString()
-    // NOTE: $create_alias is not symmetric, so we will currently get different
+    // NOTE: $create_alias is not symmetric, so we will get different
     // results according to the order of `bobAnonId` and `aliceAnonId`.
-    // TODO: make $create_alias symmetric.
     await capture({
         teamId,
         distinctId: bobAnonId,

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -276,7 +276,7 @@ export class PersonState {
          */
         const timeout = timeoutGuard('Still running "handleIdentifyOrAlias". Timeout warning after 30 sec!')
         try {
-            if (this.event.event === '$create_alias' && this.eventProperties['alias']) {
+            if (['$create_alias', '$merge_dangerously'].includes(this.event.event) && this.eventProperties['alias']) {
                 await this.merge(
                     String(this.eventProperties['alias']),
                     this.distinctId,
@@ -371,7 +371,6 @@ export class PersonState {
                 this.personContainer = this.personContainer.with(person)
             } else if (oldPerson && newPerson && oldPerson.id !== newPerson.id) {
                 await this.mergePeople({
-                    shouldIdentifyPerson: isIdentifyCall,
                     mergeInto: newPerson,
                     mergeIntoDistinctId: distinctId,
                     otherPerson: oldPerson,
@@ -411,13 +410,11 @@ export class PersonState {
         mergeIntoDistinctId,
         otherPerson,
         otherPersonDistinctId,
-        shouldIdentifyPerson = true,
     }: {
         mergeInto: Person
         mergeIntoDistinctId: string
         otherPerson: Person
         otherPersonDistinctId: string
-        shouldIdentifyPerson?: boolean
     }): Promise<void> {
         const olderCreatedAt = DateTime.min(mergeInto.created_at, otherPerson.created_at)
         const newerCreatedAt = DateTime.max(mergeInto.created_at, otherPerson.created_at)
@@ -425,7 +422,7 @@ export class PersonState {
         const mergeAllowed = this.isMergeAllowed(otherPerson)
 
         this.statsd?.increment('merge_users', {
-            call: shouldIdentifyPerson ? 'identify' : 'alias',
+            call: this.event.event, // $identify, $create_alias or $merge_dangerously
             teamId: this.teamId.toString(),
             oldPersonIdentified: String(otherPerson.is_identified),
             newPersonIdentified: String(mergeInto.is_identified),
@@ -477,8 +474,9 @@ export class PersonState {
     }
 
     private isMergeAllowed(mergeFrom: Person): boolean {
+        // $merge_dangerously has no restrictions
         // $create_alias and $identify will not merge a user who's already identified into anyone else
-        return !mergeFrom.is_identified
+        return this.event.event === '$merge_dangerously' || !mergeFrom.is_identified
     }
 
     private async handleMergeTransaction(

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -912,6 +912,29 @@ test('anonymized ip capture', async () => {
     expect(event.properties['$ip']).not.toBeDefined()
 })
 
+test('merge_dangerously', async () => {
+    await createPerson(hub, team, ['old_distinct_id'])
+
+    await processEvent(
+        'new_distinct_id',
+        '',
+        '',
+        {
+            event: '$merge_dangerously',
+            properties: { distinct_id: 'new_distinct_id', token: team.api_token, alias: 'old_distinct_id' },
+        } as any as PluginEvent,
+        team.id,
+        now,
+        new UUIDT().toString()
+    )
+
+    expect((await hub.db.fetchEvents()).length).toBe(1)
+    expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+        'old_distinct_id',
+        'new_distinct_id',
+    ])
+})
+
 test('alias', async () => {
     await createPerson(hub, team, ['old_distinct_id'])
 


### PR DESCRIPTION
## Problem

closes https://github.com/PostHog/posthog/issues/14093

<!-- Who are we building for, what are their needs, why is this important? -->
Allowing us to merge already identified users, which is a semi frequent user request.

It's dangerous because we might end up merging together users that shouldn't be merged (potentially ending up with all users merged together as a result that's difficult to reverse).

Note: we still checks that the distinct_id is not illegal first - we might choose to remove that restriction in the future, but seems safer not to for now.

Libraries don't have and will likely not get a direct function call for this as it's dangerous.

To use it one needs to send an event similar to `$create_alias`, e.g. from python one can do
```
posthog.capture('distinct-id-1', '$merge_dangerously', {'alias': 'distinct-id-2'})
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Local testing with python on an empty project
```
>>> import posthog
>>>
>>> posthog.project_api_key = 'phc_JiGhuxipDOs5fxXaJQhb4dXu3rW6GoaQQ36o5NA97u9'
>>> posthog.host = 'http://localhost:8000'
>>> posthog.capture('test-id', 'test-event')
>>> posthog.alias('test-id', 'alias-1')
>>> posthog.alias('test-id-2', 'alias-2')
>>> posthog.alias('alias-1', 'alias-2')
>>> posthog.capture('alias-1', '$merge_dangerously', {'alias': 'alias-2'})
```

Verified that the alias command failed and saw the ingestion warning and users were still separate. merge dangerously merged users together and there were no additional ingestion warnings.