### PR TITLE
feat: rename insight query tab to json tab

### DIFF
--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -69,7 +69,7 @@ export function ExportedInsight({
                                     {
                                         INSIGHT_TYPES_METADATA[
                                             !!query && !isInsightVizNode(query)
-                                                ? InsightType.QUERY
+                                                ? InsightType.JSON
                                                 : filters.insight || InsightType.TRENDS
                                         ]?.name
                                     }

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -28,7 +28,7 @@ import {
 import { objectCleanWithEmpty } from 'lib/utils'
 import { transformLegacyHiddenLegendKeys } from 'scenes/funnels/funnelUtils'
 
-const reverseInsightMap: Record<Exclude<InsightType, InsightType.QUERY | InsightType.SQL>, InsightNodeKind> = {
+const reverseInsightMap: Record<Exclude<InsightType, InsightType.JSON | InsightType.SQL>, InsightNodeKind> = {
     [InsightType.TRENDS]: NodeKind.TrendsQuery,
     [InsightType.FUNNELS]: NodeKind.FunnelsQuery,
     [InsightType.RETENTION]: NodeKind.RetentionQuery,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2089,7 +2089,7 @@
             ]
         },
         "InsightType": {
-            "enum": ["TRENDS", "STICKINESS", "LIFECYCLE", "FUNNELS", "RETENTION", "PATHS", "QUERY", "SQL"],
+            "enum": ["TRENDS", "STICKINESS", "LIFECYCLE", "FUNNELS", "RETENTION", "PATHS", "JSON", "SQL"],
             "type": "string"
         },
         "InsightVizNode": {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -123,7 +123,7 @@ describe('insightNavLogic', () => {
 
         it('can ignore set active view to QUERY when data exploration off', async () => {
             await expectLogic(theInsightNavLogic, () => {
-                theInsightNavLogic.actions.setActiveView(InsightType.QUERY)
+                theInsightNavLogic.actions.setActiveView(InsightType.JSON)
             }).toMatchValues({
                 activeView: InsightType.TRENDS,
             })
@@ -135,9 +135,9 @@ describe('insightNavLogic', () => {
             })
 
             await expectLogic(theInsightNavLogic, () => {
-                theInsightNavLogic.actions.setActiveView(InsightType.QUERY)
+                theInsightNavLogic.actions.setActiveView(InsightType.JSON)
             }).toMatchValues({
-                activeView: InsightType.QUERY,
+                activeView: InsightType.JSON,
             })
         })
 
@@ -231,7 +231,7 @@ describe('insightNavLogic', () => {
                         query: { kind: NodeKind.DataTableNode } as DataTableNode,
                     })
                 }).toMatchValues({
-                    activeView: InsightType.QUERY,
+                    activeView: InsightType.JSON,
                 })
             })
 

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -61,7 +61,7 @@ export const insightNavLogic = kea<insightNavLogicType>([
                         if (isHogQLQuery(query) || (isDataTableNode(query) && isHogQLQuery(query.source))) {
                             return InsightType.SQL
                         }
-                        return InsightType.QUERY
+                        return InsightType.JSON
                     } else {
                         return InsightType.TRENDS
                     }
@@ -122,9 +122,9 @@ export const insightNavLogic = kea<insightNavLogicType>([
                     // don't show debug tab to everyone with the data exploration flags on
                     if (allowQueryTab && user?.is_staff) {
                         tabs.push({
-                            label: 'Debug',
-                            type: InsightType.QUERY,
-                            dataAttr: 'insight-query-tab',
+                            label: 'JSON',
+                            type: InsightType.JSON,
+                            dataAttr: 'insight-json-tab',
                         })
                     }
                 }
@@ -148,7 +148,7 @@ export const insightNavLogic = kea<insightNavLogicType>([
                     actions.setQuery(queryFromKind(NodeKind.StickinessQuery))
                 } else if (view === InsightType.LIFECYCLE) {
                     actions.setQuery(queryFromKind(NodeKind.LifecycleQuery))
-                } else if (view === InsightType.QUERY) {
+                } else if (view === InsightType.JSON) {
                     actions.setQuery(TotalEventsTable)
                 } else if (view === InsightType.SQL) {
                     actions.setQuery(examples.HogQLTable)
@@ -157,7 +157,7 @@ export const insightNavLogic = kea<insightNavLogicType>([
                 actions.setFilters(
                     cleanFilters(
                         // double-check that the view is valid
-                        { ...values.filters, insight: view === InsightType.QUERY ? InsightType.TRENDS : view },
+                        { ...values.filters, insight: view === InsightType.JSON ? InsightType.TRENDS : view },
                         values.filters
                     )
                 )

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -628,6 +628,6 @@ export const insightTypeURL: Record<InsightType, string> = {
     FUNNELS: urls.insightNew({ insight: InsightType.FUNNELS }),
     RETENTION: urls.insightNew({ insight: InsightType.RETENTION }),
     PATHS: urls.insightNew({ insight: InsightType.PATHS }),
-    QUERY: urls.insightNew(undefined, undefined, JSON.stringify(examples.EventsTableFull)),
+    JSON: urls.insightNew(undefined, undefined, JSON.stringify(examples.EventsTableFull)),
     SQL: urls.insightNew(undefined, undefined, JSON.stringify(examples.HogQLTable)),
 }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -111,9 +111,9 @@ export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = 
         icon: InsightSQLIcon,
         inMenu: true,
     },
-    [InsightType.QUERY]: {
-        name: 'Query',
-        description: 'Build custom insights with our powerful query language',
+    [InsightType.JSON]: {
+        name: 'JSON',
+        description: 'Build custom insights with our JSON query language',
         icon: InsightSQLIcon,
         inMenu: false, // until data exploration is released
     },
@@ -259,7 +259,7 @@ export const scene: SceneExport = {
 export function InsightIcon({ insight }: { insight: InsightModel }): JSX.Element | null {
     let insightType = insight?.filters?.insight || InsightType.TRENDS
     if (!!insight.query && !isInsightVizNode(insight.query)) {
-        insightType = InsightType.QUERY
+        insightType = InsightType.JSON
     }
     const insightMetadata = INSIGHT_TYPES_METADATA[insightType]
     if (insightMetadata && insightMetadata.icon) {
@@ -274,7 +274,7 @@ export function NewInsightButton({ dataAttr }: NewInsightButtonProps): JSX.Eleme
     let menuEntries = Object.entries(INSIGHT_TYPES_METADATA)
     if (!featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_QUERY_TAB]) {
         menuEntries = menuEntries.filter(
-            ([insightType]) => insightType !== InsightType.QUERY && insightType !== InsightType.SQL
+            ([insightType]) => insightType !== InsightType.JSON && insightType !== InsightType.SQL
         )
     }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1427,7 +1427,7 @@ export enum InsightType {
     FUNNELS = 'FUNNELS',
     RETENTION = 'RETENTION',
     PATHS = 'PATHS',
-    QUERY = 'QUERY',
+    JSON = 'JSON',
     SQL = 'SQL',
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -260,7 +260,7 @@ class InsightType(str, Enum):
     FUNNELS = "FUNNELS"
     RETENTION = "RETENTION"
     PATHS = "PATHS"
-    QUERY = "QUERY"
+    JSON = "JSON"
     SQL = "SQL"
 
 


### PR DESCRIPTION
## Problem

#14709 is getting out of hand so I'm splitting it up

## Changes

renames the "query/debug" tab to "json" tab, so that we have (depending on flags) a "SQL" and a "JSON" tab in new insights

## How did you test this code?

👀 locally