### PR TITLE
feat(data-exploration): convert funnel line graph

### DIFF
--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -8,7 +8,7 @@ import { funnelDataLogic } from './funnelDataLogic'
 import { ChartParams, FunnelVizType } from '~/types'
 import { FunnelLayout } from 'lib/constants'
 import { FunnelHistogram, FunnelHistogramDataExploration } from './FunnelHistogram'
-import { FunnelLineGraph } from 'scenes/funnels/FunnelLineGraph'
+import { FunnelLineGraph, FunnelLineGraphDataExploration } from 'scenes/funnels/FunnelLineGraph'
 import { FunnelBarChart, FunnelBarChartDataExploration } from './FunnelBarChart/FunnelBarChart'
 import { FunnelBarGraph, FunnelBarGraphDataExploration } from './FunnelBarGraph/FunnelBarGraph'
 
@@ -18,7 +18,7 @@ export function FunnelDataExploration(props: ChartParams): JSX.Element {
     const { funnel_viz_type, layout } = funnelsFilter || {}
 
     if (funnel_viz_type == FunnelVizType.Trends) {
-        return <FunnelLineGraph {...props} />
+        return <FunnelLineGraphDataExploration {...props} />
     }
 
     if (funnel_viz_type == FunnelVizType.TimeToConvert) {

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -1,6 +1,15 @@
 import { LineGraph } from 'scenes/insights/views/LineGraph/LineGraph'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
-import { ChartParams, GraphType, GraphDataset, EntityTypes } from '~/types'
+import {
+    ChartParams,
+    GraphType,
+    GraphDataset,
+    EntityTypes,
+    FunnelStepWithNestedBreakdown,
+    IntervalType,
+    InsightModel,
+    FunnelsFilterType,
+} from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { capitalizeFirstLetter, shortTimeZone } from 'lib/utils'
 import { dayjs } from 'lib/dayjs'
@@ -8,15 +17,79 @@ import { getFormattedDate } from 'scenes/insights/InsightTooltip/insightTooltipU
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 import { buildPeopleUrl } from 'scenes/trends/persons-modal/persons-modal-utils'
 import { useValues } from 'kea'
+import { funnelDataLogic } from './funnelDataLogic'
+import { Noun } from '~/models/groupsModel'
+import { FunnelsFilter } from '~/queries/schema'
+import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 
-export function FunnelLineGraph({
+export function FunnelLineGraphDataExploration(props: Omit<ChartParams, 'filters'>): JSX.Element | null {
+    const { insightProps } = useValues(insightLogic)
+    const {
+        steps,
+        aggregationTargetLabel,
+        incompletenessOffsetFromEnd,
+        interval,
+        querySource,
+        funnelsFilter,
+        insightData,
+    } = useValues(funnelDataLogic(insightProps))
+
+    return (
+        <FunnelLineGraphComponent
+            steps={steps}
+            aggregationTargetLabel={aggregationTargetLabel}
+            incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
+            interval={interval}
+            aggregationGroupTypeIndex={querySource.aggregation_group_type_index}
+            funnelsFilter={funnelsFilter}
+            insightData={insightData}
+            filters={queryNodeToFilter(querySource)} // for persons modal
+            {...props}
+        />
+    )
+}
+
+export function FunnelLineGraph(props: Omit<ChartParams, 'filters'>): JSX.Element | null {
+    const { insightProps, insight } = useValues(insightLogic)
+    const { steps, aggregationTargetLabel, incompletenessOffsetFromEnd, filters } = useValues(funnelLogic(insightProps))
+
+    return (
+        <FunnelLineGraphComponent
+            steps={steps}
+            aggregationTargetLabel={aggregationTargetLabel}
+            incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
+            interval={filters.interval}
+            aggregationGroupTypeIndex={filters.aggregation_group_type_index}
+            funnelsFilter={filters}
+            insightData={insight}
+            filters={filters}
+            {...props}
+        />
+    )
+}
+
+type FunnelLineGraphComponentProps = Omit<ChartParams, 'filters'> & {
+    steps: FunnelStepWithNestedBreakdown[]
+    aggregationTargetLabel: Noun
+    incompletenessOffsetFromEnd: number
+    interval?: IntervalType
+    aggregationGroupTypeIndex?: number
+    funnelsFilter?: FunnelsFilter | null
+    insightData?: Partial<InsightModel> | null
+    filters: Partial<FunnelsFilterType>
+}
+
+function FunnelLineGraphComponent({
     inSharedMode,
     showPersonsModal = true,
-}: Omit<ChartParams, 'filters'>): JSX.Element | null {
-    const { insightProps, insight } = useValues(insightLogic)
-    const logic = funnelLogic(insightProps)
-    const { steps, filters, aggregationTargetLabel, incompletenessOffsetFromEnd } = useValues(logic)
-
+    steps,
+    aggregationTargetLabel,
+    incompletenessOffsetFromEnd,
+    interval,
+    aggregationGroupTypeIndex,
+    insightData,
+    filters,
+}: FunnelLineGraphComponentProps): JSX.Element | null {
     return (
         <LineGraph
             data-attr="trend-line-graph-funnel"
@@ -34,9 +107,9 @@ export function FunnelLineGraph({
                         return 'Trend'
                     }
                     return (
-                        getFormattedDate(steps[0].days?.[datum.dataIndex], filters.interval) +
+                        getFormattedDate(steps[0].days?.[datum.dataIndex], interval) +
                         ' ' +
-                        (insight.timezone ? shortTimeZone(insight.timezone) : 'UTC')
+                        (insightData?.timezone ? shortTimeZone(insightData.timezone) : 'UTC')
                     )
                 },
                 renderCount: (count) => {
@@ -44,7 +117,7 @@ export function FunnelLineGraph({
                 },
             }}
             filters={{ aggregation_axis_format: 'percentage' }}
-            labelGroupType={filters.aggregation_group_type_index ?? 'people'}
+            labelGroupType={aggregationGroupTypeIndex ?? 'people'}
             incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
             onClick={
                 !showPersonsModal
@@ -61,7 +134,7 @@ export function FunnelLineGraph({
                               action: { id: index, name: label ?? null, properties: [], type: EntityTypes.ACTIONS },
                               date_from: day ?? '',
                               date_to: day ?? '',
-                              filters: filters,
+                              filters,
                           }
 
                           const url = buildPeopleUrl(props)

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -132,7 +132,9 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         steps: [
             (s) => [s.breakdown, s.results, s.isTimeToConvertFunnel],
             (breakdown, results, isTimeToConvertFunnel): FunnelStepWithNestedBreakdown[] => {
-                if (!isTimeToConvertFunnel) {
+                // we need to check wether results are an array, since isTimeToConvertFunnel can be false,
+                // while still having "time-to-convert" results in insightData
+                if (!isTimeToConvertFunnel && Array.isArray(results)) {
                     if (isBreakdownFunnelResults(results)) {
                         const breakdownProperty = breakdown?.breakdowns
                             ? breakdown?.breakdowns.map((b) => b.property).join('::')

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -16,6 +16,8 @@ import {
     FunnelAPIResponse,
     FunnelTimeConversionMetrics,
     TrendResult,
+    FunnelConversionWindowTimeUnit,
+    FunnelConversionWindow,
 } from '~/types'
 import { FunnelsQuery, NodeKind } from '~/queries/schema'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -25,9 +27,11 @@ import { groupsModel, Noun } from '~/models/groupsModel'
 import type { funnelDataLogicType } from './funnelDataLogicType'
 import { isFunnelsQuery } from '~/queries/utils'
 import { percentage, sum, average } from 'lib/utils'
+import { dayjs } from 'lib/dayjs'
 import {
     aggregateBreakdownResult,
     flattenedStepsByBreakdown,
+    getIncompleteConversionWindowStartDate,
     getLastFilledStep,
     getReferenceStep,
     getVisibilityKey,
@@ -45,7 +49,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
     connect((props: InsightLogicProps) => ({
         values: [
             insightDataLogic(props),
-            ['querySource', 'insightFilter', 'funnelsFilter', 'breakdown', 'series', 'insightData'],
+            ['querySource', 'insightFilter', 'funnelsFilter', 'breakdown', 'series', 'interval', 'insightData'],
             groupsModel,
             ['aggregationLabel'],
         ],
@@ -275,6 +279,35 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                 }
             },
         ],
+        conversionWindow: [
+            (s) => [s.funnelsFilter],
+            (funnelsFilter): FunnelConversionWindow => {
+                const { funnel_window_interval, funnel_window_interval_unit } = funnelsFilter || {}
+                return {
+                    funnel_window_interval: funnel_window_interval || 14,
+                    funnel_window_interval_unit: funnel_window_interval_unit || FunnelConversionWindowTimeUnit.Day,
+                }
+            },
+        ],
+        incompletenessOffsetFromEnd: [
+            (s) => [s.steps, s.conversionWindow],
+            (steps, conversionWindow) => {
+                if (steps?.[0]?.days === undefined) {
+                    return 0
+                }
+
+                // subtract conversion window from today and look for a matching day
+                const startDate = getIncompleteConversionWindowStartDate(conversionWindow)
+                const startIndex = steps[0].days.findIndex((day) => dayjs(day) >= startDate)
+
+                if (startIndex !== undefined && startIndex !== -1) {
+                    return startIndex - steps[0].days.length
+                } else {
+                    return 0
+                }
+            },
+        ],
+
         /*
          * Advanced options: funnel_order_type, funnel_step_reference, exclusions
          */


### PR DESCRIPTION
## Problem

The funnel line graph aka "history trends" chart is broken for data exploration.

## Changes

This PR converts the funnel line graph and associated selectors.

## How did you test this code?

Added tests and verified it works with data exploration on/off.