### PR TITLE
feat(celery): add posthog_celery_graphile_lag_seconds gauge

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -131,7 +131,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
     sender.add_periodic_task(
         crontab(minute=0, hour="*"), pg_plugin_server_query_timing.s(), name="PG plugin server query timing"
     )
-    sender.add_periodic_task(120, graphile_worker_queue_size.s(), name="Graphile Worker queue size")
+    sender.add_periodic_task(60, graphile_worker_queue_size.s(), name="Graphile Worker queue size")
 
     sender.add_periodic_task(120, calculate_cohort.s(), name="recalculate cohorts")
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -415,7 +415,7 @@ def graphile_worker_queue_size():
         # Completed jobs are deleted and "permanently failed" jobs have attempts == max_attempts
         cursor.execute(
             """
-        SELECT task_identifier, count(*) as c, min(created_at) as oldest FROM graphile_worker.jobs
+        SELECT task_identifier, count(*) as c, EXTRACT(EPOCH FROM MIN(updated_at)) as oldest FROM graphile_worker.jobs
         WHERE attempts < max_attempts
         GROUP BY task_identifier
         """
@@ -425,7 +425,7 @@ def graphile_worker_queue_size():
         with pushed_metrics_registry("celery_graphile_worker_queue_size") as registry:
             processing_lag_gauge = Gauge(
                 "posthog_celery_graphile_lag_seconds",
-                "Age of the oldest non-attempted Graphile job per task identifier, zero if queue empty.",
+                "Oldest update (creation or retry) on pending Graphile jobs per task identifier, zero if queue empty.",
                 labelnames=["task_identifier"],
                 registry=registry,
             )

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -438,7 +438,7 @@ def graphile_worker_queue_size():
             for (task_identifier, count, oldest) in cursor.fetchall():
                 seen_task_identifier.add(task_identifier)
                 waiting_jobs_gauge.labels(task_identifier=task_identifier).set(count)
-                processing_lag_gauge.labels(task_identifier=task_identifier).set(oldest - time.time())
+                processing_lag_gauge.labels(task_identifier=task_identifier).set(time.time() - oldest)
                 statsd.gauge("graphile_waiting_jobs", count, tags={"task_identifier": task_identifier})
 
             # The query will not return rows for empty queues, creating missing points.

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -388,6 +388,9 @@ def ingestion_lag():
         pass
 
 
+KNOWN_CELERY_TASK_IDENTIFIERS = {"pluginJob"}
+
+
 @app.task(ignore_result=True)
 def graphile_worker_queue_size():
     from django.db import connections
@@ -412,22 +415,37 @@ def graphile_worker_queue_size():
         # Completed jobs are deleted and "permanently failed" jobs have attempts == max_attempts
         cursor.execute(
             """
-        SELECT task_identifier, count(*) as c FROM graphile_worker.jobs
+        SELECT task_identifier, count(*) as c, min(created_at) as oldest FROM graphile_worker.jobs
         WHERE attempts < max_attempts
         GROUP BY task_identifier
         """
         )
 
+        seen_task_identifier = set()
         with pushed_metrics_registry("celery_graphile_worker_queue_size") as registry:
+            processing_lag_gauge = Gauge(
+                "posthog_celery_graphile_lag_seconds",
+                "Age of the oldest non-attempted Graphile job per task identifier, zero if queue empty.",
+                labelnames=["task_identifier"],
+                registry=registry,
+            )
             waiting_jobs_gauge = Gauge(
                 "posthog_celery_graphile_waiting_jobs",
                 "Number of Graphile jobs in the queue, per task identifier.",
                 labelnames=["task_identifier"],
                 registry=registry,
             )
-            for (task_identifier, count) in cursor.fetchall():
+            for (task_identifier, count, oldest) in cursor.fetchall():
+                seen_task_identifier.add(task_identifier)
                 waiting_jobs_gauge.labels(task_identifier=task_identifier).set(count)
+                processing_lag_gauge.labels(task_identifier=task_identifier).set(oldest - time.time())
                 statsd.gauge("graphile_waiting_jobs", count, tags={"task_identifier": task_identifier})
+
+            # The query will not return rows for empty queues, creating missing points.
+            # Let's emit updates for known queues even if they are empty.
+            for task_identifier in KNOWN_CELERY_TASK_IDENTIFIERS - seen_task_identifier:
+                waiting_jobs_gauge.labels(task_identifier=task_identifier).set(0)
+                processing_lag_gauge.labels(task_identifier=task_identifier).set(0)
 
 
 @app.task(ignore_result=True)


### PR DESCRIPTION
## Problem

We want to alert on late Graphile jobs, and the existing `posthog_celery_graphile_waiting_jobs` gauge does not reflect user impact in terms of delay. Let's add a new `posthog_celery_graphile_lag_seconds` metric that we can alert on.

## Changes

- Add a `posthog_celery_graphile_lag_seconds` metric exported by the existing `graphile_worker_queue_size` celery job.
- Make sure that we always export lag and queue size for the `pluginJob` queue, even if it's empty
- Increase the job frequency 120->60 seconds

I though about making that gauge a timestamp, but decided against it, because sending `now()` on an empty queue felt pretty misleading. We should instead add a self-reported `latest_processed_job` gauge in plugin-server, mirroring the `latest_processed_timestamp_ms` for kafka consumers.

## How did you test this code?

Local run, commenting out [the graphile worker startup](https://github.com/PostHog/posthog/blob/1cf42c056cc479cfa020db069efc44ef8e252250/plugin-server/src/main/graphile-worker/worker-setup.ts#L41)

```
curl -s localhost:9091/metrics|grep graph
# HELP posthog_celery_graphile_lag_seconds Oldest update (creation or retry) on pending Graphile jobs per task identifier, zero if queue empty.
# TYPE posthog_celery_graphile_lag_seconds gauge
posthog_celery_graphile_lag_seconds{instance="",job="celery_graphile_worker_queue_size",task_identifier="pluginJob"} 199.49079298973083
# HELP posthog_celery_graphile_waiting_jobs Number of Graphile jobs in the queue, per task identifier.
# TYPE posthog_celery_graphile_waiting_jobs gauge
posthog_celery_graphile_waiting_jobs{instance="",job="celery_graphile_worker_queue_size",task_identifier="pluginJob"} 2
push_failure_time_seconds{instance="",job="celery_graphile_worker_queue_size"} 0
push_time_seconds{instance="",job="celery_graphile_worker_queue_size"} 1.6784564863316517e+09
```

After reverting this change and restarting plugin-server:

```
curl -s localhost:9091/metrics|grep graph
# HELP posthog_celery_graphile_lag_seconds Oldest update (creation or retry) on pending Graphile jobs per task identifier, zero if queue empty.
# TYPE posthog_celery_graphile_lag_seconds gauge
posthog_celery_graphile_lag_seconds{instance="",job="celery_graphile_worker_queue_size",task_identifier="pluginJob"} 0
# HELP posthog_celery_graphile_waiting_jobs Number of Graphile jobs in the queue, per task identifier.
# TYPE posthog_celery_graphile_waiting_jobs gauge
posthog_celery_graphile_waiting_jobs{instance="",job="celery_graphile_worker_queue_size",task_identifier="pluginJob"} 0
push_failure_time_seconds{instance="",job="celery_graphile_worker_queue_size"} 0
push_time_seconds{instance="",job="celery_graphile_worker_queue_size"} 1.6784565284896562e+09
```