### PR TITLE
feat(data-exploration): cohort edit query

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -26,15 +26,14 @@ import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
 import { Form } from 'kea-forms'
 import { NotFound } from 'lib/components/NotFound'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { NodeKind } from '~/queries/schema'
 import { Query } from '~/queries/Query/Query'
 import { pluralize } from 'lib/utils'
 
 export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const logicProps = { id }
     const logic = cohortEditLogic(logicProps)
-    const { deleteCohort, setOuterGroupsType } = useActions(logic)
-    const { cohort, cohortLoading, cohortMissing } = useValues(logic)
+    const { deleteCohort, setOuterGroupsType, setQuery } = useActions(logic)
+    const { cohort, cohortLoading, cohortMissing, query } = useValues(logic)
     const { hasAvailableFeature } = useValues(userLogic)
     const isNewCohort = cohort.id === 'new' || cohort.id === undefined
     const { featureFlags } = useValues(featureFlagLogic)
@@ -223,17 +222,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                     minutes.
                                 </div>
                             ) : featureDataExploration ? (
-                                <Query
-                                    query={{
-                                        kind: NodeKind.DataTableNode,
-                                        source: {
-                                            kind: NodeKind.PersonsNode,
-                                            cohort: cohort.id,
-                                        },
-                                        columns: undefined,
-                                        full: true,
-                                    }}
-                                />
+                                <Query query={query} setQuery={setQuery} />
                             ) : (
                                 <Persons cohort={cohort.id} />
                             )}

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -29,7 +29,7 @@ import { NEW_COHORT, NEW_CRITERIA, NEW_CRITERIA_GROUP } from 'scenes/cohorts/Coh
 import type { cohortEditLogicType } from './cohortEditLogicType'
 import { CohortLogicProps } from 'scenes/cohorts/cohortLogic'
 import { processCohort } from 'lib/utils'
-import { DataTableNode, NodeKind } from '~/queries/schema'
+import { DataTableNode, NodeKind, Node } from '~/queries/schema'
 import { isDataTableNode } from '~/queries/utils'
 
 export const cohortEditLogic = kea<cohortEditLogicType>([

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -29,6 +29,8 @@ import { NEW_COHORT, NEW_CRITERIA, NEW_CRITERIA_GROUP } from 'scenes/cohorts/Coh
 import type { cohortEditLogicType } from './cohortEditLogicType'
 import { CohortLogicProps } from 'scenes/cohorts/cohortLogic'
 import { processCohort } from 'lib/utils'
+import { DataTableNode, NodeKind } from '~/queries/schema'
+import { isDataTableNode } from '~/queries/utils'
 
 export const cohortEditLogic = kea<cohortEditLogicType>([
     props({} as CohortLogicProps),
@@ -55,9 +57,10 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
             groupIndex,
             criteriaIndex,
         }),
+        setQuery: (query: Node) => ({ query }),
     }),
 
-    reducers(() => ({
+    reducers(({ props }) => ({
         cohort: [
             NEW_COHORT as CohortType,
             {
@@ -147,6 +150,20 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
             null as number | null,
             {
                 setPollTimeout: (_, { pollTimeout }) => pollTimeout,
+            },
+        ],
+        query: [
+            {
+                kind: NodeKind.DataTableNode,
+                source: {
+                    kind: NodeKind.PersonsNode,
+                    cohort: props.id,
+                },
+                columns: undefined,
+                full: true,
+            } as DataTableNode,
+            {
+                setQuery: (state, { query }) => (isDataTableNode(query) ? query : state),
             },
         ],
     })),


### PR DESCRIPTION
## Problem

You couldn't export persons when editing a cohort.

## Changes

Now you can. I added a full set of filters as well, because why not.

![image](https://user-images.githubusercontent.com/53387/226657365-938d516d-3b6f-4290-9fee-9a024e253404.png)

## How did you test this code?

Visually