### PR TITLE
fix: improved billing page for yearly plans

### DIFF
--- a/ee/billing/billing_types.py
+++ b/ee/billing/billing_types.py
@@ -37,6 +37,7 @@ class LicenseInfo(TypedDict):
 class BillingPeriod(TypedDict):
     current_period_start: str
     current_period_end: str
+    interval: str
 
 
 class UsageSummary(TypedDict):

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -114,7 +114,7 @@ export function BillingV2({ redirectPath = '', showCurrentUsage = true }: Billin
                             {billing?.has_active_subscription && (
                                 <>
                                     <LemonLabel
-                                        info={'This is the current amount you have been billed for this month so far.'}
+                                        info={`This is the current amount you have been billed for this ${billing.billing_period.interval} so far.`}
                                     >
                                         Current bill total
                                     </LemonLabel>
@@ -396,7 +396,9 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                 {product.current_amount_usd ? (
                     <div className="flex justify-between gap-8 flex-wrap">
                         <div className="space-y-2">
-                            <LemonLabel info={'This is the current amount you have been billed for this month so far.'}>
+                            <LemonLabel
+                                info={`This is the current amount you have been billed for this ${billing?.billing_period?.interval} so far.`}
+                            >
                                 Current bill
                             </LemonLabel>
                             <div className="font-bold text-4xl">${product.current_amount_usd}</div>
@@ -418,84 +420,86 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                             : '0.00'}
                                     </div>
                                 </div>
-                                <div className="space-y-2">
-                                    <LemonLabel
-                                        info={
-                                            <>
-                                                Set a billing limit to control your recurring costs.{' '}
-                                                <b>
-                                                    Your critical data will still be ingested and available in the
-                                                    product
-                                                </b>
-                                                . Some features may stop working if your usage greatly exceeds your
-                                                billing cap.
-                                            </>
-                                        }
-                                    >
-                                        Billing limit
-                                    </LemonLabel>
-                                    <div className="flex items-center gap-1">
-                                        {!isEditingBillingLimit ? (
-                                            <>
-                                                <div
-                                                    className={clsx(
-                                                        'text-muted font-semibold mr-2',
-                                                        customLimitUsd && 'text-2xl'
-                                                    )}
-                                                >
-                                                    {customLimitUsd ? `$${customLimitUsd}` : 'No limit'}
-                                                </div>
-                                                <LemonButton
-                                                    icon={<IconEdit />}
-                                                    status="primary-alt"
-                                                    size="small"
-                                                    tooltip="Edit billing limit"
-                                                    onClick={() => setIsEditingBillingLimit(true)}
-                                                />
-                                                {customLimitUsd ? (
+                                {billing?.billing_period?.interval == 'month' && (
+                                    <div className="space-y-2">
+                                        <LemonLabel
+                                            info={
+                                                <>
+                                                    Set a billing limit to control your recurring costs.{' '}
+                                                    <b>
+                                                        Your critical data will still be ingested and available in the
+                                                        product
+                                                    </b>
+                                                    . Some features may stop working if your usage greatly exceeds your
+                                                    billing cap.
+                                                </>
+                                            }
+                                        >
+                                            Billing limit
+                                        </LemonLabel>
+                                        <div className="flex items-center gap-1">
+                                            {!isEditingBillingLimit ? (
+                                                <>
+                                                    <div
+                                                        className={clsx(
+                                                            'text-muted font-semibold mr-2',
+                                                            customLimitUsd && 'text-2xl'
+                                                        )}
+                                                    >
+                                                        {customLimitUsd ? `$${customLimitUsd}` : 'No limit'}
+                                                    </div>
                                                     <LemonButton
-                                                        icon={<IconDelete />}
+                                                        icon={<IconEdit />}
                                                         status="primary-alt"
                                                         size="small"
-                                                        tooltip="Remove billing limit"
-                                                        onClick={() => updateBillingLimit(undefined)}
+                                                        tooltip="Edit billing limit"
+                                                        onClick={() => setIsEditingBillingLimit(true)}
                                                     />
-                                                ) : null}
-                                            </>
-                                        ) : (
-                                            <>
-                                                <div style={{ maxWidth: 180 }}>
-                                                    <LemonInput
-                                                        type="number"
-                                                        fullWidth={false}
-                                                        value={billingLimitInput}
-                                                        onChange={setBillingLimitInput}
-                                                        prefix={<b>$</b>}
-                                                        disabled={billingLoading}
-                                                        min={0}
-                                                        step={10}
-                                                        suffix={<>/month</>}
-                                                    />
-                                                </div>
+                                                    {customLimitUsd ? (
+                                                        <LemonButton
+                                                            icon={<IconDelete />}
+                                                            status="primary-alt"
+                                                            size="small"
+                                                            tooltip="Remove billing limit"
+                                                            onClick={() => updateBillingLimit(undefined)}
+                                                        />
+                                                    ) : null}
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <div style={{ maxWidth: 180 }}>
+                                                        <LemonInput
+                                                            type="number"
+                                                            fullWidth={false}
+                                                            value={billingLimitInput}
+                                                            onChange={setBillingLimitInput}
+                                                            prefix={<b>$</b>}
+                                                            disabled={billingLoading}
+                                                            min={0}
+                                                            step={10}
+                                                            suffix={<>/month</>}
+                                                        />
+                                                    </div>
 
-                                                <LemonButton
-                                                    onClick={() => setIsEditingBillingLimit(false)}
-                                                    disabled={billingLoading}
-                                                    type="secondary"
-                                                >
-                                                    Cancel
-                                                </LemonButton>
-                                                <LemonButton
-                                                    onClick={() => updateBillingLimit(billingLimitInput)}
-                                                    loading={billingLoading}
-                                                    type="primary"
-                                                >
-                                                    Save
-                                                </LemonButton>
-                                            </>
-                                        )}
+                                                    <LemonButton
+                                                        onClick={() => setIsEditingBillingLimit(false)}
+                                                        disabled={billingLoading}
+                                                        type="secondary"
+                                                    >
+                                                        Cancel
+                                                    </LemonButton>
+                                                    <LemonButton
+                                                        onClick={() => updateBillingLimit(billingLimitInput)}
+                                                        loading={billingLoading}
+                                                        type="primary"
+                                                    >
+                                                        Save
+                                                    </LemonButton>
+                                                </>
+                                            )}
+                                        </div>
                                     </div>
-                                </div>
+                                )}
                                 <div className="flex-1" />
                             </>
                         )}

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -581,7 +581,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                             <div className="font-bold">Pricing breakdown</div>
 
                             <div className="flex justify-between py-2">
-                                <span>Per month</span>
+                                <span>Per {billing.billing_period?.interval}</span>
                                 <span className="font-bold">${product.unit_amount_usd}</span>
                             </div>
                         </div>

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -561,7 +561,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                         <span>
                                             {i === 0
                                                 ? `First ${summarizeUsage(tier.up_to)} ${productType.plural} / ${
-                                                      billing?.billing_period?.interval == 'month' ? 'mo' : 'yr'
+                                                      billing?.billing_period?.interval
                                                   }`
                                                 : tier.up_to
                                                 ? `${summarizeUsage(

--- a/frontend/src/scenes/billing/v2/Billing.tsx
+++ b/frontend/src/scenes/billing/v2/Billing.tsx
@@ -560,7 +560,9 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                     >
                                         <span>
                                             {i === 0
-                                                ? `First ${summarizeUsage(tier.up_to)} ${productType.plural} / mo`
+                                                ? `First ${summarizeUsage(tier.up_to)} ${productType.plural} / ${
+                                                      billing?.billing_period?.interval == 'month' ? 'mo' : 'yr'
+                                                  }`
                                                 : tier.up_to
                                                 ? `${summarizeUsage(
                                                       product.tiers?.[i - 1].up_to || null

--- a/frontend/src/scenes/billing/v2/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/v2/billing-utils.spec.ts
@@ -28,6 +28,7 @@ describe('projectUsage', () => {
             projectUsage(10000, {
                 current_period_start: dayjs().add(-100, 'hours'),
                 current_period_end: dayjs().add(100, 'hours'),
+                interval: 'month',
             })
         ).toEqual(20000)
 
@@ -35,6 +36,7 @@ describe('projectUsage', () => {
             projectUsage(10000, {
                 current_period_start: dayjs().add(-1, 'days'),
                 current_period_end: dayjs().add(30, 'days'),
+                interval: 'month',
             })
         ).toEqual(310000)
     })
@@ -44,6 +46,7 @@ describe('projectUsage', () => {
             projectUsage(10000, {
                 current_period_start: dayjs(),
                 current_period_end: dayjs().add(100, 'hours'),
+                interval: 'month',
             })
         ).toEqual(10000)
     })

--- a/frontend/src/scenes/billing/v2/billingV2Logic.ts
+++ b/frontend/src/scenes/billing/v2/billingV2Logic.ts
@@ -30,6 +30,7 @@ const parseBillingResponse = (data: Partial<BillingV2Type>): BillingV2Type => {
         data.billing_period = {
             current_period_start: dayjs(data.billing_period.current_period_start),
             current_period_end: dayjs(data.billing_period.current_period_end),
+            interval: data.billing_period.interval,
         }
 
         data.products?.forEach((x) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1110,6 +1110,7 @@ export interface BillingV2Type {
     billing_period?: {
         current_period_start: Dayjs
         current_period_end: Dayjs
+        interval: 'month' | 'year'
     }
     license?: {
         plan: LicensePlan


### PR DESCRIPTION
## Problem
We don't show the correct interval in case the billing period is yearly. We also don't need to show billing limits for yearly plans.

## Changes
Show the correct interval based on the billing response (we now support `interval`), changing the copy to "year" where appropriate (e.g. / month -> / year)
Hide billing limits

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/7335343/224080577-3c4ef762-2c1b-4495-a0d3-a472ec24bf82.png">


## How did you test this code?
Locally