### PR TITLE
feat(data-exploration): split hidden legend keys for trends/stickiness and funnels

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -35,7 +35,12 @@ import {
     RetentionPeriod,
     GroupMathType,
 } from '~/types'
-import { actionsAndEventsToSeries, filtersToQueryNode } from './filtersToQueryNode'
+import {
+    actionsAndEventsToSeries,
+    cleanHiddenLegendIndexes,
+    cleanHiddenLegendSeries,
+    filtersToQueryNode,
+} from './filtersToQueryNode'
 
 describe('actionsAndEventsToSeries', () => {
     it('sorts series by order', () => {
@@ -64,6 +69,86 @@ describe('actionsAndEventsToSeries', () => {
         expect(result[0].name).toEqual('itemWithOrder')
         expect(result[1].name).toEqual('item1')
         expect(result[2].name).toEqual('item2')
+    })
+})
+
+describe('cleanHiddenLegendIndexes', () => {
+    it('converts legend keys', () => {
+        const keys: Record<string, boolean | undefined> = {
+            1: true,
+            2: false,
+            3: undefined,
+        }
+
+        const result = cleanHiddenLegendIndexes(keys)
+
+        expect(result).toEqual([1])
+    })
+
+    it('handles undefined legend keys', () => {
+        const keys = undefined
+
+        const result = cleanHiddenLegendIndexes(keys)
+
+        expect(result).toEqual(undefined)
+    })
+
+    it('ignores invalid keys', () => {
+        const keys: Record<string, boolean | undefined> = {
+            Opera: true,
+            'events/$pageview/0/Baseline': true,
+            1: true,
+        }
+
+        const result = cleanHiddenLegendIndexes(keys)
+
+        expect(result).toEqual([1])
+    })
+})
+
+describe('cleanHiddenLegendSeries', () => {
+    it('converts legend keys', () => {
+        const keys: Record<string, boolean | undefined> = {
+            Chrome: true,
+            'Chrome iOS': true,
+            Firefox: false,
+            Safari: undefined,
+        }
+
+        const result = cleanHiddenLegendSeries(keys)
+
+        expect(result).toEqual(['Chrome', 'Chrome iOS'])
+    })
+
+    it('handles undefined legend keys', () => {
+        const keys = undefined
+
+        const result = cleanHiddenLegendSeries(keys)
+
+        expect(result).toEqual(undefined)
+    })
+
+    it('converts legacy format', () => {
+        const keys: Record<string, boolean | undefined> = {
+            Opera: true,
+            'events/$pageview/0/Baseline': true,
+            1: true,
+        }
+
+        const result = cleanHiddenLegendSeries(keys)
+
+        expect(result).toEqual(['Opera', 'Baseline'])
+    })
+
+    it('ignores digit-only keys', () => {
+        const keys: Record<string, boolean | undefined> = {
+            Opera: true,
+            1: true,
+        }
+
+        const result = cleanHiddenLegendSeries(keys)
+
+        expect(result).toEqual(['Opera'])
     })
 })
 
@@ -226,7 +311,7 @@ describe('filtersToQueryNode', () => {
                 trendsFilter: {
                     smoothing_intervals: 1,
                     show_legend: true,
-                    hidden_legend_keys: { 0: true, 10: true },
+                    hidden_legend_indexes: [0, 10],
                     compare: true,
                     aggregation_axis_format: 'numeric',
                     aggregation_axis_prefix: '£',
@@ -270,7 +355,7 @@ describe('filtersToQueryNode', () => {
                 funnel_step: 1,
                 entrance_period_start: 'abc',
                 drop_off: true,
-                hidden_legend_keys: { 0: true, 10: true },
+                hidden_legend_keys: { Chrome: true, Safari: true },
             }
 
             const result = filtersToQueryNode(filters)
@@ -303,7 +388,7 @@ describe('filtersToQueryNode', () => {
                     funnel_step: 1,
                     entrance_period_start: 'abc',
                     drop_off: true,
-                    hidden_legend_keys: { 0: true, 10: true },
+                    hidden_legend_series: ['Chrome', 'Safari'],
                 },
             }
             expect(result).toEqual(query)
@@ -409,7 +494,7 @@ describe('filtersToQueryNode', () => {
                 stickinessFilter: {
                     compare: true,
                     show_legend: true,
-                    hidden_legend_keys: { 0: true, 10: true },
+                    hidden_legend_indexes: [0, 10],
                     stickiness_days: 2,
                     shown_as: ShownAsValue.STICKINESS,
                     display: ChartDisplayType.ActionsLineGraph,

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -26,6 +26,7 @@ import {
     isLifecycleFilter,
 } from 'scenes/insights/sharedUtils'
 import { objectCleanWithEmpty } from 'lib/utils'
+import { transformLegacyHiddenLegendKeys } from 'scenes/funnels/funnelUtils'
 
 const reverseInsightMap: Record<Exclude<InsightType, InsightType.QUERY>, InsightNodeKind> = {
     [InsightType.TRENDS]: NodeKind.TrendsQuery,
@@ -78,6 +79,26 @@ export const actionsAndEventsToSeries = ({
     return series
 }
 
+export const cleanHiddenLegendIndexes = (
+    hidden_legend_keys: Record<string, boolean | undefined> | undefined
+): number[] | undefined => {
+    return hidden_legend_keys
+        ? Object.entries(hidden_legend_keys)
+              .filter(([k, v]) => /^\d+$/.test(k) && v === true)
+              .map(([k]) => Number(k))
+        : undefined
+}
+
+export const cleanHiddenLegendSeries = (
+    hidden_legend_keys: Record<string, boolean | undefined> | undefined
+): string[] | undefined => {
+    return hidden_legend_keys
+        ? Object.entries(transformLegacyHiddenLegendKeys(hidden_legend_keys))
+              .filter(([k, v]) => !/^\d+$/.test(k) && v === true)
+              .map(([k]) => k)
+        : undefined
+}
+
 export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNode => {
     if (!filters.insight) {
         throw new Error('filtersToQueryNode expects "insight"')
@@ -121,7 +142,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
         query.trendsFilter = objectCleanWithEmpty({
             smoothing_intervals: filters.smoothing_intervals,
             show_legend: filters.show_legend,
-            hidden_legend_keys: filters.hidden_legend_keys,
+            hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
             compare: filters.compare,
             aggregation_axis_format: filters.aggregation_axis_format,
             aggregation_axis_prefix: filters.aggregation_axis_prefix,
@@ -156,7 +177,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             funnel_step: filters.funnel_step,
             entrance_period_start: filters.entrance_period_start,
             drop_off: filters.drop_off,
-            hidden_legend_keys: filters.hidden_legend_keys,
+            hidden_legend_series: cleanHiddenLegendSeries(filters.hidden_legend_keys),
         })
     }
 
@@ -202,7 +223,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             display: filters.display,
             compare: filters.compare,
             show_legend: filters.show_legend,
-            hidden_legend_keys: filters.hidden_legend_keys,
+            hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
             stickiness_days: filters.stickiness_days,
             shown_as: filters.shown_as,
         })

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1889,18 +1889,11 @@
                 "funnel_window_interval_unit": {
                     "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
                 },
-                "hidden_legend_keys": {
-                    "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "not": {}
-                            }
-                        ]
+                "hidden_legend_series": {
+                    "items": {
+                        "type": "string"
                     },
-                    "type": "object"
+                    "type": "array"
                 },
                 "layout": {
                     "$ref": "#/definitions/FunnelLayout"
@@ -2688,18 +2681,11 @@
                 "display": {
                     "$ref": "#/definitions/ChartDisplayType"
                 },
-                "hidden_legend_keys": {
-                    "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "not": {}
-                            }
-                        ]
+                "hidden_legend_indexes": {
+                    "items": {
+                        "type": "number"
                     },
-                    "type": "object"
+                    "type": "array"
                 },
                 "show_legend": {
                     "type": "boolean"
@@ -2833,18 +2819,11 @@
                     "$ref": "#/definitions/ChartDisplayType"
                 },
                 "formula": {},
-                "hidden_legend_keys": {
-                    "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "not": {}
-                            }
-                        ]
+                "hidden_legend_indexes": {
+                    "items": {
+                        "type": "number"
                     },
-                    "type": "object"
+                    "type": "array"
                 },
                 "show_legend": {
                     "type": "boolean"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -293,7 +293,12 @@ export interface InsightsQueryBase extends Node {
     aggregation_group_type_index?: number
 }
 
-export type TrendsFilter = Omit<TrendsFilterType, keyof FilterType> // using everything except what it inherits from FilterType
+// using everything except what it inherits from FilterType
+// replace hidden_legend_keys with hidden_legend_indexes
+export type TrendsFilter = Omit<
+    TrendsFilterType & { hidden_legend_indexes?: number[] },
+    keyof FilterType | 'hidden_legend_keys'
+>
 export interface TrendsQuery extends InsightsQueryBase {
     kind: NodeKind.TrendsQuery
     /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
@@ -306,7 +311,12 @@ export interface TrendsQuery extends InsightsQueryBase {
     breakdown?: BreakdownFilter
 }
 
-export type FunnelsFilter = Omit<FunnelsFilterType, keyof FilterType> // using everything except what it inherits from FilterType
+// using everything except what it inherits from FilterType
+// replace hidden_legend_keys with hidden_legend_series
+export type FunnelsFilter = Omit<
+    FunnelsFilterType & { hidden_legend_series?: string[] },
+    keyof FilterType | 'hidden_legend_keys'
+>
 export interface FunnelsQuery extends InsightsQueryBase {
     kind: NodeKind.FunnelsQuery
     /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
@@ -333,7 +343,12 @@ export interface PathsQuery extends InsightsQueryBase {
     pathsFilter?: PathsFilter
 }
 
-export type StickinessFilter = Omit<StickinessFilterType, keyof FilterType> // using everything except what it inherits from FilterType
+// using everything except what it inherits from FilterType
+// replace hidden_legend_keys with hidden_legend_indexes
+export type StickinessFilter = Omit<
+    StickinessFilterType & { hidden_legend_indexes?: number[] },
+    keyof FilterType | 'hidden_legend_keys'
+>
 export interface StickinessQuery extends InsightsQueryBase {
     kind: NodeKind.StickinessQuery
     /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -413,7 +413,7 @@ class StickinessFilter(BaseModel):
 
     compare: Optional[bool] = None
     display: Optional[ChartDisplayType] = None
-    hidden_legend_keys: Optional[Dict[str, Union[bool, Any]]] = None
+    hidden_legend_indexes: Optional[List[float]] = None
     show_legend: Optional[bool] = None
     show_values_on_series: Optional[bool] = None
     shown_as: Optional[ShownAsValue] = None
@@ -438,7 +438,7 @@ class TrendsFilter(BaseModel):
     compare: Optional[bool] = None
     display: Optional[ChartDisplayType] = None
     formula: Optional[Any] = None
-    hidden_legend_keys: Optional[Dict[str, Union[bool, Any]]] = None
+    hidden_legend_indexes: Optional[List[float]] = None
     show_legend: Optional[bool] = None
     show_values_on_series: Optional[bool] = None
     shown_as: Optional[ShownAsValue] = None
@@ -523,7 +523,7 @@ class FunnelsFilter(BaseModel):
     funnel_viz_type: Optional[FunnelVizType] = None
     funnel_window_interval: Optional[float] = None
     funnel_window_interval_unit: Optional[FunnelConversionWindowTimeUnit] = None
-    hidden_legend_keys: Optional[Dict[str, Union[bool, Any]]] = None
+    hidden_legend_series: Optional[List[str]] = None
     layout: Optional[FunnelLayout] = None
 
 


### PR DESCRIPTION
## Problem

Trends/Stickiness insights use a different format for `hidden_legend_keys` from Funnel insights.

Formats:
- Trends/Stickiness: `{"19": true, "74": true}`
- Funnels: `{"Chrome":true}`
- Funnels Legacy: `{"actions/2674/1": true, "events/$pageview/0/null": true, "events/$pageview/0/Africa": true, "events/$pageview/0/Oceania": true, "events/$pageview/0/(empty string)": true}`

## Changes

This PR:
- Replaces `hidden_legend_keys` with `hidden_legend_indexes` from Trends and Stickiness insights
- Replaces `hidden_legend_keys` with `hidden_legend_series` from Funnels insights, while also converting the legacy format to the new one

It does not yet use the new formats to toggle any of the legends. This will follow in a follow up PR.

## How did you test this code?

Added tests.