### PR TITLE
feat(data-exploration): implement invalid exclusion filters hint

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
-import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
 
@@ -71,9 +70,9 @@ export function InsightContainer({
     // const {
     //     // correlationAnalysisAvailable
     // } = useValues(funnelLogic(insightProps))
-    const { isFunnelWithEnoughSteps, hasFunnelResults } = useValues(funnelDataLogic(insightProps))
-    // TODO: convert to data exploration with insightLogic
-    const { areExclusionFiltersValid } = useValues(funnelLogic(insightProps))
+    const { isFunnelWithEnoughSteps, hasFunnelResults, areExclusionFiltersValid } = useValues(
+        funnelDataLogic(insightProps)
+    )
     const {
         isTrends,
         isFunnels,

--- a/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
+++ b/frontend/src/scenes/funnels/__mocks__/funnelDataLogicMocks.ts
@@ -320,3 +320,12 @@ export const funnelResultTrends = {
     last_refresh: '2023-03-03T18:55:57.840129Z',
     is_cached: false,
 }
+
+// 1. Add step "Pageview"
+// 2. Add "Pageview" as exclusion step
+export const funnelInvalidExclusionError = {
+    type: 'validation_error',
+    code: 'invalid_input',
+    detail: "Exclusion event can't be the same as funnel step",
+    attr: null,
+}

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -23,6 +23,7 @@ import {
     funnelResultTrends,
     funnelResultWithBreakdown,
     funnelResultWithMultiBreakdown,
+    funnelInvalidExclusionError,
 } from './__mocks__/funnelDataLogicMocks'
 
 let logic: ReturnType<typeof funnelDataLogic.build>
@@ -755,6 +756,31 @@ describe('funnelDataLogic', () => {
                             ],
                         }),
                     ],
+                })
+            })
+        })
+
+        describe('areExclusionFiltersValid', () => {
+            it('for standard funnel', async () => {
+                const insight: Partial<InsightModel> = {
+                    filters: {
+                        insight: InsightType.FUNNELS,
+                    },
+                    result: funnelResult.result,
+                }
+
+                await expectLogic(logic, () => {
+                    builtDataNodeLogic.actions.loadDataSuccess(insight)
+                }).toMatchValues({
+                    areExclusionFiltersValid: true,
+                })
+            })
+
+            it('for invalid exclusion', async () => {
+                await expectLogic(logic, () => {
+                    builtDataNodeLogic.actions.loadDataFailure('', { status: 400, ...funnelInvalidExclusionError })
+                }).toMatchValues({
+                    areExclusionFiltersValid: false,
                 })
             })
         })

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -49,7 +49,16 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
     connect((props: InsightLogicProps) => ({
         values: [
             insightVizDataLogic(props),
-            ['querySource', 'insightFilter', 'funnelsFilter', 'breakdown', 'series', 'interval', 'insightData'],
+            [
+                'querySource',
+                'insightFilter',
+                'funnelsFilter',
+                'breakdown',
+                'series',
+                'interval',
+                'insightData',
+                'insightDataError',
+            ],
             groupsModel,
             ['aggregationLabel'],
         ],
@@ -346,6 +355,12 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
             (funnelsFilter): FilterType => ({
                 events: funnelsFilter?.exclusions,
             }),
+        ],
+        areExclusionFiltersValid: [
+            (s) => [s.insightDataError],
+            (insightDataError): boolean => {
+                return !(insightDataError?.status === 400 && insightDataError?.type === 'validation_error')
+            },
         ],
     })),
 ])


### PR DESCRIPTION
## Problem

The funnel insight did not handle the error for invalid exclusion filters i.e. when one excludes an event that is a funnel step specifically.

## Changes

This PR converts the `areExclusionFiltersValid` to data exploration, so that the according error state is shown.

## How did you test this code?

Added tests and verified manually.