### PR TITLE
fix(flags): Don't expand on negations in cohorts'

### DIFF
--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -143,6 +143,10 @@ class FeatureFlag(models.Model):
         if not all(property.type == "person" for property in cohort.properties.flat):
             return self.conditions
 
+        if any(property.negation for property in cohort.properties.flat):
+            # Local evaluation doesn't support negation.
+            return self.conditions
+
         # all person properties, so now if we can express the cohort as feature flag groups, we'll be golden.
 
         # If there's only one effective property group, we can always express this as feature flag groups.


### PR DESCRIPTION
## Problem

Realised negations aren't supported in local evaluation of cohorts, so disable sending those

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
