### PR TITLE
chore(ci): no need to wait for image when on master

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -27,9 +27,11 @@ jobs:
         steps:
             - name: Wait for the container image to be ready
               uses: lewagon/wait-on-check-action@v1.2.0
+              # if we are on master then we don't need to wait for the container image
+              if: github.event_name == 'pull_request'
               with:
                   check-name: Build PostHog
-                  ref: ${{ github.ref == 'refs/heads/master' && github.sha || github.event.pull_request.head.sha }}
+                  ref: ${{ github.event.pull_request.head.sha }}
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   wait-interval: 10
 


### PR DESCRIPTION
## Problem

On a pull request when running E2E CI we need to wait for the container image to be ready. 

Logically when on master, we've already passed that check on a PR so don't need it.

## Changes

only run the check on PRs

## How did you test this code?

it is tests