### PR TITLE
fix(lemon-tag): don't set cursor when it's not needed

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTag/LemonTag.scss
+++ b/frontend/src/lib/lemon-ui/LemonTag/LemonTag.scss
@@ -9,7 +9,6 @@
     color: var(--default);
     line-height: 1rem;
     white-space: nowrap;
-    cursor: default;
 
     &.highlight {
         background-color: var(--yellow-lightest);

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -110,7 +110,7 @@ export const insightNavLogic = kea<insightNavLogicType>([
                     tabs.push({
                         label: (
                             <>
-                                SQL{' '}
+                                SQL
                                 <LemonTag type="warning" className="uppercase ml-2">
                                     Beta
                                 </LemonTag>


### PR DESCRIPTION
## Problem

The "beta" tags in a navigation list render without pointer cursor.

## Changes

This changes lemon tag to not overwrite the cursor in the non-clickable state.

## How did you test this code?

👀 