### PR TITLE
feat(perf): only load experiment results once

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentWorkflow.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWorkflow.tsx
@@ -12,11 +12,7 @@ export function ExperimentWorkflow(): JSX.Element {
             <Row>
                 <Col className="exp-workflow-step step-completed w-full">
                     <Row align="middle">
-                        {true ? (
-                            <IconCheckmark style={{ color: 'var(--primary)', fontSize: 24 }} />
-                        ) : (
-                            <IconRadioButtonUnchecked />
-                        )}
+                        <IconCheckmark style={{ color: 'var(--primary)', fontSize: 24 }} />
                         <b className="ml-2">Create experiment</b>
                     </Row>
                     <div className="ml-8">Set variants, select participants, and add secondary metrics</div>

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -32,7 +32,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupsModel } from '~/models/groupsModel'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { convertPropertyGroupToProperties, toParams } from 'lib/utils'
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { IconInfo } from 'lib/lemon-ui/icons'
@@ -878,16 +878,6 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
     })),
-    afterMount(({ props, actions }) => {
-        const foundExperiment = experimentsLogic
-            .findMounted()
-            ?.values.experiments.find((experiment) => experiment.id === props.experimentId)
-        if (foundExperiment) {
-            actions.setExperiment(foundExperiment)
-        } else if (props.experimentId !== 'new') {
-            actions.loadExperiment()
-        }
-    }),
 ])
 
 function percentageDistribution(variantCount: number): number[] {


### PR DESCRIPTION
I'm already spreading myself a little thin so if this doesn't work then please do jump in as I recommend this gets fixed but am stepping on toes while working on a bunch of other stuff.

@neilkakkar is the afterMount logic still relevant? if it is, we need to tweak it a bit, as currently we load both the main and secondary experiment results **twice** on every page load! and since #14742 isn't a thing yet, we're computing them twice too 🤯 

then a minor fix for a `true ?` that's been in the codebase for a year, so safe to say we're ok with the default branch.

from my very quick testing seems removing `afterMount` didn't affect anything and fixed the double request issue