### PR TITLE
feat: command to add link to current session recording link to clipboard

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -567,6 +567,28 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                         : [],
             }
 
+            const debugCopySessionRecordingURL: Command = {
+                key: 'debug-copy-session-recording-url',
+                scope: GLOBAL_COMMAND_SCOPE,
+                resolver: {
+                    icon: IconRecording,
+                    display: 'Debug: Copy the session recording link to clipboard',
+                    executor: () => {
+                        const LOOK_BACK = 30
+                        const recordingStartTime = Math.max(
+                            Math.floor(
+                                (new Date().getTime() - (posthog?.sessionManager?._sessionStartTimestamp || 0)) / 1000
+                            ) - LOOK_BACK,
+                            0
+                        )
+                        copyToClipboard(
+                            `${window.location.origin}/recordings/${posthog?.sessionRecording?.sessionId}?t=${recordingStartTime}`,
+                            'Current session recording link to clipboard'
+                        )
+                    },
+                },
+            }
+
             const calculator: Command = {
                 key: 'calculator',
                 scope: GLOBAL_COMMAND_SCOPE,
@@ -743,6 +765,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
             actions.registerCommand(createPersonalApiKey)
             actions.registerCommand(createDashboard)
             actions.registerCommand(shareFeedback)
+            actions.registerCommand(debugCopySessionRecordingURL)
         },
         beforeUnmount: () => {
             actions.deregisterCommand('go-to')
@@ -752,6 +775,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
             actions.deregisterCommand('create-personal-api-key')
             actions.deregisterCommand('create-dashboard')
             actions.deregisterCommand('share-feedback')
+            actions.deregisterCommand('debug-copy-session-recording-url')
         },
     }),
 })


### PR DESCRIPTION
When debugging or sharing errors, it's very useful to have a session recording. This adds a command k link to the session recording of the current page to the clipboard

## How did you test this code?
Ran it locally
