### PR TITLE
fix(celery): fix graphile_worker_queue_size

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -438,7 +438,7 @@ def graphile_worker_queue_size():
             for (task_identifier, count, oldest) in cursor.fetchall():
                 seen_task_identifier.add(task_identifier)
                 waiting_jobs_gauge.labels(task_identifier=task_identifier).set(count)
-                processing_lag_gauge.labels(task_identifier=task_identifier).set(time.time() - oldest)
+                processing_lag_gauge.labels(task_identifier=task_identifier).set(time.time() - float(oldest))
                 statsd.gauge("graphile_waiting_jobs", count, tags={"task_identifier": task_identifier})
 
             # The query will not return rows for empty queues, creating missing points.


### PR DESCRIPTION
## Problem

Fix for [this sentry error](https://posthog.sentry.io/issues/3993539362/?project=1899813&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h) introduced https://github.com/PostHog/posthog/pull/14677

> unsupported operand type(s) for -: 'float' and 'decimal.Decimal'

## Changes

- force a cast to float

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
