### PR TITLE
chore: more feedback below apps in nav

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -200,9 +200,6 @@ function Pages(): JSX.Element {
                             to={urls.webPerformance()}
                         />
                     )}
-                    {featureFlags[FEATURE_FLAGS.FEEDBACK_SCENE] && (
-                        <PageButton icon={<IconMessages />} identifier={Scene.Feedback} to={urls.feedback()} />
-                    )}
                     <div className="SideBar__heading">Data</div>
 
                     <PageButton
@@ -240,6 +237,9 @@ function Pages(): JSX.Element {
                             {Object.keys(frontendApps).length > 0 && <SideBarApps />}
                         </>
                     ) : null}
+                    {featureFlags[FEATURE_FLAGS.FEEDBACK_SCENE] && (
+                        <PageButton icon={<IconMessages />} identifier={Scene.Feedback} to={urls.feedback()} />
+                    )}
                     <div className="SideBar__heading">Configuration</div>
 
                     <PageButton


### PR DESCRIPTION
## Problem

The feedback app is experimental so moving it into the apps section (if they can't see apps it will be below Annotations)

<img width="226" alt="Screenshot Feedback • PostHog (Google Chrome) 2023-03-20 at 17 36@2x" src="https://user-images.githubusercontent.com/22766134/226422092-db7b1a06-16f7-426b-b374-577195e1bae9.png">
