### PR TITLE
fix(groups): event explorer, search and lemonify

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -74,6 +74,7 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
             OpenApiParameter(
                 "group_type_index", OpenApiTypes.INT, description="Specify the group type to list", required=True
             ),
+            OpenApiParameter("search", OpenApiTypes.STR, description="Search the group name", required=True),
         ]
     )
     def list(self, request, *args, **kwargs):
@@ -89,6 +90,10 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
                 }
             )
         queryset = self.filter_queryset(self.get_queryset())
+
+        group_search = self.request.GET.get("search")
+        if group_search is not None:
+            queryset = queryset.filter(group_properties__icontains=group_search)
 
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -48,6 +48,22 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
                 ],
             },
         )
+        response = self.client.get(f"/api/projects/{self.team.id}/groups?group_type_index=0&search=Krabs").json()
+        self.assertEqual(
+            response,
+            {
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "created_at": "2021-05-01T00:00:00Z",
+                        "group_key": "org:5",
+                        "group_properties": {"industry": "finance", "name": "Mr. Krabs"},
+                        "group_type_index": 0,
+                    },
+                ],
+            },
+        )
 
     @freeze_time("2021-05-02")
     def test_groups_list_no_group_type(self):

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -5,7 +5,6 @@ import { groupLogic } from 'scenes/groups/groupLogic'
 import { EventsTable } from 'scenes/events/EventsTable'
 import { urls } from 'scenes/urls'
 import { RelatedGroups } from 'scenes/groups/RelatedGroups'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
 import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
 import { Group as IGroup, PersonsTabType, PropertyFilterType, PropertyOperator } from '~/types'
@@ -17,7 +16,6 @@ import { RelatedFeatureFlags } from 'scenes/persons/RelatedFeatureFlags'
 import { Query } from '~/queries/Query/Query'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { IconInfo } from 'lib/lemon-ui/icons'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 
 export const scene: SceneExport = {
@@ -121,13 +119,9 @@ export function Group(): JSX.Element {
                         label: (
                             <div className="flex items-center" data-attr="group-related-tab">
                                 Related people & groups
-                                <Tooltip
-                                    title={`People and groups that have shared events with this ${groupTypeName} in the last 90 days.`}
-                                >
-                                    <IconInfo className="ml-1 text-base shrink-0" />
-                                </Tooltip>
                             </div>
                         ),
+                        tooltip: `People and groups that have shared events with this ${groupTypeName} in the last 90 days.`,
                         content: <RelatedGroups id={groupKey} groupTypeIndex={groupTypeIndex} />,
                     },
                     {

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -14,6 +14,8 @@ import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsA
 import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { AlertMessage } from 'lib/lemon-ui/AlertMessage'
+import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 
 export const scene: SceneExport = {
     component: Groups,
@@ -26,8 +28,9 @@ export function Groups(): JSX.Element {
         groupName: { singular, plural },
         groups,
         groupsLoading,
+        search,
     } = useValues(groupsListLogic)
-    const { loadGroups } = useActions(groupsListLogic)
+    const { loadGroups, setSearch } = useActions(groupsListLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
     if (
@@ -67,6 +70,15 @@ export function Groups(): JSX.Element {
     return (
         <>
             <PersonPageHeader />
+            <LemonInput
+                type="search"
+                placeholder={`Search for ${plural}`}
+                onChange={setSearch}
+                value={search}
+                data-attr="group-search"
+                className="mb-4"
+            />
+            <LemonDivider className="mb-4" />
             <LemonTable
                 columns={columns}
                 rowKey="group_key"

--- a/frontend/src/scenes/groups/GroupsTabs.tsx
+++ b/frontend/src/scenes/groups/GroupsTabs.tsx
@@ -1,9 +1,9 @@
-import { Tabs } from 'antd'
 import { useActions, useValues } from 'kea'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { groupsModel } from '~/models/groupsModel'
 import { groupsListLogic } from './groupsListLogic'
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 
 export function GroupsTabs(): JSX.Element {
     const { setTab } = useActions(groupsListLogic)
@@ -18,19 +18,26 @@ export function GroupsTabs(): JSX.Element {
     ].includes(groupsAccessStatus)
 
     return (
-        <Tabs activeKey={currentTab} onChange={(activeKey) => setTab(activeKey)}>
-            <Tabs.TabPane tab="Persons" key="-1" />
-
-            {showGroupsIntroductionPage ? (
-                <Tabs.TabPane tab="Groups" key="0" />
-            ) : (
-                groupTypes.map((groupType) => (
-                    <Tabs.TabPane
-                        tab={capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural)}
-                        key={groupType.group_type_index}
-                    />
-                ))
-            )}
-        </Tabs>
+        <LemonTabs
+            activeKey={currentTab}
+            onChange={(activeKey) => setTab(activeKey)}
+            tabs={[
+                {
+                    key: '-1',
+                    label: 'Persons',
+                },
+                ...(showGroupsIntroductionPage
+                    ? [
+                          {
+                              key: '0',
+                              label: 'Groups',
+                          },
+                      ]
+                    : groupTypes.map((groupType) => ({
+                          label: capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural),
+                          key: String(groupType.group_type_index),
+                      }))),
+            ]}
+        />
     )
 }

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -3,17 +3,45 @@ import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { groupsModel } from '~/models/groupsModel'
-import { Breadcrumb, Group } from '~/types'
+import { Breadcrumb, Group, PropertyFilterType, PropertyOperator } from '~/types'
 import type { groupLogicType } from './groupLogicType'
 import { urls } from 'scenes/urls'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
+import { DataTableNode, NodeKind } from '~/queries/schema'
+import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
+
+function getGroupEventsQuery(groupTypeIndex: number, groupKey: string): DataTableNode {
+    return {
+        kind: NodeKind.DataTableNode,
+        full: true,
+        source: {
+            kind: NodeKind.EventsQuery,
+            select: defaultDataTableColumns(NodeKind.EventsQuery),
+            after: '-24h',
+            fixedProperties: [
+                {
+                    key: `$group_${groupTypeIndex}`,
+                    value: groupKey,
+                    type: PropertyFilterType.Event,
+                    operator: PropertyOperator.Exact,
+                },
+            ],
+        },
+    }
+}
 
 export const groupLogic = kea<groupLogicType>({
     path: ['groups', 'groupLogic'],
     connect: { values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes', 'aggregationLabel']] },
     actions: () => ({
-        setGroup: (groupTypeIndex: number, groupKey: string) => ({ groupTypeIndex, groupKey }),
+        setGroup: (groupTypeIndex: number, groupKey: string, groupTab?: string | null) => ({
+            groupTypeIndex,
+            groupKey,
+            groupTab,
+        }),
+        setGroupTab: (groupTab: string | null) => ({ groupTab }),
+        setGroupEventsQuery: (query: DataTableNode) => ({ query }),
     }),
     loaders: ({ values }) => ({
         groupData: [
@@ -40,6 +68,20 @@ export const groupLogic = kea<groupLogicType>({
                 setGroup: (_, { groupKey }) => groupKey,
             },
         ],
+        groupTab: [
+            null as string | null,
+            {
+                setGroup: (_, { groupTab }) => groupTab ?? null,
+                setGroupTab: (_, { groupTab }) => groupTab,
+            },
+        ],
+        groupEventsQuery: [
+            null as DataTableNode | null,
+            {
+                setGroup: (_, { groupTypeIndex, groupKey }) => getGroupEventsQuery(groupTypeIndex, groupKey),
+                setGroupEventsQuery: (_, { query }) => query,
+            },
+        ],
     },
     selectors: {
         groupTypeName: [
@@ -64,10 +106,29 @@ export const groupLogic = kea<groupLogicType>({
             ],
         ],
     },
-    urlToAction: ({ actions }) => ({
-        '/groups/:groupTypeIndex/:groupKey': ({ groupTypeIndex, groupKey }) => {
+    actionToUrl: ({ values }) => ({
+        setGroup: () => {
+            const { groupTypeIndex, groupKey, groupTab } = values
+            return urls.group(String(groupTypeIndex), groupKey, true, groupTab)
+        },
+    }),
+    urlToAction: ({ actions, values }) => ({
+        '/groups/:groupTypeIndex/:groupKey(/:groupTab)': ({ groupTypeIndex, groupKey, groupTab }) => {
             if (groupTypeIndex && groupKey) {
-                actions.setGroup(+groupTypeIndex, decodeURIComponent(groupKey))
+                if (+groupTypeIndex === values.groupTypeIndex && groupKey === values.groupKey) {
+                    actions.setGroupTab(groupTab || null)
+                } else {
+                    actions.setGroup(+groupTypeIndex, decodeURIComponent(groupKey), groupTab)
+                }
+            }
+        },
+    }),
+    listeners: ({ actions, selectors, values }) => ({
+        setGroup: (_, __, ___, previousState) => {
+            if (
+                selectors.groupTypeIndex(previousState) !== values.groupTypeIndex ||
+                selectors.groupKey(previousState) !== values.groupKey
+            ) {
                 actions.loadGroup()
             }
         },

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -8,8 +8,9 @@ import type { groupLogicType } from './groupLogicType'
 import { urls } from 'scenes/urls'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
-import { DataTableNode, NodeKind } from '~/queries/schema'
+import { DataTableNode, Node, NodeKind } from '~/queries/schema'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
+import { isDataTableNode } from '~/queries/utils'
 
 function getGroupEventsQuery(groupTypeIndex: number, groupKey: string): DataTableNode {
     return {
@@ -41,7 +42,7 @@ export const groupLogic = kea<groupLogicType>({
             groupTab,
         }),
         setGroupTab: (groupTab: string | null) => ({ groupTab }),
-        setGroupEventsQuery: (query: DataTableNode) => ({ query }),
+        setGroupEventsQuery: (query: Node) => ({ query }),
     }),
     loaders: ({ values }) => ({
         groupData: [
@@ -79,7 +80,7 @@ export const groupLogic = kea<groupLogicType>({
             null as DataTableNode | null,
             {
                 setGroup: (_, { groupTypeIndex, groupKey }) => getGroupEventsQuery(groupTypeIndex, groupKey),
-                setGroupEventsQuery: (_, { query }) => query,
+                setGroupEventsQuery: (_, { query }) => (isDataTableNode(query) ? query : null),
             },
         ],
     },
@@ -108,6 +109,10 @@ export const groupLogic = kea<groupLogicType>({
     },
     actionToUrl: ({ values }) => ({
         setGroup: () => {
+            const { groupTypeIndex, groupKey, groupTab } = values
+            return urls.group(String(groupTypeIndex), groupKey, true, groupTab)
+        },
+        setGroupTab: () => {
             const { groupTypeIndex, groupKey, groupTab } = values
             return urls.group(String(groupTypeIndex), groupKey, true, groupTab)
         },

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -29,6 +29,7 @@ export const groupsListLogic = kea<groupsListLogicType>({
     actions: () => ({
         loadGroups: (url?: string | null) => ({ url }),
         setTab: (tab: string) => ({ tab }),
+        setSearch: (search: string) => ({ search }),
     }),
     loaders: ({ values }) => ({
         groups: [
@@ -37,7 +38,10 @@ export const groupsListLogic = kea<groupsListLogicType>({
                 loadGroups: async ({ url }) => {
                     if (values.groupsEnabled) {
                         url =
-                            url || `api/projects/${values.currentTeamId}/groups/?group_type_index=${values.currentTab}`
+                            url ||
+                            `api/projects/${values.currentTeamId}/groups/?group_type_index=${values.currentTab}${
+                                values.search ? '&search=' + encodeURIComponent(values.search) : ''
+                            }`
                         return await api.get(url)
                     }
                 },
@@ -45,6 +49,13 @@ export const groupsListLogic = kea<groupsListLogicType>({
         ],
     }),
     reducers: {
+        search: [
+            '',
+            {
+                setSearch: (_, { search }) => search,
+                setTab: () => '',
+            },
+        ],
         currentTab: [
             '-1',
             {
@@ -98,6 +109,12 @@ export const groupsListLogic = kea<groupsListLogicType>({
             if (values.currentTab !== '-1') {
                 actions.setTab('-1')
             }
+        },
+    }),
+    listeners: ({ actions }) => ({
+        setSearch: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadGroups()
         },
     }),
 })

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -313,6 +313,7 @@ export const routes: Record<string, Scene> = {
     [urls.persons()]: Scene.Persons,
     [urls.groups(':groupTypeIndex')]: Scene.Groups,
     [urls.group(':groupTypeIndex', ':groupKey', false)]: Scene.Group,
+    [urls.group(':groupTypeIndex', ':groupKey', false, ':groupTab')]: Scene.Group,
     [urls.cohort(':id')]: Scene.Cohort,
     [urls.cohorts()]: Scene.Cohorts,
     [urls.experiments()]: Scene.Experiments,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -76,8 +76,8 @@ export const urls = {
     persons: (): string => '/persons',
     groups: (groupTypeIndex: string): string => `/groups/${groupTypeIndex}`,
     // :TRICKY: Note that groupKey is provided by user. We need to override urlPatternOptions for kea-router.
-    group: (groupTypeIndex: string | number, groupKey: string, encode: boolean = true): string =>
-        `/groups/${groupTypeIndex}/${encode ? encodeURIComponent(groupKey) : groupKey}`,
+    group: (groupTypeIndex: string | number, groupKey: string, encode: boolean = true, tab?: string | null): string =>
+        `/groups/${groupTypeIndex}/${encode ? encodeURIComponent(groupKey) : groupKey}${tab ? `/${tab}` : ''}`,
     cohort: (id: string | number): string => `/cohorts/${id}`,
     cohorts: (): string => '/cohorts',
     experiment: (id: string | number): string => `/experiments/${id}`,


### PR DESCRIPTION
## Problem

The event explorer under groups showed like this:

<img width="1733" alt="Screenshot 2023-03-20 at 20 59 26" src="https://user-images.githubusercontent.com/53387/226461394-7cf61054-d0c3-40f4-8f0e-c91a6633fc9e.png">

## Changes

Now it has a full set of filters, including for the time:

<img width="1734" alt="Screenshot 2023-03-20 at 21 41 41" src="https://user-images.githubusercontent.com/53387/226461440-2fe5922d-eb9c-4ffb-b01b-e3efaefe9385.png">

I also converted the ant tabs to lemon tabs, and made the URL work... and added groups search:

![2023-03-20 22 14 05](https://user-images.githubusercontent.com/53387/226467468-b34734e8-c025-4aaf-adbd-2a077fbf2dbb.gif)


## How did you test this code?

Visually