### PR TITLE
chore(deps): bump xmlsec from 1.3.12 to 1.3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -412,7 +412,7 @@ wrapt==1.14.1
     # via deprecated
 wsproto==1.1.0
     # via trio-websocket
-xmlsec==1.3.12
+xmlsec==1.3.13
     # via python3-saml
 yarl==1.7.2
     # via aiohttp


### PR DESCRIPTION
We're now on Python 3.10 and `xmlsec` 1.3.13 is the first version to test for Python 3.10 compatibility. There were also some fixes around building wheels which might be relevant.

Full changelog:

https://github.com/xmlsec/python-xmlsec/releases