### PR TITLE
feat(hogql): always prepend table name in clickhouse sql

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -1,14 +1,14 @@
 # name: TestQuery.test_event_property_filter
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 66), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -16,14 +16,14 @@
 # name: TestQuery.test_event_property_filter.1
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), equals(replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''), 'test_val3'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 66), equals(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), 'test_val3'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -31,14 +31,14 @@
 # name: TestQuery.test_event_property_filter.2
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), ilike(replaceRegexpAll(JSONExtractRaw(properties, 'path'), '^"|"$', ''), '%/%'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 66), ilike(replaceRegexpAll(JSONExtractRaw(events.properties, 'path'), '^"|"$', ''), '%/%'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -46,14 +46,14 @@
 # name: TestQuery.test_event_property_filter_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 67), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -61,14 +61,14 @@
 # name: TestQuery.test_event_property_filter_materialized.1
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(team_id, 2), equals(events.mat_key, 'test_val3'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 67), equals(events.mat_key, 'test_val3'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -76,14 +76,14 @@
 # name: TestQuery.test_event_property_filter_materialized.2
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(team_id, 2), ilike(events.mat_path, '%/%'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 67), ilike(events.mat_path, '%/%'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -91,38 +91,38 @@
 # name: TestQuery.test_full_hogql_query
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '')
   FROM events
-  WHERE equals(team_id, 2)
-  ORDER BY timestamp ASC
+  WHERE equals(events.team_id, 68)
+  ORDER BY events.timestamp ASC
   LIMIT 100
   '
 ---
 # name: TestQuery.test_full_hogql_query_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key
   FROM events
-  WHERE equals(team_id, 2)
-  ORDER BY timestamp ASC
+  WHERE equals(events.team_id, 69)
+  ORDER BY events.timestamp ASC
   LIMIT 100
   '
 ---
 # name: TestQuery.test_hogql_property_filter
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 70), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -130,14 +130,14 @@
 # name: TestQuery.test_hogql_property_filter.1
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), equals('a%sd', 'foo'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 70), equals('a%sd', 'foo'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -145,14 +145,14 @@
 # name: TestQuery.test_hogql_property_filter.2
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), equals('a%sd', 'a%sd'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 70), equals('a%sd', 'a%sd'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -160,14 +160,14 @@
 # name: TestQuery.test_hogql_property_filter.3
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT events.event,
+         events.distinct_id,
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), equals(replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''), 'test_val2'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 70), equals(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), 'test_val2'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -175,14 +175,14 @@
 # name: TestQuery.test_hogql_property_filter_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 71), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -190,14 +190,14 @@
 # name: TestQuery.test_hogql_property_filter_materialized.1
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(team_id, 2), equals('a%sd', 'foo'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 71), equals('a%sd', 'foo'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -205,14 +205,14 @@
 # name: TestQuery.test_hogql_property_filter_materialized.2
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(team_id, 2), equals('a%sd', 'a%sd'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 71), equals('a%sd', 'a%sd'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -220,14 +220,14 @@
 # name: TestQuery.test_hogql_property_filter_materialized.3
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
+  SELECT events.event,
+         events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(team_id, 2), equals(events.mat_key, 'test_val2'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 71), equals(events.mat_key, 'test_val2'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -235,28 +235,28 @@
 # name: TestQuery.test_person_property_filter
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
+  SELECT events.event,
          events.distinct_id,
-         replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+         replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          'a%sd',
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
   INNER JOIN
-    (SELECT argMax(person_distinct_id2.person_id, version) AS person_id,
-            distinct_id
+    (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+            person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(team_id, 2)
-     GROUP BY distinct_id
-     HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+     WHERE equals(person_distinct_id2.team_id, 75)
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
-    (SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''), version) AS properties___email,
-            id
+    (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''), person.version) AS properties___email,
+            person.id
      FROM person
-     WHERE equals(team_id, 2)
-     GROUP BY id
-     HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+     WHERE equals(person.team_id, 75)
+     GROUP BY person.id
+     HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
+  WHERE and(equals(events.team_id, 75), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -264,28 +264,28 @@
 # name: TestQuery.test_person_property_filter_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
+  SELECT events.event,
          events.distinct_id,
          events.mat_key,
          'a%sd',
-         concat(event, ' ', events.mat_key)
+         concat(events.event, ' ', events.mat_key)
   FROM events
   INNER JOIN
-    (SELECT argMax(person_distinct_id2.person_id, version) AS person_id,
-            distinct_id
+    (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+            person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(team_id, 2)
-     GROUP BY distinct_id
-     HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+     WHERE equals(person_distinct_id2.team_id, 76)
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
-    (SELECT argMax(person.pmat_email, version) AS properties___email,
-            id
+    (SELECT argMax(person.pmat_email, person.version) AS properties___email,
+            person.id
      FROM person
-     WHERE equals(team_id, 2)
-     GROUP BY id
-     HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+     WHERE equals(person.team_id, 76)
+     GROUP BY person.id
+     HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
+  WHERE and(equals(events.team_id, 76), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -293,11 +293,11 @@
 # name: TestQuery.test_property_filter_aggregations
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  GROUP BY replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')
+  WHERE and(equals(events.team_id, 77), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  GROUP BY replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '')
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0
@@ -306,11 +306,11 @@
 # name: TestQuery.test_property_filter_aggregations.1
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
+  SELECT replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  GROUP BY replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')
+  WHERE and(equals(events.team_id, 77), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  GROUP BY replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '')
   HAVING and(greater(count(), 1))
   ORDER BY count() DESC
   LIMIT 101
@@ -323,7 +323,7 @@
   SELECT events.mat_key,
          count()
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 78), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY events.mat_key
   ORDER BY count() DESC
   LIMIT 101
@@ -336,7 +336,7 @@
   SELECT events.mat_key,
          count()
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 78), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY events.mat_key
   HAVING and(greater(count(), 1))
   ORDER BY count() DESC
@@ -347,12 +347,12 @@
 # name: TestQuery.test_select_event_person
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT event,
-         distinct_id,
-         distinct_id
+  SELECT events.event,
+         events.distinct_id,
+         events.distinct_id
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY event ASC
+  WHERE and(equals(events.team_id, 79), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0
   '
@@ -360,13 +360,13 @@
 # name: TestQuery.test_select_hogql_expressions
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''),
-         event,
-         distinct_id,
-         concat(event, ' ', replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))
+  SELECT replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
+         events.event,
+         events.distinct_id,
+         concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') ASC
+  WHERE and(equals(events.team_id, 80), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0
   '
@@ -374,11 +374,11 @@
 # name: TestQuery.test_select_hogql_expressions.1
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at),
-         event
+  SELECT tuple(events.uuid, events.event, events.properties, events.timestamp, events.team_id, events.distinct_id, events.elements_chain, events.created_at),
+         events.event
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  ORDER BY tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at) ASC
+  WHERE and(equals(events.team_id, 80), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  ORDER BY tuple(events.uuid, events.event, events.properties, events.timestamp, events.team_id, events.distinct_id, events.elements_chain, events.created_at) ASC
   LIMIT 101
   OFFSET 0
   '
@@ -387,10 +387,10 @@
   '
   /* user_id:0 request:_snapshot_ */
   SELECT count(),
-         event
+         events.event
   FROM events
-  WHERE and(equals(team_id, 2), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  GROUP BY event
+  WHERE and(equals(events.team_id, 80), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  GROUP BY events.event
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0
@@ -400,11 +400,11 @@
   '
   /* user_id:0 request:_snapshot_ */
   SELECT count(),
-         event
+         events.event
   FROM events
-  WHERE and(equals(team_id, 2), or(equals(event, 'sign up'), like(replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''), '%val2')), less(timestamp, '2020-01-10 12:14:05.000000'), greater(timestamp, '2020-01-09 12:00:00.000000'))
-  GROUP BY event
-  ORDER BY count() DESC, event ASC
+  WHERE and(equals(events.team_id, 80), or(equals(events.event, 'sign up'), like(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), '%val2')), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  GROUP BY events.event
+  ORDER BY count() DESC, events.event ASC
   LIMIT 101
   OFFSET 0
   '

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -177,7 +177,12 @@ class _Printer(Visitor):
                 raise ValueError(f"Table alias {node.ref.name} does not resolve!")
             if not isinstance(table_ref, ast.TableRef):
                 raise ValueError(f"Table alias {node.ref.name} does not resolve to a table!")
-            join_strings.append(self._print_identifier(table_ref.table.clickhouse_table()))
+
+            if self.dialect == "clickhouse":
+                table_name = table_ref.table.clickhouse_table()
+            else:
+                table_name = table_ref.table.hogql_table()
+            join_strings.append(self._print_identifier(table_name))
 
             if node.alias is not None:
                 join_strings.append(f"AS {self._print_identifier(node.alias)}")
@@ -315,10 +320,6 @@ class _Printer(Visitor):
             return ".".join([self._print_identifier(identifier) for identifier in node.chain])
 
         if node.ref is not None:
-            select_query = self._last_select()
-            select: Optional[ast.SelectQueryRef] = select_query.ref if select_query else None
-            if select is None:
-                raise ValueError(f"Can't find SelectQueryRef for field: {original_field}")
             return self.visit(node.ref)
         else:
             raise ValueError(f"Unknown Ref, can not print {type(node.ref).__name__}")
@@ -410,16 +411,14 @@ class _Printer(Visitor):
 
             else:
                 field_sql = self._print_identifier(resolved_field.name)
-
-                # If the field is called on a table that has an alias, prepend the table alias.
-                # If there's another field with the same name in the scope that's not this, prepend the full table name.
-                # Note: we don't prepend a table name for the special "person" fields.
-                if isinstance(ref.table, ast.TableAliasRef) or ref_with_name_in_scope != ref:
-                    field_sql = f"{self.visit(ref.table)}.{field_sql}"
+                if self.context.within_non_hogql_query and ref_with_name_in_scope == ref:
+                    # Do not prepend table name in non-hogql context. We don't know what it actually is.
+                    return field_sql
+                field_sql = f"{self.visit(ref.table)}.{field_sql}"
 
         elif isinstance(ref.table, ast.SelectQueryRef) or isinstance(ref.table, ast.SelectQueryAliasRef):
             field_sql = self._print_identifier(ref.name)
-            if isinstance(ref.table, ast.SelectQueryAliasRef) or ref_with_name_in_scope != ref:
+            if isinstance(ref.table, ast.SelectQueryAliasRef):
                 field_sql = f"{self.visit(ref.table)}.{field_sql}"
 
             # :KLUDGE: Legacy person properties handling. Only used within non-HogQL queries, such as insights.

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -52,16 +52,16 @@ class TestPrinter(BaseTest):
     def test_fields_and_properties(self):
         self.assertEqual(
             self._expr("properties.bla"),
-            "replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', '')",
+            "replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', '')",
         )
         self.assertEqual(
             self._expr("properties['bla']"),
-            "replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', '')",
+            "replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', '')",
         )
         context = HogQLContext(team_id=self.team.pk)
         self.assertEqual(
             self._expr("properties.$bla", context),
-            "replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', '')",
+            "replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', '')",
         )
 
         with override_settings(PERSON_ON_EVENTS_OVERRIDE=False):
@@ -155,8 +155,8 @@ class TestPrinter(BaseTest):
 
     def test_methods(self):
         self.assertEqual(self._expr("count()"), "count()")
-        self.assertEqual(self._expr("count(distinct event)"), "count(DISTINCT event)")
-        self.assertEqual(self._expr("countIf(distinct event, 1 == 2)"), "countIf(DISTINCT event, equals(1, 2))")
+        self.assertEqual(self._expr("count(distinct event)"), "count(DISTINCT events.event)")
+        self.assertEqual(self._expr("countIf(distinct event, 1 == 2)"), "countIf(DISTINCT events.event, equals(1, 2))")
         self.assertEqual(self._expr("sumIf(1, 1 == 2)"), "sumIf(1, equals(1, 2))")
 
     def test_functions(self):
@@ -197,43 +197,43 @@ class TestPrinter(BaseTest):
     def test_logic(self):
         self.assertEqual(
             self._expr("event or timestamp"),
-            "or(event, timestamp)",
+            "or(events.event, events.timestamp)",
         )
         self.assertEqual(
             self._expr("properties.bla and properties.bla2"),
-            "and(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_1)s), '^\"|\"$', ''))",
+            "and(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', ''), replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_1)s), '^\"|\"$', ''))",
         )
         self.assertEqual(
             self._expr("event or timestamp or true or count()"),
-            "or(event, timestamp, true, count())",
+            "or(events.event, events.timestamp, true, count())",
         )
         self.assertEqual(
             self._expr("event or not timestamp"),
-            "or(event, not(timestamp))",
+            "or(events.event, not(events.timestamp))",
         )
 
     def test_comparisons(self):
         context = HogQLContext(team_id=self.team.pk)
-        self.assertEqual(self._expr("event == 'E'", context), "equals(event, %(hogql_val_0)s)")
-        self.assertEqual(self._expr("event != 'E'", context), "notEquals(event, %(hogql_val_1)s)")
-        self.assertEqual(self._expr("event > 'E'", context), "greater(event, %(hogql_val_2)s)")
-        self.assertEqual(self._expr("event >= 'E'", context), "greaterOrEquals(event, %(hogql_val_3)s)")
-        self.assertEqual(self._expr("event < 'E'", context), "less(event, %(hogql_val_4)s)")
-        self.assertEqual(self._expr("event <= 'E'", context), "lessOrEquals(event, %(hogql_val_5)s)")
-        self.assertEqual(self._expr("event like 'E'", context), "like(event, %(hogql_val_6)s)")
-        self.assertEqual(self._expr("event not like 'E'", context), "not(like(event, %(hogql_val_7)s))")
-        self.assertEqual(self._expr("event ilike 'E'", context), "ilike(event, %(hogql_val_8)s)")
-        self.assertEqual(self._expr("event not ilike 'E'", context), "not(ilike(event, %(hogql_val_9)s))")
-        self.assertEqual(self._expr("event in 'E'", context), "in(event, %(hogql_val_10)s)")
-        self.assertEqual(self._expr("event not in 'E'", context), "not(in(event, %(hogql_val_11)s))")
+        self.assertEqual(self._expr("event == 'E'", context), "equals(events.event, %(hogql_val_0)s)")
+        self.assertEqual(self._expr("event != 'E'", context), "notEquals(events.event, %(hogql_val_1)s)")
+        self.assertEqual(self._expr("event > 'E'", context), "greater(events.event, %(hogql_val_2)s)")
+        self.assertEqual(self._expr("event >= 'E'", context), "greaterOrEquals(events.event, %(hogql_val_3)s)")
+        self.assertEqual(self._expr("event < 'E'", context), "less(events.event, %(hogql_val_4)s)")
+        self.assertEqual(self._expr("event <= 'E'", context), "lessOrEquals(events.event, %(hogql_val_5)s)")
+        self.assertEqual(self._expr("event like 'E'", context), "like(events.event, %(hogql_val_6)s)")
+        self.assertEqual(self._expr("event not like 'E'", context), "not(like(events.event, %(hogql_val_7)s))")
+        self.assertEqual(self._expr("event ilike 'E'", context), "ilike(events.event, %(hogql_val_8)s)")
+        self.assertEqual(self._expr("event not ilike 'E'", context), "not(ilike(events.event, %(hogql_val_9)s))")
+        self.assertEqual(self._expr("event in 'E'", context), "in(events.event, %(hogql_val_10)s)")
+        self.assertEqual(self._expr("event not in 'E'", context), "not(in(events.event, %(hogql_val_11)s))")
 
     def test_comments(self):
         context = HogQLContext(team_id=self.team.pk)
-        self.assertEqual(self._expr("event -- something", context), "event")
+        self.assertEqual(self._expr("event -- something", context), "events.event")
 
     def test_values(self):
         context = HogQLContext(team_id=self.team.pk)
-        self.assertEqual(self._expr("event == 'E'", context), "equals(event, %(hogql_val_0)s)")
+        self.assertEqual(self._expr("event == 'E'", context), "equals(events.event, %(hogql_val_0)s)")
         self.assertEqual(context.values, {"hogql_val_0": "E"})
         self.assertEqual(
             self._expr("coalesce(4.2, 5, 'lol', 'hoo')", context),
@@ -247,10 +247,10 @@ class TestPrinter(BaseTest):
         self._assert_select_error("select 1 as team_id from events", "Alias 'team_id' is a reserved keyword.")
         self.assertEqual(
             self._select("select 1 as `-- select team_id` from events"),
-            f"SELECT 1 AS `-- select team_id` FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT 1 AS `-- select team_id` FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         # Some aliases are funny, but that's what the antlr syntax permits, and ClickHouse doesn't complain either
-        self.assertEqual(self._expr("event makes little sense"), "((event AS makes) AS little) AS sense")
+        self.assertEqual(self._expr("event makes little sense"), "((events.event AS makes) AS little) AS sense")
 
     def test_select(self):
         self.assertEqual(self._select("select 1"), "SELECT 1 LIMIT 65535")
@@ -258,7 +258,7 @@ class TestPrinter(BaseTest):
         self.assertEqual(self._select("select 1 + 2, 3"), "SELECT plus(1, 2), 3 LIMIT 65535")
         self.assertEqual(
             self._select("select 1 + 2, 3 + 4 from events"),
-            f"SELECT plus(1, 2), plus(3, 4) FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT plus(1, 2), plus(3, 4) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
 
     def test_select_alias(self):
@@ -272,117 +272,117 @@ class TestPrinter(BaseTest):
     def test_select_from(self):
         self.assertEqual(
             self._select("select 1 from events"),
-            f"SELECT 1 FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT 1 FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         self._assert_select_error("select 1 from other", 'Unknown table "other".')
 
     def test_select_where(self):
         self.assertEqual(
             self._select("select 1 from events where 1 == 2"),
-            f"SELECT 1 FROM events WHERE and(equals(team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535",
+            f"SELECT 1 FROM events WHERE and(equals(events.team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535",
         )
 
     def test_select_having(self):
         self.assertEqual(
             self._select("select 1 from events having 1 == 2"),
-            f"SELECT 1 FROM events WHERE equals(team_id, {self.team.pk}) HAVING equals(1, 2) LIMIT 65535",
+            f"SELECT 1 FROM events WHERE equals(events.team_id, {self.team.pk}) HAVING equals(1, 2) LIMIT 65535",
         )
 
     def test_select_prewhere(self):
         self.assertEqual(
             self._select("select 1 from events prewhere 1 == 2"),
-            f"SELECT 1 FROM events PREWHERE equals(1, 2) WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT 1 FROM events PREWHERE equals(1, 2) WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         self.assertEqual(
             self._select("select 1 from events prewhere 1 == 2 where 2 == 3"),
-            f"SELECT 1 FROM events PREWHERE equals(1, 2) WHERE and(equals(team_id, {self.team.pk}), equals(2, 3)) LIMIT 65535",
+            f"SELECT 1 FROM events PREWHERE equals(1, 2) WHERE and(equals(events.team_id, {self.team.pk}), equals(2, 3)) LIMIT 65535",
         )
 
     def test_select_order_by(self):
         self.assertEqual(
             self._select("select event from events order by event"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) ORDER BY event ASC LIMIT 65535",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) ORDER BY events.event ASC LIMIT 65535",
         )
         self.assertEqual(
             self._select("select event from events order by event desc"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) ORDER BY event DESC LIMIT 65535",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) ORDER BY events.event DESC LIMIT 65535",
         )
         self.assertEqual(
             self._select("select event from events order by event desc, timestamp"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) ORDER BY event DESC, timestamp ASC LIMIT 65535",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) ORDER BY events.event DESC, events.timestamp ASC LIMIT 65535",
         )
 
     def test_select_limit(self):
         self.assertEqual(
             self._select("select event from events limit 10"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 10",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
         )
         self.assertEqual(
             self._select("select event from events limit 10000000"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         self.assertEqual(
             self._select("select event from events limit (select 1000000000)"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT min2(65535, (SELECT 1000000000))",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT min2(65535, (SELECT 1000000000))",
         )
 
         self.assertEqual(
             self._select("select event from events limit (select 1000000000) with ties"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT min2(65535, (SELECT 1000000000)) WITH TIES",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT min2(65535, (SELECT 1000000000)) WITH TIES",
         )
 
     def test_select_offset(self):
         self.assertEqual(
             self._select("select event from events limit 10 offset 10"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 10 OFFSET 10",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 OFFSET 10",
         )
         self.assertEqual(
             self._select("select event from events limit 10 offset 0"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 10 OFFSET 0",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 OFFSET 0",
         )
         self.assertEqual(
             self._select("select event from events limit 10 offset 0 with ties"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 10 OFFSET 0 WITH TIES",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 OFFSET 0 WITH TIES",
         )
 
     def test_select_limit_by(self):
         self.assertEqual(
             self._select("select event from events limit 10 offset 0 by 1,event"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 10 OFFSET 0 BY 1, event",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 OFFSET 0 BY 1, events.event",
         )
 
     def test_select_group_by(self):
         self.assertEqual(
             self._select("select event from events group by event, timestamp"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) GROUP BY event, timestamp LIMIT 65535",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) GROUP BY events.event, events.timestamp LIMIT 65535",
         )
 
     def test_select_distinct(self):
         self.assertEqual(
             self._select("select distinct event from events group by event, timestamp"),
-            f"SELECT DISTINCT event FROM events WHERE equals(team_id, {self.team.pk}) GROUP BY event, timestamp LIMIT 65535",
+            f"SELECT DISTINCT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) GROUP BY events.event, events.timestamp LIMIT 65535",
         )
 
     def test_select_subquery(self):
         self.assertEqual(
             self._select("SELECT event from (select distinct event from events group by event, timestamp)"),
-            f"SELECT event FROM (SELECT DISTINCT event FROM events WHERE equals(team_id, {self.team.pk}) GROUP BY event, timestamp) LIMIT 65535",
+            f"SELECT event FROM (SELECT DISTINCT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) GROUP BY events.event, events.timestamp) LIMIT 65535",
         )
         self.assertEqual(
             self._select("SELECT event from (select distinct event from events group by event, timestamp) e"),
-            f"SELECT e.event FROM (SELECT DISTINCT event FROM events WHERE equals(team_id, {self.team.pk}) GROUP BY event, timestamp) AS e LIMIT 65535",
+            f"SELECT e.event FROM (SELECT DISTINCT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) GROUP BY events.event, events.timestamp) AS e LIMIT 65535",
         )
 
     def test_select_union_all(self):
         self.assertEqual(
-            self._select("SELECT event FROM events UNION ALL SELECT event FROM events WHERE 1 = 2"),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535 UNION ALL SELECT event FROM events WHERE and(equals(team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535",
+            self._select("SELECT events.event FROM events UNION ALL SELECT events.event FROM events WHERE 1 = 2"),
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535 UNION ALL SELECT events.event FROM events WHERE and(equals(events.team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535",
         )
         self.assertEqual(
             self._select(
-                "SELECT event FROM events UNION ALL SELECT event FROM events WHERE 1 = 2 UNION ALL SELECT event FROM events WHERE 1 = 2"
+                "SELECT events.event FROM events UNION ALL SELECT events.event FROM events WHERE 1 = 2 UNION ALL SELECT events.event FROM events WHERE 1 = 2"
             ),
-            f"SELECT event FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535 UNION ALL SELECT event FROM events WHERE and(equals(team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535 UNION ALL SELECT event FROM events WHERE and(equals(team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535",
+            f"SELECT events.event FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535 UNION ALL SELECT events.event FROM events WHERE and(equals(events.team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535 UNION ALL SELECT events.event FROM events WHERE and(equals(events.team_id, {self.team.pk}), equals(1, 2)) LIMIT 65535",
         )
         self.assertEqual(
             self._select("SELECT 1 UNION ALL (SELECT 1 UNION ALL SELECT 1) UNION ALL SELECT 1"),
@@ -399,64 +399,64 @@ class TestPrinter(BaseTest):
 
     def test_select_sample(self):
         self.assertEqual(
-            self._select("SELECT event FROM events SAMPLE 1"),
-            f"SELECT event FROM events SAMPLE 1 WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            self._select("SELECT events.event FROM events SAMPLE 1"),
+            f"SELECT events.event FROM events SAMPLE 1 WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
 
         self.assertEqual(
-            self._select("SELECT event FROM events SAMPLE 0.1 OFFSET 1/10"),
-            f"SELECT event FROM events SAMPLE 0.1 OFFSET 1/10 WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            self._select("SELECT events.event FROM events SAMPLE 0.1 OFFSET 1/10"),
+            f"SELECT events.event FROM events SAMPLE 0.1 OFFSET 1/10 WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
 
         self.assertEqual(
-            self._select("SELECT event FROM events SAMPLE 2/78 OFFSET 999"),
-            f"SELECT event FROM events SAMPLE 2/78 OFFSET 999 WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            self._select("SELECT events.event FROM events SAMPLE 2/78 OFFSET 999"),
+            f"SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
 
         with override_settings(PERSON_ON_EVENTS_OVERRIDE=False):
             self.assertEqual(
                 self._select(
-                    "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons ON persons.id=events.person_id"
+                    "SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons ON persons.id=events.person_id"
                 ),
-                f"SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN person ON equals(id, events__pdi.person_id) INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
+                f"SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN person ON equals(person.id, events__pdi.person_id) INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
             )
 
             self.assertEqual(
                 self._select(
-                    "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons SAMPLE 0.1 ON persons.id=events.person_id"
+                    "SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons SAMPLE 0.1 ON persons.id=events.person_id"
                 ),
-                f"SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN person SAMPLE 0.1 ON equals(id, events__pdi.person_id) INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
+                f"SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN person SAMPLE 0.1 ON equals(person.id, events__pdi.person_id) INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
             )
 
         with override_settings(PERSON_ON_EVENTS_OVERRIDE=True):
             self.assertEqual(
                 self._select(
-                    "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons ON persons.id=events.person_id"
+                    "SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons ON persons.id=events.person_id"
                 ),
-                f"SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN person ON equals(id, person_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
+                f"SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN person ON equals(person.id, events.person_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
             )
 
             self.assertEqual(
                 self._select(
-                    "SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons SAMPLE 0.1 ON persons.id=events.person_id"
+                    "SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN persons SAMPLE 0.1 ON persons.id=events.person_id"
                 ),
-                f"SELECT event FROM events SAMPLE 2/78 OFFSET 999 JOIN person SAMPLE 0.1 ON equals(id, person_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
+                f"SELECT events.event FROM events SAMPLE 2/78 OFFSET 999 JOIN person SAMPLE 0.1 ON equals(person.id, events.person_id) WHERE and(equals(person.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 65535",
             )
 
     def test_count_distinct(self):
         self.assertEqual(
             self._select("SELECT count(distinct event) FROM events"),
-            f"SELECT count(DISTINCT event) FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT count(DISTINCT events.event) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
 
     def test_count_star(self):
         self.assertEqual(
             self._select("SELECT count(*) FROM events"),
-            f"SELECT count(*) FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT count(*) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
 
     def test_count_if_distinct(self):
         self.assertEqual(
             self._select("SELECT countIf(distinct event, event like '%a%') FROM events"),
-            f"SELECT countIf(DISTINCT event, like(event, %(hogql_val_0)s)) FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT countIf(DISTINCT events.event, like(events.event, %(hogql_val_0)s)) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -46,7 +46,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT count(), event FROM events WHERE and(equals(team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY event LIMIT 100",
+                f"SELECT count(), events.event FROM events WHERE and(equals(events.team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY events.event LIMIT 100",
             )
             self.assertEqual(
                 response.hogql,
@@ -61,7 +61,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT count, event FROM (SELECT count() AS count, event FROM events WHERE and(equals(team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY event) GROUP BY count, event LIMIT 100",
+                f"SELECT count, event FROM (SELECT count() AS count, events.event FROM events WHERE and(equals(events.team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY events.event) GROUP BY count, event LIMIT 100",
             )
             self.assertEqual(
                 response.hogql,
@@ -76,7 +76,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT c.count, c.event FROM (SELECT count(*) AS count, event FROM events WHERE and(equals(team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY event) AS c GROUP BY c.count, c.event LIMIT 100",
+                f"SELECT c.count, c.event FROM (SELECT count(*) AS count, events.event FROM events WHERE and(equals(events.team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY events.event) AS c GROUP BY c.count, c.event LIMIT 100",
             )
             self.assertEqual(
                 response.hogql,
@@ -91,7 +91,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', '') FROM person WHERE and(equals(team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_1)s), '^\"|\"$', ''), %(hogql_val_2)s)) LIMIT 100",
+                f"SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', '') FROM person WHERE and(equals(person.team_id, {self.team.id}), equals(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), %(hogql_val_2)s)) LIMIT 100",
             )
             self.assertEqual(
                 response.hogql,
@@ -105,7 +105,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT DISTINCT person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.id}) LIMIT 100",
+                f"SELECT DISTINCT person_distinct_id2.person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.id}) LIMIT 100",
             )
             self.assertEqual(
                 response.hogql,
@@ -134,7 +134,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.hogql,
-                "SELECT event, timestamp, pdi.distinct_id, p.id, p.properties.sneaky_mail FROM events AS e LEFT JOIN person_distinct_id2 AS pdi ON equals(pdi.distinct_id, e.distinct_id) LEFT JOIN person AS p ON equals(p.id, pdi.person_id) LIMIT 100",
+                "SELECT event, timestamp, pdi.distinct_id, p.id, p.properties.sneaky_mail FROM events AS e LEFT JOIN person_distinct_ids AS pdi ON equals(pdi.distinct_id, e.distinct_id) LEFT JOIN persons AS p ON equals(p.id, pdi.person_id) LIMIT 100",
             )
             self.assertEqual(response.results[0][0], "random event")
             self.assertEqual(response.results[0][2], "bla")
@@ -161,7 +161,11 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, e.timestamp, pdi.person_id FROM events AS e INNER JOIN (SELECT distinct_id, argMax(person_distinct_id2.person_id, version) AS person_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.id}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS pdi ON equals(e.distinct_id, pdi.distinct_id) WHERE equals(e.team_id, {self.team.id}) LIMIT 100",
+                f"SELECT e.event, e.timestamp, pdi.person_id FROM events AS e INNER JOIN (SELECT person_distinct_id2.distinct_id, "
+                f"argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id FROM person_distinct_id2 WHERE "
+                f"equals(person_distinct_id2.team_id, {self.team.id}) GROUP BY person_distinct_id2.distinct_id HAVING "
+                f"equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS pdi ON "
+                f"equals(e.distinct_id, pdi.distinct_id) WHERE equals(e.team_id, {self.team.id}) LIMIT 100",
             )
             self.assertEqual(
                 response.hogql,
@@ -183,7 +187,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT event, timestamp, events__pdi.distinct_id, events__pdi.person_id FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE equals(team_id, {self.team.pk}) LIMIT 10",
+                f"SELECT events.event, events.timestamp, events__pdi.distinct_id, events__pdi.person_id FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(response.results[0][0], "random event")
             self.assertEqual(response.results[0][2], "bla")
@@ -202,7 +206,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, e.timestamp, e__pdi.distinct_id, e__pdi.person_id FROM events AS e INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10",
+                f"SELECT e.event, e.timestamp, e__pdi.distinct_id, e__pdi.person_id FROM events AS e INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(response.results[0][0], "random event")
             self.assertEqual(response.results[0][2], "bla")
@@ -218,12 +222,15 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.hogql,
-                # TODO: store original db name in hogql
-                "SELECT pdi.distinct_id, pdi.person.created_at FROM person_distinct_id2 AS pdi LIMIT 10",
+                "SELECT pdi.distinct_id, pdi.person.created_at FROM person_distinct_ids AS pdi LIMIT 10",
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT pdi.distinct_id, pdi__person.created_at FROM person_distinct_id2 AS pdi INNER JOIN (SELECT argMax(person.created_at, version) AS created_at, id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id HAVING equals(argMax(is_deleted, version), 0)) AS pdi__person ON equals(pdi.person_id, pdi__person.id) WHERE equals(pdi.team_id, {self.team.pk}) LIMIT 10",
+                f"SELECT pdi.distinct_id, pdi__person.created_at FROM person_distinct_id2 AS pdi INNER JOIN (SELECT "
+                f"argMax(person.created_at, person.version) AS created_at, person.id FROM person WHERE "
+                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, "
+                f"person.version), 0)) AS pdi__person ON equals(pdi.person_id, pdi__person.id) WHERE "
+                f"equals(pdi.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(response.results[0][0], "bla")
             self.assertEqual(response.results[0][1], datetime.datetime(2020, 1, 10, 0, 0))
@@ -238,16 +245,15 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.hogql,
-                # TODO: store original db name in hogql
-                "SELECT pdi.distinct_id, pdi.person.properties.sneaky_mail FROM person_distinct_id2 AS pdi LIMIT 10",
+                "SELECT pdi.distinct_id, pdi.person.properties.sneaky_mail FROM person_distinct_ids AS pdi LIMIT 10",
             )
             self.assertEqual(
                 response.clickhouse,
                 f"SELECT pdi.distinct_id, pdi__person.properties___sneaky_mail FROM person_distinct_id2 AS pdi INNER JOIN "
-                f"(SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), version) "
-                f"AS properties___sneaky_mail, id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id HAVING "
-                f"equals(argMax(is_deleted, version), 0)) AS pdi__person ON equals(pdi.person_id, pdi__person.id) "
-                f"WHERE equals(pdi.team_id, {self.team.pk}) LIMIT 10",
+                f"(SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', ''), person.version) "
+                f"AS properties___sneaky_mail, person.id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id "
+                f"HAVING equals(argMax(person.is_deleted, person.version), 0)) AS pdi__person ON "
+                f"equals(pdi.person_id, pdi__person.id) WHERE equals(pdi.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(response.results[0][0], "bla")
             self.assertEqual(response.results[0][1], "tim@posthog.com")
@@ -262,26 +268,14 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT event, timestamp, events__pdi.distinct_id, events__pdi__person.id FROM events "
-                f"INNER JOIN (SELECT "
-                f"argMax(person_distinct_id2.person_id, version) AS person_id, "
-                f"distinct_id "
-                f"FROM person_distinct_id2 "
-                f"WHERE equals(team_id, {self.team.pk}) "
-                f"GROUP BY distinct_id "
-                f"HAVING equals(argMax(is_deleted, version), 0)"
-                f") AS events__pdi "
-                f"ON equals(events.distinct_id, events__pdi.distinct_id) "
-                f"INNER JOIN ("
-                f"SELECT id "
-                f"FROM person "
-                f"WHERE equals(team_id, {self.team.pk}) "
-                f"GROUP BY id "
-                f"HAVING equals(argMax(is_deleted, version), 0)"
-                f") AS events__pdi__person "
-                f"ON equals(events__pdi.person_id, events__pdi__person.id) "
-                f"WHERE equals(team_id, {self.team.pk}) "
-                f"LIMIT 10",
+                f"SELECT events.event, events.timestamp, events__pdi.distinct_id, events__pdi__person.id FROM events "
+                f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
+                f"person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
+                f"person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
+                f"INNER JOIN (SELECT person.id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING "
+                f"equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON "
+                f"equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(
                 response.hogql,
@@ -302,14 +296,15 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT event, timestamp, events__pdi.distinct_id, events__pdi__person.properties___sneaky_mail "
-                f"FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-                f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING "
-                f"equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, "
-                f"events__pdi.distinct_id) INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, "
-                f"%(hogql_val_0)s), '^\"|\"$', ''), version) AS properties___sneaky_mail, id FROM person WHERE equals(team_id, "
-                f"{self.team.pk}) GROUP BY id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person ON "
-                f"equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(team_id, {self.team.pk}) LIMIT 10",
+                f"SELECT events.event, events.timestamp, events__pdi.distinct_id, events__pdi__person.properties___sneaky_mail FROM events "
+                f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
+                f"person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) "
+                f"AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN (SELECT "
+                f"argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', ''), person.version) "
+                f"AS properties___sneaky_mail, person.id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING "
+                f"equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, "
+                f"events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(
                 response.hogql,
@@ -329,14 +324,15 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, e.timestamp, e__pdi.distinct_id, e__pdi__person.properties___sneaky_mail "
-                f"FROM events AS e INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, "
-                f"distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id "
-                f"HAVING equals(argMax(is_deleted, version), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) "
-                f"INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), "
-                f"version) AS properties___sneaky_mail, id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id "
-                f"HAVING equals(argMax(is_deleted, version), 0)) AS e__pdi__person ON equals(e__pdi.person_id, "
-                f"e__pdi__person.id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10",
+                f"SELECT e.event, e.timestamp, e__pdi.distinct_id, e__pdi__person.properties___sneaky_mail FROM events AS e "
+                f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
+                f"person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
+                f"person_distinct_id2.version), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) INNER JOIN "
+                f"(SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', ''), "
+                f"person.version) AS properties___sneaky_mail, person.id FROM person WHERE equals(person.team_id, {self.team.pk}) "
+                f"GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS e__pdi__person ON "
+                f"equals(e__pdi.person_id, e__pdi__person.id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(
                 response.hogql,
@@ -357,13 +353,13 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(
                 response.clickhouse,
                 f"SELECT e.event, e.timestamp, e__pdi__person.properties___sneaky_mail FROM events AS e INNER JOIN (SELECT "
-                f"argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 "
-                f"WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) "
-                f"AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) INNER JOIN (SELECT "
-                f"argMax(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), version) "
-                f"AS properties___sneaky_mail, id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id HAVING "
-                f"equals(argMax(is_deleted, version), 0)) AS e__pdi__person ON equals(e__pdi.person_id, "
-                f"e__pdi__person.id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10",
+                f"argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id "
+                f"FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id "
+                f"HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS e__pdi ON equals(e.distinct_id, "
+                f"e__pdi.distinct_id) INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, "
+                f"%(hogql_val_0)s), '^\"|\"$', ''), person.version) AS properties___sneaky_mail, person.id FROM person WHERE "
+                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
+                f"AS e__pdi__person ON equals(e__pdi.person_id, e__pdi__person.id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(
                 response.hogql,
@@ -380,18 +376,15 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 self.team,
             )
             expected = (
-                "SELECT s__pdi__person.properties___sneaky_mail, count() "
-                "FROM events AS s "
-                "INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-                f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) "
-                "GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) "
-                "AS s__pdi ON equals(s.distinct_id, s__pdi.distinct_id) "
-                "INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), version) "
-                "AS properties___sneaky_mail, id FROM person "
-                f"WHERE equals(team_id, {self.team.pk}) GROUP BY id HAVING equals(argMax(is_deleted, version), 0)) "
-                "AS s__pdi__person ON equals(s__pdi.person_id, s__pdi__person.id) "
-                f"WHERE equals(s.team_id, {self.team.pk}) GROUP BY s__pdi__person.properties___sneaky_mail "
-                "LIMIT 10"
+                f"SELECT s__pdi__person.properties___sneaky_mail, count() FROM events AS s INNER JOIN (SELECT argMax(person_distinct_id2.person_id, "
+                f"person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE "
+                f"equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING "
+                f"equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS s__pdi ON "
+                f"equals(s.distinct_id, s__pdi.distinct_id) INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, "
+                f"%(hogql_val_0)s), '^\"|\"$', ''), person.version) AS properties___sneaky_mail, person.id FROM person WHERE "
+                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
+                f"AS s__pdi__person ON equals(s__pdi.person_id, s__pdi__person.id) WHERE equals(s.team_id, {self.team.pk}) "
+                f"GROUP BY s__pdi__person.properties___sneaky_mail LIMIT 10"
             )
             self.assertEqual(response.clickhouse, expected)
             self.assertEqual(
@@ -430,14 +423,16 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT event, timestamp, events__pdi__person.id, events__pdi__person.properties___sneaky_mail "
-                f"FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-                f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING "
-                f"equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, "
-                f"events__pdi.distinct_id) INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, "
-                f"%(hogql_val_0)s), '^\"|\"$', ''), version) AS properties___sneaky_mail, id FROM person WHERE equals(team_id, "
-                f"{self.team.pk}) GROUP BY id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person ON "
-                f"equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(team_id, {self.team.pk}) LIMIT 10",
+                f"SELECT events.event, events.timestamp, events__pdi__person.id, events__pdi__person.properties___sneaky_mail "
+                f"FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
+                f"person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
+                f"person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
+                f"INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), "
+                f"'^\"|\"$', ''), person.version) AS properties___sneaky_mail, person.id FROM person WHERE "
+                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
+                f"AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id) "
+                f"WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(
                 response.hogql,
@@ -458,7 +453,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT event, timestamp, events.person_id, replaceRegexpAll(JSONExtractRaw(events.person_properties, %(hogql_val_0)s), '^\"|\"$', '') FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 10",
+                f"SELECT events.event, events.timestamp, events.person_id, replaceRegexpAll(JSONExtractRaw(events.person_properties, %(hogql_val_0)s), '^\"|\"$', '') FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
             )
             self.assertEqual(
                 response.hogql,
@@ -497,11 +492,11 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                         )
                     },
                 )
-                self.assertEqual(response.results, [("$pageview", 2)])
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(team_id, {self.team.pk}), in(events__pdi.person_id, (SELECT person_id FROM cohortpeople WHERE and(equals(team_id, {self.team.pk}), equals(cohort_id, {cohort.pk})) GROUP BY person_id, cohort_id, version HAVING greater(sum(sign), 0)))) GROUP BY event LIMIT 100",
+                    f"SELECT events.event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(events.team_id, {self.team.pk}), in(events__pdi.person_id, (SELECT cohortpeople.person_id FROM cohortpeople WHERE and(equals(cohortpeople.team_id, {self.team.pk}), equals(cohortpeople.cohort_id, {cohort.pk})) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version HAVING greater(sum(cohortpeople.sign), 0)))) GROUP BY events.event LIMIT 100",
                 )
+                self.assertEqual(response.results, [("$pageview", 2)])
 
             with override_settings(PERSON_ON_EVENTS_OVERRIDE=True):
                 response = execute_hogql_query(
@@ -513,11 +508,14 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                         )
                     },
                 )
-                self.assertEqual(response.results, [("$pageview", 2)])
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT event, count(*) FROM events WHERE and(equals(team_id, {self.team.pk}), in(person_id, (SELECT person_id FROM cohortpeople WHERE and(equals(team_id, {self.team.pk}), equals(cohort_id, {cohort.pk})) GROUP BY person_id, cohort_id, version HAVING greater(sum(sign), 0)))) GROUP BY event LIMIT 100",
+                    f"SELECT events.event, count(*) FROM events WHERE and(equals(events.team_id, {self.team.pk}), in(events.person_id, "
+                    f"(SELECT cohortpeople.person_id FROM cohortpeople WHERE and(equals(cohortpeople.team_id, {self.team.pk}), "
+                    f"equals(cohortpeople.cohort_id, {cohort.pk})) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, "
+                    f"cohortpeople.version HAVING greater(sum(cohortpeople.sign), 0)))) GROUP BY events.event LIMIT 100",
                 )
+                self.assertEqual(response.results, [("$pageview", 2)])
 
     def test_prop_cohort_static(self):
         with freeze_time("2020-01-10"):
@@ -548,7 +546,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 self.assertEqual(response.results, [("$pageview", 1)])
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(team_id, {self.team.pk}), in(events__pdi.person_id, (SELECT person_id FROM person_static_cohort WHERE and(equals(team_id, {self.team.pk}), equals(cohort_id, {cohort.pk}))))) GROUP BY event LIMIT 100",
+                    f"SELECT events.event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(events.team_id, {self.team.pk}), in(events__pdi.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(equals(person_static_cohort.team_id, {self.team.pk}), equals(person_static_cohort.cohort_id, {cohort.pk}))))) GROUP BY events.event LIMIT 100",
                 )
 
             with override_settings(PERSON_ON_EVENTS_OVERRIDE=True):
@@ -564,7 +562,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 self.assertEqual(response.results, [("$pageview", 1)])
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT event, count(*) FROM events WHERE and(equals(team_id, {self.team.pk}), in(person_id, (SELECT person_id FROM person_static_cohort WHERE and(equals(team_id, {self.team.pk}), equals(cohort_id, {cohort.pk}))))) GROUP BY event LIMIT 100",
+                    f"SELECT events.event, count(*) FROM events WHERE and(equals(events.team_id, {self.team.pk}), in(events.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(equals(person_static_cohort.team_id, {self.team.pk}), equals(person_static_cohort.cohort_id, {cohort.pk}))))) GROUP BY events.event LIMIT 100",
                 )
 
     def test_join_with_property_materialized_session_id(self):

--- a/posthog/hogql/transforms/test/test_lazy_tables.py
+++ b/posthog/hogql/transforms/test/test_lazy_tables.py
@@ -10,14 +10,14 @@ class TestLazyTables(BaseTest):
     def test_resolve_lazy_tables(self):
         printed = self._print_select("select event, pdi.person_id from events")
         expected = (
-            "SELECT event, events__pdi.person_id "
+            "SELECT events.event, events__pdi.person_id "
             "FROM events "
             "INNER JOIN "
-            "(SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-            f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id "
-            "HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi "
+            "(SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id "
+            f"FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id "
+            "HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi "
             "ON equals(events.distinct_id, events__pdi.distinct_id) "
-            f"WHERE equals(team_id, {self.team.pk}) "
+            f"WHERE equals(events.team_id, {self.team.pk}) "
             "LIMIT 65535"
         )
         self.assertEqual(printed, expected)
@@ -26,32 +26,25 @@ class TestLazyTables(BaseTest):
     def test_resolve_lazy_tables_traversed_fields(self):
         printed = self._print_select("select event, person_id from events")
         expected = (
-            "SELECT event, events__pdi.person_id "
-            "FROM events "
-            "INNER JOIN "
-            "(SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-            f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id "
-            "HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi "
-            "ON equals(events.distinct_id, events__pdi.distinct_id) "
-            f"WHERE equals(team_id, {self.team.pk}) "
-            "LIMIT 65535"
+            f"SELECT events.event, events__pdi.person_id FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, "
+            f"person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE "
+            f"equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING "
+            f"equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi "
+            f"ON equals(events.distinct_id, events__pdi.distinct_id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 
     def test_resolve_lazy_tables_two_levels(self):
         printed = self._print_select("select event, pdi.person.id from events")
         expected = (
-            "SELECT event, events__pdi__person.id "
-            "FROM events "
-            "INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-            f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id "
-            "HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi "
-            "ON equals(events.distinct_id, events__pdi.distinct_id) "
-            f"INNER JOIN (SELECT id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id "
-            "HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person "
-            "ON equals(events__pdi.person_id, events__pdi__person.id) "
-            f"WHERE equals(team_id, {self.team.pk}) "
-            "LIMIT 65535"
+            f"SELECT events.event, events__pdi__person.id FROM events INNER JOIN (SELECT "
+            f"argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id "
+            f"FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id "
+            f"HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON "
+            f"equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN (SELECT person.id FROM person WHERE "
+            f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
+            f"AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id) "
+            f"WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 
@@ -59,17 +52,14 @@ class TestLazyTables(BaseTest):
     def test_resolve_lazy_tables_two_levels_traversed(self):
         printed = self._print_select("select event, person.id from events")
         expected = (
-            "SELECT event, events__pdi__person.id "
-            "FROM events "
-            "INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-            f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id "
-            "HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi "
-            "ON equals(events.distinct_id, events__pdi.distinct_id) "
-            f"INNER JOIN (SELECT id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id "
-            "HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person "
-            "ON equals(events__pdi.person_id, events__pdi__person.id) "
-            f"WHERE equals(team_id, {self.team.pk}) "
-            "LIMIT 65535"
+            f"SELECT events.event, events__pdi__person.id FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, "
+            f"person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE "
+            f"equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING "
+            f"equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON "
+            f"equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN (SELECT person.id FROM person WHERE "
+            f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
+            f"AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id) "
+            f"WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 
@@ -79,12 +69,12 @@ class TestLazyTables(BaseTest):
         expected = (
             "SELECT person_distinct_ids__person.`properties___$browser` "
             "FROM person_distinct_id2 INNER JOIN "
-            "(SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), version) "
-            "AS `properties___$browser`, id FROM person "
-            f"WHERE equals(team_id, {self.team.pk}) GROUP BY id "
-            "HAVING equals(argMax(is_deleted, version), 0)"
-            ") AS person_distinct_ids__person ON equals(person_id, person_distinct_ids__person.id) "
-            f"WHERE equals(team_id, {self.team.pk}) "
+            "(SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', ''), person.version) "
+            "AS `properties___$browser`, person.id FROM person "
+            f"WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id "
+            "HAVING equals(argMax(person.is_deleted, person.version), 0)"
+            ") AS person_distinct_ids__person ON equals(person_distinct_id2.person_id, person_distinct_ids__person.id) "
+            f"WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
             "LIMIT 65535"
         )
         self.assertEqual(printed, expected)
@@ -92,17 +82,15 @@ class TestLazyTables(BaseTest):
     def test_resolve_lazy_tables_two_levels_properties(self):
         printed = self._print_select("select event, pdi.person.properties.$browser from events")
         expected = (
-            "SELECT event, events__pdi__person.`properties___$browser` FROM events INNER JOIN "
-            "(SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-            f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) "
-            "GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)"
-            ") AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN "
-            "(SELECT argMax(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), version) "
-            "AS `properties___$browser`, id FROM person "
-            f"WHERE equals(team_id, {self.team.pk}) GROUP BY id HAVING equals(argMax(is_deleted, version), 0)"
-            ") AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id) "
-            f"WHERE equals(team_id, {self.team.pk}) "
-            "LIMIT 65535"
+            f"SELECT events.event, events__pdi__person.`properties___$browser` FROM events INNER JOIN "
+            f"(SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
+            f"person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
+            f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
+            f"person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
+            f"INNER JOIN (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', "
+            f"''), person.version) AS `properties___$browser`, person.id FROM person WHERE equals(person.team_id, {self.team.pk}) "
+            f"GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person "
+            f"ON equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 
@@ -110,15 +98,16 @@ class TestLazyTables(BaseTest):
     def test_resolve_lazy_tables_two_levels_properties_duplicate(self):
         printed = self._print_select("select event, person.properties, person.properties.name from events")
         expected = (
-            "SELECT event, events__pdi__person.properties, events__pdi__person.properties___name "
-            "FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id "
-            f"FROM person_distinct_id2 WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)"
-            ") AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN "
-            "(SELECT argMax(person.properties, version) AS properties, "
-            "argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', ''), version) AS properties___name, "
-            f"id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person "
-            "ON equals(events__pdi.person_id, events__pdi__person.id) "
-            f"WHERE equals(team_id, {self.team.pk}) LIMIT 65535"
+            f"SELECT events.event, events__pdi__person.properties, events__pdi__person.properties___name FROM events "
+            f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
+            f"person_distinct_id2.distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
+            f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
+            f"person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
+            f"INNER JOIN (SELECT argMax(person.properties, person.version) AS properties, "
+            f"argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', ''), person.version) "
+            f"AS properties___name, person.id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id "
+            f"HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON "
+            f"equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -47,10 +47,10 @@ class TestPropertyTypes(BaseTest):
         )
         expected = (
             "SELECT multiply("
-            "toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', '')), "
-            "toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_1)s), '^\"|\"$', ''))), "
-            "equals(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_2)s), '^\"|\"$', ''), %(hogql_val_3)s) "
-            f"FROM events WHERE equals(team_id, {self.team.pk}) LIMIT 65535"
+            "toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_0)s), '^\"|\"$', '')), "
+            "toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_1)s), '^\"|\"$', ''))), "
+            "equals(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_2)s), '^\"|\"$', ''), %(hogql_val_3)s) "
+            f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 
@@ -59,10 +59,10 @@ class TestPropertyTypes(BaseTest):
             "select properties.tickets, properties.provided_timestamp, properties.$initial_browser from persons"
         )
         expected = (
-            "SELECT toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', '')), "
-            "parseDateTimeBestEffort(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_1)s), '^\"|\"$', '')), "
-            "replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_2)s), '^\"|\"$', '') "
-            f"FROM person WHERE equals(team_id, {self.team.pk}) LIMIT 65535"
+            "SELECT toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', '')), "
+            "parseDateTimeBestEffort(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', '')), "
+            "replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_2)s), '^\"|\"$', '') "
+            f"FROM person WHERE equals(person.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 
@@ -71,14 +71,14 @@ class TestPropertyTypes(BaseTest):
         printed = self._print_select("select properties.$screen_width * person.properties.tickets from events")
         expected = (
             "SELECT multiply("
-            "toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_1)s), '^\"|\"$', '')), "
+            "toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(events.properties, %(hogql_val_1)s), '^\"|\"$', '')), "
             "toFloat64OrNull(events__pdi__person.properties___tickets)) FROM events INNER JOIN "
-            "(SELECT argMax(person_distinct_id2.person_id, version) AS person_id, distinct_id FROM person_distinct_id2 "
-            f"WHERE equals(team_id, {self.team.pk}) GROUP BY distinct_id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi "
+            "(SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id FROM person_distinct_id2 "
+            f"WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi "
             "ON equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN (SELECT "
-            "argMax(replaceRegexpAll(JSONExtractRaw(properties, %(hogql_val_0)s), '^\"|\"$', ''), version) AS properties___tickets, "
-            f"id FROM person WHERE equals(team_id, {self.team.pk}) GROUP BY id HAVING equals(argMax(is_deleted, version), 0)) AS events__pdi__person "
-            f"ON equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(team_id, {self.team.pk}) LIMIT 65535"
+            "argMax(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', ''), person.version) AS properties___tickets, "
+            f"person.id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person "
+            f"ON equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535"
         )
         self.assertEqual(printed, expected)
 


### PR DESCRIPTION
## Problem

I saw one error where a materialised column was inaccessible outside a select subquery, since we didn't prepend the table name.

## Changes

Adds a common sense security measure: in printed ClickHouse SQL, we now prepend each accessed field with the name of the table it's on.

## How did you test this code?

Updated the tests. Hoping CI will catch anything else.