### PR TITLE
feat: query into log comment

### DIFF
--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -14,6 +14,7 @@
       <env name="PRINT_SQL" value="1" />
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="SKIP_SERVICE_VERSION_REQUIREMENTS" value="1" />
+      <env name="CAPTURE_TIME_TO_SEE_DATA" value="0" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
     <option name="SDK_NAME" value="Python 3.10 (posthog)" />

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -150,6 +150,9 @@ def process_query(team: Team, query_json: Dict, is_hogql_enabled: bool) -> Dict:
     # query_json has been parsed by QuerySchemaParser
     # it _should_ be impossible to end up in here with a "bad" query
     query_kind = query_json.get("kind")
+
+    tag_queries(query=query_json)
+
     if query_kind == "EventsQuery":
         events_query = EventsQuery.parse_obj(query_json)
         response = run_events_query(query=events_query, team=team)


### PR DESCRIPTION
## Problem

We don't tag query into clickhouse log comment in the same way we tag filters

## Changes

We do now!

(fly by adds the CAPTURE_TIME_TO_SEE_DATA env variable to pycharm (but disabled) cos I always forget what it is)

## How did you test this code?

Checking the query log locally with `select log_comment from system.query_log
                   where log_comment like '%/query/%'
                   order by event_time desc
`