### PR TITLE
feat(poe-v2): scaffolding for PoE v2 on event queries, full support in retention queries

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -195,7 +195,7 @@
      FROM
        (SELECT pdi.person_id AS person_id,
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
-        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_1_level_level_0_level_0_0
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_24_level_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -208,7 +208,7 @@
           AND event IN ['signup']
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND (((first_time_condition_1_level_level_0_level_0_0))) ) as person
+       AND (((first_time_condition_24_level_level_0_level_0_0))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -237,9 +237,9 @@
        (SELECT pdi.person_id AS person_id,
                countIf(timestamp > now() - INTERVAL 2 year
                        AND timestamp < now()
-                       AND event = '$pageview') > 0 AS performed_event_condition_2_level_level_0_level_0_level_0_0,
+                       AND event = '$pageview') > 0 AS performed_event_condition_25_level_level_0_level_0_level_0_0,
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
-        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_2_level_level_0_level_1_level_0_level_0_level_0_0
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_25_level_level_0_level_1_level_0_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -252,8 +252,8 @@
           AND event IN ['$pageview', 'signup']
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND ((((performed_event_condition_2_level_level_0_level_0_level_0_0))
-             AND ((((NOT first_time_condition_2_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person
+       AND ((((performed_event_condition_25_level_level_0_level_0_level_0_0))
+             AND ((((NOT first_time_condition_25_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -146,7 +146,7 @@
       ))
     ',
     <class 'dict'> {
-      'global_cohort_id_0': 30,
+      'global_cohort_id_0': 28,
     },
   )
 ---

--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -298,7 +298,7 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
 
         new_query = f"""
         SELECT {", ".join(_inner_fields)} FROM events AS {self.EVENT_TABLE_ALIAS}
-        {self._get_distinct_id_query()}
+        {self._get_person_ids_query()}
         WHERE team_id = %(team_id)s
         AND event IN %({event_param_name})s
         {date_condition}

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -1,17 +1,16 @@
 from posthog.models.group.util import get_aggregation_target_field
 from posthog.queries.retention.retention_events_query import RetentionEventsQuery
-from posthog.utils import PersonOnEventsMode
 
 
 class ClickhouseRetentionEventsQuery(RetentionEventsQuery):
     def target_field(self) -> str:
         if self._aggregate_users_by_distinct_id and not self._filter.aggregation_group_type_index:
-            return f"{self.EVENT_TABLE_ALIAS}.distinct_id as target"
+            return f"{self.EVENT_TABLE_ALIAS}.distinct_id AS target"
         else:
             return "{} as target".format(
                 get_aggregation_target_field(
                     self._filter.aggregation_group_type_index,
                     self.EVENT_TABLE_ALIAS,
-                    f"{self.DISTINCT_ID_TABLE_ALIAS if self._person_on_events_mode == PersonOnEventsMode.DISABLED else self.EVENT_TABLE_ALIAS}.person_id",
+                    self._person_id_alias,
                 )
             )

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -662,7 +662,8 @@
   SELECT distinct_id,
          person_id
   FROM events
-  WHERE distinct_id IN ('person1',
+  WHERE team_id = 2
+    AND distinct_id IN ('person1',
                         'person2')
   GROUP BY distinct_id,
            person_id

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -656,6 +656,191 @@
            intervals_from_base
   '
 ---
+# name: TestClickhouseRetention.test_groups_filtering_person_on_events_v2
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE distinct_id IN ('person1',
+                        'person2')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'person1', -1, 0)
+  '
+---
+# name: TestClickhouseRetention.test_groups_filtering_person_on_events_v2.1
+  '
+  WITH actor_query AS
+    (WITH 'Day' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+               if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT override_person_id as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+        INNER JOIN
+          (SELECT group_key,
+                  argMax(group_properties, _timestamp) AS group_properties_0
+           FROM groups
+           WHERE team_id = 2
+             AND group_type_index = 0
+           GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-12 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-19 00:00:00', 'UTC')
+          AND (JSONHas(group_properties_0, 'industry'))
+          AND notEmpty(e.person_id)
+        GROUP BY target,
+                 event_date),
+          target_event_query as
+       (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp), 'UTC') AS event_date,
+                        if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target,
+                        [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-06-12 00:00:00' , 'UTC')),
+                              toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                          )
+                      ] as breakdown_values
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT override_person_id as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+        INNER JOIN
+          (SELECT group_key,
+                  argMax(group_properties, _timestamp) AS group_properties_0
+           FROM groups
+           WHERE team_id = 2
+             AND group_type_index = 0
+           GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-12 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-19 00:00:00', 'UTC')
+          AND (JSONHas(group_properties_0, 'industry'))
+          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
+                                                      intervals_from_base,
+                                                      actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---
+# name: TestClickhouseRetention.test_groups_filtering_person_on_events_v2.2
+  '
+  WITH actor_query AS
+    (WITH 'Week' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+               if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT override_person_id as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+        INNER JOIN
+          (SELECT group_key,
+                  argMax(group_properties, _timestamp) AS group_properties_0
+           FROM groups
+           WHERE team_id = 2
+             AND group_type_index = 0
+           GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
+          AND (JSONHas(group_properties_0, 'industry'))
+          AND notEmpty(e.person_id)
+        GROUP BY target,
+                 event_date),
+          target_event_query as
+       (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp), 0, 'UTC') AS event_date,
+                        if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target,
+                        [
+                          dateDiff(
+                              'Week',
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00' , 0, 'UTC')),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                          )
+                      ] as breakdown_values
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT override_person_id as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+        INNER JOIN
+          (SELECT group_key,
+                  argMax(group_properties, _timestamp) AS group_properties_0
+           FROM groups
+           WHERE team_id = 2
+             AND group_type_index = 0
+           GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
+          AND (JSONHas(group_properties_0, 'industry'))
+          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
+                                                      intervals_from_base,
+                                                      actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---
 # name: TestClickhouseRetention.test_groups_in_period_person_on_events
   '
   

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.test import override_settings
 
 from posthog.models.filters.retention_filter import RetentionFilter
@@ -6,7 +8,7 @@ from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.instance_setting import override_instance_config
 from posthog.models.person import Person
 from posthog.queries.retention import Retention
-from posthog.queries.test.test_retention import _create_events, _date, pluck
+from posthog.queries.test.test_retention import _create_event, _create_events, _date, pluck
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -215,22 +217,104 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
     def test_groups_filtering_person_on_events_v2(self):
         self._create_groups_and_events()
 
-        _create_events(
-            self.team,
-            [
-                ("person1", _date(1), {"$group_0": "org:5"}),
-                ("person2", _date(2), {"$group_0": "org:5"}),
-                ("person1", _date(3), {"$group_0": "org:5"}),
-                ("person2", _date(4), {"$group_0": "org:5"}),
-                ("person1", _date(5), {"$group_0": "org:5"}),
-                ("person2", _date(6), {"$group_0": "org:5"}),
-                ("person1", _date(7), {"$group_0": "org:5"}),
-                ("person2", _date(8), {"$group_0": "org:5"}),
-                ("person3", _date(1), {"$group_1": "project:4"}),
-                ("person3", _date(2), {"$group_1": "project:4"}),
-                ("person3", _date(3), {"$group_1": "project:4"}),
-                ("person3", _date(4), {"$group_1": "project:4"}),
-            ],
+        person_id1 = str(uuid.uuid4())
+        person_id2 = str(uuid.uuid4())
+        person_id3 = str(uuid.uuid4())
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person1",
+            person_id=person_id1,
+            timestamp=_date(1),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person2",
+            person_id=person_id2,
+            timestamp=_date(2),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person1",
+            person_id=person_id1,
+            timestamp=_date(3),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person2",
+            person_id=person_id2,
+            timestamp=_date(4),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person1",
+            person_id=person_id1,
+            timestamp=_date(5),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person2",
+            person_id=person_id2,
+            timestamp=_date(6),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person1",
+            person_id=person_id1,
+            timestamp=_date(7),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person2",
+            person_id=person_id2,
+            timestamp=_date(8),
+            properties={"$group_0": "org:5"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person3",
+            person_id=person_id3,
+            timestamp=_date(1),
+            properties={"$group_1": "project:4"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person3",
+            person_id=person_id3,
+            timestamp=_date(1),
+            properties={"$group_1": "project:4"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person3",
+            person_id=person_id3,
+            timestamp=_date(1),
+            properties={"$group_1": "project:4"},
+        )
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="person3",
+            person_id=person_id3,
+            timestamp=_date(1),
+            properties={"$group_1": "project:4"},
         )
 
         create_person_id_override_by_distinct_id("person1", "person2", self.team.pk)

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -210,9 +210,6 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
             )
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=True)
-    @also_test_with_materialized_columns(
-        group_properties=[(0, "industry")], materialize_only_with_person_on_events=True
-    )
     @snapshot_clickhouse_queries
     def test_groups_filtering_person_on_events_v2(self):
         self._create_groups_and_events()

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -256,6 +256,7 @@ class TestClickhouseRetention(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
+        # We expect 1s across the board due to the override set up from person1 to person2, making them the same person
         self.assertEqual(
             pluck(result, "values", "count"),
             [[1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1], [1, 1], [1]],

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results
   '
-  /* user_id:47 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:48 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results
   '
-  /* user_id:52 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:53 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -140,7 +140,7 @@
 ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_and_events_out_of_time_range_timezones
   '
-  /* user_id:53 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:54 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -280,7 +280,7 @@
 ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:55 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:56 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -420,7 +420,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results
   '
-  /* user_id:56 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -619,7 +619,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:58 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:59 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:60 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -6,7 +6,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               e.distinct_id as target
+               e.distinct_id AS target
         FROM events e
         WHERE team_id = 2
           AND e.event = 'target event'
@@ -16,7 +16,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               e.distinct_id as target,
+               e.distinct_id AS target,
                [
                           dateDiff(
                               'Day',

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -106,7 +106,7 @@ class EventQuery(metaclass=ABCMeta):
     def _determine_should_join_distinct_ids(self) -> None:
         pass
 
-    def _get_distinct_id_query(self) -> str:
+    def _get_person_ids_query(self) -> str:
         if self._should_join_distinct_ids:
             return f"""
             INNER JOIN ({get_team_distinct_ids_query(self._team_id)}) AS {self.DISTINCT_ID_TABLE_ALIAS}

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -318,7 +318,7 @@ class FOSSCohortQuery(EventQuery):
             date_condition, date_params = self._get_date_condition()
             query = f"""
             SELECT {", ".join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {self._get_person_ids_query()}
             WHERE team_id = %(team_id)s
             AND event IN %({event_param_name})s
             {date_condition}

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -100,7 +100,7 @@ class FunnelEventQuery(EventQuery):
             {{extra_select_fields}}
             FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_distinct_id_query()}
+            {self._get_person_ids_query()}
             {person_query}
             {groups_query}
             {{extra_join}}

--- a/posthog/queries/paths/paths_event_query.py
+++ b/posthog/queries/paths/paths_event_query.py
@@ -113,7 +113,7 @@ class PathEventQuery(EventQuery):
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_distinct_id_query()}
+            {self._get_person_ids_query()}
             {person_query}
             {groups_query}
             {funnel_paths_join}

--- a/posthog/queries/retention/retention_events_query.py
+++ b/posthog/queries/retention/retention_events_query.py
@@ -159,7 +159,7 @@ class RetentionEventsQuery(EventQuery):
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_distinct_id_query()}
+            {self._get_person_ids_query()}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/posthog/queries/retention/retention_events_query.py
+++ b/posthog/queries/retention/retention_events_query.py
@@ -177,9 +177,7 @@ class RetentionEventsQuery(EventQuery):
         if self._aggregate_users_by_distinct_id and not self._filter.aggregation_group_type_index:
             return f"{self.EVENT_TABLE_ALIAS}.distinct_id as target"
         else:
-            return "{} as target".format(
-                f"{self.DISTINCT_ID_TABLE_ALIAS if self._person_on_events_mode == PersonOnEventsMode.DISABLED else self.EVENT_TABLE_ALIAS}.person_id"
-            )
+            return "{} as target".format(self._person_id_alias)
 
     def get_timestamp_field(self) -> str:
         start_of_week_day = QueryDateRange.determine_extra_trunc_func_args(self._trunc_func)

--- a/posthog/queries/stickiness/stickiness_event_query.py
+++ b/posthog/queries/stickiness/stickiness_event_query.py
@@ -56,7 +56,7 @@ class StickinessEventsQuery(EventQuery):
                 countDistinct({get_trunc_func_ch(self._filter.interval)}(toTimeZone(toDateTime(timestamp, 'UTC'), %(timezone)s))) as num_intervals
             FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_distinct_id_query()}
+            {self._get_person_ids_query()}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -76,7 +76,8 @@
   SELECT distinct_id,
          person_id
   FROM events
-  WHERE distinct_id IN ('person1',
+  WHERE team_id = 2
+    AND distinct_id IN ('person1',
                         'person2')
   GROUP BY distinct_id,
            person_id

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -70,6 +70,89 @@
            intervals_from_base
   '
 ---
+# name: TestFOSSRetention.test_month_interval_with_person_on_events_v2
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE distinct_id IN ('person1',
+                        'person2')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'person1', -1, 0)
+  '
+---
+# name: TestFOSSRetention.test_month_interval_with_person_on_events_v2.1
+  '
+  WITH actor_query AS
+    (WITH 'Month' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfMonth(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+               if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT override_person_id as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-01-10 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-12-10 00:00:00', 'UTC')
+          AND notEmpty(e.person_id)
+        GROUP BY target,
+                 event_date),
+          target_event_query as
+       (SELECT DISTINCT toStartOfMonth(toDateTime(e.timestamp), 'UTC') AS event_date,
+                        if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target,
+                        [
+                          dateDiff(
+                              'Month',
+                              toStartOfMonth(toDateTime('2020-01-10 00:00:00' , 'UTC')),
+                              toStartOfMonth(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                          )
+                      ] as breakdown_values
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT override_person_id as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-01-10 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-12-10 00:00:00', 'UTC')
+          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
+                                                      intervals_from_base,
+                                                      actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---
 # name: TestFOSSRetention.test_retention_event_action
   '
   WITH actor_query AS

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import datetime
 
 import pytz
@@ -229,6 +230,86 @@ def retention_test_factory(retention):
         def test_month_interval_with_person_on_events_v2(self):
             _create_person(team=self.team, distinct_ids=["person1", "alias1"], properties={"email": "person1@test.com"})
             _create_person(team=self.team, distinct_ids=["person2"], properties={"email": "person2@test.com"})
+
+            person_id1 = str(uuid.uuid4())
+            person_id2 = str(uuid.uuid4())
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person1",
+                person_id=person_id1,
+                timestamp=_date(day=0, month=-5),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person2",
+                person_id=person_id2,
+                timestamp=_date(day=0, month=-4),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person1",
+                person_id=person_id1,
+                timestamp=_date(day=0, month=-3),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person2",
+                person_id=person_id2,
+                timestamp=_date(day=0, month=-2),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person1",
+                person_id=person_id1,
+                timestamp=_date(day=0, month=-1),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person2",
+                person_id=person_id2,
+                timestamp=_date(day=0, month=0),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person1",
+                person_id=person_id1,
+                timestamp=_date(day=0, month=1),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person2",
+                person_id=person_id2,
+                timestamp=_date(day=0, month=2),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person1",
+                person_id=person_id1,
+                timestamp=_date(day=0, month=3),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person2",
+                person_id=person_id2,
+                timestamp=_date(day=0, month=4),
+            )
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id="person1",
+                person_id=person_id1,
+                timestamp=_date(day=0, month=5),
+            )
 
             _create_events(
                 self.team,

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -270,6 +270,7 @@ def retention_test_factory(retention):
                 ],
             )
 
+            # We expect 1s across the board due to the override set up from person1 to person2, making them the same person
             self.assertEqual(
                 pluck(result, "values", "count"),
                 [

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -163,7 +163,7 @@ class LifecycleEventQuery(EventQuery):
                 event_table_alias=self.EVENT_TABLE_ALIAS,
                 person_column=f"{self.DISTINCT_ID_TABLE_ALIAS if self._person_on_events_mode == PersonOnEventsMode.DISABLED else self.EVENT_TABLE_ALIAS}.person_id",
                 created_at_clause=created_at_clause,
-                distinct_id_query=self._get_distinct_id_query(),
+                distinct_id_query=self._get_person_ids_query(),
                 person_query=person_query,
                 groups_query=groups_query,
                 prop_query=prop_query,

--- a/posthog/queries/trends/trends_event_query_base.py
+++ b/posthog/queries/trends/trends_event_query_base.py
@@ -55,7 +55,7 @@ class TrendsEventQueryBase(EventQuery):
         query = f"""
             FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_distinct_id_query()}
+            {self._get_person_ids_query()}
             {person_query}
             {groups_query}
             {session_query}

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -780,8 +780,6 @@ def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_
     """
     )
 
-    print(person_ids_result)
-    
     person_id_from, person_id_to = [row[1] for row in person_ids_result]
 
     sync_execute(

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -774,7 +774,7 @@ def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_
         f"""
         SELECT distinct_id, person_id
         FROM events
-        WHERE distinct_id IN ('{distinct_id_from}', '{distinct_id_to}')
+        WHERE team_id = {team_id} AND distinct_id IN ('{distinct_id_from}', '{distinct_id_to}')
         GROUP BY distinct_id, person_id
         ORDER BY if(distinct_id = '{distinct_id_from}', -1, 0)
     """

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -780,6 +780,8 @@ def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_
     """
     )
 
+    print(person_ids_result)
+    
     person_id_from, person_id_to = [row[1] for row in person_ids_result]
 
     sync_execute(

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -765,6 +765,10 @@ def _create_insight(
     return insight, dashboard, dashboard_tile
 
 
+# Populate the person_overrides table with an override from the person_id
+# for a person with a given distinct ID `distinct_id_from` to a given distinct ID
+# `distinct_id_to` such that with person_on_events_mode set to V2_ENABLED these
+# persons will both count as 1
 def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int):
     person_ids_result = sync_execute(
         f"""


### PR DESCRIPTION
#14792 and the general top-down approach (instead of the previous bottom-up) really made things much easier.

This PR gets the scaffolding in `event_query` for PoE v2 as well as adds full support in retention queries