### PR TITLE
fix: insight logic can use a cached insight with no filters if it has a query

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -1150,7 +1150,10 @@ export const insightLogic = kea<insightLogicType>([
             const hasDashboardItemId =
                 !!props.dashboardItemId && props.dashboardItemId !== 'new' && !props.dashboardItemId.startsWith('new-')
             const isCachedWithResultAndFilters =
-                !!props.cachedInsight && !!props.cachedInsight?.result && !!props.cachedInsight?.filters
+                !!props.cachedInsight &&
+                !!props.cachedInsight?.result &&
+                (Object.keys(props.cachedInsight?.filters || {}).length > 0 ||
+                    Object.keys(props.cachedInsight?.query || {}).length > 0)
 
             if (!isCachedWithResultAndFilters) {
                 if (hasDashboardItemId) {


### PR DESCRIPTION
## Problem

Insight logic was checking `!!blah.filters` in `aftermount`. filters is always present as `{}` from API.

So, we would have accidentally accepted an insight with empty `filters` and no `query`. Or ignoring an insight with undefined `filters` but a valid `query`

## Changes

* safer check for the presence of `filters` or `query`
* tests to cover expected behaviour

## How did you test this code?

developer tests and 👀 locally
