### PR TITLE
fix: allow traceheaders for any CORS request

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -4,6 +4,8 @@ import os
 from datetime import timedelta
 from typing import List
 
+from corsheaders.defaults import default_headers
+
 from posthog.settings.base_variables import BASE_DIR, DEBUG, TEST
 from posthog.settings.statsd import STATSD_HOST
 from posthog.settings.utils import get_from_env, get_list, str_to_bool
@@ -203,6 +205,7 @@ LOGOUT_URL = "/logout"
 LOGIN_REDIRECT_URL = "/"
 APPEND_SLASH = False
 CORS_URLS_REGEX = r"^/api/.*$"
+CORS_ALLOW_HEADERS = default_headers + ("traceparent", "request-id", "request-context")
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -553,6 +553,7 @@ def cors_response(request, response):
 
     # Handle headers that sentry randomly sends for every request.
     # Would cause a CORS failure otherwise.
+    # specified here to override the default added by the cors headers package in web.py
     allow_headers = request.META.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "").split(",")
     allow_headers = [header for header in allow_headers if header in ["traceparent", "request-id", "request-context"]]
 


### PR DESCRIPTION
## Problem

We have some trace headers allowed for a small set of routes using a `cors_response` method in `posthog/utils.py`

But in [this community slack thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1678110869718499) we discover that other endpoints might need these too. In this case API calls from the toolbar. 

follow up to #14601 

## Changes

We already use the `django-cors-headers` package recommended by DRF (see https://github.com/adamchainz/django-cors-headers)

That sends a default set of allow headers for every CORS preflight request. 

This change adds the three tracing headers we allow to those responses.

Since capture/decide are already happy, this doesn't change those endpoints.

## How did you test this code?

added a developer test and checked the toolbar locally
