### PR TITLE
wip: poc: data manager logic

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataManagerLogic.test.ts
+++ b/frontend/src/queries/nodes/DataNode/dataManagerLogic.test.ts
@@ -1,0 +1,91 @@
+import { initKeaTests } from '~/test/init'
+import { expectLogic } from 'kea-test-utils'
+
+import { dataManagerLogic } from '~/queries/nodes/DataNode/dataManagerLogic'
+import { NodeKind, TrendsQuery } from '~/queries/schema'
+import { connect, kea, selectors, path } from 'kea'
+import { useMocks } from '~/mocks/jest'
+
+import type { dummyLogicType } from './dataManagerLogic.testType'
+
+// jest.mock('~/queries/query')
+
+const TEST_QUERY_ID = 'test-id'
+
+const dummyLogic = kea<dummyLogicType>([
+    path(['queries', 'nodes', 'DataNode', 'dataManagerLogic', 'test']),
+    connect({
+        values: [dataManagerLogic, ['getQueryLoading', 'getQueryResponse', 'getQueryError']],
+    }),
+    selectors({
+        dummyLoading: [(s) => [s.getQueryLoading], (getQueryLoading) => getQueryLoading(TEST_QUERY_ID)],
+        dummyResponse: [(s) => [s.getQueryResponse], (getQueryResponse) => getQueryResponse(TEST_QUERY_ID)],
+        dummyError: [(s) => [s.getQueryError], (getQueryError) => getQueryError(TEST_QUERY_ID)],
+    }),
+])
+
+describe('dataManagerLogic', () => {
+    let logic: ReturnType<typeof dataManagerLogic.build>
+
+    beforeEach(async () => {
+        initKeaTests()
+        logic = dataManagerLogic()
+        logic.mount()
+    })
+    afterEach(() => logic?.unmount())
+
+    it('with valid response', async () => {
+        useMocks({
+            get: { '/api/projects/:team/insights/trend/': { result: ['result from api'] } },
+        })
+        dummyLogic.mount()
+
+        const query: TrendsQuery = {
+            kind: NodeKind.TrendsQuery,
+            series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+        }
+
+        await expectLogic(logic, () => {
+            logic.actions.runQuery(TEST_QUERY_ID, query)
+        })
+            // .toDispatchActions(dataNodeLogic.findMounted({ key: TEST_QUERY_ID }), ['loadResults', 'loadResultsSuccess'])
+            // .toMatchValues(dummyLogic, {
+            //     dummyLoading: true,
+            //     // dummyResponse: { a: 1 },
+            // })
+            .toFinishAllListeners()
+            // .delay(0)
+            .toMatchValues(dummyLogic, {
+                dummyLoading: false,
+                dummyResponse: { result: ['result from api'] },
+            })
+    })
+
+    it('with error response', async () => {
+        useMocks({
+            get: { '/api/projects/:team/insights/trend/': [500, { status: 0, detail: 'error from api' }] },
+        })
+        dummyLogic.mount()
+
+        const query: TrendsQuery = {
+            kind: NodeKind.TrendsQuery,
+            series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+        }
+
+        await expectLogic(logic, () => {
+            logic.actions.runQuery(TEST_QUERY_ID, query)
+        })
+            // .toDispatchActions(dataNodeLogic.findMounted({ key: TEST_QUERY_ID }), ['loadResults', 'loadResultsSuccess'])
+            // .toMatchValues(dummyLogic, {
+            //     dummyLoading: true,
+            //     // dummyResponse: { a: 1 },
+            // })
+            .toFinishAllListeners()
+            // .delay(0)
+            .toMatchValues(dummyLogic, {
+                dummyLoading: false,
+                // dummyResponse: { result: ['result from api'] },
+                dummyError: { a: 1 },
+            })
+    })
+})

--- a/frontend/src/queries/nodes/DataNode/dataManagerLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataManagerLogic.ts
@@ -1,0 +1,94 @@
+import { kea, path, selectors, reducers, actions, defaults, BuiltLogic, listeners, connect } from 'kea'
+import { loaders } from 'kea-loaders'
+import { AnyDataNode } from '~/queries/schema'
+import { dataNodeLogic } from './dataNodeLogic'
+import { dataNodeLogicType } from './dataNodeLogicType'
+
+import type { dataManagerLogicType } from './dataManagerLogicType'
+
+export type QueryId = string
+export type QueryStore = Record<QueryId, BuiltLogic<dataNodeLogicType>>
+// {
+//     queryObject: AnyDataNode
+//     results: Record<string, Record<string, any>>
+//     isLoading: boolean
+// }
+
+export const dataManagerLogic = kea<dataManagerLogicType>([
+    path(['queries', 'nodes', 'dataManagerLogic']),
+    // connect({
+    //     actions:
+    // }),
+    actions({
+        runQuery: (queryId: QueryId, queryObject: AnyDataNode) => {
+            console.log('runQuery: ', queryId, queryObject)
+            const logic = dataNodeLogic.build({ key: queryId, query: queryObject })
+            const unmount = logic.mount()
+            return { queryId, queryObject, logic, unmount }
+        },
+        // cancelQuery: (queryId: QueryId) => ({ queryId }),
+        // querySuccess: (queryId: QueryId, queryObject: AnyDataNode, results: Record<string, any>) => ({
+        //     queryId,
+        //     queryObject,
+        //     results,
+        // }),
+        // queryFailure: (queryId: QueryId, error: Error) => ({ queryId, error }),
+    }),
+    // defaults({
+    //     queries: {},
+    // }),
+    // loaders(({ values }) => ({
+    //     queries: {
+    //         runQuery: ({ queryId, queryObject }: { queryId: QueryId; queryObject: AnyDataNode }): QueryStore => {
+    //             // console.log('V: ', values.queries)
+    //             // console.log('queryId: ', queryId)
+    //             // console.log('queryObject: ', queryObject)
+    //             // const logic = dataNodeLogic.build({ key: queryId, query: queryObject })
+    //             // console.log('logic: ', logic.values.responseLoading)
+    //             // const queries = { ...values.queries, [queryId]: logic }
+    //             // // console.log('queries: ', queries)
+    //             // return queries
+    //             // values.queries[queryId].actions.
+    //         },
+    //     },
+    // })),
+    reducers({
+        queries: [
+            {},
+            {
+                runQuery: (state, { queryId, queryObject, logic, unmount }) => {
+                    return { ...state, [queryId]: { logic, unmount } }
+                },
+            },
+        ],
+        // - queries: Record<queryId, Record>
+        // - results: Record<queryId, any>
+        // - lastUpdatedAt: Record<queryId, Date>
+        // - isLoading: Record<queryId, bool>
+    }),
+    selectors({
+        // logic: [(s) => [s.queries], (queries: QueryStore) => (queryId: QueryId) => queries[queryId]?.logic],
+        getQueryLoading: [
+            (s) => [s.queries],
+            (queries: QueryStore) => (queryId: QueryId) => {
+                const logic = queries[queryId]?.logic
+                return logic ? logic.values.responseLoading : null
+            },
+        ],
+        getQueryResponse: [
+            (s) => [s.queries],
+            (queries: QueryStore) => (queryId: QueryId) => {
+                const logic = queries[queryId]?.logic
+                return logic ? logic.values.response : null
+            },
+        ],
+        getQueryError: [
+            (s) => [s.queries],
+            (queries: QueryStore) => (queryId: QueryId) => {
+                const logic = queries[queryId]?.logic
+                return logic ? logic.values.responseError : null
+            },
+        ],
+    }),
+    // listeners({}),
+])

--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -4,13 +4,13 @@ import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 
 export function ComputationTimeWithRefresh(): JSX.Element | null {
-    const { lastRefresh } = useValues(dataNodeLogic)
+    // const { lastRefresh } = useValues(dataNodeLogic)
 
     usePeriodicRerender(15000)
 
     return (
         <div className="flex items-center text-muted-alt">
-            Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
+            {/* Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'} */}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -86,6 +86,8 @@ export function InsightContainer({
         supportsDisplay,
         insightFilter,
         exportContext,
+        response,
+        queryId,
     } = useValues(insightDataLogic(insightProps))
 
     // Empty states that completely replace the graph
@@ -208,6 +210,10 @@ export function InsightContainer({
                 data-attr="insights-graph"
                 className="insights-graph-container"
             >
+                <pre className="w-full min-h-20 p-2 text-white bg-primary">
+                    <p>QueryId: {queryId}</p>
+                    {response ? JSON.stringify(response, null, 2) : 'none'}
+                </pre>
                 <div>
                     <div
                         className={clsx('flex items-center justify-between insights-graph-header', {

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -1,11 +1,9 @@
-import { BindLogic, useValues } from 'kea'
+import { useValues } from 'kea'
 import clsx from 'clsx'
 
-import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { isFunnelsQuery } from '~/queries/utils'
 
-import { dataNodeLogic, DataNodeLogicProps } from '../DataNode/dataNodeLogic'
 import { InsightQueryNode, InsightVizNode } from '../../schema'
 
 import { InsightContainer } from './InsightContainer'
@@ -24,9 +22,6 @@ type InsightVizProps = {
 }
 
 export function InsightViz({ query, setQuery }: InsightVizProps): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
-    const dataNodeLogicProps: DataNodeLogicProps = { query: query.source, key: insightVizDataNodeKey(insightProps) }
-
     const { insightMode } = useValues(insightSceneLogic)
 
     const isFunnels = isFunnelsQuery(query.source)
@@ -36,18 +31,16 @@ export function InsightViz({ query, setQuery }: InsightVizProps): JSX.Element {
     }
 
     return (
-        <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-            <div
-                className={clsx('insight-wrapper', {
-                    'insight-wrapper--singlecolumn': isFunnels,
-                })}
-            >
-                <EditorFilters query={query.source} setQuery={setQuerySource} showing={insightMode === ItemMode.Edit} />
+        <div
+            className={clsx('insight-wrapper', {
+                'insight-wrapper--singlecolumn': isFunnels,
+            })}
+        >
+            <EditorFilters query={query.source} setQuery={setQuerySource} showing={insightMode === ItemMode.Edit} />
 
-                <div className="insights-container" data-attr="insight-view">
-                    <InsightContainer insightMode={insightMode} />
-                </div>
+            <div className="insights-container" data-attr="insight-view">
+                <InsightContainer insightMode={insightMode} />
             </div>
-        </BindLogic>
+        </div>
     )
 }

--- a/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
@@ -15,13 +15,16 @@ import { funnelDataLogic } from '../funnelDataLogic'
 
 export function FunnelBarChartDataExploration(props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { visibleStepsWithConversionMetrics } = useValues(funnelDataLogic(insightProps))
+    const { visibleStepsWithConversionMetrics, insightData, results } = useValues(funnelDataLogic(insightProps))
     return (
-        <FunnelBarChartComponent
-            isUsingDataExploration
-            visibleStepsWithConversionMetrics={visibleStepsWithConversionMetrics}
-            {...props}
-        />
+        <>
+            <pre>{JSON.stringify(insightData, null, 2)}</pre>
+            <FunnelBarChartComponent
+                isUsingDataExploration
+                visibleStepsWithConversionMetrics={visibleStepsWithConversionMetrics}
+                {...props}
+            />
+        </>
     )
 }
 


### PR DESCRIPTION
## Problem

We need to connect `dataNodeLogic` with `insightDataLogic`, but that doesn't work as `dataNodeLogic` is mounted after `insightDataLogic`. Thus we [use a hack and pass in an empty query](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/insights/insightDataLogic.ts#L70-L71).

This PR is a POC for a data manager

> How about another idea: data manager
> I think we'll eventually want to refactor the data node logics to go through a singleton manager logic. This would make app level throttling, and possibly a lot of caching/reloading/refetching easier as well.
> basically removing the key from dataNodeLogic altogether, and handling the various keys/query combos within the logic itself

```
dataMangerLogic
  actions:
    - runQuery(queryId, queryObject)
    - cancelQuery(queryId)
    - querySuccess(queryId, queryObject, results)
    - queryFailure(queryId, error)
  values:
    - queries: Record<queryId, Record>
    - results: Record<queryId, any>
    - lastUpdatedAt: Record<queryId, Date>
    - isLoading: Record<queryId, bool>
```

> You can then just use a selector in any other logic to fetch the query or result based on some id, and handle the nulls as needed there.

## Changes

Redoes what https://github.com/PostHog/posthog/pull/14507 did, based on master.

Next up:
- use insight dashboardItemId as queryId
- cancel query, when new one is loaded for same key

Problems:
- how do we avoid needing to implement reference counting / garbage collection for the queries?
- can we implement in such a way that no-memoized selectors aren't necessary (not for performance, but for better DX)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
