### PR TITLE
fix(hogql): funnel person property breakdown

### DIFF
--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -61,10 +61,10 @@ class EnterpriseColumnOptimizer(FOSSColumnOptimizer):
                 ] += 1
             elif self.filter.breakdown_type == "hogql":
                 if isinstance(self.filter.breakdown, list):
-                    breakdown = self.filter.breakdown[0]
+                    expr = str(self.filter.breakdown[0])
                 else:
-                    breakdown = self.filter.breakdown
-                count_hogql_properties(breakdown, counter)
+                    expr = str(self.filter.breakdown)
+                count_hogql_properties(expr, counter)
 
             # If we have a breakdowns attribute then make sure we pull in everything we
             # need to calculate it

--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -3,14 +3,13 @@ from typing import Set, cast
 
 from posthog.clickhouse.materialized_columns.column import ColumnName
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, FunnelCorrelationType
-from posthog.hogql.parser import parse_expr
 from posthog.models.action.util import get_action_tables_and_properties
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.filters.properties_timeline_filter import PropertiesTimelineFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.property import PropertyIdentifier
-from posthog.models.property.util import HogQLPropertyChecker, box_value, extract_tables_and_properties
+from posthog.models.property.util import box_value, count_hogql_properties, extract_tables_and_properties
 from posthog.queries.column_optimizer.foss_column_optimizer import FOSSColumnOptimizer
 from posthog.queries.trends.util import is_series_group_based
 
@@ -60,18 +59,18 @@ class EnterpriseColumnOptimizer(FOSSColumnOptimizer):
                 counter[
                     (self.filter.breakdown, self.filter.breakdown_type, self.filter.breakdown_group_type_index)
                 ] += 1
+            elif self.filter.breakdown_type == "hogql":
+                if isinstance(self.filter.breakdown, list):
+                    breakdown = self.filter.breakdown[0]
+                else:
+                    breakdown = self.filter.breakdown
+                count_hogql_properties(breakdown, counter)
 
             # If we have a breakdowns attribute then make sure we pull in everything we
             # need to calculate it
             for breakdown in self.filter.breakdowns or []:
                 if breakdown["type"] == "hogql":
-                    node = parse_expr(breakdown["property"])
-                    property_checker = HogQLPropertyChecker()
-                    property_checker.visit(node)
-                    for field in property_checker.event_properties:
-                        counter[(field, "event", None)] += 1
-                    for field in property_checker.person_properties:
-                        counter[(field, "person", None)] += 1
+                    count_hogql_properties(breakdown["property"], counter)
                 else:
                     counter[(breakdown["property"], breakdown["type"], self.filter.breakdown_group_type_index)] += 1
 

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -1,3 +1,119 @@
+# name: TestInsight.test_insight_funnels_hogql_breakdown
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(person_props, 'fish'), '^"|"$', '')) AS value,
+            count(*) as count
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+     WHERE team_id = 2
+       AND event IN ['user did things', 'user signed up']
+       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
+       AND (and(less(toInt64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'int_value'), '^"|"$', '')), 10), notEquals('bla', 'a%sd')))
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestInsight.test_insight_funnels_hogql_breakdown.1
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner ,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 <= latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           pdi.person_id as person_id,
+                           person.person_props as person_props ,
+                           if(event = 'user signed up', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'user did things', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(person_props, 'fish'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    INNER JOIN
+                      (SELECT id,
+                              argMax(properties, version) as person_props
+                       FROM person
+                       WHERE team_id = 2
+                       GROUP BY id
+                       HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    WHERE team_id = 2
+                      AND event IN ['user did things', 'user signed up']
+                      AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
+                      AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
+                      AND (and(less(toInt64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'int_value'), '^"|"$', '')), 10), notEquals('bla', 'a%sd')))
+                      AND (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max_steps)
+  GROUP BY prop
+  '
+---
 # name: TestInsight.test_insight_funnels_hogql_global_filters
   '
   /* user_id:0 request:_snapshot_ */

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -2530,7 +2530,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             self.assertEqual(response_json["result"][1]["count"], 0)
             self.assertEqual(response_json["timezone"], "UTC")
 
-    # @snapshot_clickhouse_queries
+    @snapshot_clickhouse_queries
     @also_test_with_materialized_columns(event_properties=["int_value"], person_properties=["fish"])
     def test_insight_funnels_hogql_breakdown(self) -> None:
         with freeze_time("2012-01-15T04:01:34.000Z"):
@@ -2549,7 +2549,44 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                     "properties": json.dumps(
                         [
                             {"key": "toInt(properties.int_value) < 10 and 'bla' != 'a%sd'", "type": "hogql"},
-                            {"key": "like(person.properties.fish, '%fish%')", "type": "hogql"},
+                        ]
+                    ),
+                    "funnel_window_days": 14,
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_json = response.json()
+            self.assertEqual(len(response_json["result"]), 1)
+            self.assertEqual(len(response_json["result"][0]), 2)
+            self.assertEqual(response_json["result"][0][0]["name"], "user signed up")
+            self.assertEqual(response_json["result"][0][0]["count"], 1)
+            self.assertEqual(response_json["result"][0][0]["breakdown"], ["there is no fish"])
+            self.assertEqual(response_json["result"][0][0]["breakdown_value"], ["there is no fish"])
+            self.assertEqual(response_json["result"][0][1]["name"], "user did things")
+            self.assertEqual(response_json["result"][0][1]["count"], 0)
+            self.assertEqual(response_json["result"][0][1]["breakdown"], ["there is no fish"])
+            self.assertEqual(response_json["result"][0][1]["breakdown_value"], ["there is no fish"])
+            self.assertEqual(response_json["timezone"], "UTC")
+
+    # @snapshot_clickhouse_queries
+    @also_test_with_materialized_columns(event_properties=["int_value"], person_properties=["fish"])
+    def test_insight_funnels_hogql_breakdown_old_style(self) -> None:
+        with freeze_time("2012-01-15T04:01:34.000Z"):
+            _create_person(team=self.team, distinct_ids=["1"], properties={"fish": "there is no fish"})
+            _create_event(team=self.team, event="user signed up", distinct_id="1", properties={"int_value": 1})
+            _create_event(team=self.team, event="user did things", distinct_id="1", properties={"int_value": 20})
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/insights/funnel/",
+                {
+                    "breakdown_type": "hogql",
+                    "breakdown": "person.properties.fish",
+                    "events": [
+                        {"id": "user signed up", "type": "events", "order": 0},
+                        {"id": "user did things", "type": "events", "order": 1},
+                    ],
+                    "properties": json.dumps(
+                        [
+                            {"key": "toInt(properties.int_value) < 10 and 'bla' != 'a%sd'", "type": "hogql"},
                         ]
                     ),
                     "funnel_window_days": 14,

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -2570,7 +2570,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
     # @snapshot_clickhouse_queries
     @also_test_with_materialized_columns(event_properties=["int_value"], person_properties=["fish"])
-    def test_insight_funnels_hogql_breakdown_old_style(self) -> None:
+    def test_insight_funnels_hogql_breakdown_single(self) -> None:
         with freeze_time("2012-01-15T04:01:34.000Z"):
             _create_person(team=self.team, distinct_ids=["1"], properties={"fish": "there is no fish"})
             _create_event(team=self.team, event="user signed up", distinct_id="1", properties={"int_value": 1})

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -806,7 +806,9 @@ def extract_tables_and_properties(props: List[Property]) -> TCounter[PropertyIde
     return Counter(cast(Iterable, counters))
 
 
-def count_hogql_properties(expr: str, counter: Optional[TCounter] = None) -> TCounter:
+def count_hogql_properties(
+    expr: str, counter: Optional[TCounter[PropertyIdentifier]] = None
+) -> TCounter[PropertyIdentifier]:
     if not counter:
         counter = Counter()
     node = parse_expr(expr)

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -796,13 +796,7 @@ def extract_tables_and_properties(props: List[Property]) -> TCounter[PropertyIde
     counters: List[tuple] = []
     for prop in props:
         if prop.type == "hogql":
-            node = parse_expr(prop.key)
-            property_checker = HogQLPropertyChecker()
-            property_checker.visit(node)
-            for field in property_checker.event_properties:
-                counters.append((field, "event", None))
-            for field in property_checker.person_properties:
-                counters.append((field, "person", None))
+            counters.extend(count_hogql_properties(prop.key))
         elif prop.type == "behavioral" and prop.event_type == "actions":
             action = Action.objects.get(pk=prop.key)
             action_counter = get_action_tables_and_properties(action)
@@ -810,6 +804,19 @@ def extract_tables_and_properties(props: List[Property]) -> TCounter[PropertyIde
         else:
             counters.append((prop.key, prop.type, prop.group_type_index))
     return Counter(cast(Iterable, counters))
+
+
+def count_hogql_properties(expr: str, counter: Optional[TCounter] = None) -> TCounter:
+    if not counter:
+        counter = Counter()
+    node = parse_expr(expr)
+    property_checker = HogQLPropertyChecker()
+    property_checker.visit(node)
+    for field in property_checker.event_properties:
+        counter[(field, "event", None)] += 1
+    for field in property_checker.person_properties:
+        counter[(field, "person", None)] += 1
+    return counter
 
 
 def get_session_property_filter_statement(prop: Property, idx: int, prepend: str = "") -> Tuple[str, Dict[str, Any]]:


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/14730

Funnel breakdown doesn't work when breaking by hogql and e.g. `person.properties.email`.

Turns out I implemented the fix in the unreleased "multiple breakdowns" version, which is a flag that's locally enabled for me. AFAIK we're possibly deprecating that with regards to the data exploration refactor, so going to fix this case instead of blindly enabling the flag for all.

## Changes

Same fix for a different case. 

## How did you test this code?

Red green