### PR TITLE
fix: hide query based insights in recently viewed list

### DIFF
--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -6,11 +6,13 @@ import { DashboardLogicProps } from 'scenes/dashboard/dashboardLogic'
 import { DashboardPlacement, InsightModel, PersonType } from '~/types'
 import api from 'lib/api'
 import { loaders } from 'kea-loaders'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export const projectHomepageLogic = kea<projectHomepageLogicType>([
     path(['scenes', 'project-homepage', 'projectHomepageLogic']),
     connect({
-        values: [teamLogic, ['currentTeamId', 'currentTeam']],
+        values: [teamLogic, ['currentTeamId', 'currentTeam'], featureFlagLogic, ['featureFlags']],
     }),
 
     selectors({
@@ -22,6 +24,10 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
                 placement: DashboardPlacement.ProjectHomepage,
             }),
         ],
+        allowQueryInsights: [
+            (s) => [s.featureFlags],
+            (featureFlags) => !!featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_QUERY_TAB],
+        ],
     }),
 
     loaders(({ values }) => ({
@@ -29,7 +35,9 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
             [] as InsightModel[],
             {
                 loadRecentInsights: async () => {
-                    return await api.get(`api/projects/${values.currentTeamId}/insights/my_last_viewed`)
+                    return await api.get(
+                        `api/projects/${values.currentTeamId}/insights/my_last_viewed?include_query_insights=${values.allowQueryInsights}`
+                    )
                 },
             },
         ],

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1857,6 +1857,74 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert [r["id"] for r in response_data] == [insight_1_id]
 
+    def test_get_recently_viewed_insights_excludes_query_based_insights_by_default(self) -> None:
+        insight_1_id, _ = self.dashboard_api.create_insight({"short_id": "12345678"})
+        insight_2_id, _ = self.dashboard_api.create_insight(
+            {
+                "short_id": "3456",
+                "query": {
+                    "kind": "DataTableNode",
+                    "source": {
+                        "kind": "EventsQuery",
+                        "select": [
+                            "*",
+                            "event",
+                            "person",
+                            "coalesce(properties.$current_url, properties.$screen_name) # Url / Screen",
+                            "properties.$lib",
+                            "timestamp",
+                        ],
+                        "properties": [{"type": "event", "key": "$browser", "operator": "exact", "value": "Chrome"}],
+                        "limit": 100,
+                    },
+                },
+            }
+        )
+
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_1_id}/viewed")
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_2_id}/viewed")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/my_last_viewed")
+        response_data = response.json()
+
+        # No results if no insights have been viewed
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert [r["id"] for r in response_data] == [insight_1_id]
+
+    def test_get_recently_viewed_insights_can_include_query_based_insights(self) -> None:
+        insight_1_id, _ = self.dashboard_api.create_insight({"short_id": "12345678"})
+        insight_2_id, _ = self.dashboard_api.create_insight(
+            {
+                "short_id": "3456",
+                "query": {
+                    "kind": "DataTableNode",
+                    "source": {
+                        "kind": "EventsQuery",
+                        "select": [
+                            "*",
+                            "event",
+                            "person",
+                            "coalesce(properties.$current_url, properties.$screen_name) # Url / Screen",
+                            "properties.$lib",
+                            "timestamp",
+                        ],
+                        "properties": [{"type": "event", "key": "$browser", "operator": "exact", "value": "Chrome"}],
+                        "limit": 100,
+                    },
+                },
+            }
+        )
+
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_1_id}/viewed")
+        self.client.post(f"/api/projects/{self.team.id}/insights/{insight_2_id}/viewed")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/my_last_viewed?include_query_insights=true")
+        response_data = response.json()
+
+        # No results if no insights have been viewed
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert [r["id"] for r in response_data] == [insight_2_id, insight_1_id]
+
     def test_get_recently_viewed_insights_when_no_insights_viewed(self) -> None:
         insight_1_id, _ = self.dashboard_api.create_insight({"short_id": "12345678"})
 


### PR DESCRIPTION
## Problem

We're hiding query based insights in the saved insights list based on a flag. But not in the home page recently viewed list

## Changes

hides them

![2023-03-15 19 48 49](https://user-images.githubusercontent.com/984817/225428985-7eabc28c-0878-45f8-9e1e-4c8befdd3e01.gif)

## How did you test this code?

dev tests and 👀 locally