### PR TITLE
feat(sampling): decrease time to show timeout screen to 5s

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -67,7 +67,7 @@ import { globalInsightLogic } from './globalInsightLogic'
 import { transformLegacyHiddenLegendKeys } from 'scenes/funnels/funnelUtils'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
-const SHOW_TIMEOUT_MESSAGE_AFTER = 15000
+const SHOW_TIMEOUT_MESSAGE_AFTER = 5000
 export const UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES = 3
 
 export const defaultFilterTestAccounts = (current_filter_test_accounts: boolean): boolean => {


### PR DESCRIPTION
Currently we let a hedgehog run on the screen for 15s before we show something actionable to the user. 

\>5s I personally start checking other tabs, doing other things and thus never see the actionable message with:

1. Things to improve query speed
2. More importantly, a button to speed the query up

So I'd love to decrease this to 5s.