### PR TITLE
fix(LemonSwitch): properly set up IDs for lemon switches

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -33,7 +33,7 @@ export function LemonSwitch({
     icon,
     'data-attr': dataAttr,
 }: LemonSwitchProps): JSX.Element {
-    const id = useMemo(() => rawId || `lemon-checkbox-${switchCounter++}`, [rawId])
+    const id = useMemo(() => rawId || `lemon-switch-${switchCounter++}`, [rawId])
     const [isActive, setIsActive] = useState(false)
 
     return (

--- a/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
@@ -34,6 +34,7 @@ export function SamplingFilter({
                         Sampling
                     </LemonLabel>
                     <LemonSwitch
+                        id="sampling-toggle"
                         className="m-2"
                         onChange={(checked) => (checked ? setSamplingPercentage(10) : setSamplingPercentage(null))}
                         checked={!!samplingPercentage}

--- a/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
@@ -34,7 +34,6 @@ export function SamplingFilter({
                         Sampling
                     </LemonLabel>
                     <LemonSwitch
-                        id="sampling-toggle"
                         className="m-2"
                         onChange={(checked) => (checked ? setSamplingPercentage(10) : setSamplingPercentage(null))}
                         checked={!!samplingPercentage}


### PR DESCRIPTION
Some copy pasta here meant that if a checkbox and toggle were both in the DOM toggling one would mess with the other :D