### PR TITLE
fix: generate cache type without a silly bug

### DIFF
--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -82,10 +82,14 @@ def get_cache_type_for_query(cacheable: Dict) -> CacheType:
 
 
 def get_cache_type(cacheable: Optional[FilterType] | Optional[Dict]) -> CacheType:
-    if isinstance(cacheable, FilterType):
-        return get_cache_type_for_filter(cacheable)
-    elif isinstance(cacheable, dict):
+    if isinstance(cacheable, dict):
         return get_cache_type_for_query(cacheable)
+    elif cacheable is not None:
+        # even though it appears to work mypy does not like
+        # elif isinstance(cacheable, FilterType):
+        # you should not, apparently, use isinstance with a Generic type
+        # luckily if cacheable is not a dict it must be a filter
+        return get_cache_type_for_filter(cacheable)
     else:
         logger.error("could_not_determine_cache_type_for_insight", cacheable=cacheable)
         raise Exception("Could not determine cache type. Must provide a filter or a query")

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -82,12 +82,12 @@ def get_cache_type_for_query(cacheable: Dict) -> CacheType:
 
 
 def get_cache_type(cacheable: Optional[FilterType] | Optional[Dict]) -> CacheType:
-    if isinstance(cacheable, Filter):
+    if isinstance(cacheable, FilterType):
         return get_cache_type_for_filter(cacheable)
     elif isinstance(cacheable, dict):
         return get_cache_type_for_query(cacheable)
     else:
-        logger.error("could_not_determine_cache_type_for_insight")
+        logger.error("could_not_determine_cache_type_for_insight", cacheable=cacheable)
         raise Exception("Could not determine cache type. Must provide a filter or a query")
 
 


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/14619

There's a subtle typo bug that accidentally works for most cases where the method receives `FilterType` as a parameter but I check if the instance is a `Filter`

But there are other types included in `FilterType`

## Changes

adds a developer test and fixes the bug

## How did you test this code?

with a test