### PR TITLE
fix: redirect after onboarding completed & invites sent

### DIFF
--- a/frontend/src/scenes/ingestion/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/ingestionLogic.ts
@@ -494,9 +494,10 @@ export const ingestionLogic = kea<ingestionLogicType>([
         setState: () => getUrl(values),
         updateCurrentTeamSuccess: (val) => {
             if (
-                router.values.location.pathname.includes(
+                (router.values.location.pathname.includes(
                     values.showBillingStep ? '/ingestion/billing' : '/ingestion/superpowers'
-                ) &&
+                ) ||
+                    router.values.location.pathname.includes('/ingestion/invites-sent')) &&
                 val.payload?.completed_snippet_onboarding
             ) {
                 return combineUrl(urls.events(), { onboarding_completed: true }).url


### PR DESCRIPTION
## Problem

Reported by a user in [slack](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1678484652387609?thread_ts=1678484624.825929&cid=C01GLBKHKQT), this screen was not redirecting properly after the user clicked the Continue button.

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/18598166/224603359-93d7aa91-0c17-4c7a-bf53-42a505c8e923.png">


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Fixed it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 No tests here... :(

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
