### PR TITLE
chore(ci): skip service version requirements when running CI E2E tests

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -111,6 +111,7 @@ jobs:
                   OPT_OUT_CAPTURE=1
                   SELF_CAPTURE=0
                   E2E_TESTING=1
+                  SKIP_SERVICE_VERSION_REQUIREMENTS=1
                   EMAIL_HOST=email.test.posthog.net
                   SITE_URL=http://localhost:8000
                   NO_RESTART_LOOP=1


### PR DESCRIPTION
## Problem

E2E tests failed on master because they picked up a version of CH outside of the service version requirements.

## Changes

We'd rather run them and see them fail for reasons than not run them and them fail anyway

## How did you test this code?

it is tests