### PR TITLE
fix: speculative fix: lookup logic to make sure it is mounted in timeout handler

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
@@ -4,7 +4,7 @@ import { featureFlagLogic } from './../../../lib/logic/featureFlagLogic'
 import { FilterType, InsightType } from './../../../types'
 import { insightLogic } from './../insightLogic'
 import { kea, path, connect, actions, reducers, props, selectors, listeners } from 'kea'
-import { captureException, withScope } from '@sentry/react'
+
 import type { samplingFilterLogicType } from './samplingFilterLogicType'
 import { InsightLogicProps } from '~/types'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
@@ -17,27 +17,6 @@ export interface SamplingFilterLogicProps {
     insightProps: InsightLogicProps
     insightType?: InsightType
     setFilters?: (filters: Partial<FilterType>) => void
-}
-
-function defaultSamplingFor(props: SamplingFilterLogicProps): number | null {
-    const mountedLogic = samplingFilterLogic.findMounted(props)
-    if (!mountedLogic) {
-        return null
-    }
-
-    try {
-        if (mountedLogic.values.filters.sampling_factor) {
-            return mountedLogic.values.filters.sampling_factor * 100
-        } else {
-            return null
-        }
-    } catch (e) {
-        withScope(function (scope) {
-            scope.setTag('logic', 'samplingFilterLogic')
-            captureException(e)
-        })
-        return null
-    }
 }
 
 export const samplingFilterLogic = kea<samplingFilterLogicType>([
@@ -61,15 +40,18 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
     actions(() => ({
         setSamplingPercentage: (samplingPercentage: number | null) => ({ samplingPercentage }),
     })),
-    reducers(({ props }) => ({
+    reducers(() => ({
         samplingPercentage: [
-            defaultSamplingFor(props),
+            null as number | null,
             {
                 // clicking on the active button untoggles it and disables sampling
                 setSamplingPercentage: (oldSamplingPercentage, { samplingPercentage }) =>
                     samplingPercentage === oldSamplingPercentage ? null : samplingPercentage,
                 setGlobalInsightFilters: (_, { globalInsightFilters }) => {
                     return globalInsightFilters.sampling_factor ? globalInsightFilters.sampling_factor * 100 : null
+                },
+                setInsightFilters: (_, { filters }) => {
+                    return filters.sampling_factor ? filters.sampling_factor * 100 : null
                 },
             },
         ],

--- a/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
@@ -10,6 +10,7 @@ import { InsightLogicProps } from '~/types'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { retentionLogic } from 'scenes/retention/retentionLogic'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
+import { subscriptions } from 'kea-subscriptions'
 
 export const AVAILABLE_SAMPLING_PERCENTAGES = [0.1, 1, 10, 25]
 
@@ -49,9 +50,6 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
                     samplingPercentage === oldSamplingPercentage ? null : samplingPercentage,
                 setGlobalInsightFilters: (_, { globalInsightFilters }) => {
                     return globalInsightFilters.sampling_factor ? globalInsightFilters.sampling_factor * 100 : null
-                },
-                setInsightFilters: (_, { filters }) => {
-                    return filters.sampling_factor ? filters.sampling_factor * 100 : null
                 },
             },
         ],
@@ -98,6 +96,14 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
                 actions.setPathsFilters(newFilters)
             } else {
                 actions.setInsightFilters(newFilters)
+            }
+        },
+    })),
+    subscriptions(({ values, actions }) => ({
+        filters: (filter) => {
+            const newSamplingPercentage = filter.sampling_factor ? filter.sampling_factor * 100 : null
+            if (newSamplingPercentage !== values.samplingPercentage) {
+                actions.setSamplingPercentage(newSamplingPercentage)
             }
         },
     })),

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -942,6 +942,12 @@ export const insightLogic = kea<insightLogicType>([
                     } catch (e) {
                         withScope(function (scope) {
                             scope.setTag('logic', 'insightLogic')
+                            // TODO if this tombstone isn't triggered, we can remove this entire tombstone try catch block
+                            // because the breakpoint above is working
+                            scope.setTag(
+                                'tombstone',
+                                'insight timeout message shown - https://posthog.sentry.io/issues/3972299454'
+                            )
                             captureException(e)
                         })
                         console.warn('Error setting insight timeout', e)

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -811,7 +811,7 @@ export const insightLogic = kea<insightLogicType>([
             },
         ],
     }),
-    listeners(({ actions, selectors, values, cache }) => ({
+    listeners(({ actions, selectors, values, cache, props }) => ({
         setFiltersMerge: ({ filters }) => {
             actions.setFilters({ ...values.filters, ...filters })
         },
@@ -915,13 +915,18 @@ export const insightLogic = kea<insightLogicType>([
             actions.markInsightErrored(null)
             values.timeout && clearTimeout(values.timeout || undefined)
             const view = values.filters.insight
+            const capturedProps = props
             actions.setTimeout(
                 window.setTimeout(() => {
                     try {
-                        if (values && view == values.filters.insight) {
-                            actions.markInsightTimedOut(queryId)
+                        const mountedLogic = insightLogic.findMounted(capturedProps)
+                        if (!mountedLogic) {
+                            return
+                        }
+                        if (mountedLogic.values && view == mountedLogic.values.filters.insight) {
+                            mountedLogic.actions.markInsightTimedOut(queryId)
                             const tags = {
-                                insight: values.filters.insight,
+                                insight: mountedLogic.values.filters.insight,
                                 scene: sceneLogic.isMounted() ? sceneLogic.values.scene : null,
                             }
                             posthog.capture('insight timeout message shown', tags)


### PR DESCRIPTION
## Problem

We've had a few error reports that are hard to replicate but have the insightLogic timeout handling in the stack trace

see private thread in slack: https://posthog.slack.com/archives/C045L1VEG87/p1678728198798259
or sentry errors: https://posthog.sentry.io/issues/3972299454/events/da6fb70157a54915a5a0481afa705eb2/?project=1899813&referrer=issue-list&statsPeriod=14d

## Changes

* Finds the mounted logic for the props captured for the handler and only tries to handle the timeout if the logic is available
* does the same in setting the default value in the sampling filter logic

## How did you test this code?

ran locally and saw I could still load a dashboard
