### PR TITLE
feat: define new insight urls in one place

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/InsightsNav.tsx
+++ b/frontend/src/scenes/insights/InsightNav/InsightsNav.tsx
@@ -4,9 +4,9 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { FunnelsCue } from '../views/Trends/FunnelsCue'
 import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { Link } from 'lib/lemon-ui/Link'
-import { urls } from 'scenes/urls'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
+import { insightTypeURL } from 'scenes/insights/utils'
 
 export function InsightsNav(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
@@ -22,7 +22,7 @@ export function InsightsNav(): JSX.Element {
                 tabs={tabs.map(({ label, type, dataAttr }) => ({
                     key: type,
                     label: (
-                        <Link to={urls.insightNew({ insight: type })} preventClick data-attr={dataAttr}>
+                        <Link to={insightTypeURL[type]} preventClick data-attr={dataAttr}>
                             <Tooltip placement="top" title={INSIGHT_TYPES_METADATA[type].description}>
                                 {label}
                             </Tooltip>

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -9,6 +9,7 @@ import {
     FunnelVizType,
     InsightModel,
     InsightShortId,
+    InsightType,
     PathsFilterType,
     PathType,
     StepOrderValue,
@@ -66,6 +67,8 @@ import {
     isTimeToSeeDataSessionsQuery,
     isTrendsQuery,
 } from '~/queries/utils'
+import { urls } from 'scenes/urls'
+import { examples } from '~/queries/examples'
 
 export const getDisplayNameFromEntityFilter = (
     filter: EntityFilter | ActionFilter | null,
@@ -616,4 +619,15 @@ export function sortDates(dates: Array<string | null>): Array<string | null> {
 // Gets content-length header from a fetch Response
 export function getResponseBytes(apiResponse: Response): number {
     return parseInt(apiResponse.headers.get('Content-Length') ?? '0')
+}
+
+export const insightTypeURL: Record<InsightType, string> = {
+    TRENDS: urls.insightNew({ insight: InsightType.TRENDS }),
+    STICKINESS: urls.insightNew({ insight: InsightType.STICKINESS }),
+    LIFECYCLE: urls.insightNew({ insight: InsightType.LIFECYCLE }),
+    FUNNELS: urls.insightNew({ insight: InsightType.FUNNELS }),
+    RETENTION: urls.insightNew({ insight: InsightType.RETENTION }),
+    PATHS: urls.insightNew({ insight: InsightType.PATHS }),
+    QUERY: urls.insightNew(undefined, undefined, JSON.stringify(examples.EventsTableFull)),
+    SQL: urls.insightNew(undefined, undefined, JSON.stringify(examples.HogQLTable)),
 }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -40,7 +40,7 @@ import { More } from 'lib/lemon-ui/LemonButton/More'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonButton, LemonButtonWithSideAction } from 'lib/lemon-ui/LemonButton'
 import { InsightCard } from 'lib/components/Cards/InsightCard'
-import { summariseInsight } from 'scenes/insights/utils'
+import { insightTypeURL, summariseInsight } from 'scenes/insights/utils'
 import { groupsModel } from '~/models/groupsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
@@ -56,7 +56,6 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { isInsightVizNode } from '~/queries/utils'
-import { examples } from '~/queries/examples'
 
 interface NewInsightButtonProps {
     dataAttr: string
@@ -255,17 +254,6 @@ export const INSIGHT_TYPE_OPTIONS: LemonSelectOptions<string> = [
 export const scene: SceneExport = {
     component: SavedInsights,
     logic: savedInsightsLogic,
-}
-
-const insightTypeURL: Record<InsightType, string> = {
-    TRENDS: urls.insightNew({ insight: InsightType.TRENDS }),
-    STICKINESS: urls.insightNew({ insight: InsightType.STICKINESS }),
-    LIFECYCLE: urls.insightNew({ insight: InsightType.LIFECYCLE }),
-    FUNNELS: urls.insightNew({ insight: InsightType.FUNNELS }),
-    RETENTION: urls.insightNew({ insight: InsightType.RETENTION }),
-    PATHS: urls.insightNew({ insight: InsightType.PATHS }),
-    QUERY: urls.insightNew(undefined, undefined, JSON.stringify(examples.EventsTableFull)),
-    SQL: urls.insightNew(undefined, undefined, JSON.stringify(examples.HogQLTable)),
 }
 
 export function InsightIcon({ insight }: { insight: InsightModel }): JSX.Element | null {


### PR DESCRIPTION
## Problem

new insight urls are built in more than one place, so they'd got out of sync

## Changes

defines them in one place

## How did you test this code?

👀 locally