### PR TITLE
fix: Prevent scrollbar flicker during DashboardModal contents animation

### DIFF
--- a/frontend/src/scenes/dashboard/NewDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.tsx
@@ -36,17 +36,27 @@ function TemplateItem({
             onMouseLeave={() => setIsHovering(false)}
             data-attr={dataAttr}
         >
-            <div
-                className={clsx('transition-all w-full overflow-hidden', isHovering ? 'h-4 min-h-4' : 'h-30 min-h-30')}
-            >
-                <FallbackCoverImage src={template?.image_url} alt="cover photo" index={index} imageClassName="h-30" />
-            </div>
+            <div className={'overflow-hidden'}>
+                <div
+                    className={clsx(
+                        'transition-all w-full overflow-hidden',
+                        isHovering ? 'h-4 min-h-4' : 'h-30 min-h-30'
+                    )}
+                >
+                    <FallbackCoverImage
+                        src={template?.image_url}
+                        alt="cover photo"
+                        index={index}
+                        imageClassName="h-30"
+                    />
+                </div>
 
-            <h5 className="px-2 mb-1">{template?.template_name}</h5>
-            <div className="px-2 py-1 overflow-y-auto grow">
-                <p className={clsx('text-muted-alt text-xs', isHovering ? '' : 'line-clamp-2')}>
-                    {template?.dashboard_description ?? ' '}
-                </p>
+                <h5 className="px-2 mb-1">{template?.template_name}</h5>
+                <div className="px-2 py-1 overflow-y-auto grow">
+                    <p className={clsx('text-muted-alt text-xs', isHovering ? '' : 'line-clamp-2')}>
+                        {template?.dashboard_description ?? ' '}
+                    </p>
+                </div>
             </div>
         </div>
     )


### PR DESCRIPTION
This change introduces a wrapper div around TemplateItem contents that will prevent a scrollbar from showing up during a height animation on a Dashboard template.

Fixes: #14854

## Problem
This change is a minor improvement to the user experience when choosing a new Dashboard template.

## Changes
(https://jam.dev/c/c91edb76-b140-4c10-8a2b-95b30d4b7a03)

## How did you test this code?

1. Clicked "New Dashboard" under http://localhost:8000/dashboard
2. Hovered over a dashboard template and observed that scrollbar would no longer show during a height change animation
