### PR TITLE
chore(celery): add scheduler tasks to KNOWN_CELERY_TASK_IDENTIFIERS

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -388,7 +388,7 @@ def ingestion_lag():
         pass
 
 
-KNOWN_CELERY_TASK_IDENTIFIERS = {"pluginJob"}
+KNOWN_CELERY_TASK_IDENTIFIERS = {"pluginJob", "runEveryHour", "runEveryMinute", "runEveryDay"}
 
 
 @app.task(ignore_result=True)


### PR DESCRIPTION
## Problem

Spotty timeseries for these identifiers, that can bring aggregation artifacts.


![image](https://user-images.githubusercontent.com/6241083/224693272-cba33486-84e0-4963-b2d2-5397cef22ce1.png)


## Changes

Add `"runEveryHour", "runEveryMinute", "runEveryDay"` to the know task identifiers, so that we can monitor them better.

If these go up, it's the sign that `posthog-plugins-scheduler` is too slow.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
