### PR TITLE
feat(flags): Shorter wait times before timing out

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -102,68 +102,35 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
-  '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -191,7 +158,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -211,6 +178,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -102,35 +102,68 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+  '
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -158,7 +191,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -178,22 +211,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -522,3 +522,21 @@
   WHERE "posthog_grouptypemapping"."team_id" = 2
   '
 ---
+# name: TestResiliency.test_feature_flags_v3_with_slow_db_doesnt_try_to_compute_conditions_again
+  '
+  SELECT pg_sleep(1);
+  
+  SELECT (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
+          AND "posthog_person"."properties" ? 'email'
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
+         (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
+          AND "posthog_person"."properties" ? 'email'
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -808,7 +808,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         # new person with "other_id" is yet to be created
 
         # caching flag definitions in the above mean fewer queries
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(14):
             # one extra query to find person_id for $anon_distinct_id
             response = self._post_decide(
                 api_version=2,

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -28,7 +28,7 @@ from .feature_flag import (
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
-FLAG_MATCHING_QUERY_TIMEOUT_MS = 3 * 1000  # 3 seconds. Any longer and we'll just error out.
+FLAG_MATCHING_QUERY_TIMEOUT_MS = 1 * 1000  # 1 second. Any longer and we'll just error out.
 
 
 class FeatureFlagMatchReason(str, Enum):
@@ -72,13 +72,15 @@ class FlagsMatcherCache:
 
     @cached_property
     def group_types_to_indexes(self) -> Dict[GroupTypeName, GroupTypeIndex]:
+        if self.failed_to_fetch_flags:
+            raise DatabaseError("Failed to fetch group type mapping previously, not trying again.")
         try:
             with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
                 group_type_mapping_rows = GroupTypeMapping.objects.filter(team_id=self.team_id)
                 return {row.group_type: row.group_type_index for row in group_type_mapping_rows}
-        except DatabaseError:
+        except DatabaseError as err:
             self.failed_to_fetch_flags = True
-            return {}
+            raise err
 
     @cached_property
     def group_type_index_to_name(self) -> Dict[GroupTypeIndex, GroupTypeName]:
@@ -86,6 +88,9 @@ class FlagsMatcherCache:
 
 
 class FeatureFlagMatcher:
+
+    failed_to_fetch_conditions = False
+
     def __init__(
         self,
         feature_flags: List[FeatureFlag],
@@ -109,9 +114,6 @@ class FeatureFlagMatcher:
     def get_match(self, feature_flag: FeatureFlag) -> FeatureFlagMatch:
         # If aggregating flag by groups and relevant group type is not passed - flag is off!
         if self.hashed_identifier(feature_flag) is None:
-            if self.cache.failed_to_fetch_flags:
-                raise DatabaseError("Failed to get group type mapping for team")
-
             return FeatureFlagMatch(match=False, reason=FeatureFlagMatchReason.NO_GROUP_TYPE)
 
         highest_priority_evaluation_reason = FeatureFlagMatchReason.NO_CONDITION_MATCH
@@ -228,6 +230,8 @@ class FeatureFlagMatcher:
         return True, FeatureFlagMatchReason.CONDITION_MATCH
 
     def _condition_matches(self, feature_flag: FeatureFlag, condition_index: int) -> bool:
+        if self.failed_to_fetch_conditions:
+            raise DatabaseError("Failed to fetch conditions for feature flag previously, not trying again.")
         return self.query_conditions.get(f"flag_{feature_flag.pk}_condition_{condition_index}", False)
 
     # Define contiguous sub-domains within [0, 1].
@@ -245,85 +249,89 @@ class FeatureFlagMatcher:
 
     @cached_property
     def query_conditions(self) -> Dict[str, bool]:
-        with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
-            team_id = self.feature_flags[0].team_id
-            person_query: QuerySet = Person.objects.filter(
-                team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id
-            )
-            basic_group_query: QuerySet = Group.objects.filter(team_id=team_id)
-            group_query_per_group_type_mapping: Dict[GroupTypeIndex, Tuple[QuerySet, List[str]]] = {}
-            # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
-            # If no groups for a group type are passed in, we can skip querying for that group type,
-            # since the result will always be `false`.
-            for group_type, group_key in self.groups.items():
-                group_type_index = self.cache.group_types_to_indexes.get(group_type)
-                if group_type_index is not None:
-                    # a tuple of querySet and field names
-                    group_query_per_group_type_mapping[group_type_index] = (
-                        basic_group_query.filter(group_type_index=group_type_index, group_key=group_key),
-                        [],
-                    )
+        try:
+            with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
+                team_id = self.feature_flags[0].team_id
+                person_query: QuerySet = Person.objects.filter(
+                    team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id
+                )
+                basic_group_query: QuerySet = Group.objects.filter(team_id=team_id)
+                group_query_per_group_type_mapping: Dict[GroupTypeIndex, Tuple[QuerySet, List[str]]] = {}
+                # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
+                # If no groups for a group type are passed in, we can skip querying for that group type,
+                # since the result will always be `false`.
+                for group_type, group_key in self.groups.items():
+                    group_type_index = self.cache.group_types_to_indexes.get(group_type)
+                    if group_type_index is not None:
+                        # a tuple of querySet and field names
+                        group_query_per_group_type_mapping[group_type_index] = (
+                            basic_group_query.filter(group_type_index=group_type_index, group_key=group_key),
+                            [],
+                        )
 
-            person_fields = []
+                person_fields = []
 
-            for feature_flag in self.feature_flags:
-                for index, condition in enumerate(feature_flag.conditions):
-                    key = f"flag_{feature_flag.pk}_condition_{index}"
-                    expr: Any = None
-                    if len(condition.get("properties", {})) > 0:
-                        # Feature Flags don't support OR filtering yet
-                        target_properties = self.property_value_overrides
-                        if feature_flag.aggregation_group_type_index is not None:
-                            target_properties = self.group_property_value_overrides.get(
-                                self.cache.group_type_index_to_name[feature_flag.aggregation_group_type_index], {}
+                for feature_flag in self.feature_flags:
+                    for index, condition in enumerate(feature_flag.conditions):
+                        key = f"flag_{feature_flag.pk}_condition_{index}"
+                        expr: Any = None
+                        if len(condition.get("properties", {})) > 0:
+                            # Feature Flags don't support OR filtering yet
+                            target_properties = self.property_value_overrides
+                            if feature_flag.aggregation_group_type_index is not None:
+                                target_properties = self.group_property_value_overrides.get(
+                                    self.cache.group_type_index_to_name[feature_flag.aggregation_group_type_index], {}
+                                )
+                            expr = properties_to_Q(
+                                Filter(data=condition).property_groups.flat,
+                                override_property_values=target_properties,
                             )
-                        expr = properties_to_Q(
-                            Filter(data=condition).property_groups.flat,
-                            override_property_values=target_properties,
-                        )
 
-                    if feature_flag.aggregation_group_type_index is None:
-                        person_query = person_query.annotate(
-                            **{
-                                key: ExpressionWrapper(
-                                    expr if expr else RawSQL("true", []), output_field=BooleanField()
-                                )
-                            }
-                        )
-                        person_fields.append(key)
-                    else:
-                        if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
-                            # ignore flags that didn't have the right groups passed in
-                            continue
-                        group_query, group_fields = group_query_per_group_type_mapping[
-                            feature_flag.aggregation_group_type_index
-                        ]
-                        group_query = group_query.annotate(
-                            **{
-                                key: ExpressionWrapper(
-                                    expr if expr else RawSQL("true", []), output_field=BooleanField()
-                                )
-                            }
-                        )
-                        group_fields.append(key)
-                        group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
-                            group_query,
-                            group_fields,
-                        )
+                        if feature_flag.aggregation_group_type_index is None:
+                            person_query = person_query.annotate(
+                                **{
+                                    key: ExpressionWrapper(
+                                        expr if expr else RawSQL("true", []), output_field=BooleanField()
+                                    )
+                                }
+                            )
+                            person_fields.append(key)
+                        else:
+                            if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
+                                # ignore flags that didn't have the right groups passed in
+                                continue
+                            group_query, group_fields = group_query_per_group_type_mapping[
+                                feature_flag.aggregation_group_type_index
+                            ]
+                            group_query = group_query.annotate(
+                                **{
+                                    key: ExpressionWrapper(
+                                        expr if expr else RawSQL("true", []), output_field=BooleanField()
+                                    )
+                                }
+                            )
+                            group_fields.append(key)
+                            group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
+                                group_query,
+                                group_fields,
+                            )
 
-            all_conditions = {}
-            if len(person_fields) > 0:
-                person_query = person_query.values(*person_fields)
-                if len(person_query) > 0:
-                    all_conditions = {**person_query[0]}
+                all_conditions = {}
+                if len(person_fields) > 0:
+                    person_query = person_query.values(*person_fields)
+                    if len(person_query) > 0:
+                        all_conditions = {**person_query[0]}
 
-            for group_query, group_fields in group_query_per_group_type_mapping.values():
-                group_query = group_query.values(*group_fields)
-                if len(group_query) > 0:
-                    assert len(group_query) == 1, f"Expected 1 group query result, got {len(group_query)}"
-                    all_conditions = {**all_conditions, **group_query[0]}
+                for group_query, group_fields in group_query_per_group_type_mapping.values():
+                    group_query = group_query.values(*group_fields)
+                    if len(group_query) > 0:
+                        assert len(group_query) == 1, f"Expected 1 group query result, got {len(group_query)}"
+                        all_conditions = {**all_conditions, **group_query[0]}
 
-            return all_conditions
+                return all_conditions
+        except Exception as e:
+            self.failed_to_fetch_conditions = True
+            raise e
 
     def hashed_identifier(self, feature_flag: FeatureFlag) -> Optional[str]:
         """
@@ -475,33 +483,38 @@ def get_all_feature_flags(
             skip_experience_continuity_flags=True,
         )
 
-    if hash_key_override is not None:
-        # setting overrides only when we get an override
-        if person_id is None:
-            # :TRICKY: Some ingestion delays may mean that `$identify` hasn't yet created
-            # the new person on which decide was called.
-            # In this case, we can try finding the person_id for the old distinct id.
-            # This is safe, since once `$identify` is processed, it would only add the distinct_id to this
-            # existing person. If, because of race conditions, a person merge is called for later,
-            # then https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L421
-            # will take care of it^.
-            with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
-                person_id = (
-                    PersonDistinctId.objects.filter(distinct_id=hash_key_override, team_id=team_id)
-                    .values_list("person_id", flat=True)
-                    .first()
-                )
-            # If even this old person doesn't exist yet, we're facing severe ingestion delays
-            # and there's not much we can do, since all person properties based feature flags
-            # would fail server side anyway.
+    # make the entire hash key override logic a single transaction
+    # with a small timeout
+    try:
+        with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
+            if hash_key_override is not None:
+                # setting overrides only when we get an override
+                if person_id is None:
+                    # :TRICKY: Some ingestion delays may mean that `$identify` hasn't yet created
+                    # the new person on which decide was called.
+                    # In this case, we can try finding the person_id for the old distinct id.
+                    # This is safe, since once `$identify` is processed, it would only add the distinct_id to this
+                    # existing person. If, because of race conditions, a person merge is called for later,
+                    # then https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L421
+                    # will take care of it^.
+                    person_id = (
+                        PersonDistinctId.objects.filter(distinct_id=hash_key_override, team_id=team_id)
+                        .values_list("person_id", flat=True)
+                        .first()
+                    )
+                    # If even this old person doesn't exist yet, we're facing severe ingestion delays
+                    # and there's not much we can do, since all person properties based feature flags
+                    # would fail server side anyway.
 
-        if person_id is not None:
-            try:
-                set_feature_flag_hash_key_overrides(all_feature_flags, team_id, person_id, hash_key_override)
-            except Exception as e:
-                # If the database is in read-only mode, we can't handle experience continuity flags.
-                # Do not error on decide for this case.
-                capture_exception(e)
+                if person_id is not None:
+                    set_feature_flag_hash_key_overrides(all_feature_flags, team_id, person_id, hash_key_override)
+
+    except Exception as e:
+        # If the database is in read-only mode, we can't handle experience continuity flags,
+        # since the set_feature_flag_hash_key_overrides call will fail.
+
+        # For this case, and for any other case, do not error out on decide, we can handle it!
+        capture_exception(e)
 
     # :TRICKY: Consistency matters only when personIDs exist
     # as overrides are stored on personIDs.
@@ -521,29 +534,27 @@ def get_all_feature_flags(
 def set_feature_flag_hash_key_overrides(
     feature_flags: List[FeatureFlag], team_id: int, person_id: int, hash_key_override: str
 ) -> None:
-
-    with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
-        existing_flag_overrides = set(
-            FeatureFlagHashKeyOverride.objects.filter(team_id=team_id, person_id=person_id).values_list(
-                "feature_flag_key", flat=True
-            )
+    existing_flag_overrides = set(
+        FeatureFlagHashKeyOverride.objects.filter(team_id=team_id, person_id=person_id).values_list(
+            "feature_flag_key", flat=True
         )
-        new_overrides = []
-        for feature_flag in feature_flags:
-            if feature_flag.ensure_experience_continuity and feature_flag.key not in existing_flag_overrides:
-                new_overrides.append(
-                    FeatureFlagHashKeyOverride(
-                        team_id=team_id,
-                        person_id=person_id,
-                        feature_flag_key=feature_flag.key,
-                        hash_key=hash_key_override,
-                    )
+    )
+    new_overrides = []
+    for feature_flag in feature_flags:
+        if feature_flag.ensure_experience_continuity and feature_flag.key not in existing_flag_overrides:
+            new_overrides.append(
+                FeatureFlagHashKeyOverride(
+                    team_id=team_id,
+                    person_id=person_id,
+                    feature_flag_key=feature_flag.key,
+                    hash_key=hash_key_override,
                 )
+            )
 
-        if new_overrides:
-            # :TRICKY: regarding the ignore_conflicts parameter:
-            # This can happen if the same person is being processed by multiple workers
-            # / we got multiple requests for the same person
-            # at the same time. In this case, we can safely ignore the error.
-            # We don't want to return an error response for `/decide` just because of this.
-            FeatureFlagHashKeyOverride.objects.bulk_create(new_overrides, ignore_conflicts=True)
+    if new_overrides:
+        # :TRICKY: regarding the ignore_conflicts parameter:
+        # This can happen if the same person is being processed by multiple workers
+        # / we got multiple requests for the same person
+        # at the same time. In this case, we can safely ignore the error.
+        # We don't want to return an error response for `/decide` just because of this.
+        FeatureFlagHashKeyOverride.objects.bulk_create(new_overrides, ignore_conflicts=True)

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -483,12 +483,12 @@ def get_all_feature_flags(
             skip_experience_continuity_flags=True,
         )
 
-    # make the entire hash key override logic a single transaction
-    # with a small timeout
-    try:
-        with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
-            if hash_key_override is not None:
-                # setting overrides only when we get an override
+    # setting overrides only when we get an override
+    if hash_key_override is not None:
+        # make the entire hash key override logic a single transaction
+        # with a small timeout
+        try:
+            with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
                 if person_id is None:
                     # :TRICKY: Some ingestion delays may mean that `$identify` hasn't yet created
                     # the new person on which decide was called.
@@ -509,12 +509,12 @@ def get_all_feature_flags(
                 if person_id is not None:
                     set_feature_flag_hash_key_overrides(all_feature_flags, team_id, person_id, hash_key_override)
 
-    except Exception as e:
-        # If the database is in read-only mode, we can't handle experience continuity flags,
-        # since the set_feature_flag_hash_key_overrides call will fail.
+        except Exception as e:
+            # If the database is in read-only mode, we can't handle experience continuity flags,
+            # since the set_feature_flag_hash_key_overrides call will fail.
 
-        # For this case, and for any other case, do not error out on decide, we can handle it!
-        capture_exception(e)
+            # For this case, and for any other case, do not error out on decide, we can handle it!
+            capture_exception(e)
 
     # :TRICKY: Consistency matters only when personIDs exist
     # as overrides are stored on personIDs.


### PR DESCRIPTION
## Problem

We'd have `FLAG_MATCHING_TIMEOUT_MS` for every request to the db when the first one timed out; which would push us over the 10s limit for multiple flags.

Similarly, having a 3s timeout on _every_ operation was too much, so have combined these limits together into a more logical grouping.

This still isn't the most optimal, as we can have in the worst case, 3s pgbouncer wait + 1s statement timeout everywhere it's called (5 places), so total 20s worst case, which is twice as long as the smallest we want.

However, to de-risk things, and know exactly what breaks, making this change in pieces.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
