### PR TITLE
fix(empty-state): properly fix query timeout state

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.scss
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.scss
@@ -50,7 +50,7 @@
             display: flex;
             justify-content: center;
             font-size: 4rem;
-            height: 4rem;
+            height: auto;
             line-height: 1em;
             text-align: center;
             margin-bottom: 0.75rem;

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -55,7 +55,7 @@ export function InsightTimeoutState({
     return (
         <div className="insight-empty-state warning">
             <div className="empty-state-inner">
-                <div className="illustration-main h-auto">
+                <div className="illustration-main">
                     {isLoading ? <Animation type={AnimationType.SportsHog} /> : <IconErrorOutline />}
                 </div>
                 {isLoading ? (


### PR DESCRIPTION
My previous fix didn't do it because Tailwind's `h-auto` was not taking precedence like the element styling was.

I've confirmed this works