### PR TITLE
feat: do not return a list for time to see sessions query

### DIFF
--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -122,7 +122,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
                 }
 
                 if (response && sourceKind === NodeKind.TimeToSeeDataSessionsQuery) {
-                    return (response as NonNullable<TimeToSeeDataSessionsQuery['response']>).map((row) => ({
+                    return (response as NonNullable<TimeToSeeDataSessionsQuery['response']>).results.map((row) => ({
                         result: row,
                     }))
                 }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2787,18 +2787,8 @@
                     "type": "string"
                 },
                 "response": {
-                    "additionalProperties": false,
-                    "description": "Cached query response",
-                    "properties": {
-                        "results": {
-                            "items": {
-                                "type": "object"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": ["results"],
-                    "type": "object"
+                    "$ref": "#/definitions/TimeToSeeDataSessionsQueryResponse",
+                    "description": "Cached query response"
                 },
                 "teamId": {
                     "description": "Project to filter on. Defaults to current project",
@@ -2806,6 +2796,19 @@
                 }
             },
             "required": ["kind"],
+            "type": "object"
+        },
+        "TimeToSeeDataSessionsQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "results": {
+                    "items": {
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
             "type": "object"
         },
         "TrendsFilter": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2787,11 +2787,18 @@
                     "type": "string"
                 },
                 "response": {
+                    "additionalProperties": false,
                     "description": "Cached query response",
-                    "items": {
-                        "type": "object"
+                    "properties": {
+                        "results": {
+                            "items": {
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": ["results"],
+                    "type": "object"
                 },
                 "teamId": {
                     "description": "Project to filter on. Defaults to current project",

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -388,7 +388,7 @@ export interface TimeToSeeDataSessionsQuery extends DataNode {
     /** Project to filter on. Defaults to current project */
     teamId?: number
 
-    response?: Record<string, any>[]
+    response?: { results: Record<string, any>[] }
 }
 
 export interface TimeToSeeDataQuery extends DataNode {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -379,6 +379,10 @@ export const dateRangeForFilter = (source: FilterType | undefined): DateRange | 
     return { date_from: source.date_from, date_to: source.date_to }
 }
 
+export interface TimeToSeeDataSessionsQueryResponse {
+    results: Record<string, any>[]
+}
+
 export interface TimeToSeeDataSessionsQuery extends DataNode {
     kind: NodeKind.TimeToSeeDataSessionsQuery
 
@@ -388,7 +392,7 @@ export interface TimeToSeeDataSessionsQuery extends DataNode {
     /** Project to filter on. Defaults to current project */
     teamId?: number
 
-    response?: { results: Record<string, any>[] }
+    response?: TimeToSeeDataSessionsQueryResponse
 }
 
 export interface TimeToSeeDataQuery extends DataNode {

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta
-from typing import Dict, List, cast
+from typing import Dict, cast
 
 import posthoganalytics
 from dateutil.parser import isoparse
@@ -105,7 +105,7 @@ def _response_to_dict(response: BaseModel) -> Dict:
     return dict
 
 
-def process_query(team: Team, query_json: Dict, is_hogql_enabled: bool) -> Dict | List:
+def process_query(team: Team, query_json: Dict, is_hogql_enabled: bool) -> Dict:
     try:
         query_kind = query_json.get("kind")
         if query_kind == "EventsQuery":
@@ -136,7 +136,7 @@ def process_query(team: Team, query_json: Dict, is_hogql_enabled: bool) -> Dict 
         elif query_kind == "TimeToSeeDataSessionsQuery":
             sessions_query_serializer = SessionsQuerySerializer(data=query_json)
             sessions_query_serializer.is_valid(raise_exception=True)
-            return get_sessions(sessions_query_serializer).data
+            return {"results": get_sessions(sessions_query_serializer).data}
         elif query_kind == "TimeToSeeDataQuery":
             serializer = SessionEventsQuerySerializer(
                 data={
@@ -147,7 +147,7 @@ def process_query(team: Team, query_json: Dict, is_hogql_enabled: bool) -> Dict 
                 }
             )
             serializer.is_valid(raise_exception=True)
-            return get_session_events(serializer) or []
+            return get_session_events(serializer) or {}
         else:
             raise ValidationError("Unsupported query kind: %s" % query_kind)
     except Exception as e:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -420,13 +420,20 @@ class StickinessFilter(BaseModel):
     stickiness_days: Optional[float] = None
 
 
+class Response1(BaseModel):
+    class Config:
+        extra = Extra.forbid
+
+    results: List[Dict[str, Any]]
+
+
 class TimeToSeeDataSessionsQuery(BaseModel):
     class Config:
         extra = Extra.forbid
 
     dateRange: Optional[DateRange] = Field(None, description="Date range for the query")
     kind: str = Field("TimeToSeeDataSessionsQuery", const=True)
-    response: Optional[List[Dict[str, Any]]] = Field(None, description="Cached query response")
+    response: Optional[Response1] = Field(None, description="Cached query response")
     teamId: Optional[float] = Field(None, description="Project to filter on. Defaults to current project")
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -420,21 +420,11 @@ class StickinessFilter(BaseModel):
     stickiness_days: Optional[float] = None
 
 
-class Response1(BaseModel):
+class TimeToSeeDataSessionsQueryResponse(BaseModel):
     class Config:
         extra = Extra.forbid
 
     results: List[Dict[str, Any]]
-
-
-class TimeToSeeDataSessionsQuery(BaseModel):
-    class Config:
-        extra = Extra.forbid
-
-    dateRange: Optional[DateRange] = Field(None, description="Date range for the query")
-    kind: str = Field("TimeToSeeDataSessionsQuery", const=True)
-    response: Optional[Response1] = Field(None, description="Cached query response")
-    teamId: Optional[float] = Field(None, description="Project to filter on. Defaults to current project")
 
 
 class TrendsFilter(BaseModel):
@@ -598,6 +588,16 @@ class RetentionFilter(BaseModel):
     returning_entity: Optional[Dict[str, Any]] = None
     target_entity: Optional[Dict[str, Any]] = None
     total_intervals: Optional[float] = None
+
+
+class TimeToSeeDataSessionsQuery(BaseModel):
+    class Config:
+        extra = Extra.forbid
+
+    dateRange: Optional[DateRange] = Field(None, description="Date range for the query")
+    kind: str = Field("TimeToSeeDataSessionsQuery", const=True)
+    response: Optional[TimeToSeeDataSessionsQueryResponse] = Field(None, description="Cached query response")
+    teamId: Optional[float] = Field(None, description="Project to filter on. Defaults to current project")
 
 
 class EventsNode(BaseModel):


### PR DESCRIPTION
## Problem

In #14619 I had to allow insight caching to deal with Lists or Dicts. But that's only because the time to see data sessions listing query returns a list directly

see #13927

## Changes

wraps the list in a dict

## How did you test this code?

👀 locally