### PR TITLE
Revert "chore(ci): chose correct commit wsha on master"

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -29,7 +29,7 @@ jobs:
               uses: lewagon/wait-on-check-action@v1.2.0
               with:
                   check-name: Build PostHog
-                  ref: ${{ github.ref == 'refs/heads/master' && github.sha || github.event.pull_request.head.sha }}
+                  ref: ${{ github.event.pull_request.head.sha }}
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   wait-interval: 10
 


### PR DESCRIPTION
Reverts PostHog/posthog#14813

Attempted as a fix for e2e CI always failing on master.

With that change we get the error

```
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
/opt/hostedtoolcache/Ruby/2.7.4/x64/lib/ruby/gems/2.7.0/gems/octokit-4.25.0/lib/octokit/response/raise_error.rb:14:in `on_complete': GET https://api.github.com/repos/PostHog/posthog/commits//check-runs?per_page=100: 422 - No commit found for SHA: /check-runs // See: https://docs.github.com/rest/commits/commits#get-a-commit (Octokit::UnprocessableEntity)
```