### PR TITLE
feat: export queries to images

### DIFF
--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -98,7 +98,7 @@ export function ExportedInsight({
                 >
                     {!!query ? (
                         !!insight.result ? (
-                            <Query query={query} readOnly={true} />
+                            <Query query={query} readOnly={true} cachedResults={insight.result} />
                         ) : (
                             <QueriesUnsupportedHere />
                         )

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -597,10 +597,8 @@ function InsightCardInternal(
     const [metaPrimaryHeight, setMetaPrimaryHeight] = useState<number | undefined>(undefined)
     const [areDetailsShown, setAreDetailsShown] = useState(false)
 
-    const exportedAndCached =
-        dashboardPlacement &&
-        [DashboardPlacement.Public, DashboardPlacement.Export].includes(dashboardPlacement) &&
-        !!insight.result
+    const exportedAndCached = dashboardPlacement && dashboardPlacement == DashboardPlacement.Export && !!insight.result
+    const sharedAndCached = dashboardPlacement && dashboardPlacement == DashboardPlacement.Public && !!insight.result
     const canMakeQueryAPICalls =
         dashboardPlacement &&
         [DashboardPlacement.Dashboard, DashboardPlacement.ProjectHomepage, DashboardPlacement.FeatureFlag].includes(
@@ -645,7 +643,7 @@ function InsightCardInternal(
                                 : undefined
                         }
                     >
-                        {exportedAndCached ? (
+                        {exportedAndCached || (isUsingDashboardQueryTiles && sharedAndCached) ? (
                             <Query query={insight.query} readOnly={true} cachedResults={insight.result} />
                         ) : isUsingDashboardQueryTiles && canMakeQueryAPICalls ? (
                             <Query query={insight.query} readOnly={true} />

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -645,7 +645,7 @@ function InsightCardInternal(
                                 : undefined
                         }
                     >
-                        {isUsingDashboardQueryTiles && exportedAndCached ? (
+                        {exportedAndCached ? (
                             <Query query={insight.query} readOnly={true} cachedResults={insight.result} />
                         ) : isUsingDashboardQueryTiles && canMakeQueryAPICalls ? (
                             <Query query={insight.query} readOnly={true} />

--- a/frontend/src/lib/components/Cards/InsightCard/QueriesUnsupportedHere.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/QueriesUnsupportedHere.tsx
@@ -4,7 +4,7 @@ export function QueriesUnsupportedHere(): JSX.Element {
     return (
         <div className="text-center">
             <span className="text-muted">
-                Query insights are not <strong>yet</strong> supported in this view.
+                Not all Query types are supported in this view <strong>yet</strong>.
             </span>
             <XRayHog2 className="w-full h-full object-contain" />
         </div>

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -43,7 +43,7 @@ def calculate_cache_key(target: Union[DashboardTile, Insight]) -> Optional[str]:
     insight = target if isinstance(target, Insight) else target.insight
     dashboard = target.dashboard if isinstance(target, DashboardTile) else None
 
-    if insight is None or not insight.filters:
+    if insight is None or (not insight.filters and insight.query is None):
         return None
 
     return generate_insight_cache_key(insight, dashboard)


### PR DESCRIPTION
## Problem

follow up to #14619, see #13927 

There were a few things stopping exporting to images from working

Primarily...

Sharing dashboards was working for queries because the access token is converted to a real user and so the feature flag check is successful

Exporting of images is carried out as an impersonated user so we can't check if the feature flag is on.

## Changes

* Since the flag has to be on for a user to think to export a query as an image, let's not check the flag specifically for the case of exporting to image.
* when checking if an insight is valid for generating a cache key allow for empty filters when a query is present
* when generating an insight export to image, pass in the cached results to the query component

## dashboard with queries exported to image

![export-for-caching (10)](https://user-images.githubusercontent.com/984817/224292995-0a01f599-4840-44e1-972e-b8c8393ac298.png)

## How did you test this code?

👀 locally
