### PR TITLE
feat(data-exploration): convert funnel bar chart

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
@@ -2,7 +2,7 @@ import { useValues } from 'kea'
 import { useMemo } from 'react'
 import { funnelLogic } from '../funnelLogic'
 import './FunnelBarChart.scss'
-import { ChartParams } from '~/types'
+import { ChartParams, FunnelStepWithConversionMetrics } from '~/types'
 import clsx from 'clsx'
 import { useScrollable } from 'lib/hooks/useScrollable'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
@@ -10,16 +10,41 @@ import { useFunnelTooltip } from '../useFunnelTooltip'
 import { StepLegend } from './StepLegend'
 import { StepBars } from './StepBars'
 import { StepBarLabels } from './StepBarLabels'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { funnelDataLogic } from '../funnelDataLogic'
+
+export function FunnelBarChartDataExploration(props: ChartParams): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { visibleStepsWithConversionMetrics } = useValues(funnelDataLogic(insightProps))
+    return (
+        <FunnelBarChartComponent
+            isUsingDataExploration
+            visibleStepsWithConversionMetrics={visibleStepsWithConversionMetrics}
+            {...props}
+        />
+    )
+}
+
+export function FunnelBarChart(props: ChartParams): JSX.Element {
+    const { visibleStepsWithConversionMetrics } = useValues(funnelLogic)
+    return <FunnelBarChartComponent visibleStepsWithConversionMetrics={visibleStepsWithConversionMetrics} {...props} />
+}
 
 interface FunnelBarChartCSSProperties extends React.CSSProperties {
     '--bar-width': string
     '--bar-row-height': string
 }
 
-/** Funnel results in bar form. Requires `funnelLogic` to be bound. */
-export function FunnelBarChart({ showPersonsModal = true }: ChartParams): JSX.Element {
-    const { visibleStepsWithConversionMetrics } = useValues(funnelLogic)
+type FunnelBarChartComponent = {
+    visibleStepsWithConversionMetrics: FunnelStepWithConversionMetrics[]
+    isUsingDataExploration?: boolean
+} & ChartParams
 
+export function FunnelBarChartComponent({
+    showPersonsModal = true,
+    isUsingDataExploration = false,
+    visibleStepsWithConversionMetrics,
+}: FunnelBarChartComponent): JSX.Element {
     const [scrollRef, scrollableClassNames] = useScrollable()
     const { height } = useResizeObserver({ ref: scrollRef })
 

--- a/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { useScrollable } from 'lib/hooks/useScrollable'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { useFunnelTooltip } from '../useFunnelTooltip'
-import { StepLegend } from './StepLegend'
+import { StepLegend, StepLegendDataExploration } from './StepLegend'
 import { StepBars } from './StepBars'
 import { StepBarLabels } from './StepBarLabels'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -112,12 +112,21 @@ export function FunnelBarChartComponent({
                         <td />
                         {visibleStepsWithConversionMetrics.map((step, stepIndex) => (
                             <td key={stepIndex}>
-                                <StepLegend
-                                    step={step.nested_breakdown?.length ? step.nested_breakdown[0] : step}
-                                    stepIndex={stepIndex}
-                                    showTime={showTime}
-                                    showPersonsModal={showPersonsModal}
-                                />
+                                {isUsingDataExploration ? (
+                                    <StepLegendDataExploration
+                                        step={step.nested_breakdown?.length ? step.nested_breakdown[0] : step}
+                                        stepIndex={stepIndex}
+                                        showTime={showTime}
+                                        showPersonsModal={showPersonsModal}
+                                    />
+                                ) : (
+                                    <StepLegend
+                                        step={step.nested_breakdown?.length ? step.nested_breakdown[0] : step}
+                                        stepIndex={stepIndex}
+                                        showTime={showTime}
+                                        showPersonsModal={showPersonsModal}
+                                    />
+                                )}
                             </td>
                         ))}
                     </tr>

--- a/frontend/src/scenes/funnels/FunnelBarChart/StepLegend.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart/StepLegend.tsx
@@ -10,14 +10,33 @@ import { capitalizeFirstLetter, humanFriendlyDuration, percentage, pluralize } f
 import { ValueInspectorButton } from '../ValueInspectorButton'
 import { FunnelStepMore } from '../FunnelStepMore'
 import { userLogic } from 'scenes/userLogic'
+import { Noun } from '~/models/groupsModel'
 
-interface StepLegendProps extends ChartParams {
+type StepLegendProps = {
     step: FunnelStepWithConversionMetrics
     stepIndex: number
     showTime: boolean
-}
-export function StepLegend({ step, stepIndex, showTime, showPersonsModal }: StepLegendProps): JSX.Element {
+} & ChartParams
+
+export function StepLegendDataExploration(props: StepLegendProps): JSX.Element {
     const { aggregationTargetLabel } = useValues(funnelLogic)
+    return <StepLegendComponent aggregationTargetLabel={aggregationTargetLabel} {...props} />
+}
+
+export function StepLegend(props: StepLegendProps): JSX.Element {
+    const { aggregationTargetLabel } = useValues(funnelLogic)
+    return <StepLegendComponent aggregationTargetLabel={aggregationTargetLabel} {...props} />
+}
+
+type StepLegendComponentProps = StepLegendProps & { aggregationTargetLabel: Noun }
+
+export function StepLegendComponent({
+    step,
+    stepIndex,
+    showTime,
+    showPersonsModal,
+    aggregationTargetLabel,
+}: StepLegendComponentProps): JSX.Element {
     const { openPersonsModalForStep } = useActions(funnelLogic)
     const { hasAvailableFeature } = useValues(userLogic)
 

--- a/frontend/src/scenes/trends/types.ts
+++ b/frontend/src/scenes/trends/types.ts
@@ -1,11 +1,13 @@
 import { ActionFilter, ActorType, FilterType, GraphDataset, TrendResult } from '~/types'
 
+// TODO: This does not match the actual API response
 export interface TrendResponse {
     result: TrendResult[]
     filters: FilterType
     next?: string
 }
 
+// TODO: Move to ~/types
 export interface IndexedTrendResult extends TrendResult {
     /**
      * The index after applying visualization-specific sorting (e.g. for pie


### PR DESCRIPTION
## Problem

The funnel bar chart is broken for data exploration.

## Changes

This PR converts the funnel bar chart to data exploration. **The chart component is not yet mounted for data exploration, as the Funnel component one level higher needed to be converted before, see https://github.com/PostHog/posthog/pull/14700.**

## How did you test this code?

Compared the funnel bar chart with data exploration on and off, by manually replacing the component.