### PR TITLE
fix: do not throw on empty funnel results

### DIFF
--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -9,11 +9,11 @@ import { FunnelVizType, InsightLogicProps, InsightModel, InsightType } from '~/t
 import { ActionsNode, DataNode, EventsNode, FunnelsQuery, InsightQueryNode, NodeKind } from '~/queries/schema'
 import {
     funnelResult,
-    funnelResultWithBreakdown,
-    funnelResultWithMultiBreakdown,
     funnelResultTimeToConvert,
     funnelResultTimeToConvertWithoutConversions,
     funnelResultTrends,
+    funnelResultWithBreakdown,
+    funnelResultWithMultiBreakdown,
 } from './__mocks__/funnelDataLogicMocks'
 
 let logic: ReturnType<typeof funnelDataLogic.build>
@@ -200,6 +200,18 @@ describe('funnelDataLogic', () => {
                             }),
                         ]),
                     ]),
+                })
+            })
+
+            it('with breakdown and no results', async () => {
+                const insight: Partial<InsightModel> = {
+                    result: [],
+                }
+
+                await expectLogic(logic, () => {
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
+                }).toMatchValues({
+                    results: expect.arrayContaining([]),
                 })
             })
 

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -98,7 +98,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
             (insightData: FunnelAPIResponse | null): FunnelResultType => {
                 // TODO: after hooking up data manager, check that we have a funnels result here
                 if (insightData?.result) {
-                    if (isBreakdownFunnelResults(insightData.result) && insightData.result[0][0].breakdowns) {
+                    if (isBreakdownFunnelResults(insightData.result) && insightData.result?.[0]?.[0]?.breakdowns) {
                         // in order to stop the UI having to check breakdowns and breakdown
                         // this collapses breakdowns onto the breakdown property
                         return insightData.result.map((series) =>


### PR DESCRIPTION
## Problem

<img width="972" alt="Screenshot 2023-03-13 at 15 46 07" src="https://user-images.githubusercontent.com/984817/224753801-24bffd51-c792-4186-8357-24ef3913857d.png">

If a funnel had a breakdown and no results we show an error

## Changes

don't

## How did you test this code?

developer test and 👀 locally