### PR TITLE
chore(async-liveness): add async liveness check

### DIFF
--- a/plugin-server/functional_tests/plugins.test.ts
+++ b/plugin-server/functional_tests/plugins.test.ts
@@ -367,3 +367,17 @@ test.concurrent(
     },
     120000
 )
+
+test.concurrent(`liveness check endpoint works`, async () => {
+    await waitForExpect(async () => {
+        const response = await fetch('http://localhost:6738/_health')
+        expect(response.status).toBe(200)
+
+        const body = await response.json()
+        expect(body).toEqual(
+            expect.objectContaining({
+                checks: expect.objectContaining({ 'on-event-ingestion': 'ok' }),
+            })
+        )
+    })
+})

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -75,6 +75,12 @@ export const startAnalyticsEventsIngestionConsumer = async ({
     // Subscribe to the heatbeat event to track when the consumer has last
     // successfully consumed a message. This is used to determine if the
     // consumer is healthy.
+    const isHealthy = makeHealthCheck(queue)
+
+    return { queue, isHealthy }
+}
+
+export function makeHealthCheck(queue: IngestionConsumer) {
     const sessionTimeout = 30000
     const { HEARTBEAT } = queue.consumer.events
     let lastHeartbeat: number = Date.now()
@@ -96,8 +102,7 @@ export const startAnalyticsEventsIngestionConsumer = async ({
             return false
         }
     }
-
-    return { queue, isHealthy }
+    return isHealthy
 }
 
 export async function eachBatchIngestionWithOverflow(

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -4,6 +4,7 @@ import * as schedule from 'node-schedule'
 import { KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
 import { Hub } from '../../types'
 import { status } from '../../utils/status'
+import { makeHealthCheck } from './analytics-events-ingestion-consumer'
 import { eachBatchAsyncHandlers } from './batch-processing/each-batch-async-handlers'
 import { IngestionConsumer } from './kafka-queue'
 
@@ -33,7 +34,9 @@ export const startOnEventHandlerConsumer = async ({
         await queue.emitConsumerGroupMetrics()
     })
 
-    return queue
+    const isHealthy = makeHealthCheck(queue)
+
+    return { queue, isHealthy: () => isHealthy() }
 }
 
 export const buildOnEventIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -321,10 +321,14 @@ export async function startPluginsServer(
             serverInstance = serverInstance ? serverInstance : { hub }
 
             piscina = piscina ?? makePiscina(serverConfig)
-            onEventHandlerConsumer = await startOnEventHandlerConsumer({
+            const { queue: onEventQueue, isHealthy: isOnEventsIngestionHealthy } = await startOnEventHandlerConsumer({
                 hub: hub,
                 piscina: piscina,
             })
+
+            onEventHandlerConsumer = onEventQueue
+
+            healthChecks['on-event-ingestion'] = isOnEventsIngestionHealthy
         }
 
         // If we have


### PR DESCRIPTION
To make sure pods are restarted if they get stuck.

Related to https://status.posthog.com/incidents/4g4sbxc0vmk0

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
