### PR TITLE
chore: remove isort - ruff is doing the job now

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -121,16 +121,15 @@ jobs:
                   python -m pip install -r requirements-dev.txt
                   python -m pip install -r requirements.txt
 
+            - name: Check for errors, import sort, and code style violations
+              run: |
+                  cd current
+                  ruff .
+
             - name: Check formatting
               run: |
                   cd current
                   black --exclude posthog/hogql/grammar --check .
-                  isort --skip posthog/hogql/grammar --check-only .
-
-            - name: Check for errors and code style violations
-              run: |
-                  cd current
-                  ruff .
 
             - name: Check static typing
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -121,7 +121,7 @@ jobs:
                   python -m pip install -r requirements-dev.txt
                   python -m pip install -r requirements.txt
 
-            - name: Check for errors, import sort, and code style violations
+            - name: Check for syntax errors, import sort, and code style violations
               run: |
                   cd current
                   ruff .

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:61 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:60 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:60 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:61 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/package.json
+++ b/package.json
@@ -271,9 +271,8 @@
             "prettier --write"
         ],
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
-            "black",
             "ruff",
-            "isort"
+            "black"
         ],
         "*.png": [
             "optipng -clobber -o4 -strip all"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -30,7 +30,6 @@ types-python-dateutil>=2.8.3
 types-pytz==2021.3.2
 types-redis==4.3.20
 types-requests==2.26.1
-isort==5.2.2
 pytest==6.2.5
 pytest-django==4.1.0
 pytest-env==0.6.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -111,9 +111,7 @@ inflect==5.6.2
 iniconfig==1.1.1
     # via pytest
 isort==5.2.2
-    # via
-    #   -r requirements-dev.in
-    #   datamodel-code-generator
+    # via datamodel-code-generator
 itypes==1.2.0
     # via coreapi
 jinja2==2.11.3


### PR DESCRIPTION
- chore: Remove isort - ruff is doing the job now
- update requirements

## Problem

Isort is a duplicate task now that we are running on ruff

## Changes

- Remove isort from the pre-commit hook
- Run ruff first in pre-commit since it's faster than black (fail fast)
- Remove isort from the requirements-dev

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
