### PR TITLE
fix(deps): update deps following package rename

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -73,5 +73,5 @@ whitenoise==5.2.0
 mimesis==5.2.1
 more-itertools==9.0.0
 django-two-factor-auth==1.14.0
-dj-2fa-social-auth==0.1.0
+dj-two-factor-social-auth==0.1.2
 phonenumberslite==8.13.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ defusedxml==0.6.0
     #   social-auth-core
 deprecated==1.2.13
     # via redis
-dj-2fa-social-auth==0.1.0
+dj-two-factor-social-auth==0.1.2
     # via -r requirements.in
 dj-database-url==0.5.0
     # via -r requirements.in
@@ -124,7 +124,7 @@ django-ipware==3.0.2
 django-loginas==0.3.9
     # via -r requirements.in
 django-model-utils==4.3.1
-    # via dj-2fa-social-auth
+    # via dj-two-factor-social-auth
 django-otp==1.1.4
     # via django-two-factor-auth
 django-phonenumber-field==6.4.0
@@ -142,7 +142,7 @@ django-structlog==2.1.3
 django-two-factor-auth==1.14.0
     # via
     #   -r requirements.in
-    #   dj-2fa-social-auth
+    #   dj-two-factor-social-auth
 djangorestframework==3.12.2
     # via
     #   -r requirements.in
@@ -349,7 +349,7 @@ sniffio==1.2.0
 social-auth-app-django==5.0.0
     # via
     #   -r requirements.in
-    #   dj-2fa-social-auth
+    #   dj-two-factor-social-auth
 social-auth-core==4.3.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
Our build is broken because `dj-2fa-social-auth` no longer exists, it was nuked entirely and renamed to `dj-two-factor-social-auth` 4 hours ago. 

Quick fix but ideally we'd not use this package at all