### PR TITLE
fix(sampling): remove interpolation and use params instead

### DIFF
--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -147,7 +147,8 @@ def get_breakdown_prop_values(
         cast_as_float=filter.using_histogram,
     )
 
-    sample_clause = f"SAMPLE {filter.sampling_factor}" if filter.sampling_factor else ""
+    sample_clause = "SAMPLE %(sampling_factor)s" if filter.sampling_factor else ""
+    sampling_params = {"sampling_factor": filter.sampling_factor}
 
     if filter.using_histogram:
         bucketing_expression = _to_bucketing_expression(cast(int, filter.breakdown_histogram_bin_count))
@@ -195,6 +196,7 @@ def get_breakdown_prop_values(
             **sessions_join_params,
             **extra_params,
             **date_params,
+            **sampling_params,
             **filter.hogql_context.values,
         },
         query_type="get_breakdown_prop_values",

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -86,7 +86,8 @@ class FunnelEventQuery(EventQuery):
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
 
-        sample_clause = f"SAMPLE {self._filter.sampling_factor}" if self._filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factor)s" if self._filter.sampling_factor else ""
+        self.params.update({"sampling_factor": self._filter.sampling_factor})
 
         # KLUDGE: Ideally we wouldn't mix string variables with f-string interpolation
         # but due to ordering requirements in functions building this query we do

--- a/posthog/queries/paths/paths_event_query.py
+++ b/posthog/queries/paths/paths_event_query.py
@@ -106,7 +106,8 @@ class PathEventQuery(EventQuery):
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
 
-        sample_clause = f"SAMPLE {self._filter.sampling_factor}" if self._filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factor)s" if self._filter.sampling_factor else ""
+        self.params.update({"sampling_factor": self._filter.sampling_factor})
 
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}

--- a/posthog/queries/retention/retention_events_query.py
+++ b/posthog/queries/retention/retention_events_query.py
@@ -145,7 +145,8 @@ class RetentionEventsQuery(EventQuery):
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
 
-        sample_clause = f"SAMPLE {self._filter.sampling_factor}" if self._filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factor)s" if self._filter.sampling_factor else ""
+        self.params.update({"sampling_factor": self._filter.sampling_factor})
 
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}

--- a/posthog/queries/stickiness/stickiness_event_query.py
+++ b/posthog/queries/stickiness/stickiness_event_query.py
@@ -45,7 +45,8 @@ class StickinessEventsQuery(EventQuery):
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
 
-        sample_clause = f"SAMPLE {self._filter.sampling_factor}" if self._filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factor)s" if self._filter.sampling_factor else ""
+        self.params.update({"sampling_factor": self._filter.sampling_factor})
 
         query = f"""
             SELECT

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -201,10 +201,19 @@ class TrendsBreakdown:
         person_join_condition, person_join_params = self._person_join_condition()
         groups_join_condition, groups_join_params = self._groups_join_condition()
         sessions_join_condition, sessions_join_params = self._sessions_join_condition()
-        self.params = {**self.params, **_params, **person_join_params, **groups_join_params, **sessions_join_params}
-        breakdown_filter_params = {**breakdown_filter_params, **_breakdown_filter_params}
 
-        sample_clause = f"SAMPLE {self.filter.sampling_factor}" if self.filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factor)s" if self.filter.sampling_factor else ""
+        sampling_params = {"sampling_factor": self.filter.sampling_factor}
+
+        self.params = {
+            **self.params,
+            **_params,
+            **person_join_params,
+            **groups_join_params,
+            **sessions_join_params,
+            **sampling_params,
+        }
+        breakdown_filter_params = {**breakdown_filter_params, **_breakdown_filter_params}
 
         if self.filter.display in NON_TIME_SERIES_DISPLAY_TYPES:
             breakdown_filter = breakdown_filter.format(**breakdown_filter_params)

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -155,7 +155,8 @@ class LifecycleEventQuery(EventQuery):
 
         null_person_filter = f"AND notEmpty({self.EVENT_TABLE_ALIAS}.person_id)" if self._using_person_on_events else ""
 
-        sample_clause = f"SAMPLE {self._filter.sampling_factor}" if self._filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factor)s" if self._filter.sampling_factor else ""
+        self.params.update({"sampling_factor": self._filter.sampling_factor})
 
         return (
             LIFECYCLE_EVENTS_QUERY.format(

--- a/posthog/queries/trends/trends_event_query_base.py
+++ b/posthog/queries/trends/trends_event_query_base.py
@@ -50,7 +50,8 @@ class TrendsEventQueryBase(EventQuery):
         session_query, session_params = self._get_sessions_query()
         self.params.update(session_params)
 
-        sample_clause = f"SAMPLE {self._filter.sampling_factor}" if self._filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factors)s" if self._filter.sampling_factor else ""
+        self.params.update({"sampling_factor": self._filter.sampling_factor})
 
         query = f"""
             FROM events {self.EVENT_TABLE_ALIAS}

--- a/posthog/queries/trends/trends_event_query_base.py
+++ b/posthog/queries/trends/trends_event_query_base.py
@@ -50,7 +50,7 @@ class TrendsEventQueryBase(EventQuery):
         session_query, session_params = self._get_sessions_query()
         self.params.update(session_params)
 
-        sample_clause = "SAMPLE %(sampling_factors)s" if self._filter.sampling_factor else ""
+        sample_clause = "SAMPLE %(sampling_factor)s" if self._filter.sampling_factor else ""
         self.params.update({"sampling_factor": self._filter.sampling_factor})
 
         query = f"""


### PR DESCRIPTION
We were using interpolation in the sample clause. Given existing validation this was safe but certainly not best practice. This changes that.