### PR TITLE
feat: add a way to abort exports

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -255,7 +255,7 @@ export function addHistoricalEventsExportCapabilityV2(
 
         if (params.abortMessage) {
             // For manually triggering the export to abort
-            await stopExport(params, `Export aborted ${params.abortMessage}`, 'fail')
+            await stopExport(params, `Export aborted: ${params.abortMessage}`, 'fail')
             return
         }
 
@@ -408,6 +408,9 @@ export function addHistoricalEventsExportCapabilityV2(
 
         if (activeExportParameters.abortMessage) {
             // For manually triggering the export to abort
+            createLog(`Export manually aborted ${activeExportParameters.abortMessage}`, {
+                type: PluginLogEntryType.Info,
+            })
             return
         }
 

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -131,6 +131,7 @@ export interface ExportParams {
     parallelism: number
     dateFrom: ISOTimestamp
     dateTo: ISOTimestamp
+    abortMessage?: string
 }
 
 interface CoordinationPayload {
@@ -250,6 +251,10 @@ export function addHistoricalEventsExportCapabilityV2(
         if (!params) {
             // No export running!
             return
+        }
+
+        if (params.abortMessage) {
+            await stopExport(params, `Export aborted ${params.abortMessage}`, 'fail')
         }
 
         const { done, running } = (await meta.storage.get(EXPORT_COORDINATION_KEY, {})) as CoordinationPayload

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -254,7 +254,9 @@ export function addHistoricalEventsExportCapabilityV2(
         }
 
         if (params.abortMessage) {
+            // For manually triggering the export to abort
             await stopExport(params, `Export aborted ${params.abortMessage}`, 'fail')
+            return
         }
 
         const { done, running } = (await meta.storage.get(EXPORT_COORDINATION_KEY, {})) as CoordinationPayload
@@ -401,6 +403,11 @@ export function addHistoricalEventsExportCapabilityV2(
         const activeExportParameters = await getExportParameters()
         if (activeExportParameters?.id != payload.exportId) {
             // This export has finished or has been stopped
+            return
+        }
+
+        if (activeExportParameters.abortMessage) {
+            // For manually triggering the export to abort
             return
         }
 

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -104,6 +104,12 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
 
     describe('exportHistoricalEvents()', () => {
         const exportHistoricalEvents = getTestMethod('exportHistoricalEvents')
+        const exportParams = {
+            id: 1,
+            parallelism: 3,
+            dateFrom: '2021-10-29T00:00:00.000Z' as ISOTimestamp,
+            dateTo: '2021-11-01T05:00:00.000Z' as ISOTimestamp,
+        }
 
         const defaultPayload: ExportHistoricalEventsJobPayload = {
             timestampCursor: 1635724800000,
@@ -118,12 +124,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
 
         beforeEach(async () => {
             await resetTestDatabase()
-            await storage().set(EXPORT_PARAMETERS_KEY, {
-                id: 1,
-                parallelism: 3,
-                dateFrom: '2021-10-29T00:00:00.000Z' as ISOTimestamp,
-                dateTo: '2021-11-01T05:00:00.000Z' as ISOTimestamp,
-            })
+            await storage().set(EXPORT_PARAMETERS_KEY, exportParams)
         })
 
         afterEach(() => {
@@ -370,6 +371,15 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
             expect(hub.db.queuePluginLogEntry).not.toHaveBeenCalled()
         })
 
+        it('stops export if abortMessage is set', async () => {
+            await storage().set(EXPORT_PARAMETERS_KEY, { ...exportParams, abortMessage: 'test aborting' })
+
+            await exportHistoricalEvents(defaultPayload)
+
+            expect(fetchEventsForInterval).not.toHaveBeenCalled()
+            expect(hub.db.queuePluginLogEntry).not.toHaveBeenCalled()
+        })
+
         it('does nothing if a different export is running', async () => {
             await exportHistoricalEvents({ ...defaultPayload, exportId: 779 })
 
@@ -568,7 +578,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
             it('handles export being completed', async () => {
                 await coordinateHistoricalExport({
                     hasChanges: false,
-                    exportIsDone: true,
+                    exportIsDone: false,
                     progress: 1,
                     done: [],
                     running: [],
@@ -579,6 +589,34 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                 expect(hub.db.queuePluginLogEntry).toHaveBeenCalledWith(
                     expect.objectContaining({
                         message: expect.stringContaining('Export has finished!'),
+                    })
+                )
+                expect(await storage().get(EXPORT_PARAMETERS_KEY, null)).toEqual(null)
+            })
+
+            it('stops export if abortMessage is set', async () => {
+                await storage().set(EXPORT_PARAMETERS_KEY, { ...params, abortMessage: 'test aborting' })
+
+                await coordinateHistoricalExport({
+                    hasChanges: true,
+                    exportIsDone: false,
+                    progress: 0.7553,
+                    done: [
+                        '2021-10-29T00:00:00.000Z',
+                        '2021-10-30T00:00:00.000Z',
+                        '2021-10-31T00:00:00.000Z',
+                    ] as ISOTimestamp[],
+                    running: ['2021-11-01T00:00:00.000Z'] as ISOTimestamp[],
+                    toStartRunning: [['2021-11-01T00:00:00.000Z', '2021-11-01T05:00:00.000Z']] as Array<
+                        [ISOTimestamp, ISOTimestamp]
+                    >,
+                    toResume: [],
+                })
+
+                expect(vm.meta.jobs.exportHistoricalEventsV2).not.toHaveBeenCalled()
+                expect(hub.db.queuePluginLogEntry).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.stringContaining('test aborting'),
                     })
                 )
                 expect(await storage().get(EXPORT_PARAMETERS_KEY, null)).toEqual(null)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

For various reasons export jobs can get stuck in bad states.
We've sometimes used the workaround to delete the plugin config, but that also stops the running update and loses all the history - obviously not great.

## Changes

This allows us to add an abortMessage in Postgres to the export parameters to a running historical export job, which would stop it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
