### PR TITLE
feat(sampling): clearly mark sampling as beta in the UI

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
@@ -32,7 +32,7 @@ export function SamplingFilter({
                         info={infoTooltipContent || DEFAULT_SAMPLING_INFO_TOOLTIP_CONTENT}
                         infoLink="https://posthog.com/manual/sampling"
                     >
-                        Sampling
+                        Sampling (Beta)
                     </LemonLabel>
                     <LemonSwitch
                         className="m-2"


### PR DESCRIPTION
let's clearly mark sampling as beta in the UI to reduce expectations and encourage clicking the info icon
