### PR TITLE
feat(actions): support "any event" when creating an action

### DIFF
--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -1,4 +1,4 @@
-import { EventName } from './EventName'
+import { LemonEventName } from './EventName'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { URL_MATCHING_HINTS } from 'scenes/actions/hints'
 import { Col, Radio, RadioChangeEvent } from 'antd'
@@ -55,7 +55,7 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                     {step.event != null && step.event !== '$autocapture' && step.event !== '$pageview' && (
                         <div className="space-y-1">
                             <LemonLabel>Event name</LemonLabel>
-                            <EventName
+                            <LemonEventName
                                 value={step.event}
                                 onChange={(value) =>
                                     sendStep({
@@ -63,6 +63,7 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                                         event: value || '',
                                     })
                                 }
+                                placeholder="Any event"
                             />
 
                             <small>
@@ -88,26 +89,24 @@ export function ActionStep({ step, actionId, isOnlyStep, index, identifier, onDe
                         </div>
                     )}
 
-                    {step.event && (
-                        <div className="mt-6 space-y-2">
-                            <h3>Filters</h3>
-                            {(!step.properties || step.properties.length === 0) && (
-                                <div className="text-muted">This match group has no additional filters.</div>
-                            )}
-                            <PropertyFilters
-                                propertyFilters={step.properties}
-                                pageKey={identifier}
-                                eventNames={step.event ? [step.event] : []}
-                                onChange={(properties) => {
-                                    sendStep({
-                                        ...step,
-                                        properties: properties as [],
-                                    })
-                                }}
-                                showConditionBadge
-                            />
-                        </div>
-                    )}
+                    <div className="mt-6 space-y-2">
+                        <h3>Filters</h3>
+                        {(!step.properties || step.properties.length === 0) && (
+                            <div className="text-muted">This match group has no additional filters.</div>
+                        )}
+                        <PropertyFilters
+                            propertyFilters={step.properties}
+                            pageKey={identifier}
+                            eventNames={step.event ? [step.event] : []}
+                            onChange={(properties) => {
+                                sendStep({
+                                    ...step,
+                                    properties: properties as [],
+                                })
+                            }}
+                            showConditionBadge
+                        />
+                    </div>
                 </div>
             </div>
         </Col>

--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -1,30 +1,14 @@
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { LemonTaxonomicStringPopover, TaxonomicStringPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { LemonTaxonomicStringPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 interface EventNameInterface {
     value: string
     onChange: (value: string) => void
     disabled?: boolean
+    placeholder?: string
 }
-
-export function EventName({ value, onChange }: EventNameInterface): JSX.Element {
-    return (
-        <TaxonomicStringPopover
-            groupType={TaxonomicFilterGroupType.Events}
-            onChange={onChange}
-            value={value}
-            type="secondary"
-            style={{ maxWidth: '24rem' }}
-            placeholder="Choose an event"
-            dataAttr="event-name-box"
-            renderValue={(v) => <PropertyKeyInfo value={v} disablePopover />}
-            allowClear
-        />
-    )
-}
-
-export function LemonEventName({ value, onChange, disabled }: EventNameInterface): JSX.Element {
+export function LemonEventName({ value, onChange, disabled, placeholder }: EventNameInterface): JSX.Element {
     return (
         <LemonTaxonomicStringPopover
             groupType={TaxonomicFilterGroupType.Events}
@@ -33,7 +17,7 @@ export function LemonEventName({ value, onChange, disabled }: EventNameInterface
             value={value}
             type="secondary"
             status="stealth"
-            placeholder="Select an event"
+            placeholder={placeholder ?? 'Select an event'}
             dataAttr="event-name-box"
             renderValue={(v) => <PropertyKeyInfo value={v} disablePopover />}
             allowClear

--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -82,13 +82,6 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 saveAction: async (updatedAction: ActionEditType, breakpoint) => {
                     let action = { ...updatedAction }
 
-                    action.steps = action.steps
-                        ? action.steps.filter((step) => {
-                              // Will discard any match groups that were added but for which a type of event selection has not been made
-                              return step.event
-                          })
-                        : []
-
                     try {
                         if (action.id) {
                             action = await api.actions.update(action.id, action, props.temporaryToken)

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -199,7 +199,9 @@ def action_to_expr(action: Action) -> ast.Expr:
 
     or_queries = []
     for step in steps:
-        exprs: List[ast.Expr] = [parse_expr("event = {event}", {"event": ast.Constant(value=step.event)})]
+        exprs: List[ast.Expr] = []
+        if step.event is not None and step.event != "":
+            exprs.append(parse_expr("event = {event}", {"event": ast.Constant(value=step.event)}))
 
         if step.event == AUTOCAPTURE_EVENT:
             if step.selector:

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -200,7 +200,7 @@ def action_to_expr(action: Action) -> ast.Expr:
     or_queries = []
     for step in steps:
         exprs: List[ast.Expr] = []
-        if step.event is not None and step.event != "":
+        if step.event:
             exprs.append(parse_expr("event = {event}", {"event": ast.Constant(value=step.event)}))
 
         if step.event == AUTOCAPTURE_EVENT:

--- a/posthog/models/action/util.py
+++ b/posthog/models/action/util.py
@@ -98,7 +98,7 @@ def filter_event(
             conditions.append(f"{value_expr} LIKE %({prop_name})s")
             params.update({prop_name: f"%{step.url}%"})
 
-    if step.event is not None and step.event != "":
+    if step.event:
         params.update({f"{prepend}_{index}": step.event})
         conditions.append(f"event = %({prepend}_{index})s")
 

--- a/posthog/models/action/util.py
+++ b/posthog/models/action/util.py
@@ -79,7 +79,7 @@ def filter_event(
 ) -> Tuple[List[str], Dict]:
     from posthog.models.property.util import get_property_string_expr
 
-    params = {"{}_{}".format(prepend, index): step.event}
+    params = {}
     conditions = []
 
     if table_name != "":
@@ -98,7 +98,9 @@ def filter_event(
             conditions.append(f"{value_expr} LIKE %({prop_name})s")
             params.update({prop_name: f"%{step.url}%"})
 
-    conditions.append(f"event = %({prepend}_{index})s")
+    if step.event is not None and step.event != "":
+        params.update({f"{prepend}_{index}": step.event})
+        conditions.append(f"event = %({prepend}_{index})s")
 
     return conditions, params
 


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/14694

Sometimes you'd like an action that wildcard matches event names. With HogQL you could (`event like 'bla%'`), though our interface always forces you to choose an event when creating an action.

## Changes

Adds an "Any event" option when creating an action:

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/53387/224646455-490a7bbf-86b4-4678-b748-e2fe0de443e9.png">

(doesn't work on toolbar because custom property on actions never worked on the toolbar)

This works with both the HogQL powered and the old event lists:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/53387/224647476-53a997bf-dfec-41b1-ada6-bc366e18466a.png">
<img width="731" alt="image" src="https://user-images.githubusercontent.com/53387/224647562-fd456f2d-063d-400a-87dd-b18213845265.png">

and trends and other places...

<img width="1379" alt="image" src="https://user-images.githubusercontent.com/53387/224647761-1ff8e9f4-e88b-4a77-bc26-cce27888587c.png">



## How did you test this code?

Tested that everything works through the interface.

Tested webhooks from plugin server:

<img width="1695" alt="image" src="https://user-images.githubusercontent.com/53387/224646262-802f6e59-6f8e-4980-bad8-4a54d8627c47.png">

Running CI for more tests