### PR TITLE
feat: "revert "feat: changelog notifications behind the notifications bell""

### DIFF
--- a/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
+++ b/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
@@ -12,7 +12,7 @@ import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
 
 export function NotificationBell(): JSX.Element {
-    const { unreadCount, hasImportantChanges, importantChanges, isNotificationPopoverOpen, hasUnread } =
+    const { unreadCount, hasNotifications, notifications, isNotificationPopoverOpen, hasUnread } =
         useValues(notificationsLogic)
     const { toggleNotificationsPopover, togglePolling } = useActions(notificationsLogic)
 
@@ -40,8 +40,8 @@ export function NotificationBell(): JSX.Element {
                         be here!
                     </p>
                     <LemonDivider />
-                    {hasImportantChanges ? (
-                        importantChanges.map((logItem, index) => (
+                    {hasNotifications ? (
+                        notifications.map((logItem, index) => (
                             <ActivityLogRow logItem={logItem} key={index} showExtendedDescription={false} />
                         ))
                     ) : (

--- a/frontend/src/layout/navigation/TopBar/notificationsLogic.tsx
+++ b/frontend/src/layout/navigation/TopBar/notificationsLogic.tsx
@@ -6,9 +6,22 @@ import { ActivityLogItem, humanize, HumanizedActivityLogItem } from 'lib/compone
 
 import type { notificationsLogicType } from './notificationsLogicType'
 import { describerFor } from 'lib/components/ActivityLog/activityLogLogic'
+import { dayjs } from 'lib/dayjs'
+import ReactMarkdown from 'react-markdown'
+import posthog from 'posthog-js'
 
 const POLL_TIMEOUT = 5 * 60 * 1000
 const MARK_READ_TIMEOUT = 2500
+
+export interface ChangelogFlagPayload {
+    notificationDate: dayjs.Dayjs
+    markdown: string
+}
+
+export interface ChangesResponse {
+    results: ActivityLogItem[]
+    last_read: string
+}
 
 export const notificationsLogic = kea<notificationsLogicType>([
     path(['layout', 'navigation', 'TopBar', 'notificationsLogic']),
@@ -19,14 +32,22 @@ export const notificationsLogic = kea<notificationsLogicType>([
         setMarkReadTimeout: (markReadTimeout: number) => ({ markReadTimeout }),
         incrementErrorCount: true,
         clearErrorCount: true,
-        markAllAsRead: true,
+        markAllAsRead: (bookmarkDate: string) => ({ bookmarkDate }),
     }),
     loaders(({ actions, values }) => ({
         importantChanges: [
-            [] as HumanizedActivityLogItem[],
+            null as ChangesResponse | null,
             {
-                markAllAsRead: () => {
-                    return values.importantChanges.map((ic) => ({ ...ic, unread: false }))
+                markAllAsRead: ({ bookmarkDate }) => {
+                    const current = values.importantChanges
+                    if (!current) {
+                        return null
+                    }
+
+                    return {
+                        last_read: bookmarkDate,
+                        results: current.results.map((ic) => ({ ...ic, unread: false })),
+                    }
                 },
                 loadImportantChanges: async (_, breakpoint) => {
                     await breakpoint(1)
@@ -36,15 +57,15 @@ export const notificationsLogic = kea<notificationsLogicType>([
                     try {
                         const response = (await api.get(
                             `api/projects/${teamLogic.values.currentTeamId}/activity_log/important_changes`
-                        )) as ActivityLogItem[]
+                        )) as ChangesResponse
                         // we can't rely on automatic success action here because we swallow errors so always succeed
                         actions.clearErrorCount()
-                        return humanize(response, describerFor, true)
+                        return response
                     } catch (e) {
                         // swallow errors as this isn't user initiated
                         // increment a counter to backoff calling the API while errors persist
                         actions.incrementErrorCount()
-                        return []
+                        return null
                     } finally {
                         const pollTimeoutMilliseconds = values.errorCounter
                             ? POLL_TIMEOUT * values.errorCounter
@@ -89,17 +110,19 @@ export const notificationsLogic = kea<notificationsLogicType>([
             if (!values.isNotificationPopoverOpen) {
                 clearTimeout(values.markReadTimeout)
             } else {
-                if (values.importantChanges?.[0]) {
+                if (values.notifications?.[0]) {
+                    const bookmarkDate = values.notifications.reduce((a, b) =>
+                        a.created_at.isAfter(b.created_at) ? a : b
+                    ).created_at
                     actions.setMarkReadTimeout(
                         window.setTimeout(async () => {
-                            const bookmarkDate = values.importantChanges[0].created_at.toISOString()
                             await api.create(
                                 `api/projects/${teamLogic.values.currentTeamId}/activity_log/bookmark_activity_notification`,
                                 {
-                                    bookmark: bookmarkDate,
+                                    bookmark: bookmarkDate.toISOString(),
                                 }
                             )
-                            actions.markAllAsRead()
+                            actions.markAllAsRead(bookmarkDate.toISOString())
                         }, MARK_READ_TIMEOUT)
                     )
                 }
@@ -107,10 +130,62 @@ export const notificationsLogic = kea<notificationsLogicType>([
         },
     })),
     selectors({
-        unread: [(s) => [s.importantChanges], (importantChanges) => importantChanges.filter((ic) => ic.unread)],
+        notifications: [
+            (s) => [s.importantChanges],
+            (importantChanges): HumanizedActivityLogItem[] => {
+                const importantChangesHumanized = humanize(importantChanges?.results || [], describerFor, true)
+
+                let changelogNotification: ChangelogFlagPayload | null = null
+                const flagPayload = posthog.getFeatureFlagPayload('changelog-notification')
+                if (!!flagPayload) {
+                    changelogNotification = {
+                        markdown: flagPayload['markdown'],
+                        notificationDate: dayjs(flagPayload['notificationDate']),
+                    } as ChangelogFlagPayload
+                }
+
+                if (changelogNotification) {
+                    const lastRead = importantChanges?.last_read ? dayjs(importantChanges.last_read) : null
+                    const changeLogIsUnread =
+                        !!lastRead &&
+                        (lastRead.isBefore(changelogNotification.notificationDate) ||
+                            lastRead == changelogNotification.notificationDate)
+
+                    const changelogNotificationHumanized: HumanizedActivityLogItem = {
+                        email: 'joe@posthog.com',
+                        name: 'Joe',
+                        isSystem: true,
+                        description: (
+                            <>
+                                <ReactMarkdown linkTarget="_blank">{changelogNotification.markdown}</ReactMarkdown>
+                            </>
+                        ),
+                        created_at: changelogNotification.notificationDate,
+                        unread: changeLogIsUnread,
+                    }
+                    const notifications = [changelogNotificationHumanized, ...importantChangesHumanized]
+                    notifications.sort((a, b) => {
+                        if (a.created_at.isBefore(b.created_at)) {
+                            return 1
+                        } else if (a.created_at.isAfter(b.created_at)) {
+                            return -1
+                        } else {
+                            return 0
+                        }
+                    })
+                    return notifications
+                }
+
+                return humanize(importantChanges?.results || [], describerFor, true)
+            },
+        ],
+        hasNotifications: [(s) => [s.notifications], (notifications) => !!notifications.length],
+        unread: [
+            (s) => [s.notifications],
+            (notifications: HumanizedActivityLogItem[]) => notifications.filter((ic) => ic.unread),
+        ],
         unreadCount: [(s) => [s.unread], (unread) => (unread || []).length],
         hasUnread: [(s) => [s.unreadCount], (unreadCount) => unreadCount > 0],
-        hasImportantChanges: [(s) => [s.importantChanges], (importantChanges) => (importantChanges || []).length > 0],
     }),
     events(({ actions, values }) => ({
         afterMount: () => actions.loadImportantChanges(null),

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
@@ -1,7 +1,7 @@
 import { initKeaTests } from '~/test/init'
 import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
-import { ActivityScope, humanize } from 'lib/components/ActivityLog/humanizeActivity'
+import { ActivityLogItem, ActivityScope, humanize } from 'lib/components/ActivityLog/humanizeActivity'
 import { activityLogLogic, describerFor } from 'lib/components/ActivityLog/activityLogLogic'
 import { featureFlagsActivityResponseJson } from 'lib/components/ActivityLog/__mocks__/activityLogMocks'
 import { flagActivityDescriber } from 'scenes/feature-flags/activityDescriptions'
@@ -110,6 +110,27 @@ describe('the activity log logic', () => {
             expect(JSON.stringify(logic.values.humanizedActivity)).toEqual(
                 JSON.stringify(humanize(featureFlagsActivityResponseJson, describerFor))
             )
+        })
+    })
+
+    describe('incident regression test for #inc-2023-03-09-us-cloud-ui-unavailable-when-users-have-a-notification', () => {
+        it('backend sends unexpected field and describer should not explode', () => {
+            expect(() => {
+                humanize(
+                    [
+                        {
+                            // a very unexpected activity log item received in production
+                            type: 'insight',
+                            after: true,
+                            field: 'saved',
+                            action: 'changed',
+                            before: false,
+                        } as unknown as ActivityLogItem,
+                    ],
+                    describerFor,
+                    true
+                )
+            }).not.toThrow()
         })
     })
 })

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -273,11 +273,13 @@ export function insightActivityDescriber(logItem: ActivityLogItem, asNotificatio
                 continue // insight updates have to have a "field" to be described
             }
 
-            const {
-                description,
-                extendedDescription: _extendedDescription,
-                suffix,
-            } = insightActionsMapping[change.field](change, logItem, asNotification)
+            const actionHandler = insightActionsMapping[change.field]
+            const processedChange = actionHandler(change, logItem, asNotification)
+            if (processedChange === null) {
+                continue // // unexpected log from backend is indescribable
+            }
+
+            const { description, extendedDescription: _extendedDescription, suffix } = processedChange
             if (description) {
                 changes = changes.concat(description)
             }

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -63,7 +63,14 @@ class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
         )[:10]
 
         serialized_data = ActivityLogSerializer(instance=other_peoples_changes, many=True, context={"user": user}).data
-        return Response(status=status.HTTP_200_OK, data=serialized_data)
+        last_read_date = NotificationViewed.objects.filter(user=user).first()
+        return Response(
+            status=status.HTTP_200_OK,
+            data={
+                "results": serialized_data,
+                "last_read": last_read_date.last_viewed_activity_date if last_read_date else None,
+            },
+        )
 
     @action(methods=["POST"], detail=False)
     def bookmark_activity_notification(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -67,8 +67,9 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         self.client.force_login(self.user)
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
         assert changes.status_code == status.HTTP_200_OK
-        assert len(changes.json()) == 10
-        assert [c["scope"] for c in changes.json()] == [
+        results = changes.json()["results"]
+        assert len(results) == 10
+        assert [c["scope"] for c in results] == [
             "FeatureFlag",
             "FeatureFlag",
             "Insight",
@@ -80,7 +81,7 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
             "Insight",
             "Insight",
         ]
-        assert [c["unread"] for c in changes.json()] == [True] * 10
+        assert [c["unread"] for c in results] == [True] * 10
 
     def test_reading_notifications_marks_them_unread(self):
         # user one has created 10 insights and 2 flags
@@ -89,7 +90,7 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
         assert changes.status_code == status.HTTP_200_OK
 
-        most_recent_date = changes.json()[2]["created_at"]
+        most_recent_date = changes.json()["results"][2]["created_at"]
 
         # the user can mark where they have read up to
         bookmark_response = self.client.post(
@@ -99,7 +100,8 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
 
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
 
-        assert [c["unread"] for c in changes.json()] == [True, True] + ([False] * 8)
+        assert [c["unread"] for c in changes.json()["results"]] == [True, True] + ([False] * 8)
+        assert changes.json()["last_read"] == most_recent_date
 
     def _create_insight(
         self, data: Dict[str, Any], team_id: Optional[int] = None, expected_status: int = status.HTTP_201_CREATED


### PR DESCRIPTION
Reverts PostHog/posthog#14650

An activity log item that could not be described could cause a describer to throw an uncaught exception. But no longer