### PR TITLE
feat: gzip the query endpoint responses

### DIFF
--- a/posthog/gzip_middleware.py
+++ b/posthog/gzip_middleware.py
@@ -40,11 +40,14 @@ class ScopedGZipMiddleware(GZipMiddleware):
         super().__init__(get_response)
         try:
             self.allowed_paths = [re.compile(pattern) for pattern in settings.GZIP_RESPONSE_ALLOW_LIST]
+            self.allowed_post_paths = [re.compile(pattern) for pattern in settings.GZIP_POST_RESPONSE_ALLOW_LIST]
         except re.error as ex:
             raise InvalidGZipAllowList(str(ex)) from ex
 
     def process_response(self, request, response):
         if request.method == "GET" and allowed_path(request.path, self.allowed_paths):
+            return super().process_response(request, response)
+        elif request.method == "POST" and allowed_path(request.path, self.allowed_post_paths):
             return super().process_response(request, response)
         else:
             return response

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -281,6 +281,7 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/api/projects/\\d+/persons/?$",
                 "^/api/organizations/@current/plugins/?$",
                 "^api/projects/@current/feature_flags/my_flags/?$",
+                "^/?api/projects/\\d+/query/?$",
             ]
         ),
     )

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -250,6 +250,17 @@ CSRF_COOKIE_NAME = "posthog_csrftoken"
 
 # see posthog.gzip_middleware.ScopedGZipMiddleware
 # for how adding paths here can add vulnerability to the "breach" attack
+GZIP_POST_RESPONSE_ALLOW_LIST = get_list(
+    os.getenv(
+        "GZIP_POST_RESPONSE_ALLOW_LIST",
+        ",".join(
+            [
+                "^/?api/projects/\\d+/query/?$",
+            ]
+        ),
+    )
+)
+
 GZIP_RESPONSE_ALLOW_LIST = get_list(
     os.getenv(
         "GZIP_RESPONSE_ALLOW_LIST",


### PR DESCRIPTION
## Problem

We only gzip responses from endpoints on an allowlist _and_ that are GET requests. But query is a POST

## Changes

Adds an allowlist for gzipping POST responses

## How did you test this code?

👀 locally. events explorer went from 700kb to 25kb