### PR TITLE
feat(data-exploration): convert funnel histogram

### DIFF
--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -1,7 +1,7 @@
 import './Funnel.scss'
 import { BindLogic, useValues } from 'kea'
 import { ChartParams, FunnelVizType } from '~/types'
-import { FunnelHistogram } from './FunnelHistogram'
+import { FunnelHistogram, FunnelHistogramDataExploration } from './FunnelHistogram'
 import { funnelLogic } from './funnelLogic'
 import { FunnelLineGraph } from 'scenes/funnels/FunnelLineGraph'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -20,7 +20,7 @@ export function FunnelDataExploration(props: ChartParams): JSX.Element {
     }
 
     if (funnel_viz_type == FunnelVizType.TimeToConvert) {
-        return <FunnelHistogram />
+        return <FunnelHistogramDataExploration />
     }
 
     return (

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -8,6 +8,31 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { FunnelLayout } from 'lib/constants'
 import { FunnelBarChart } from './FunnelBarChart/FunnelBarChart'
 import { FunnelBarGraph } from './FunnelBarGraph'
+import { funnelDataLogic } from './funnelDataLogic'
+
+export function FunnelDataExploration(props: ChartParams): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
+    const { funnel_viz_type, layout } = funnelsFilter
+
+    if (funnel_viz_type == FunnelVizType.Trends) {
+        return <FunnelLineGraph {...props} />
+    }
+
+    if (funnel_viz_type == FunnelVizType.TimeToConvert) {
+        return <FunnelHistogram />
+    }
+
+    return (
+        <BindLogic logic={funnelLogic} props={insightProps}>
+            {(layout || FunnelLayout.vertical) === FunnelLayout.vertical ? (
+                <FunnelBarChart {...props} />
+            ) : (
+                <FunnelBarGraph {...props} />
+            )}
+        </BindLogic>
+    )
+}
 
 export function Funnel(props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -13,7 +13,7 @@ import { funnelDataLogic } from './funnelDataLogic'
 export function FunnelDataExploration(props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
-    const { funnel_viz_type, layout } = funnelsFilter
+    const { funnel_viz_type, layout } = funnelsFilter || {}
 
     if (funnel_viz_type == FunnelVizType.Trends) {
         return <FunnelLineGraph {...props} />

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -6,7 +6,7 @@ import { funnelLogic } from './funnelLogic'
 import { FunnelLineGraph } from 'scenes/funnels/FunnelLineGraph'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { FunnelLayout } from 'lib/constants'
-import { FunnelBarChart } from './FunnelBarChart/FunnelBarChart'
+import { FunnelBarChart, FunnelBarChartDataExploration } from './FunnelBarChart/FunnelBarChart'
 import { FunnelBarGraph } from './FunnelBarGraph'
 import { funnelDataLogic } from './funnelDataLogic'
 
@@ -26,7 +26,7 @@ export function FunnelDataExploration(props: ChartParams): JSX.Element {
     return (
         <BindLogic logic={funnelLogic} props={insightProps}>
             {(layout || FunnelLayout.vertical) === FunnelLayout.vertical ? (
-                <FunnelBarChart {...props} />
+                <FunnelBarChartDataExploration {...props} />
             ) : (
                 <FunnelBarGraph {...props} />
             )}

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -7,11 +7,36 @@ import { funnelLogic } from './funnelLogic'
 import { Histogram } from 'scenes/insights/views/Histogram'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import './FunnelHistogram.scss'
+import { HistogramGraphDatum } from '~/types'
+import { funnelDataLogic } from './funnelDataLogic'
+
+export function FunnelHistogramDataExploration(): JSX.Element | null {
+    const { insightProps, isInDashboardContext } = useValues(insightLogic)
+    const { histogramGraphData } = useValues(funnelDataLogic(insightProps))
+
+    return (
+        <FunnelHistogramComponent isInDashboardContext={isInDashboardContext} histogramGraphData={histogramGraphData} />
+    )
+}
 
 export function FunnelHistogram(): JSX.Element | null {
     const { insightProps, isInDashboardContext } = useValues(insightLogic)
-    const logic = funnelLogic(insightProps)
-    const { histogramGraphData } = useValues(logic)
+    const { histogramGraphData } = useValues(funnelLogic(insightProps))
+
+    return (
+        <FunnelHistogramComponent isInDashboardContext={isInDashboardContext} histogramGraphData={histogramGraphData} />
+    )
+}
+
+type FunnelHistogramComponentProps = {
+    isInDashboardContext: boolean
+    histogramGraphData: HistogramGraphDatum[] | null
+}
+
+export function FunnelHistogramComponent({
+    isInDashboardContext,
+    histogramGraphData,
+}: FunnelHistogramComponentProps): JSX.Element | null {
     const ref = useRef(null)
     const [width, height] = useSize(ref)
 

--- a/frontend/src/scenes/insights/views/Funnels/FunnelInsight.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelInsight.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
-import { Funnel } from 'scenes/funnels/Funnel'
+import { Funnel, FunnelDataExploration } from 'scenes/funnels/Funnel'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 
@@ -17,7 +17,7 @@ export function FunnelInsightDataExploration(): JSX.Element {
                 'non-empty-state': nonEmptyState,
             })}
         >
-            <Funnel />
+            <FunnelDataExploration />
         </div>
     )
 }

--- a/frontend/src/scenes/trends/types.ts
+++ b/frontend/src/scenes/trends/types.ts
@@ -1,13 +1,11 @@
 import { ActionFilter, ActorType, FilterType, GraphDataset, TrendResult } from '~/types'
 
-// TODO: This does not match the actual API response
 export interface TrendResponse {
     result: TrendResult[]
     filters: FilterType
     next?: string
 }
 
-// TODO: Move to ~/types
 export interface IndexedTrendResult extends TrendResult {
     /**
      * The index after applying visualization-specific sorting (e.g. for pie


### PR DESCRIPTION
This PR is a rebase of https://github.com/PostHog/posthog/pull/14606 with upstream `data-exploration-legends-5`, so that the data exploration version of funnel bar chart can be used.

## Problem

Part of the ongoing effort to convert all insights to data exploration.

## Changes

This PR
- Adds a `FunnelDataExploration` variant of `Funnel` (the component to display the funnel viz)
- Uses the already converted selectors to add a `FunnelHistogramDataExploration` variant of `FunnelHistogram` (the viz for the "time to convert" graph
- Use the data exploration variant of `FunnelBarChart` conditionally

## How did you test this code?

Clicking around.