### PR TITLE
fix: shared dashboards with squill

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -648,21 +648,7 @@ function InsightCardInternal(
                         ) : isUsingDashboardQueryTiles && canMakeQueryAPICalls ? (
                             <Query query={insight.query} />
                         ) : (
-                            <>
-                                <pre>
-                                    {JSON.stringify(
-                                        {
-                                            exportedAndCached,
-                                            sharedAndCached,
-                                            canMakeQueryAPICalls,
-                                            isUsingDashboardQueryTiles,
-                                        },
-                                        null,
-                                        2
-                                    )}
-                                </pre>
-                                <QueriesUnsupportedHere />
-                            </>
+                            <QueriesUnsupportedHere />
                         )}
                     </div>
                 ) : (

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -643,12 +643,24 @@ function InsightCardInternal(
                                 : undefined
                         }
                     >
-                        {exportedAndCached || (isUsingDashboardQueryTiles && sharedAndCached) ? (
+                        {exportedAndCached || sharedAndCached ? (
                             <Query query={insight.query} cachedResults={insight.result} />
                         ) : isUsingDashboardQueryTiles && canMakeQueryAPICalls ? (
                             <Query query={insight.query} />
                         ) : (
                             <>
+                                <pre>
+                                    {JSON.stringify(
+                                        {
+                                            exportedAndCached,
+                                            sharedAndCached,
+                                            canMakeQueryAPICalls,
+                                            isUsingDashboardQueryTiles,
+                                        },
+                                        null,
+                                        2
+                                    )}
+                                </pre>
                                 <QueriesUnsupportedHere />
                             </>
                         )}

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -64,7 +64,7 @@ class DashboardTileSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "insight"]
         depth = 1
 
-    def to_representation(self, instance: Insight):
+    def to_representation(self, instance: DashboardTile):
         representation = super().to_representation(instance)
 
         insight_representation = representation["insight"] or {}  # May be missing for text tiles


### PR DESCRIPTION
## Problem

Some interesting cookie fun made shared dashboards appear to work with flagged features when not in an incognito window

see #13927 

## Changes

* does not check the feature flag for data exploration on a shared dashboard
* fly-by correction of a typehint

## How did you test this code?

* visiting a shared dashboard with squill on it
* seeing it fail
* removing the flag check
* seeing it work