### PR TITLE
fix: set query in insightDataLogic on setInsight

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -79,6 +79,11 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         return null
                     }
 
+                    if (Object.keys(props.query).length === 0) {
+                        // no need to try and load a query before properly initialized
+                        return null
+                    }
+
                     actions.abortAnyRunningQuery()
                     cache.abortController = new AbortController()
                     const methodOptions: ApiMethodOptions = {

--- a/frontend/src/scenes/insights/insightDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.test.ts
@@ -4,13 +4,17 @@ import { initKeaTests } from '~/test/init'
 import { ChartDisplayType, InsightLogicProps, InsightShortId, InsightType } from '~/types'
 
 import { insightDataLogic } from './insightDataLogic'
-import { NodeKind } from '~/queries/schema'
+import { NodeKind, TrendsQuery } from '~/queries/schema'
 import { useMocks } from '~/mocks/jest'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
+import { examples } from '~/queries/examples'
 
 const Insight123 = '123' as InsightShortId
 
 describe('insightDataLogic', () => {
-    let logic: ReturnType<typeof insightDataLogic.build>
+    let theInsightDataLogic: ReturnType<typeof insightDataLogic.build>
+    let theInsightLogic: ReturnType<typeof insightLogic.build>
 
     beforeEach(() => {
         useMocks({
@@ -68,16 +72,134 @@ describe('insightDataLogic', () => {
         })
     })
 
+    describe('reacts when the insight changes', () => {
+        const props = { dashboardItemId: Insight123 }
+        beforeEach(() => {
+            theInsightDataLogic = insightDataLogic(props)
+            theInsightDataLogic.mount()
+
+            theInsightLogic = insightLogic(props)
+            theInsightLogic.mount()
+        })
+
+        it('sets query when present', async () => {
+            const q = {
+                kind: NodeKind.DataTableNode,
+                source: {
+                    kind: NodeKind.EventsQuery,
+                    select: ['*'],
+                    after: '-24h',
+                    limit: 100,
+                },
+            }
+
+            await expectLogic(theInsightDataLogic, () => {
+                theInsightLogic.actions.setInsight({ query: q }, {})
+            })
+                .toDispatchActions(['setQuery'])
+                .toMatchValues({
+                    query: q,
+                })
+        })
+        it('sets query when filters is present and override is set', async () => {
+            const q = examples.InsightTrendsQuery as TrendsQuery
+
+            const filters = queryNodeToFilter(q)
+
+            await expectLogic(theInsightDataLogic, () => {
+                theInsightLogic.actions.setInsight({ filters }, { overrideFilter: true })
+            })
+                .toDispatchActions(['setQuery'])
+                .toMatchValues({
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            breakdown: {
+                                breakdown: '$geoip_country_code',
+                                breakdown_type: 'event',
+                            },
+                            dateRange: {
+                                date_from: '-7d',
+                            },
+                            filterTestAccounts: false,
+                            interval: 'day',
+                            kind: NodeKind.TrendsQuery,
+                            properties: {
+                                type: 'AND',
+                                values: [
+                                    {
+                                        type: 'OR',
+                                        values: [
+                                            {
+                                                key: '$current_url',
+                                                operator: 'exact',
+                                                type: 'event',
+                                                value: ['https://hedgebox.net/files/'],
+                                            },
+                                            {
+                                                key: '$geoip_country_code',
+                                                operator: 'exact',
+                                                type: 'event',
+                                                value: ['US', 'AU'],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            series: [
+                                {
+                                    custom_name: 'Views',
+                                    event: '$pageview',
+                                    kind: 'EventsNode',
+                                    name: '$pageview',
+                                    properties: [
+                                        {
+                                            key: '$browser',
+                                            operator: 'exact',
+                                            type: 'event',
+                                            value: 'Chrome',
+                                        },
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 2,
+                                        },
+                                    ],
+                                },
+                            ],
+                            trendsFilter: {
+                                display: 'ActionsAreaGraph',
+                            },
+                        },
+                    },
+                })
+        })
+        it('does not set query when filters is present and override is not set', async () => {
+            const q = examples.InsightTrendsQuery as TrendsQuery
+
+            const filters = queryNodeToFilter(q)
+
+            await expectLogic(theInsightDataLogic, () => {
+                theInsightLogic.actions.setInsight({ filters }, { overrideFilter: false })
+            }).toNotHaveDispatchedActions(['setQuery'])
+        })
+        it('does not set query when insight is invalid', async () => {
+            await expectLogic(theInsightDataLogic, () => {
+                theInsightLogic.actions.setInsight({ filters: {}, query: undefined }, {})
+            }).toNotHaveDispatchedActions(['setQuery'])
+        })
+    })
+
     describe('manages query source state', () => {
         const props = { dashboardItemId: Insight123 }
         beforeEach(() => {
-            logic = insightDataLogic(props)
-            logic.mount()
+            theInsightDataLogic = insightDataLogic(props)
+            theInsightDataLogic.mount()
         })
 
         it('updateQuerySource updates the query source', () => {
-            expectLogic(logic, () => {
-                logic.actions.updateQuerySource({ filterTestAccounts: true })
+            expectLogic(theInsightDataLogic, () => {
+                theInsightDataLogic.actions.updateQuerySource({ filterTestAccounts: true })
             }).toMatchValues({
                 query: expect.objectContaining({
                     source: expect.objectContaining({
@@ -86,20 +208,20 @@ describe('insightDataLogic', () => {
                 }),
             })
 
-            expect(logic.values.querySource).toMatchObject({ filterTestAccounts: true })
+            expect(theInsightDataLogic.values.querySource).toMatchObject({ filterTestAccounts: true })
         })
     })
 
     describe('manages insight filter state', () => {
         const props = { dashboardItemId: Insight123 }
         beforeEach(() => {
-            logic = insightDataLogic(props)
-            logic.mount()
+            theInsightDataLogic = insightDataLogic(props)
+            theInsightDataLogic.mount()
         })
 
         it('updateInsightFilter updates the insight filter', () => {
-            expectLogic(logic, () => {
-                logic.actions.updateInsightFilter({ display: ChartDisplayType.ActionsAreaGraph })
+            expectLogic(theInsightDataLogic, () => {
+                theInsightDataLogic.actions.updateInsightFilter({ display: ChartDisplayType.ActionsAreaGraph })
             }).toMatchValues({
                 query: expect.objectContaining({
                     source: expect.objectContaining({
@@ -110,7 +232,7 @@ describe('insightDataLogic', () => {
                 }),
             })
 
-            expect(logic.values.insightFilter).toMatchObject({ display: 'ActionsAreaGraph' })
+            expect(theInsightDataLogic.values.insightFilter).toMatchObject({ display: 'ActionsAreaGraph' })
         })
     })
 })

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -197,6 +197,8 @@ export const insightDataLogic = kea<insightDataLogicType>([
         setInsight: ({ insight: { filters, query }, options: { overrideFilter } }) => {
             if (overrideFilter && query == null) {
                 actions.setQuery(queryFromFilters(cleanFilters(filters || {})))
+            } else if (query) {
+                actions.setQuery(query)
             }
         },
         loadInsightSuccess: ({ insight }) => {
@@ -250,7 +252,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
                     ...values.insight,
                     result: insightData?.result,
                     next: insightData?.next,
-                    filters: queryNodeToFilter(values.querySource),
+                    filters: values.insight.query ? {} : queryNodeToFilter(values.querySource),
                 },
                 {}
             )


### PR DESCRIPTION
## Problem

If a query-based insight was not already cached, and we loaded it from a dashboard, then the insight view would default to trends

## Changes

ensures we set the query in the insightDataLogic when setting insight on the insightLogic

## How did you test this code?

👀 locally