### PR TITLE
fix: remove unused prop

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -16,7 +16,6 @@ export interface PropertyValueProps {
     endpoint?: string // Endpoint to fetch options from
     placeholder?: string
     className?: string
-    bordered?: boolean
     onSet: CallableFunction
     value?: string | number | Array<string | number> | null
     operator: PropertyOperator
@@ -38,7 +37,6 @@ export function PropertyValue({
     endpoint = undefined,
     placeholder = undefined,
     className,
-    bordered = true,
     onSet,
     value,
     operator,
@@ -108,7 +106,6 @@ export function PropertyValue({
         },
         ['data-attr']: 'prop-val',
         dropdownMatchSelectWidth: 350,
-        bordered,
         placeholder,
         allowClear: Boolean(value),
         onKeyDown: (e: React.KeyboardEvent) => {


### PR DESCRIPTION
## Problem

Was getting errors in a Cypress test about the presence of "bordered" as a prop in `PropertyValueSelect`

## Changes

We're not passing it, and it defaults to true. But it defaults to true in antd anyway. So the prop has no value for us

## How did you test this code?

this PR and its visual regression tests, and 👀 locally