### PR TITLE
chore: use if not exists for person overrides dictionary

### DIFF
--- a/posthog/models/person_overrides/sql.py
+++ b/posthog/models/person_overrides/sql.py
@@ -160,7 +160,7 @@ GROUP BY
 
 # ClickHouse dictionaries allow us to JOIN events with their new override_person_ids (if any).
 PERSON_OVERRIDES_CREATE_DICTIONARY_SQL = f"""
-    CREATE OR REPLACE DICTIONARY IF NOT EXISTS `{CLICKHOUSE_DATABASE}`.`person_overrides_dict`
+    CREATE DICTIONARY IF NOT EXISTS `{CLICKHOUSE_DATABASE}`.`person_overrides_dict`
     ON CLUSTER '{CLICKHOUSE_CLUSTER}' (
         team_id INT,
         old_person_id UUID,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Some people have ClickHouse databases of type `Ordinary` instead of
`Atomic`. This means `CREATE OR REPLACE` isn't supported. See
https://github.com/PostHog/posthog/issues/14552 for an example of this.

## Changes

I don't _think_ there should already be a dictionary defined so the
replace shouldn't be needed. We still need to make sure migrations are
retriable as they aren't atomic for ClickHouse migrations, but I _think_
the `if not exists` should be enough.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
