### PR TITLE
chore: Expose ClickHouse logs in `docker-compose.dev.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ staticfiles
 settings.yml
 .DS_Store
 debug.log
+clickhouse-server.log
+clickhouse-server.err.log
 *.swp
 *.swo
 node_modules/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,6 +41,9 @@ services:
             - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
+            - ./clickhouse-server.log:/var/log/clickhouse-server/clickhouse-server.log
+            - ./clickhouse-server.err.log:/var/log/clickhouse-server/clickhouse-server.err.log
+        restart: on-failure
 
     zookeeper:
         extends:
@@ -53,6 +56,7 @@ services:
             service: kafka
         ports:
             - '9092:9092'
+        restart: on-failure
 
     object_storage:
         extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,7 +43,6 @@ services:
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
             - ./clickhouse-server.log:/var/log/clickhouse-server/clickhouse-server.log
             - ./clickhouse-server.err.log:/var/log/clickhouse-server/clickhouse-server.err.log
-        restart: on-failure
 
     zookeeper:
         extends:
@@ -56,7 +55,6 @@ services:
             service: kafka
         ports:
             - '9092:9092'
-        restart: on-failure
 
     object_storage:
         extends:


### PR DESCRIPTION
## Problem

I've occasionally been running into ClickHouse and Kafka init errors in my local environment. This was hard to debug and I've always had to do Ctrl+C and re-run `docker compose up`, which took time.
 
## Changes

Let's restart ClickHouse and Kafka automatically on error, and expose ClickHouse logs.