### PR TITLE
feat: Tag plugin-server sentry with region

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -108,6 +108,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         APP_METRICS_GATHERED_FOR_ALL: isDevEnv() ? true : false,
         MAX_TEAM_ID_TO_BUFFER_ANONYMOUS_EVENTS_FOR: 0,
         USE_KAFKA_FOR_SCHEDULED_TASKS: true,
+        DEPLOYMENT: 'default', // Used as a Sentry tag
     }
 }
 

--- a/plugin-server/src/sentry.ts
+++ b/plugin-server/src/sentry.ts
@@ -20,6 +20,7 @@ export function initSentry(config: PluginsServerConfig): void {
             initialScope: {
                 tags: {
                     PLUGIN_SERVER_MODE: config.PLUGIN_SERVER_MODE,
+                    DEPLOYMENT: config.DEPLOYMENT,
                 },
             },
             tracesSampleRate: config.SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -175,6 +175,7 @@ export interface PluginsServerConfig {
     USE_KAFKA_FOR_SCHEDULED_TASKS: boolean // distribute scheduled tasks across the scheduler workers
     EVENT_OVERFLOW_BUCKET_CAPACITY: number
     EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: number
+    DEPLOYMENT: string
 }
 
 export interface Hub extends PluginsServerConfig {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Currently there's no way to know which region the error is coming from, which is not great distinguishing if the problem is in EU, US or DEV.  Related PR: https://github.com/PostHog/posthog-cloud-infra/pull/1316

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

1. made every ingested event throw a sentry error
```
--- a/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
@@ -4,6 +4,7 @@ import { PreIngestionEvent } from 'types'
 import { parseEventTimestamp } from '../timestamps'
 import { captureIngestionWarning } from '../utils'
 import { EventPipelineRunner } from './runner'
+import * as Sentry from '@sentry/node'

 export async function prepareEventStep(runner: EventPipelineRunner, event: PluginEvent): Promise<PreIngestionEvent> {
     const { ip, site_url, team_id, uuid } = event
@@ -13,6 +14,11 @@ export async function prepareEventStep(runner: EventPipelineRunner, event: Plugi

         captureIngestionWarning(runner.hub.db, team_id, type, details)
     }
+    try {
+        throw Error("testing")
+    } catch (err) {
+        Sentry.captureException(err)
+    }
```
2. Then started the plugin-server with 
```
SENTRY_DSN='<DNS-for-Karl-playground' REGION='testing' SELF_CAPTURE=0 DEBUG=1 ./bin/start
```
3. Sent an ingestion event and saw a sentry error that had "testing" region set: https://posthog.sentry.io/issues/4007907226/?project=6605447&query=is%3Aunresolved&referrer=issue-stream
<img width="539" alt="Screenshot 2023-03-15 at 15 22 28" src="https://user-images.githubusercontent.com/890921/225340095-d4be5797-eaff-4ad9-b308-5112a4b05c31.png">

v2: with deployment https://posthog.sentry.io/issues/4007977076/?project=6605447&query=is%3Aunresolved&referrer=issue-stream
