### PR TITLE
feat(data-exploration): convert legend button

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.scss
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.scss
@@ -1,14 +1,3 @@
-.InsightLegendButton {
-    display: flex;
-    align-items: center;
-
-    .InsightLegendButton-title {
-        margin-left: 0.5rem;
-        font-size: 14px;
-        font-weight: 500;
-    }
-}
-
 .InsightLegendMenu {
     box-shadow: none !important;
     background-color: var(--bg-light);

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -2,7 +2,7 @@ import './InsightLegend.scss'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { ChartDisplayType, FilterType, InsightType } from '~/types'
+import { ChartDisplayType, FilterType } from '~/types'
 import clsx from 'clsx'
 import { isFilterWithDisplay } from 'scenes/insights/sharedUtils'
 import { InsightLegendRow } from './InsightLegendRow'
@@ -13,20 +13,15 @@ export interface InsightLegendProps {
     inCardView?: boolean
 }
 
-const trendTypeCanShowLegendDenyList = [
+export const trendTypeCanShowLegendDenyList = [
     ChartDisplayType.WorldMap,
     ChartDisplayType.ActionsTable,
     ChartDisplayType.BoldNumber,
     ChartDisplayType.ActionsBarValue,
 ]
 
-const insightViewCanShowLegendAllowList = [InsightType.TRENDS, InsightType.STICKINESS]
-
 export const shouldShowLegend = (filters: Partial<FilterType>): boolean =>
-    insightViewCanShowLegendAllowList.includes(filters.insight || InsightType.TRENDS) &&
-    isFilterWithDisplay(filters) &&
-    !!filters.display &&
-    !trendTypeCanShowLegendDenyList.includes(filters.display)
+    isFilterWithDisplay(filters) && !!filters.display && !trendTypeCanShowLegendDenyList.includes(filters.display)
 
 function shouldHighlightThisRow(
     hiddenLegendKeys: Record<string, boolean | undefined>,

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -13,7 +13,7 @@ export interface InsightLegendProps {
     inCardView?: boolean
 }
 
-export const trendTypeCanShowLegendDenyList = [
+export const displayTypesWithoutLegend = [
     ChartDisplayType.WorldMap,
     ChartDisplayType.ActionsTable,
     ChartDisplayType.BoldNumber,
@@ -21,7 +21,7 @@ export const trendTypeCanShowLegendDenyList = [
 ]
 
 export const shouldShowLegend = (filters: Partial<FilterType>): boolean =>
-    isFilterWithDisplay(filters) && !!filters.display && !trendTypeCanShowLegendDenyList.includes(filters.display)
+    isFilterWithDisplay(filters) && !!filters.display && !displayTypesWithoutLegend.includes(filters.display)
 
 function shouldHighlightThisRow(
     hiddenLegendKeys: Record<string, boolean | undefined>,

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -2,37 +2,14 @@ import './InsightLegend.scss'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { ChartDisplayType, FilterType } from '~/types'
 import clsx from 'clsx'
-import { isFilterWithDisplay } from 'scenes/insights/sharedUtils'
 import { InsightLegendRow } from './InsightLegendRow'
+import { shouldShowLegend, shouldHighlightThisRow } from './utils'
 
 export interface InsightLegendProps {
     readOnly?: boolean
     horizontal?: boolean
     inCardView?: boolean
-}
-
-export const displayTypesWithoutLegend = [
-    ChartDisplayType.WorldMap,
-    ChartDisplayType.ActionsTable,
-    ChartDisplayType.BoldNumber,
-    ChartDisplayType.ActionsBarValue,
-]
-
-export const shouldShowLegend = (filters: Partial<FilterType>): boolean =>
-    isFilterWithDisplay(filters) && !!filters.display && !displayTypesWithoutLegend.includes(filters.display)
-
-function shouldHighlightThisRow(
-    hiddenLegendKeys: Record<string, boolean | undefined>,
-    rowIndex: number,
-    highlightedSeries: number | null
-): boolean {
-    const numberOfSeriesToSkip = Object.entries(hiddenLegendKeys).filter(
-        ([key, isHidden]) => isHidden && Number(key) < rowIndex
-    ).length
-    const isSkipped = hiddenLegendKeys[rowIndex]
-    return highlightedSeries !== null && !isSkipped && highlightedSeries + numberOfSeriesToSkip === rowIndex
 }
 
 export function InsightLegend({ horizontal, inCardView, readOnly = false }: InsightLegendProps): JSX.Element | null {

--- a/frontend/src/lib/components/InsightLegend/InsightLegendButton.scss
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendButton.scss
@@ -1,0 +1,10 @@
+.InsightLegendButton {
+    display: flex;
+    align-items: center;
+
+    .InsightLegendButton-title {
+        margin-left: 0.5rem;
+        font-size: 14px;
+        font-weight: 500;
+    }
+}

--- a/frontend/src/lib/components/InsightLegend/InsightLegendButton.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendButton.tsx
@@ -5,7 +5,7 @@ import { IconLegend } from 'lib/lemon-ui/icons'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { TrendsFilterType } from '~/types'
-import { shouldShowLegend } from './InsightLegend'
+import { shouldShowLegend } from './utils'
 
 export function InsightLegendButtonDataExploration(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)

--- a/frontend/src/lib/components/InsightLegend/InsightLegendButton.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendButton.tsx
@@ -1,18 +1,65 @@
 import { Button } from 'antd'
 import { useActions, useValues } from 'kea'
 import { IconLegend } from 'lib/lemon-ui/icons'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { isFilterWithDisplay } from 'scenes/insights/sharedUtils'
+import { TrendsFilterType } from '~/types'
 import { shouldShowLegend } from './InsightLegend'
+
+export function InsightLegendButtonDataExploration(): JSX.Element | null {
+    const { insightProps } = useValues(insightLogic)
+    const { insightFilter, hasLegend } = useValues(insightDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightDataLogic(insightProps))
+
+    const showLegend = (insightFilter as TrendsFilterType)?.show_legend
+    const toggleShowLegend = (): void => {
+        updateInsightFilter({ show_legend: !showLegend })
+    }
+
+    return (
+        <InsightLegendButtonComponent
+            hasLegend={hasLegend}
+            showLegend={showLegend}
+            toggleShowLegend={toggleShowLegend}
+        />
+    )
+}
 
 export function InsightLegendButton(): JSX.Element | null {
     const { filters } = useValues(insightLogic)
     const { toggleInsightLegend } = useActions(insightLogic)
 
-    return shouldShowLegend(filters) && isFilterWithDisplay(filters) ? (
-        <Button className="InsightLegendButton" onClick={toggleInsightLegend}>
+    const hasLegend = shouldShowLegend(filters)
+    const showLegend = (filters as TrendsFilterType).show_legend
+
+    return (
+        <InsightLegendButtonComponent
+            hasLegend={hasLegend}
+            showLegend={showLegend}
+            toggleShowLegend={toggleInsightLegend}
+        />
+    )
+}
+
+type InsightLegendButtonComponentProps = {
+    hasLegend: boolean
+    showLegend?: boolean
+    toggleShowLegend: () => void
+}
+
+export function InsightLegendButtonComponent({
+    hasLegend,
+    showLegend,
+    toggleShowLegend,
+}: InsightLegendButtonComponentProps): JSX.Element | null {
+    if (!hasLegend) {
+        return null
+    }
+
+    return (
+        <Button className="InsightLegendButton" onClick={toggleShowLegend}>
             <IconLegend />
-            <span className="InsightLegendButton-title">{filters.show_legend ? 'Hide' : 'Show'} legend</span>
+            <span className="InsightLegendButton-title">{showLegend ? 'Hide' : 'Show'} legend</span>
         </Button>
-    ) : null
+    )
 }

--- a/frontend/src/lib/components/InsightLegend/InsightLegendButton.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendButton.tsx
@@ -1,3 +1,4 @@
+import './InsightLegendButton.scss'
 import { Button } from 'antd'
 import { useActions, useValues } from 'kea'
 import { IconLegend } from 'lib/lemon-ui/icons'

--- a/frontend/src/lib/components/InsightLegend/utils.ts
+++ b/frontend/src/lib/components/InsightLegend/utils.ts
@@ -1,0 +1,24 @@
+import { ChartDisplayType, FilterType } from '~/types'
+import { isFilterWithDisplay } from 'scenes/insights/sharedUtils'
+
+export const displayTypesWithoutLegend = [
+    ChartDisplayType.WorldMap,
+    ChartDisplayType.ActionsTable,
+    ChartDisplayType.BoldNumber,
+    ChartDisplayType.ActionsBarValue,
+]
+
+export const shouldShowLegend = (filters: Partial<FilterType>): boolean =>
+    isFilterWithDisplay(filters) && !!filters.display && !displayTypesWithoutLegend.includes(filters.display)
+
+export function shouldHighlightThisRow(
+    hiddenLegendKeys: Record<string, boolean | undefined>,
+    rowIndex: number,
+    highlightedSeries: number | null
+): boolean {
+    const numberOfSeriesToSkip = Object.entries(hiddenLegendKeys).filter(
+        ([key, isHidden]) => isHidden && Number(key) < rowIndex
+    ).length
+    const isSkipped = hiddenLegendKeys[rowIndex]
+    return highlightedSeries !== null && !isSkipped && highlightedSeries + numberOfSeriesToSkip === rowIndex
+}

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -19,7 +19,7 @@ import {
 import clsx from 'clsx'
 import { PathCanvasLabel } from 'scenes/paths/PathsLabel'
 import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
-import { InsightLegendButton } from 'lib/components/InsightLegend/InsightLegendButton'
+import { InsightLegendButtonDataExploration } from 'lib/components/InsightLegend/InsightLegendButton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { Animation } from 'lib/components/Animation/Animation'
 import { AnimationType } from 'lib/animations/animations'
@@ -219,7 +219,7 @@ export function InsightContainer({
                         <div>
                             {isFunnels ? <FunnelCanvasLabel /> : null}
                             {isPaths ? <PathCanvasLabel /> : null}
-                            <InsightLegendButton />
+                            <InsightLegendButtonDataExploration />
                         </div>
                     </div>
                     {!!BlockingEmptyState ? (

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -38,7 +38,7 @@ import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { subscriptions } from 'kea-subscriptions'
 import { queryExportContext } from '~/queries/query'
 import { objectsEqual } from 'lib/utils'
-import { trendTypeCanShowLegendDenyList } from 'lib/components/InsightLegend/InsightLegend'
+import { displayTypesWithoutLegend } from 'lib/components/InsightLegend/InsightLegend'
 
 const defaultQuery = (insightProps: InsightLogicProps): Node => {
     const filters = insightProps.cachedInsight?.filters
@@ -137,7 +137,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
         hasLegend: [
             (s) => [s.isTrends, s.isStickiness, s.display],
             (isTrends, isStickiness, display) =>
-                (isTrends || isStickiness) && !!display && !trendTypeCanShowLegendDenyList.includes(display),
+                (isTrends || isStickiness) && !!display && !displayTypesWithoutLegend.includes(display),
         ],
 
         isQueryBasedInsight: [

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -38,7 +38,7 @@ import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { subscriptions } from 'kea-subscriptions'
 import { queryExportContext } from '~/queries/query'
 import { objectsEqual } from 'lib/utils'
-import { displayTypesWithoutLegend } from 'lib/components/InsightLegend/InsightLegend'
+import { displayTypesWithoutLegend } from 'lib/components/InsightLegend/utils'
 
 const defaultQuery = (insightProps: InsightLogicProps): Node => {
     const filters = insightProps.cachedInsight?.filters

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -38,6 +38,7 @@ import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { subscriptions } from 'kea-subscriptions'
 import { queryExportContext } from '~/queries/query'
 import { objectsEqual } from 'lib/utils'
+import { trendTypeCanShowLegendDenyList } from 'lib/components/InsightLegend/InsightLegend'
 
 const defaultQuery = (insightProps: InsightLogicProps): Node => {
     const filters = insightProps.cachedInsight?.filters
@@ -131,6 +132,12 @@ export const insightDataLogic = kea<insightDataLogicType>([
         isNonTimeSeriesDisplay: [
             (s) => [s.display],
             (display) => !!display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display),
+        ],
+
+        hasLegend: [
+            (s) => [s.isTrends, s.isStickiness, s.display],
+            (isTrends, isStickiness, display) =>
+                (isTrends || isStickiness) && !!display && !trendTypeCanShowLegendDenyList.includes(display),
         ],
 
         isQueryBasedInsight: [


### PR DESCRIPTION
## Problem

The legend button is displayed when it shouldn't be (e.g. funnels) and doesn't work for data exploration.

## Changes

This PR:
- adds a data exploration version of the legend button
- does a bit of refactoring for upcoming changes

## How did you test this code?

Verified that the button works for the existing version and data exploration.