### PR TITLE
chore(ci): chose correct commit wsha on master

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -29,7 +29,7 @@ jobs:
               uses: lewagon/wait-on-check-action@v1.2.0
               with:
                   check-name: Build PostHog
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{ github.ref == 'refs/heads/master' && github.sha || github.event.pull_request.head.sha }}
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   wait-interval: 10
 


### PR DESCRIPTION
## Problem

follow up to #14502 

This end-to-end job always fails during setup on master. Is it because we're picking the pull request SHA?

## Changes

choose either head SHA for master or pull request SHA otherwise

## How did you test this code?

opening the PR to see what happens