### PR TITLE
fix(flags): Ensure flags show up correctly in impersonated sessions

### DIFF
--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -18,5 +18,6 @@ declare global {
             isIdentifiedID: boolean
             featureFlags: Record<string, boolean | string>
         }
+        IMPERSONATED_SESSION?: boolean
     }
 }

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -27,6 +27,13 @@ export function loadPostHogJS(): void {
                 debug: window.JS_POSTHOG_SELF_CAPTURE,
                 bootstrap: !!window.POSTHOG_USER_IDENTITY_WITH_FLAGS ? window.POSTHOG_USER_IDENTITY_WITH_FLAGS : {},
                 opt_in_site_apps: true,
+                loaded: (posthog) => {
+                    if (window.IMPERSONATED_SESSION) {
+                        posthog.opt_out_capturing()
+                    } else {
+                        posthog.opt_in_capturing()
+                    }
+                },
             })
         )
 

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -22,6 +22,7 @@
     window.JS_POSTHOG_HOST = {{js_posthog_host | safe}};
     window.JS_POSTHOG_SELF_CAPTURE = {{self_capture | yesno:"true,false" }};
     window.POSTHOG_USER_IDENTITY_WITH_FLAGS = JSON.parse("{{ posthog_bootstrap | escapejs }}")
+    window.IMPERSONATED_SESSION = {{impersonated_session | yesno:"true,false"}};
     </script>
 {% endif %}
 {% if sentry_dsn %}

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -308,7 +308,8 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     template = get_template(template_name)
 
-    context["opt_out_capture"] = os.getenv("OPT_OUT_CAPTURE", False) or is_impersonated_session(request)
+    context["opt_out_capture"] = os.getenv("OPT_OUT_CAPTURE", False)
+    context["impersonated_session"] = is_impersonated_session(request)
     context["self_capture"] = settings.SELF_CAPTURE
 
     if os.environ.get("SENTRY_DSN"):


### PR DESCRIPTION
## Problem

A problem that has been annoying everyone for almost forever: Not being able to see flags in impersonated sessions.

Now, you can!


Opt-out capture earlier was creating a posthog instance with a fake token which just didn't work. The intention here being to not capture events at all.

Now, we do the same by opting out of capture (as a side effect of which we call opt-in capture every time we (or anyone else) logs back in as themselves ). This ensures flags can load seamlessly


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Create staff account locally, invite user 2, impersonate user 2, see everything works and flags work; go back to user 1, see nothing breaks.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
