### PR TITLE
fix(hogql): person properties in a funnel breakdown

### DIFF
--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -2462,6 +2462,45 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(response_json["result"][1]["count"], 0)
             self.assertEqual(response_json["timezone"], "UTC")
 
+    # @snapshot_clickhouse_queries
+    @also_test_with_materialized_columns(event_properties=["int_value"], person_properties=["fish"])
+    def test_insight_funnels_hogql_breakdown(self) -> None:
+        with freeze_time("2012-01-15T04:01:34.000Z"):
+            _create_person(team=self.team, distinct_ids=["1"], properties={"fish": "there is no fish"})
+            _create_event(team=self.team, event="user signed up", distinct_id="1", properties={"int_value": 1})
+            _create_event(team=self.team, event="user did things", distinct_id="1", properties={"int_value": 20})
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/insights/funnel/",
+                {
+                    "breakdown_type": "hogql",
+                    "breakdowns": [{"property": "person.properties.fish", "type": "hogql"}],
+                    "events": [
+                        {"id": "user signed up", "type": "events", "order": 0},
+                        {"id": "user did things", "type": "events", "order": 1},
+                    ],
+                    "properties": json.dumps(
+                        [
+                            {"key": "toInt(properties.int_value) < 10 and 'bla' != 'a%sd'", "type": "hogql"},
+                            {"key": "like(person.properties.fish, '%fish%')", "type": "hogql"},
+                        ]
+                    ),
+                    "funnel_window_days": 14,
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_json = response.json()
+            self.assertEqual(len(response_json["result"]), 1)
+            self.assertEqual(len(response_json["result"][0]), 2)
+            self.assertEqual(response_json["result"][0][0]["name"], "user signed up")
+            self.assertEqual(response_json["result"][0][0]["count"], 1)
+            self.assertEqual(response_json["result"][0][0]["breakdown"], ["there is no fish"])
+            self.assertEqual(response_json["result"][0][0]["breakdown_value"], ["there is no fish"])
+            self.assertEqual(response_json["result"][0][1]["name"], "user did things")
+            self.assertEqual(response_json["result"][0][1]["count"], 0)
+            self.assertEqual(response_json["result"][0][1]["breakdown"], ["there is no fish"])
+            self.assertEqual(response_json["result"][0][1]["breakdown_value"], ["there is no fish"])
+            self.assertEqual(response_json["timezone"], "UTC")
+
     def test_insight_retention_hogql(self) -> None:
         with freeze_time("2012-01-15T04:01:34.000Z"):
             _create_person(

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -769,33 +769,34 @@ def build_selector_regex(selector: Selector) -> str:
     return regex
 
 
+class HogQLPropertyChecker(TraversingVisitor):
+    def __init__(self):
+        self.event_properties: List[str] = []
+        self.person_properties: List[str] = []
+
+    def visit_field(self, node: ast.Field):
+        if len(node.chain) > 1 and node.chain[0] == "properties":
+            self.event_properties.append(node.chain[1])
+
+        if len(node.chain) > 2 and node.chain[0] == "person" and node.chain[1] == "properties":
+            self.person_properties.append(node.chain[2])
+
+        if (
+            len(node.chain) > 3
+            and node.chain[0] == "pdi"
+            and node.chain[1] == "person"
+            and node.chain[2] == "properties"
+        ):
+            self.person_properties.append(node.chain[3])
+
+
 def extract_tables_and_properties(props: List[Property]) -> TCounter[PropertyIdentifier]:
     counters: List[tuple] = []
-
-    class PropertyChecker(TraversingVisitor):
-        def __init__(self):
-            self.event_properties: List[str] = []
-            self.person_properties: List[str] = []
-
-        def visit_field(self, node: ast.Field):
-            if len(node.chain) > 1 and node.chain[0] == "properties":
-                self.event_properties.append(node.chain[1])
-
-            if len(node.chain) > 2 and node.chain[0] == "person" and node.chain[1] == "properties":
-                self.person_properties.append(node.chain[2])
-
-            if (
-                len(node.chain) > 3
-                and node.chain[0] == "pdi"
-                and node.chain[1] == "person"
-                and node.chain[2] == "properties"
-            ):
-                self.person_properties.append(node.chain[3])
 
     for prop in props:
         if prop.type == "hogql":
             node = parse_expr(prop.key)
-            property_checker = PropertyChecker()
+            property_checker = HogQLPropertyChecker()
             property_checker.visit(node)
             for field in property_checker.event_properties:
                 counters.append((field, "event", None))


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/14730

You can't breakdown with person properties when using hogql on a funnel.

## Changes

Now you can.

## How did you test this code?

Wrote a test. Tested in the browser.