### PR TITLE
feat(query-performance): async migration for creating minmax indexes for materialized columns (2)

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -132,7 +132,7 @@ def create_minmax_index(table: TablesWithMaterializedColumns, column_names: List
         ADD INDEX {index_name} ({expression})
         TYPE minmax GRANULARITY 1
         """,
-        settings={"alter_sync": 1},
+        settings={"alter_sync": 2},
     )
 
     return index_name

--- a/posthog/async_migrations/migrations/0009_minmax_indexes_for_materialized_columns.py
+++ b/posthog/async_migrations/migrations/0009_minmax_indexes_for_materialized_columns.py
@@ -1,18 +1,6 @@
-from functools import cached_property, partial
 from typing import List
 
-import structlog
-from clickhouse_driver.errors import ServerException
-from django.conf import settings
-
 from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
-from posthog.clickhouse.materialized_columns import get_materialized_columns
-from posthog.client import sync_execute
-from posthog.models.property.property import TableWithProperties
-
-logger = structlog.get_logger(__name__)
-
-TABLES_TO_INDEX: List[TableWithProperties] = ["events", "person", "groups"]
 
 
 class Migration(AsyncMigrationDefinition):
@@ -23,51 +11,6 @@ class Migration(AsyncMigrationDefinition):
     posthog_max_version = "1.49.99"
 
     def is_required(self):
-        return settings.EE_AVAILABLE and any(self.has_missing_index(table) for table in TABLES_TO_INDEX)
+        return False
 
-    def has_missing_index(self, table: TableWithProperties) -> bool:
-        table_to_check = "sharded_events" if table == "events" else table
-        indexes = set(
-            row[0]
-            for row in sync_execute(
-                "SELECT name FROM system.data_skipping_indices WHERE table = %(table)s", {"table": table_to_check}
-            )
-        )
-        return any(f"minmax_{column_name}" not in indexes for column_name in get_materialized_columns(table).values())
-
-    @cached_property
-    def operations(self):
-        operations = []
-        for table in TABLES_TO_INDEX:
-            for column_name in get_materialized_columns(table).values():
-                operations.append(
-                    AsyncMigrationOperation(fn=partial(self.attempt_add_materialized_column_index, table, column_name))
-                )
-
-        return operations
-
-    def attempt_add_materialized_column_index(self, table: TableWithProperties, column_name: str, query_id: str):
-        from ee.clickhouse.materialized_columns.columns import add_minmax_index
-
-        execute_on_cluster = f"ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'" if table == "events" else ""
-        updated_table = "sharded_events" if table == "events" else table
-
-        try:
-            index_name = add_minmax_index(table, column_name)
-            sync_execute(
-                f"""
-                ALTER TABLE {updated_table}
-                {execute_on_cluster}
-                MATERIALIZE INDEX {index_name}
-                """,
-                {
-                    "mutations_sync": 2,
-                    "max_execution_time": 2 * 24 * 60 * 60,  # two days
-                    "send_timeout": 2 * 24 * 60 * 60,  # two days,
-                    "receive_timeout": 2 * 24 * 60 * 60,  # two days,
-                },
-            )
-        except ServerException as err:
-            # We ignore indexes that already exist (due to being added before this migration runs)
-            if "index with this name already exists" not in str(err):
-                raise err
+    operations: List[AsyncMigrationOperation] = []

--- a/posthog/async_migrations/migrations/0010_minmax_indexes_for_materialized_columns.py
+++ b/posthog/async_migrations/migrations/0010_minmax_indexes_for_materialized_columns.py
@@ -1,0 +1,72 @@
+from functools import cached_property, partial
+from typing import List, Set
+
+import structlog
+from django.conf import settings
+
+from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.clickhouse.materialized_columns import ColumnName, get_materialized_columns
+from posthog.client import sync_execute
+from posthog.models.property.property import TableWithProperties
+from posthog.utils import chunked_iterable
+
+logger = structlog.get_logger(__name__)
+
+TABLES_TO_INDEX: List[TableWithProperties] = ["events", "person", "groups"]
+
+
+class Migration(AsyncMigrationDefinition):
+    description = "Create minmax indexes for materialized columns to speed up queries"
+
+    depends_on = "0009_minmax_indexes_for_materialized_columns"
+    posthog_min_version = "1.43.0"
+    posthog_max_version = "1.49.99"
+
+    def is_required(self):
+        return settings.EE_AVAILABLE and any(self.has_missing_index(table) for table in TABLES_TO_INDEX)
+
+    def get_indexed_columns(self, table: TableWithProperties) -> Set[ColumnName]:
+        table_to_check = "sharded_events" if table == "events" else table
+        index_expressions = sync_execute(
+            """
+            SELECT expr
+            FROM system.data_skipping_indices
+            WHERE table = %(table)s
+              AND name LIKE %(pattern)s
+            """,
+            {"table": table_to_check, "pattern": "minmax_%"},
+        )
+
+        indexed_columns: Set[ColumnName] = set()
+        for (expression,) in index_expressions:
+            indexed_columns |= set(expr.strip("`") for expr in expression.split(", "))
+
+        return indexed_columns
+
+    def has_missing_index(self, table: TableWithProperties) -> bool:
+        already_indexed = self.get_indexed_columns(table)
+        return any(column_name not in already_indexed for column_name in get_materialized_columns(table).values())
+
+    @cached_property
+    def operations(self):
+        operations = []
+        for table in TABLES_TO_INDEX:
+            for column_names in chunked_iterable(
+                get_materialized_columns(table).values(), settings.MATERIALIZE_COLUMNS_MAX_AT_ONCE
+            ):
+                operations.append(
+                    AsyncMigrationOperation(fn=partial(self.attempt_add_materialized_column_index, table, column_names))
+                )
+
+        return operations
+
+    def attempt_add_materialized_column_index(self, table: TableWithProperties, column_names: List[str], query_id: str):
+        from ee.clickhouse.materialized_columns.columns import create_minmax_index
+
+        already_indexed = self.get_indexed_columns(table)
+        to_index = [column_name for column_name in column_names if column_name not in already_indexed]
+        if len(to_index) > 0:
+            logger.info("Creating minmax index for materialized columns.", table=table, column_names=to_index)
+            create_minmax_index(table, to_index)
+        else:
+            logger.info("Columns already indexed, skipping adding a new index.", table=table, column_names=column_names)

--- a/posthog/clickhouse/materialized_columns/column.py
+++ b/posthog/clickhouse/materialized_columns/column.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Dict, List, Literal, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from posthog.cache_utils import cache_for
 from posthog.models.property import PropertyName, TableColumn, TableWithProperties
@@ -21,14 +21,14 @@ def materialize(
     property: PropertyName,
     column_name=None,
     table_column: TableColumn = "properties",
-    create_minmax_index=False,
-) -> None:
-    pass
+    create_index=False,
+) -> Optional[ColumnName]:
+    return None
 
 
 def backfill_materialized_columns(
     table: TableWithProperties,
-    properties: List[Tuple[PropertyName, TableColumn]],
+    properties: List[Tuple[PropertyName, TableColumn, ColumnName]],
     backfill_period: timedelta,
     test_settings=None,
 ) -> None:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -15,6 +15,7 @@ import uuid
 import zlib
 from enum import Enum
 from functools import lru_cache, wraps
+from itertools import islice
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1232,3 +1233,12 @@ def patchable(fn):
     inner._patch = patch  # type: ignore
 
     return inner
+
+
+def chunked_iterable(iterable, size):
+    it = iter(iterable)
+    while True:
+        chunk = tuple(islice(it, size))
+        if not chunk:
+            break
+        yield chunk


### PR DESCRIPTION
## Problem

Original issue: https://github.com/PostHog/posthog/issues/14200

Async migration 0009 caused problems due to materialization and number of indexes.

## Changes

Create a new async migration 0010 that:
- Creates materialized columns in chunks (limiting the number of indexes created)
- Not doing materialization as unmaterialized columns combined with indexes seems to result in errors.

Backwards compatibility is retained by leveraging existing indexes.

## How did you test this code?

- Manually creating materialized columns and verifying results
- Running the async migration