### PR TITLE
chore: add icon story sorting and filtering

### DIFF
--- a/frontend/src/lib/lemon-ui/icons/icons.stories.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.stories.tsx
@@ -1,34 +1,39 @@
-import * as React from 'react'
-import * as icons from './icons'
-import { Meta } from '@storybook/react'
-import { LemonTable } from 'lib/lemon-ui/LemonTable'
-import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
-import { IconMagnifier } from './icons'
-import Fuse from 'fuse.js'
-import { useEffect } from 'react'
+import * as React from "react";
+import * as icons from "./icons";
+import { Meta } from "@storybook/react";
+import { LemonTable } from "lib/lemon-ui/LemonTable";
+import { LemonCheckbox } from "lib/lemon-ui/LemonCheckbox";
+import { LemonButton } from "lib/lemon-ui/LemonButton";
+import { LemonInput } from "lib/lemon-ui/LemonInput/LemonInput";
+import { IconMagnifier } from "./icons";
+import Fuse from "fuse.js";
+import { useEffect } from "react";
 
-const { IconGauge, IconWithCount } = icons
+const { IconGauge, IconWithCount } = icons;
 
 interface IconDefinition {
-    name: string
-    icon: (...args: any[]) => JSX.Element
+  name: string;
+  icon: (...args: any[]) => JSX.Element;
 }
 
 const allIcons: IconDefinition[] = Object.entries(icons)
-    .filter(([key]) => key !== 'IconWithCount')
-    .map(([key, Icon]) => ({ name: key, icon: Icon }))
-    .sort((a, b) => a.name.localeCompare(b.name))
+  .filter(([key]) => key !== "IconWithCount")
+  .map(([key, Icon]) => ({ name: key, icon: Icon }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const fuse = new Fuse(allIcons, {
+  keys: ["name"],
+  threshold: 0.3,
+});
 
 export default {
-    title: 'Lemon UI/Icons',
-    parameters: {
-        options: { showPanel: false },
-        testOptions: { skip: true }, // There are too many icons, the snapshots are huge in table form
-        docs: {
-            description: {
-                component: `
+  title: "Lemon UI/Icons",
+  parameters: {
+    options: { showPanel: false },
+    testOptions: { skip: true }, // There are too many icons, the snapshots are huge in table form
+    docs: {
+      description: {
+        component: `
 
 [Related Figma area](https://www.figma.com/file/Y9G24U4r04nEjIDGIEGuKI/PostHog-Design-System-One?node-id=3139%3A1388)
 
@@ -40,121 +45,126 @@ When adding new icons from Figma please make sure to:
 - [ ] Follow the existing \`IconFoo\` naming convention and use the \`<SvgIcon>\` component instead of \`<svg>\`
 - [ ] Ensure all colors in the SVG are set to \`currentColor\` so that themes can be applied
 `,
-            },
-        },
+      },
     },
-} as Meta
+  },
+} as Meta;
 
 export function Library(): JSX.Element {
-    const [showBorder, setShowBorder] = React.useState(true)
-    const [search, setSearch] = React.useState('')
-    const [filteredIcons, setFilteredIcons] = React.useState(allIcons)
+  const [showBorder, setShowBorder] = React.useState(true);
+  const [search, setSearch] = React.useState("");
+  const [filteredIcons, setFilteredIcons] = React.useState(allIcons);
 
-    const fuse = new Fuse(allIcons, {
-        keys: ['name'],
-        threshold: 0.3,
-    })
+  useEffect(() => {
+    if (search.trim() !== "") {
+      setFilteredIcons(
+        fuse
+          .search(search)
+          .map((result) => result.item)
+          .sort((a, b) => a.name.localeCompare(b.name))
+      );
+    }
+  }, [search]);
 
-    useEffect(() => {
-        if (search.trim() !== '') {
-            setFilteredIcons(
-                fuse
-                    .search(search)
-                    .map((result) => result.item)
-                    .sort((a, b) => a.name.localeCompare(b.name))
-            )
-        }
-    }, [search])
+  return (
+    <div className="space-y-2">
+      <div className={"flex flex-row justify-between"}>
+        <LemonCheckbox
+          bordered
+          checked={showBorder}
+          onChange={setShowBorder}
+          label="Show border"
+        />
+        <LemonInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Filter"
+          prefix={<IconMagnifier />}
+        />
+      </div>
+      <LemonTable
+        dataSource={filteredIcons}
+        columns={[
+          {
+            title: "Name",
+            key: "name",
+            dataIndex: "name",
+            render: function RenderName(name) {
+              return <code>{`<${name as string} />`}</code>;
+            },
+          },
+          {
+            title: "Icon",
+            key: "icon",
+            dataIndex: "icon",
+            render: function RenderIcon(Icon) {
+              Icon = Icon as IconDefinition["icon"];
+              return (
+                <Icon
+                  style={{
+                    fontSize: "1.5rem",
+                    boxShadow: showBorder ? "0px 0px 1px 1px red" : null,
+                  }}
+                />
+              );
+            },
+          },
 
-    return (
-        <div className="space-y-2">
-            <div className={'flex flex-row justify-between'}>
-                <LemonCheckbox bordered checked={showBorder} onChange={setShowBorder} label="Show border" />
-                <LemonInput value={search} onChange={setSearch} placeholder="Filter" prefix={<IconMagnifier />} />
-            </div>
-            <LemonTable
-                dataSource={filteredIcons}
-                columns={[
-                    {
-                        title: 'Name',
-                        key: 'name',
-                        dataIndex: 'name',
-                        render: function RenderName(name) {
-                            return <code>{`<${name as string} />`}</code>
-                        },
-                    },
-                    {
-                        title: 'Icon',
-                        key: 'icon',
-                        dataIndex: 'icon',
-                        render: function RenderIcon(Icon) {
-                            Icon = Icon as IconDefinition['icon']
-                            return (
-                                <Icon
-                                    style={{
-                                        fontSize: '1.5rem',
-                                        boxShadow: showBorder ? '0px 0px 1px 1px red' : null,
-                                    }}
-                                />
-                            )
-                        },
-                    },
-
-                    {
-                        title: 'In Button',
-                        key: 'button-icon',
-                        dataIndex: 'icon',
-                        render: function RenderButton(Icon) {
-                            Icon = Icon as IconDefinition['icon']
-                            return (
-                                <LemonButton type="secondary" icon={<Icon />}>
-                                    Button
-                                </LemonButton>
-                            )
-                        },
-                    },
-                ]}
-            />
-        </div>
-    )
+          {
+            title: "In Button",
+            key: "button-icon",
+            dataIndex: "icon",
+            render: function RenderButton(Icon) {
+              Icon = Icon as IconDefinition["icon"];
+              return (
+                <LemonButton type="secondary" icon={<Icon />}>
+                  Button
+                </LemonButton>
+              );
+            },
+          },
+        ]}
+      />
+    </div>
+  );
 }
 
 export function IconWithCountBubble(): JSX.Element {
-    return (
-        <span className="inline-flex text-2xl border border-primary">
-            <IconWithCount count={7}>
-                <IconGauge />
-            </IconWithCount>
-        </span>
-    )
+  return (
+    <span className="inline-flex text-2xl border border-primary">
+      <IconWithCount count={7}>
+        <IconGauge />
+      </IconWithCount>
+    </span>
+  );
 }
 
 export function IconWithCountHidingZero(): JSX.Element {
-    return (
-        <span className="inline-flex text-2xl border border-primary">
-            <IconWithCount count={0} showZero={false}>
-                <IconGauge />
-            </IconWithCount>
-        </span>
-    )
+  return (
+    <span className="inline-flex text-2xl border border-primary">
+      <IconWithCount count={0} showZero={false}>
+        <IconGauge />
+      </IconWithCount>
+    </span>
+  );
 }
 
 export function IconWithCountShowingZero(): JSX.Element {
-    return (
-        <span className="inline-flex text-2xl border border-primary">
-            <IconWithCount count={0} showZero={true}>
-                <IconGauge />
-            </IconWithCount>
-        </span>
-    )
+  return (
+    <span className="inline-flex text-2xl border border-primary">
+      <IconWithCount count={0} showZero={true}>
+        <IconGauge />
+      </IconWithCount>
+    </span>
+  );
 }
 
 export function IconWithCountOverflowing(): JSX.Element {
-    return (
-        <span className="inline-flex text-2xl border border-primary">
-            <IconWithCount count={11} showZero={true}>
-                <IconGauge />
-            </IconWithCount>
-        </span>
-    )
+  return (
+    <span className="inline-flex text-2xl border border-primary">
+      <IconWithCount count={11} showZero={true}>
+        <IconGauge />
+      </IconWithCount>
+    </span>
+  );
 }

--- a/frontend/src/lib/lemon-ui/icons/icons.stories.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.stories.tsx
@@ -4,6 +4,10 @@ import { Meta } from '@storybook/react'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
+import { IconMagnifier } from './icons'
+import Fuse from 'fuse.js'
+import { useEffect } from 'react'
 
 const { IconGauge, IconWithCount } = icons
 
@@ -15,6 +19,7 @@ interface IconDefinition {
 const allIcons: IconDefinition[] = Object.entries(icons)
     .filter(([key]) => key !== 'IconWithCount')
     .map(([key, Icon]) => ({ name: key, icon: Icon }))
+    .sort((a, b) => a.name.localeCompare(b.name))
 
 export default {
     title: 'Lemon UI/Icons',
@@ -42,11 +47,33 @@ When adding new icons from Figma please make sure to:
 
 export function Library(): JSX.Element {
     const [showBorder, setShowBorder] = React.useState(true)
+    const [search, setSearch] = React.useState('')
+    const [filteredIcons, setFilteredIcons] = React.useState(allIcons)
+
+    const fuse = new Fuse(allIcons, {
+        keys: ['name'],
+        threshold: 0.3,
+    })
+
+    useEffect(() => {
+        if (search.trim() !== '') {
+            setFilteredIcons(
+                fuse
+                    .search(search)
+                    .map((result) => result.item)
+                    .sort((a, b) => a.name.localeCompare(b.name))
+            )
+        }
+    }, [search])
+
     return (
         <div className="space-y-2">
-            <LemonCheckbox bordered checked={showBorder} onChange={setShowBorder} label="Show border" />
+            <div className={'flex flex-row justify-between'}>
+                <LemonCheckbox bordered checked={showBorder} onChange={setShowBorder} label="Show border" />
+                <LemonInput value={search} onChange={setSearch} placeholder="Filter" prefix={<IconMagnifier />} />
+            </div>
             <LemonTable
-                dataSource={allIcons}
+                dataSource={filteredIcons}
                 columns={[
                     {
                         title: 'Name',

--- a/frontend/src/lib/lemon-ui/icons/icons.stories.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.stories.tsx
@@ -1,39 +1,39 @@
-import * as React from "react";
-import * as icons from "./icons";
-import { Meta } from "@storybook/react";
-import { LemonTable } from "lib/lemon-ui/LemonTable";
-import { LemonCheckbox } from "lib/lemon-ui/LemonCheckbox";
-import { LemonButton } from "lib/lemon-ui/LemonButton";
-import { LemonInput } from "lib/lemon-ui/LemonInput/LemonInput";
-import { IconMagnifier } from "./icons";
-import Fuse from "fuse.js";
-import { useEffect } from "react";
+import * as React from 'react'
+import * as icons from './icons'
+import { Meta } from '@storybook/react'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
+import { IconMagnifier } from './icons'
+import Fuse from 'fuse.js'
+import { useEffect } from 'react'
 
-const { IconGauge, IconWithCount } = icons;
+const { IconGauge, IconWithCount } = icons
 
 interface IconDefinition {
-  name: string;
-  icon: (...args: any[]) => JSX.Element;
+    name: string
+    icon: (...args: any[]) => JSX.Element
 }
 
 const allIcons: IconDefinition[] = Object.entries(icons)
-  .filter(([key]) => key !== "IconWithCount")
-  .map(([key, Icon]) => ({ name: key, icon: Icon }))
-  .sort((a, b) => a.name.localeCompare(b.name));
+    .filter(([key]) => key !== 'IconWithCount')
+    .map(([key, Icon]) => ({ name: key, icon: Icon }))
+    .sort((a, b) => a.name.localeCompare(b.name))
 
 const fuse = new Fuse(allIcons, {
-  keys: ["name"],
-  threshold: 0.3,
-});
+    keys: ['name'],
+    threshold: 0.3,
+})
 
 export default {
-  title: "Lemon UI/Icons",
-  parameters: {
-    options: { showPanel: false },
-    testOptions: { skip: true }, // There are too many icons, the snapshots are huge in table form
-    docs: {
-      description: {
-        component: `
+    title: 'Lemon UI/Icons',
+    parameters: {
+        options: { showPanel: false },
+        testOptions: { skip: true }, // There are too many icons, the snapshots are huge in table form
+        docs: {
+            description: {
+                component: `
 
 [Related Figma area](https://www.figma.com/file/Y9G24U4r04nEjIDGIEGuKI/PostHog-Design-System-One?node-id=3139%3A1388)
 
@@ -45,126 +45,116 @@ When adding new icons from Figma please make sure to:
 - [ ] Follow the existing \`IconFoo\` naming convention and use the \`<SvgIcon>\` component instead of \`<svg>\`
 - [ ] Ensure all colors in the SVG are set to \`currentColor\` so that themes can be applied
 `,
-      },
+            },
+        },
     },
-  },
-} as Meta;
+} as Meta
 
 export function Library(): JSX.Element {
-  const [showBorder, setShowBorder] = React.useState(true);
-  const [search, setSearch] = React.useState("");
-  const [filteredIcons, setFilteredIcons] = React.useState(allIcons);
+    const [showBorder, setShowBorder] = React.useState(true)
+    const [search, setSearch] = React.useState('')
+    const [filteredIcons, setFilteredIcons] = React.useState(allIcons)
 
-  useEffect(() => {
-    if (search.trim() !== "") {
-      setFilteredIcons(
-        fuse
-          .search(search)
-          .map((result) => result.item)
-          .sort((a, b) => a.name.localeCompare(b.name))
-      );
-    }
-  }, [search]);
+    useEffect(() => {
+        if (search.trim() !== '') {
+            setFilteredIcons(
+                fuse
+                    .search(search)
+                    .map((result) => result.item)
+                    .sort((a, b) => a.name.localeCompare(b.name))
+            )
+        }
+    }, [search])
 
-  return (
-    <div className="space-y-2">
-      <div className={"flex flex-row justify-between"}>
-        <LemonCheckbox
-          bordered
-          checked={showBorder}
-          onChange={setShowBorder}
-          label="Show border"
-        />
-        <LemonInput
-          value={search}
-          onChange={setSearch}
-          placeholder="Filter"
-          prefix={<IconMagnifier />}
-        />
-      </div>
-      <LemonTable
-        dataSource={filteredIcons}
-        columns={[
-          {
-            title: "Name",
-            key: "name",
-            dataIndex: "name",
-            render: function RenderName(name) {
-              return <code>{`<${name as string} />`}</code>;
-            },
-          },
-          {
-            title: "Icon",
-            key: "icon",
-            dataIndex: "icon",
-            render: function RenderIcon(Icon) {
-              Icon = Icon as IconDefinition["icon"];
-              return (
-                <Icon
-                  style={{
-                    fontSize: "1.5rem",
-                    boxShadow: showBorder ? "0px 0px 1px 1px red" : null,
-                  }}
-                />
-              );
-            },
-          },
+    return (
+        <div className="space-y-2">
+            <div className={'flex flex-row justify-between'}>
+                <LemonCheckbox bordered checked={showBorder} onChange={setShowBorder} label="Show border" />
+                <LemonInput value={search} onChange={setSearch} placeholder="Filter" prefix={<IconMagnifier />} />
+            </div>
+            <LemonTable
+                dataSource={filteredIcons}
+                columns={[
+                    {
+                        title: 'Name',
+                        key: 'name',
+                        dataIndex: 'name',
+                        render: function RenderName(name) {
+                            return <code>{`<${name as string} />`}</code>
+                        },
+                    },
+                    {
+                        title: 'Icon',
+                        key: 'icon',
+                        dataIndex: 'icon',
+                        render: function RenderIcon(Icon) {
+                            Icon = Icon as IconDefinition['icon']
+                            return (
+                                <Icon
+                                    style={{
+                                        fontSize: '1.5rem',
+                                        boxShadow: showBorder ? '0px 0px 1px 1px red' : null,
+                                    }}
+                                />
+                            )
+                        },
+                    },
 
-          {
-            title: "In Button",
-            key: "button-icon",
-            dataIndex: "icon",
-            render: function RenderButton(Icon) {
-              Icon = Icon as IconDefinition["icon"];
-              return (
-                <LemonButton type="secondary" icon={<Icon />}>
-                  Button
-                </LemonButton>
-              );
-            },
-          },
-        ]}
-      />
-    </div>
-  );
+                    {
+                        title: 'In Button',
+                        key: 'button-icon',
+                        dataIndex: 'icon',
+                        render: function RenderButton(Icon) {
+                            Icon = Icon as IconDefinition['icon']
+                            return (
+                                <LemonButton type="secondary" icon={<Icon />}>
+                                    Button
+                                </LemonButton>
+                            )
+                        },
+                    },
+                ]}
+            />
+        </div>
+    )
 }
 
 export function IconWithCountBubble(): JSX.Element {
-  return (
-    <span className="inline-flex text-2xl border border-primary">
-      <IconWithCount count={7}>
-        <IconGauge />
-      </IconWithCount>
-    </span>
-  );
+    return (
+        <span className="inline-flex text-2xl border border-primary">
+            <IconWithCount count={7}>
+                <IconGauge />
+            </IconWithCount>
+        </span>
+    )
 }
 
 export function IconWithCountHidingZero(): JSX.Element {
-  return (
-    <span className="inline-flex text-2xl border border-primary">
-      <IconWithCount count={0} showZero={false}>
-        <IconGauge />
-      </IconWithCount>
-    </span>
-  );
+    return (
+        <span className="inline-flex text-2xl border border-primary">
+            <IconWithCount count={0} showZero={false}>
+                <IconGauge />
+            </IconWithCount>
+        </span>
+    )
 }
 
 export function IconWithCountShowingZero(): JSX.Element {
-  return (
-    <span className="inline-flex text-2xl border border-primary">
-      <IconWithCount count={0} showZero={true}>
-        <IconGauge />
-      </IconWithCount>
-    </span>
-  );
+    return (
+        <span className="inline-flex text-2xl border border-primary">
+            <IconWithCount count={0} showZero={true}>
+                <IconGauge />
+            </IconWithCount>
+        </span>
+    )
 }
 
 export function IconWithCountOverflowing(): JSX.Element {
-  return (
-    <span className="inline-flex text-2xl border border-primary">
-      <IconWithCount count={11} showZero={true}>
-        <IconGauge />
-      </IconWithCount>
-    </span>
-  );
+    return (
+        <span className="inline-flex text-2xl border border-primary">
+            <IconWithCount count={11} showZero={true}>
+                <IconGauge />
+            </IconWithCount>
+        </span>
+    )
 }


### PR DESCRIPTION
## Problem

When I'm looking for an icon I find it really hard to scan the list in storybook for two reasons

1) they're not sorted
2) it's really long

## Changes

* sort the list by name
* allow filtering the list by name

![icon-search](https://user-images.githubusercontent.com/984817/225149184-17bc815b-2456-462e-a21f-4f64a421c890.gif)
 
## How did you test this code?

running it