### PR TITLE
feat(data-exploration): convert funnel bar graph

### DIFF
--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -1,14 +1,16 @@
 import './Funnel.scss'
 import { BindLogic, useValues } from 'kea'
-import { ChartParams, FunnelVizType } from '~/types'
-import { FunnelHistogram, FunnelHistogramDataExploration } from './FunnelHistogram'
-import { funnelLogic } from './funnelLogic'
-import { FunnelLineGraph } from 'scenes/funnels/FunnelLineGraph'
+
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { FunnelLayout } from 'lib/constants'
-import { FunnelBarChart, FunnelBarChartDataExploration } from './FunnelBarChart/FunnelBarChart'
-import { FunnelBarGraph } from './FunnelBarGraph/FunnelBarGraph'
+import { funnelLogic } from './funnelLogic'
 import { funnelDataLogic } from './funnelDataLogic'
+
+import { ChartParams, FunnelVizType } from '~/types'
+import { FunnelLayout } from 'lib/constants'
+import { FunnelHistogram, FunnelHistogramDataExploration } from './FunnelHistogram'
+import { FunnelLineGraph } from 'scenes/funnels/FunnelLineGraph'
+import { FunnelBarChart, FunnelBarChartDataExploration } from './FunnelBarChart/FunnelBarChart'
+import { FunnelBarGraph, FunnelBarGraphDataExploration } from './FunnelBarGraph/FunnelBarGraph'
 
 export function FunnelDataExploration(props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
@@ -28,7 +30,7 @@ export function FunnelDataExploration(props: ChartParams): JSX.Element {
             {(layout || FunnelLayout.vertical) === FunnelLayout.vertical ? (
                 <FunnelBarChartDataExploration {...props} />
             ) : (
-                <FunnelBarGraph {...props} />
+                <FunnelBarGraphDataExploration {...props} />
             )}
         </BindLogic>
     )

--- a/frontend/src/scenes/funnels/FunnelBarGraph/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph/FunnelBarGraph.tsx
@@ -8,7 +8,7 @@ import './FunnelBarGraph.scss'
 import { useActions, useValues } from 'kea'
 import { FunnelLayout } from 'lib/constants'
 import { getBreakdownMaxIndex, getReferenceStep } from '../funnelUtils'
-import { ChartParams, FunnelStepReference, StepOrderValue } from '~/types'
+import { ChartParams, FunnelStepReference, FunnelStepWithConversionMetrics, StepOrderValue } from '~/types'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { getActionFilterFromFunnelStep } from 'scenes/insights/views/Funnels/funnelStepTableUtils'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
@@ -17,15 +17,55 @@ import { ValueInspectorButton } from '../ValueInspectorButton'
 import { DuplicateStepIndicator } from './DuplicateStepIndicator'
 import { Bar } from './Bar'
 import { AverageTimeInspector } from './AverageTimeInspector'
+import { Noun } from '~/models/groupsModel'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { funnelDataLogic } from '../funnelDataLogic'
+import { FunnelsFilter } from '~/queries/schema'
+
+export function FunnelBarGraphDataExploration(props: ChartParams): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { visibleStepsWithConversionMetrics, aggregationTargetLabel, funnelsFilter } = useValues(
+        funnelDataLogic(insightProps)
+    )
+    return (
+        <FunnelBarGraphComponent
+            steps={visibleStepsWithConversionMetrics}
+            stepReference={funnelsFilter?.funnel_step_reference || FunnelStepReference.total}
+            aggregationTargetLabel={aggregationTargetLabel}
+            funnelsFilter={funnelsFilter}
+            {...props}
+        />
+    )
+}
 
 export function FunnelBarGraph(props: ChartParams): JSX.Element {
-    const {
-        filters,
-        visibleStepsWithConversionMetrics: steps,
-        stepReference,
-        aggregationTargetLabel,
-        isInDashboardContext,
-    } = useValues(funnelLogic)
+    const { filters, visibleStepsWithConversionMetrics, stepReference, aggregationTargetLabel } = useValues(funnelLogic)
+    return (
+        <FunnelBarGraphComponent
+            steps={visibleStepsWithConversionMetrics}
+            stepReference={stepReference}
+            aggregationTargetLabel={aggregationTargetLabel}
+            funnelsFilter={filters}
+            {...props}
+        />
+    )
+}
+
+type FunnelBarGraphComponentProps = {
+    steps: FunnelStepWithConversionMetrics[]
+    stepReference: FunnelStepReference
+    aggregationTargetLabel: Noun
+    funnelsFilter?: FunnelsFilter | null
+} & ChartParams
+
+export function FunnelBarGraphComponent({
+    steps,
+    stepReference,
+    aggregationTargetLabel,
+    funnelsFilter,
+    ...props
+}: FunnelBarGraphComponentProps): JSX.Element {
+    const { isInDashboardContext } = useValues(funnelLogic)
     const { openPersonsModalForStep } = useActions(funnelLogic)
 
     const { ref: graphRef, width } = useResizeObserver()
@@ -57,7 +97,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                     <section key={step.order} className="funnel-step">
                         <div className="funnel-series-container">
                             <div className={`funnel-series-linebox ${showLineBefore ? 'before' : ''}`} />
-                            {filters.funnel_order_type === StepOrderValue.UNORDERED ? (
+                            {funnelsFilter?.funnel_order_type === StepOrderValue.UNORDERED ? (
                                 <SeriesGlyph variant="funnel-step-glyph">
                                     <IconInfinity style={{ fill: 'var(--primary_alt)', width: 14 }} />
                                 </SeriesGlyph>
@@ -67,15 +107,15 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                             <div className={`funnel-series-linebox ${showLineAfter ? 'after' : ''}`} />
                         </div>
                         <header>
-                            <div style={{ display: 'flex', alignItems: 'center', maxWidth: '100%', flexGrow: 1 }}>
+                            <div className="flex items-center max-w-full grow">
                                 <div className="funnel-step-title">
-                                    {filters.funnel_order_type === StepOrderValue.UNORDERED ? (
+                                    {funnelsFilter?.funnel_order_type === StepOrderValue.UNORDERED ? (
                                         <span>Completed {step.order + 1} steps</span>
                                     ) : (
                                         <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
                                     )}
                                 </div>
-                                {filters.funnel_order_type !== StepOrderValue.UNORDERED &&
+                                {funnelsFilter?.funnel_order_type !== StepOrderValue.UNORDERED &&
                                     stepIndex > 0 &&
                                     step.action_id === steps[stepIndex - 1].action_id && <DuplicateStepIndicator />}
                                 <FunnelStepMore stepIndex={stepIndex} />
@@ -118,6 +158,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                     }
                                                     disabled={isInDashboardContext}
                                                     popoverTitle={
+                                                        // eslint-disable-next-line react/forbid-dom-props
                                                         <div style={{ wordWrap: 'break-word' }}>
                                                             <PropertyKeyInfo value={step.name} />
                                                             {' • '}
@@ -190,6 +231,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                         <div
                                             className="funnel-bar-empty-space"
                                             onClick={() => openPersonsModalForStep({ step, converted: false })} // dropoff value for steps is negative
+                                            // eslint-disable-next-line react/forbid-dom-props
                                             style={{
                                                 flex: `${1 - breakdownSum / basisStep.count} 1 0`,
                                                 cursor: `${!props.inCardView ? 'pointer' : ''}`,
@@ -248,6 +290,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                         <div
                                             className="funnel-bar-empty-space"
                                             onClick={() => openPersonsModalForStep({ step, converted: false })} // dropoff value for steps is negative
+                                            // eslint-disable-next-line react/forbid-dom-props
                                             style={{
                                                 flex: `${1 - step.conversionRates.fromBasisStep} 1 0`,
                                                 cursor: `${!props.inCardView ? 'pointer' : ''}`,
@@ -285,7 +328,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                             )
                                         </span>
                                     </div>
-                                    <div className="text-muted-alt conversion-metadata-caption" style={{ flexGrow: 1 }}>
+                                    <div className="text-muted-alt conversion-metadata-caption grow">
                                         completed step
                                     </div>
                                 </div>


### PR DESCRIPTION
## Problem

The funnel bar graph aka "top-to-bottom" chart is broken for data exploration.

## Changes

This PR converts the funnel bar graph.

## How did you test this code?

Compared the funnel bar graph with data exploration on and off.