### PR TITLE
fix(3000): Disable dark mode handling outside of 3000 UI

### DIFF
--- a/frontend/src/layout/navigation-3000/themeLogic.ts
+++ b/frontend/src/layout/navigation-3000/themeLogic.ts
@@ -1,4 +1,6 @@
 import { actions, events, kea, path, reducers, selectors } from 'kea'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import type { themeLogicType } from './themeLogicType'
 
@@ -27,9 +29,13 @@ export const themeLogic = kea<themeLogicType>([
     }),
     selectors({
         isDarkModeOn: [
-            (s) => [s.darkModeSavedPreference, s.darkModeSystemPreference],
-            (darkModeSavedPreference, darkModeSystemPreference) => {
-                return darkModeSavedPreference ?? darkModeSystemPreference
+            (s) => [s.darkModeSavedPreference, s.darkModeSystemPreference, featureFlagLogic.selectors.featureFlags],
+            (darkModeSavedPreference, darkModeSystemPreference, featureFlags) => {
+                // Dark mode is a PostHog 3000 feature
+                // User-saved preference is used when set, oterwise we fall back to the system value
+                return featureFlags[FEATURE_FLAGS.POSTHOG_3000]
+                    ? darkModeSavedPreference ?? darkModeSystemPreference
+                    : false
             },
         ],
         isThemeSyncedWithSystem: [


### PR DESCRIPTION
## Problem

#14821 introduced a bug where using the classic UI on a system with dark mode enabled causes text to be low contrast on graphs:

<img width="1223" alt="Screenshot 2023-03-20 at 12 50 48" src="https://user-images.githubusercontent.com/4550621/226399614-e4e70ce3-e188-49bd-91a7-c42d87a6007a.png">

## Changes

This completely disables dark mode handling when the PostHog 3000 feature flag is off.