### PR TITLE
feat: use same top heading for insight card and exported insight

### DIFF
--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -1,19 +1,18 @@
-import { ChartDisplayType, InsightLogicProps, InsightModel, InsightType } from '~/types'
+import { ChartDisplayType, InsightLogicProps, InsightModel } from '~/types'
 import { BindLogic } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightViz } from 'lib/components/Cards/InsightCard/InsightCard'
 import './ExportedInsight.scss'
-import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
-import { dateFilterToText } from 'lib/utils'
 import { FriendlyLogo } from '~/toolbar/assets/FriendlyLogo'
 import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
 import { ExportOptions, ExportType } from '~/exporter/types'
 import clsx from 'clsx'
 import { SINGLE_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
-import { isDataTableNode, isInsightVizNode } from '~/queries/utils'
+import { isDataTableNode } from '~/queries/utils'
 import { QueriesUnsupportedHere } from 'lib/components/Cards/InsightCard/QueriesUnsupportedHere'
 import { Query } from '~/queries/Query/Query'
+import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 
 export function ExportedInsight({
     insight,
@@ -63,18 +62,7 @@ export function ExportedInsight({
                     <div className="ExportedInsight__header">
                         <div>
                             <h5>
-                                <span
-                                    title={INSIGHT_TYPES_METADATA[filters.insight || InsightType.TRENDS]?.description}
-                                >
-                                    {
-                                        INSIGHT_TYPES_METADATA[
-                                            !!query && !isInsightVizNode(query)
-                                                ? InsightType.QUERY
-                                                : filters.insight || InsightType.TRENDS
-                                        ]?.name
-                                    }
-                                </span>{' '}
-                                • {dateFilterToText(filters.date_from, filters.date_to, 'Last 7 days')}
+                                <TopHeading insight={insight} />
                             </h5>
                             <h4 title={name} className="ExportedInsight__header__title">
                                 {name || derived_name}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import { capitalizeFirstLetter, dateFilterToText } from 'lib/utils'
+import { capitalizeFirstLetter } from 'lib/utils'
 import React, { useEffect, useState } from 'react'
 import { Layout } from 'react-grid-layout'
 import {
@@ -34,7 +34,6 @@ import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { ResizeHandle1D, ResizeHandle2D } from '../handles'
 import './InsightCard.scss'
 import { InsightDetails } from './InsightDetails'
-import { INSIGHT_TYPES_METADATA, InsightTypeMetadata, QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { ActionsHorizontalBar, ActionsLineGraph, ActionsPie } from 'scenes/trends/viz'
 import { DashboardInsightsTable } from 'scenes/insights/views/InsightsTable/DashboardInsightsTable'
@@ -62,11 +61,11 @@ import {
 import { CardMeta, Resizeable } from 'lib/components/Cards/CardMeta'
 import { DashboardPrivilegeLevel, FEATURE_FLAGS } from 'lib/constants'
 import { Query } from '~/queries/Query/Query'
-import { containsHogQLQuery, dateRangeFor, isDataTableNode, isInsightQueryNode } from '~/queries/utils'
 import { PieChartFilled } from '@ant-design/icons'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { QueriesUnsupportedHere } from 'lib/components/Cards/InsightCard/QueriesUnsupportedHere'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 
 type DisplayedType = ChartDisplayType | 'RetentionContainer' | 'FunnelContainer' | 'PathsContainer'
 
@@ -414,44 +413,6 @@ function InsightMeta({
                 </>
             }
         />
-    )
-}
-
-function TopHeading({ insight }: { insight: InsightModel }): JSX.Element {
-    const { filters, query } = insight
-
-    let insightType: InsightTypeMetadata
-
-    // check the query first because the backend still adds defaults to empty filters :/
-    if (!!query?.kind) {
-        if (isDataTableNode(query) && containsHogQLQuery(query)) {
-            insightType = QUERY_TYPES_METADATA[query.source.kind]
-        } else {
-            insightType = QUERY_TYPES_METADATA[query.kind]
-        }
-    } else if (!!filters.insight) {
-        insightType = INSIGHT_TYPES_METADATA[filters.insight]
-    } else {
-        // maintain the existing default
-        insightType = INSIGHT_TYPES_METADATA[InsightType.TRENDS]
-    }
-
-    let { date_from, date_to } = filters
-    if (!!query) {
-        const queryDateRange = dateRangeFor(query)
-        if (!!queryDateRange) {
-            date_from = queryDateRange.date_from
-            date_to = queryDateRange.date_to
-        }
-    }
-
-    const defaultDateRange = query == undefined || isInsightQueryNode(query) ? 'Last 7 days' : null
-    const dateText = dateFilterToText(date_from, date_to, defaultDateRange)
-    return (
-        <>
-            <span title={insightType?.description}>{insightType?.name}</span>
-            {dateText ? <> • {dateText}</> : null}
-        </>
     )
 }
 

--- a/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
@@ -1,0 +1,42 @@
+import { InsightModel, InsightType } from '~/types'
+import { INSIGHT_TYPES_METADATA, InsightTypeMetadata, QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
+import { containsHogQLQuery, dateRangeFor, isDataTableNode, isInsightQueryNode } from '~/queries/utils'
+import { dateFilterToText } from 'lib/utils'
+
+export function TopHeading({ insight }: { insight: InsightModel }): JSX.Element {
+    const { filters, query } = insight
+
+    let insightType: InsightTypeMetadata
+
+    // check the query first because the backend still adds defaults to empty filters :/
+    if (!!query?.kind) {
+        if (isDataTableNode(query) && containsHogQLQuery(query)) {
+            insightType = QUERY_TYPES_METADATA[query.source.kind]
+        } else {
+            insightType = QUERY_TYPES_METADATA[query.kind]
+        }
+    } else if (!!filters.insight) {
+        insightType = INSIGHT_TYPES_METADATA[filters.insight]
+    } else {
+        // maintain the existing default
+        insightType = INSIGHT_TYPES_METADATA[InsightType.TRENDS]
+    }
+
+    let { date_from, date_to } = filters
+    if (!!query) {
+        const queryDateRange = dateRangeFor(query)
+        if (!!queryDateRange) {
+            date_from = queryDateRange.date_from
+            date_to = queryDateRange.date_to
+        }
+    }
+
+    const defaultDateRange = query == undefined || isInsightQueryNode(query) ? 'Last 7 days' : null
+    const dateText = dateFilterToText(date_from, date_to, defaultDateRange)
+    return (
+        <>
+            <span title={insightType?.description}>{insightType?.name}</span>
+            {dateText ? <> • {dateText}</> : null}
+        </>
+    )
+}


### PR DESCRIPTION
## Problem

#14709 is getting unwieldy

This change doesn't need to be in it

## Changes

Insight card and exported insights construct the top heading separately and can diverge, this avoids that

## How did you test this code?

👀 locally
