### PR TITLE
fix(events): return all person properties

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:58 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:58 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/models/event/events_query.py
+++ b/posthog/models/event/events_query.py
@@ -173,11 +173,10 @@ def run_events_query(
                 query_result.results[index] = list(result)
                 if distinct_to_person.get(distinct_id):
                     person = distinct_to_person[distinct_id]
-                    properties = person.properties or {}
                     query_result.results[index][column_index] = {
                         "uuid": person.uuid,
                         "created_at": person.created_at,
-                        "properties": {"name": properties.get("name"), "email": properties.get("email")},
+                        "properties": person.properties or {},
                         "distinct_id": distinct_id,
                     }
                 else:


### PR DESCRIPTION
## Problem

While [this PR](https://github.com/PostHog/posthog/issues/14693) is about the live events table, the event explorer table also has the same issue.

## Changes

Now that on this curated table we're anyway making a second (postgres) query to get the persons, there's no reason not to return all person properties.

## How did you test this code?

Made myself Chrome:
<img width="813" alt="image" src="https://user-images.githubusercontent.com/53387/224836391-a3416ea1-dae5-4e21-be06-848419332eb4.png">

I didn't write any real tests. How to even test this E2E ? 🤔 