### PR TITLE
feat(sampling): make sampling configuration a toggle + advanced configuration

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonLabel/LemonLabel.tsx
+++ b/frontend/src/lib/lemon-ui/LemonLabel/LemonLabel.tsx
@@ -2,10 +2,12 @@ import './LemonLabel.scss'
 import { Tooltip } from '../Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
 import clsx from 'clsx'
+import { Link, LinkProps } from '../Link'
 
 export interface LemonLabelProps
     extends Pick<React.LabelHTMLAttributes<HTMLLabelElement>, 'htmlFor' | 'form' | 'children' | 'className'> {
     info?: React.ReactNode
+    infoLink?: LinkProps['to']
     showOptional?: boolean
     onExplanationClick?: () => void
 }
@@ -16,6 +18,7 @@ export function LemonLabel({
     className,
     showOptional,
     onExplanationClick,
+    infoLink,
     ...props
 }: LemonLabelProps): JSX.Element {
     return (
@@ -32,7 +35,9 @@ export function LemonLabel({
 
             {info ? (
                 <Tooltip title={info}>
-                    <IconInfo className="text-xl text-muted-alt shrink-0" />
+                    <Link to={infoLink} target="_blank" className="inline-flex">
+                        <IconInfo className="text-xl text-muted-alt shrink-0" />
+                    </Link>
                 </Tooltip>
             ) : null}
         </label>

--- a/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
@@ -1,10 +1,7 @@
 import { EditorFilterProps } from '~/types'
-import { LemonButton, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonLabel, LemonSwitch } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-
-import { IconInfo } from 'lib/lemon-ui/icons'
 import { AVAILABLE_SAMPLING_PERCENTAGES, samplingFilterLogic, SamplingFilterLogicProps } from './samplingFilterLogic'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 interface SamplingFilterProps extends Omit<EditorFilterProps, 'insight' | 'value'> {
     infoTooltipContent?: string
@@ -29,27 +26,34 @@ export function SamplingFilter({
     if (samplingAvailable) {
         return (
             <>
-                <span>
-                    <b>Sampling percentage</b>{' '}
-                    <Tooltip title={infoTooltipContent || DEFAULT_SAMPLING_INFO_TOOLTIP_CONTENT}>
-                        <Link to="https://posthog.com/manual/sampling" target="_blank">
-                            <IconInfo className="text-xl text-muted-alt shrink-0" />
-                        </Link>
-                    </Tooltip>
-                </span>
-                <div className="SamplingFilter">
-                    <div className="flex items-center gap-2">
-                        {AVAILABLE_SAMPLING_PERCENTAGES.map((percentage, key) => (
-                            <LemonButton
-                                key={key}
-                                type="secondary"
-                                size="small"
-                                active={samplingPercentage === percentage}
-                                onClick={() => setSamplingPercentage(percentage)}
-                            >{`${percentage}%`}</LemonButton>
-                        ))}
-                    </div>
+                <div className="flex items-center gap-1">
+                    <LemonLabel
+                        info={infoTooltipContent || DEFAULT_SAMPLING_INFO_TOOLTIP_CONTENT}
+                        infoLink="https://posthog.com/manual/sampling"
+                    >
+                        Sampling
+                    </LemonLabel>
+                    <LemonSwitch
+                        className="m-2"
+                        onChange={(checked) => (checked ? setSamplingPercentage(10) : setSamplingPercentage(null))}
+                        checked={!!samplingPercentage}
+                    />
                 </div>
+                {!!samplingPercentage ? (
+                    <div className="SamplingFilter">
+                        <div className="flex items-center gap-2">
+                            {AVAILABLE_SAMPLING_PERCENTAGES.map((percentage, key) => (
+                                <LemonButton
+                                    key={key}
+                                    type="secondary"
+                                    size="small"
+                                    active={samplingPercentage === percentage}
+                                    onClick={() => setSamplingPercentage(percentage)}
+                                >{`${percentage}%`}</LemonButton>
+                            ))}
+                        </div>
+                    </div>
+                ) : null}
             </>
         )
     }

--- a/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
@@ -39,7 +39,7 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
         ],
     })),
     actions(() => ({
-        setSamplingPercentage: (samplingPercentage: number) => ({ samplingPercentage }),
+        setSamplingPercentage: (samplingPercentage: number | null) => ({ samplingPercentage }),
     })),
     reducers(({ values }) => ({
         samplingPercentage: [


### PR DESCRIPTION
We may even want to hide the other options further, behind some "Advanced options" you need to click.

Haven't thought too deeply about how to make that a great experience yet though, so for now an incremental improvement


https://user-images.githubusercontent.com/38760734/223719522-ec9a1d47-46c7-4290-bf6e-a2ac85064664.mov

