### PR TITLE
fix: use kea localstorage plugin for refresh notice

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, key, listeners, path, props, reducers, resetContext, selectors } from 'kea'
 import { promptLogic } from 'lib/logic/promptLogic'
 import { getEventNamesForAction, objectsEqual, sum, toParams, uuid } from 'lib/utils'
 import posthog from 'posthog-js'
@@ -64,6 +64,11 @@ import { dayjs, now } from 'lib/dayjs'
 import { isInsightVizNode } from '~/queries/utils'
 import { userLogic } from 'scenes/userLogic'
 import { globalInsightLogic } from './globalInsightLogic'
+import { localStoragePlugin } from 'kea-localstorage'
+
+resetContext({
+    plugins: [localStoragePlugin],
+})
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 const SHOW_TIMEOUT_MESSAGE_AFTER = 15000
@@ -1165,9 +1170,6 @@ export const insightLogic = kea<insightLogicType>([
                 insightSceneLogic.findMounted()?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
                 eventUsageLogic.actions.reportInsightsTabReset()
             }
-        },
-        acknowledgeRefreshButtonChanged: () => {
-            localStorage.setItem('acknowledged_refresh_button_changed', 'true')
         },
     })),
     events(({ props, values, actions }) => ({


### PR DESCRIPTION
## Problem

The notice about the refresh button kept popping up and was driving me nuts. 
<img width="396" alt="image" src="https://user-images.githubusercontent.com/18598166/224600912-c7cf3c86-cfd0-4fca-9e77-0c127d8939e4.png">

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Changed it to use the kea localstorage plugin properly. 

There does seem to be one other bug here in that the localstorage key isn't actually set until I navigate elsewhere. If I hit the menu icon the notice disappears, but the localstorage value isn't actually changed. But when I do something else like click another nav item, _then_ the value is actually set. If instead of navigating elsewhere I just refresh the page, I get the notice again. This seems more like an issue with Kea than with the implementation? Regardless, this PR makes it work in the majority of cases, so I'd say it's an improvement. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
