### PR TITLE
feat(hogql): add sampling support

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -619,7 +619,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:56 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:55 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:58 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -619,7 +619,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:55 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:56 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:58 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -356,10 +356,9 @@ class RatioExpr(Expr):
 
 
 class SampleExpr(Expr):
-    offset_value: Optional[RatioExpr]
-
     # k or n
     sample_value: RatioExpr
+    offset_value: Optional[RatioExpr]
 
 
 JoinExpr.update_forward_refs(SampleExpr=SampleExpr)

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -360,7 +360,8 @@ class SampleExpr(Expr):
 
     # k or n
     sample_value: RatioExpr
-    
+
+
 JoinExpr.update_forward_refs(SampleExpr=SampleExpr)
 JoinExpr.update_forward_refs(SelectUnionQuery=SelectUnionQuery)
 JoinExpr.update_forward_refs(SelectQuery=SelectQuery)

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -360,7 +360,7 @@ class SampleExpr(Expr):
 
     # k or n
     sample_value: RatioExpr
-SampleExpr.update_forward_refs(JoinExpr)
-
+    
+JoinExpr.update_forward_refs(SampleExpr=SampleExpr)
 JoinExpr.update_forward_refs(SelectUnionQuery=SelectUnionQuery)
 JoinExpr.update_forward_refs(SelectQuery=SelectQuery)

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -325,6 +325,7 @@ class JoinExpr(Expr):
     table_final: Optional[bool] = None
     constraint: Optional[Expr] = None
     next_join: Optional["JoinExpr"] = None
+    sample: Optional["SampleExpr"] = None
 
 
 class SelectQuery(Expr):
@@ -347,6 +348,18 @@ class SelectQuery(Expr):
 class SelectUnionQuery(Expr):
     ref: Optional[SelectUnionQueryRef] = None
     select_queries: List[SelectQuery]
+
+
+class RatioExpr(Expr):
+    left: Constant
+    right: Optional[Constant] = None
+
+
+class SampleExpr(Expr):
+    offset_value: Optional[RatioExpr]
+
+    # k or n
+    sample_value: RatioExpr
 
 
 JoinExpr.update_forward_refs(SelectUnionQuery=SelectUnionQuery)

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -360,7 +360,7 @@ class SampleExpr(Expr):
 
     # k or n
     sample_value: RatioExpr
-
+SampleExpr.update_forward_refs(JoinExpr)
 
 JoinExpr.update_forward_refs(SelectUnionQuery=SelectUnionQuery)
 JoinExpr.update_forward_refs(SelectQuery=SelectQuery)

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -184,15 +184,17 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return join1
 
     def visitJoinExprTable(self, ctx: HogQLParser.JoinExprTableContext):
+        sample = None
         if ctx.sampleClause():
-            raise NotImplementedError(f"Unsupported: SAMPLE (JoinExprTable.sampleClause)")
+            sample = self.visit(ctx.sampleClause())
         table = self.visit(ctx.tableExpr())
         table_final = True if ctx.FINAL() else None
         if isinstance(table, ast.JoinExpr):
             # visitTableExprAlias returns a JoinExpr to pass the alias
             table.table_final = table_final
+            table.sample = sample
             return table
-        return ast.JoinExpr(table=table, table_final=table_final)
+        return ast.JoinExpr(table=table, table_final=table_final, sample=sample)
 
     def visitJoinExprParens(self, ctx: HogQLParser.JoinExprParensContext):
         return self.visit(ctx.joinExpr())
@@ -255,7 +257,12 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return column_expr_list[0]
 
     def visitSampleClause(self, ctx: HogQLParser.SampleClauseContext):
-        raise NotImplementedError(f"Unsupported node: SampleClause")
+        ratio_expressions = ctx.ratioExpr()
+
+        sample_ratio_expr = self.visit(ratio_expressions[0])
+        offset_ratio_expr = self.visit(ratio_expressions[1]) if len(ratio_expressions) > 1 and ctx.OFFSET() else None
+
+        return ast.SampleExpr(sample_value=sample_ratio_expr, offset_value=offset_ratio_expr)
 
     def visitLimitExpr(self, ctx: HogQLParser.LimitExprContext):
         raise NotImplementedError(f"Unsupported node: LimitExpr")
@@ -268,7 +275,14 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return ast.OrderExpr(expr=self.visit(ctx.columnExpr()), order=cast(Literal["ASC", "DESC"], order))
 
     def visitRatioExpr(self, ctx: HogQLParser.RatioExprContext):
-        raise NotImplementedError(f"Unsupported node: RatioExpr")
+        number_literals = ctx.numberLiteral()
+
+        left = number_literals[0]
+        right = number_literals[1] if ctx.SLASH() and len(number_literals) > 1 else None
+
+        return ast.RatioExpr(
+            left=self.visitNumberLiteral(left), right=self.visitNumberLiteral(right) if right else None
+        )
 
     def visitSettingExprList(self, ctx: HogQLParser.SettingExprListContext):
         raise NotImplementedError(f"Unsupported node: SettingExprList")

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -462,16 +462,16 @@ class _Printer(Visitor):
         return property_sql
 
     def visit_sample_expr(self, node: ast.SampleExpr):
-        sample_value = self.visit_ratio_expr(ref.sample_value)
+        sample_value = self.visit_ratio_expr(node.sample_value)
         offset_clause = ""
-        if ref.offset_value:
-            offset_value = self.visit_ratio_expr(ref.offset_value)
+        if node.offset_value:
+            offset_value = self.visit_ratio_expr(node.offset_value)
             offset_clause = f" OFFSET {offset_value}"
 
         return f"SAMPLE {sample_value}{offset_clause}"
 
     def visit_ratio_expr(self, node: ast.RatioExpr):
-        return self.visit(ref.left) if ref.right is None else f"{self.visit(ref.left)}/{self.visit(ref.right)}"
+        return self.visit(node.left) if node.right is None else f"{self.visit(node.left)}/{self.visit(node.right)}"
 
     def visit_select_query_alias_ref(self, ref: ast.SelectQueryAliasRef):
         return self._print_identifier(ref.name)

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -471,7 +471,7 @@ class _Printer(Visitor):
         return f"SAMPLE {sample_value}{offset_clause}"
 
     def visit_ratio_expr(self, ref: ast.RatioExpr):
-        return ref.left.value if ref.right is None else f"{ref.left.value}/{ref.right.value}"
+        return self.visit(ref.left) if ref.right is None else f"{self.visit(ref.left)}/{self.visit(ref.right)}"
 
     def visit_select_query_alias_ref(self, ref: ast.SelectQueryAliasRef):
         return self._print_identifier(ref.name)

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -461,7 +461,7 @@ class _Printer(Visitor):
 
         return property_sql
 
-    def visit_sample_expr(self, ref: ast.SampleExpr):
+    def visit_sample_expr(self, node: ast.SampleExpr):
         sample_value = self.visit_ratio_expr(ref.sample_value)
         offset_clause = ""
         if ref.offset_value:
@@ -470,7 +470,7 @@ class _Printer(Visitor):
 
         return f"SAMPLE {sample_value}{offset_clause}"
 
-    def visit_ratio_expr(self, ref: ast.RatioExpr):
+    def visit_ratio_expr(self, node: ast.RatioExpr):
         return self.visit(ref.left) if ref.right is None else f"{self.visit(ref.left)}/{self.visit(ref.right)}"
 
     def visit_select_query_alias_ref(self, ref: ast.SelectQueryAliasRef):

--- a/posthog/hogql/test/test_parser.py
+++ b/posthog/hogql/test/test_parser.py
@@ -723,3 +723,69 @@ class TestParser(BaseTest):
                 ]
             ),
         )
+
+    def test_sample_clause(self):
+        self.assertEqual(
+            parse_select("select 1 from events sample 1/10 offset 999"),
+            ast.SelectQuery(
+                select=[ast.NumericConstant(value=1)],
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=["events"]),
+                    sample=ast.SampleExpr(
+                        offset_value=ast.RatioExpr(left=ast.NumericConstant(value=999)),
+                        sample_value=ast.RatioExpr(
+                            left=ast.NumericConstant(value=1), right=ast.NumericConstant(value=10)
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            parse_select("select 1 from events sample 0.1 offset 999"),
+            ast.SelectQuery(
+                select=[ast.NumericConstant(value=1)],
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=["events"]),
+                    sample=ast.SampleExpr(
+                        offset_value=ast.RatioExpr(left=ast.NumericConstant(value=999)),
+                        sample_value=ast.RatioExpr(
+                            left=ast.NumericConstant(value=0.1),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            parse_select("select 1 from events sample 10 offset 1/2"),
+            ast.SelectQuery(
+                select=[ast.NumericConstant(value=1)],
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=["events"]),
+                    sample=ast.SampleExpr(
+                        offset_value=ast.RatioExpr(
+                            left=ast.NumericConstant(value=1), right=ast.NumericConstant(value=2)
+                        ),
+                        sample_value=ast.RatioExpr(
+                            left=ast.NumericConstant(value=10),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            parse_select("select 1 from events sample 10"),
+            ast.SelectQuery(
+                select=[ast.NumericConstant(value=1)],
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=["events"]),
+                    sample=ast.SampleExpr(
+                        sample_value=ast.RatioExpr(
+                            left=ast.NumericConstant(value=10),
+                        ),
+                    ),
+                ),
+            ),
+        )

--- a/posthog/hogql/test/test_parser.py
+++ b/posthog/hogql/test/test_parser.py
@@ -728,13 +728,13 @@ class TestParser(BaseTest):
         self.assertEqual(
             parse_select("select 1 from events sample 1/10 offset 999"),
             ast.SelectQuery(
-                select=[ast.NumericConstant(value=1)],
+                select=[ast.Constant(value=1)],
                 select_from=ast.JoinExpr(
                     table=ast.Field(chain=["events"]),
                     sample=ast.SampleExpr(
-                        offset_value=ast.RatioExpr(left=ast.NumericConstant(value=999)),
+                        offset_value=ast.RatioExpr(left=ast.Constant(value=999)),
                         sample_value=ast.RatioExpr(
-                            left=ast.NumericConstant(value=1), right=ast.NumericConstant(value=10)
+                            left=ast.Constant(value=1), right=ast.Constant(value=10)
                         ),
                     ),
                 ),
@@ -744,13 +744,13 @@ class TestParser(BaseTest):
         self.assertEqual(
             parse_select("select 1 from events sample 0.1 offset 999"),
             ast.SelectQuery(
-                select=[ast.NumericConstant(value=1)],
+                select=[ast.Constant(value=1)],
                 select_from=ast.JoinExpr(
                     table=ast.Field(chain=["events"]),
                     sample=ast.SampleExpr(
-                        offset_value=ast.RatioExpr(left=ast.NumericConstant(value=999)),
+                        offset_value=ast.RatioExpr(left=ast.Constant(value=999)),
                         sample_value=ast.RatioExpr(
-                            left=ast.NumericConstant(value=0.1),
+                            left=ast.Constant(value=0.1),
                         ),
                     ),
                 ),
@@ -760,15 +760,15 @@ class TestParser(BaseTest):
         self.assertEqual(
             parse_select("select 1 from events sample 10 offset 1/2"),
             ast.SelectQuery(
-                select=[ast.NumericConstant(value=1)],
+                select=[ast.Constant(value=1)],
                 select_from=ast.JoinExpr(
                     table=ast.Field(chain=["events"]),
                     sample=ast.SampleExpr(
                         offset_value=ast.RatioExpr(
-                            left=ast.NumericConstant(value=1), right=ast.NumericConstant(value=2)
+                            left=ast.Constant(value=1), right=ast.Constant(value=2)
                         ),
                         sample_value=ast.RatioExpr(
-                            left=ast.NumericConstant(value=10),
+                            left=ast.Constant(value=10),
                         ),
                     ),
                 ),
@@ -778,12 +778,12 @@ class TestParser(BaseTest):
         self.assertEqual(
             parse_select("select 1 from events sample 10"),
             ast.SelectQuery(
-                select=[ast.NumericConstant(value=1)],
+                select=[ast.Constant(value=1)],
                 select_from=ast.JoinExpr(
                     table=ast.Field(chain=["events"]),
                     sample=ast.SampleExpr(
                         sample_value=ast.RatioExpr(
-                            left=ast.NumericConstant(value=10),
+                            left=ast.Constant(value=10),
                         ),
                     ),
                 ),

--- a/posthog/hogql/test/test_parser.py
+++ b/posthog/hogql/test/test_parser.py
@@ -733,9 +733,7 @@ class TestParser(BaseTest):
                     table=ast.Field(chain=["events"]),
                     sample=ast.SampleExpr(
                         offset_value=ast.RatioExpr(left=ast.Constant(value=999)),
-                        sample_value=ast.RatioExpr(
-                            left=ast.Constant(value=1), right=ast.Constant(value=10)
-                        ),
+                        sample_value=ast.RatioExpr(left=ast.Constant(value=1), right=ast.Constant(value=10)),
                     ),
                 ),
             ),
@@ -764,9 +762,7 @@ class TestParser(BaseTest):
                 select_from=ast.JoinExpr(
                     table=ast.Field(chain=["events"]),
                     sample=ast.SampleExpr(
-                        offset_value=ast.RatioExpr(
-                            left=ast.Constant(value=1), right=ast.Constant(value=2)
-                        ),
+                        offset_value=ast.RatioExpr(left=ast.Constant(value=1), right=ast.Constant(value=2)),
                         sample_value=ast.RatioExpr(
                             left=ast.Constant(value=10),
                         ),

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -406,24 +406,23 @@ class TestPrinter(TestCase):
             self._select("SELECT 1 FROM (SELECT 1 UNION ALL SELECT 1)"),
             "SELECT 1 FROM (SELECT 1 UNION ALL SELECT 1) LIMIT 65535",
         )
-        
-        
+
     def test_select_sample(self):
         self.assertEqual(
             self._select("SELECT event FROM events SAMPLE 1"),
             "SELECT event FROM events SAMPLE 1 WHERE equals(team_id, 42) LIMIT 65535",
         )
-        
+
         self.assertEqual(
             self._select("SELECT event FROM events SAMPLE 0.1 OFFSET 1/10"),
             "SELECT event FROM events SAMPLE 0.1 OFFSET 1/10 WHERE equals(team_id, 42) LIMIT 65535",
         )
-        
+
         self.assertEqual(
             self._select("SELECT event FROM events SAMPLE 2/78 OFFSET 999"),
             "SELECT event FROM events SAMPLE 2/78 OFFSET 999 WHERE equals(team_id, 42) LIMIT 65535",
         )
-        
+
         self.assertEqual(
             self._select("SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons ON persons.id=events.person_id"),
             "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN person ON equals(id, events__pdi.person_id) INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, 42) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(person.team_id, 42), equals(events.team_id, 42)) LIMIT 65535",

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -427,3 +427,10 @@ class TestPrinter(TestCase):
             self._select("SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons ON persons.id=events.person_id"),
             "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN person ON equals(id, events__pdi.person_id) INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, 42) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(person.team_id, 42), equals(events.team_id, 42)) LIMIT 65535",
         )
+
+        self.assertEqual(
+            self._select(
+                "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons SAMPLE 0.1 ON persons.id=events.person_id"
+            ),
+            "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN person SAMPLE 0.1 ON equals(id, events__pdi.person_id) INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, 42) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(person.team_id, 42), equals(events.team_id, 42)) LIMIT 65535",
+        )

--- a/posthog/hogql/test/test_visitor.py
+++ b/posthog/hogql/test/test_visitor.py
@@ -80,6 +80,10 @@ class TestVisitor(BaseTest):
                                 right=ast.Field(chain=["e"]),
                             ),
                         ),
+                        sample=ast.SampleExpr(
+                            sample_value=ast.RatioExpr(left=ast.Constant(value=1), right=ast.Constant(value=2)),
+                            offset_value=ast.RatioExpr(left=ast.Constant(value=1), right=ast.Constant(value=2)),
+                        ),
                     ),
                     where=ast.Constant(value=True),
                     prewhere=ast.Constant(value=True),

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -57,6 +57,14 @@ class TraversingVisitor(Visitor):
         for expr in node.args:
             self.visit(expr)
 
+    def visit_sample_expr(self, node: ast.SampleExpr):
+        self.visit(node.sample_value)
+        self.visit(node.offset_value)
+
+    def visit_ratio_expr(self, node: ast.RatioExpr):
+        self.visit(node.left)
+        self.visit(node.right)
+
     def visit_join_expr(self, node: ast.JoinExpr):
         self.visit(node.table)
         self.visit(node.constraint)
@@ -190,6 +198,12 @@ class CloningVisitor(Visitor):
             args=[self.visit(arg) for arg in node.args],
         )
 
+    def visit_ratio_expr(self, node: ast.RatioExpr):
+        return ast.RatioExpr(left=self.visit(node.left), right=self.visit(node.right))
+
+    def visit_sample_expr(self, node: ast.SampleExpr):
+        return ast.SampleExpr(sample_value=self.visit(node.sample_value), offset_value=self.visit(node.offset_value))
+
     def visit_join_expr(self, node: ast.JoinExpr):
         return ast.JoinExpr(
             table=self.visit(node.table),
@@ -198,6 +212,7 @@ class CloningVisitor(Visitor):
             alias=node.alias,
             join_type=node.join_type,
             constraint=self.visit(node.constraint),
+            sample=self.visit(node.sample),
         )
 
     def visit_select_query(self, node: ast.SelectQuery):


### PR DESCRIPTION
Adds support for a `SAMPLE` clause to HogQL, with `OFFSET` support as well.

https://clickhouse.com/docs/en/sql-reference/statements/select/sample/