### PR TITLE
fix: Remove sentry noise for missing group_type

### DIFF
--- a/plugin-server/src/worker/ingestion/property-definitions-manager.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-manager.ts
@@ -255,9 +255,8 @@ ON CONSTRAINT posthog_eventdefinition_team_id_name_80fa0b87_uniq DO UPDATE SET l
     ): AsyncGenerator<PartialPropertyDefinition> {
         if (event === '$groupidentify') {
             const { $group_type: groupType, $group_set: groupPropertiesToSet } = properties
-            const groupTypeIndex = await this.groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
-
-            if (groupPropertiesToSet != null) {
+            if (groupType != null && groupPropertiesToSet != null) {
+                const groupTypeIndex = await this.groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
                 // TODO: add further validation that group properties are of the
                 // expected type
                 yield* this.extract(groupPropertiesToSet, PropertyDefinitionTypeEnum.Group, groupTypeIndex)

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -2330,6 +2330,32 @@ test('groupidentify', async () => {
     })
 })
 
+test('groupidentify without group_type ingests event', async () => {
+    await createPerson(hub, team, ['distinct_id1'])
+
+    await processEvent(
+        'distinct_id1',
+        '',
+        '',
+        {
+            event: '$groupidentify',
+            properties: {
+                token: team.api_token,
+                distinct_id: 'distinct_id1',
+                $group_key: 'org::5',
+                $group_set: {
+                    foo: 'bar',
+                },
+            },
+        } as any as PluginEvent,
+        team.id,
+        now,
+        new UUIDT().toString()
+    )
+
+    expect((await hub.db.fetchEvents()).length).toBe(1)
+})
+
 test('$groupidentify updating properties', async () => {
     const next: DateTime = now.plus({ minutes: 1 })
 

--- a/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/property-definitions-manager.test.ts
@@ -365,6 +365,19 @@ describe('PropertyDefinitionsManager()', () => {
             })
         })
 
+        it('regression tests: handles group type property being empty', async () => {
+            await hub.db.insertGroupType(teamId, 'project', 0)
+            await hub.db.insertGroupType(teamId, 'organization', 1)
+
+            await manager.updateEventNamesAndProperties(teamId, '$groupidentify', {
+                $group_key: 'org::5',
+                $group_set: {
+                    foo: 'bar',
+                    numeric: 3,
+                },
+            })
+        })
+
         describe('first event has not yet been ingested', () => {
             it('calls posthog.identify and posthog.capture', async () => {
                 // NOTE: that this functionality is dependent on users being a


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The sentry error:
https://posthog.sentry.io/issues/3802805391/events/latest/?project=6423401&referrer=latest-event

Note that when we get `$groupidentify` without `$group_type` we just ignore it and don't create the group, so we should ignore it here too.

https://github.com/PostHog/posthog/blob/d4ac1da322f2a84cc4626a10636802279b97f619/plugin-server/src/worker/ingestion/process-event.ts#L239-L241




## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
