### PR TITLE
fix: recent performance pageviews node was returning wrong shape object

### DIFF
--- a/ee/api/performance_events.py
+++ b/ee/api/performance_events.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, OrderedDict
 
 import pytz
 from django.utils import timezone
@@ -196,7 +196,7 @@ class ListPerformanceEventQuerySerializer(serializers.Serializer):
         return data
 
 
-def load_performance_events_recent_pageviews(team_id: int, date_from: datetime, date_to: datetime) -> List[Dict]:
+def load_performance_events_recent_pageviews(team_id: int, date_from: datetime, date_to: datetime) -> OrderedDict:
     results = RecentPageViewPerformanceEvents.query(team_id, date_from=date_from, date_to=date_to)
 
     try:

--- a/ee/api/performance_events.py
+++ b/ee/api/performance_events.py
@@ -196,7 +196,7 @@ class ListPerformanceEventQuerySerializer(serializers.Serializer):
         return data
 
 
-def load_performance_events_recent_pageviews(team_id: int, date_from: datetime, date_to: datetime) -> Dict:
+def load_performance_events_recent_pageviews(team_id: int, date_from: datetime, date_to: datetime) -> List[Dict]:
     results = RecentPageViewPerformanceEvents.query(team_id, date_from=date_from, date_to=date_to)
 
     try:

--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -311,6 +311,25 @@ const TimeToSeeDataWaterfall: TimeToSeeDataWaterfallNode = {
     },
 }
 
+const RecentPageViewsWithPerformance: DataTableNode = {
+    kind: NodeKind.DataTableNode,
+    source: {
+        kind: NodeKind.RecentPerformancePageViewNode,
+        dateRange: {
+            date_to: null,
+            date_from: '-2h',
+        },
+    },
+    columns: ['page_url', 'duration', 'timestamp', 'context.columns.waterfallButton'],
+    expandable: false,
+    showExport: false,
+    showReload: true,
+    showActions: false,
+    showEventFilter: false,
+    showPropertyFilter: false,
+    showColumnConfigurator: false,
+}
+
 const HogQLRaw: HogQLQuery = {
     kind: NodeKind.HogQLQuery,
     query: `   select event,
@@ -350,6 +369,7 @@ export const examples: Record<string, Node> = {
     InsightPathsQuery,
     InsightStickinessQuery,
     InsightLifecycleQuery,
+    RecentPageViewsWithPerformance,
     TimeToSeeDataSessionsTable,
     TimeToSeeDataSessionsJSON,
     TimeToSeeDataWaterfall,

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -181,7 +181,7 @@ def process_query(team: Team, query_json: Dict, is_hogql_enabled: bool) -> Dict:
             date_to=parse_as_date_or(recent_performance_query.dateRange.date_to, now()),
         )
 
-        return results
+        return {"results": results}
     elif query_kind == "TimeToSeeDataSessionsQuery":
         sessions_query_serializer = SessionsQuerySerializer(data=query_json)
         sessions_query_serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
## Problem

Recent performance claimed it returned a dict, but was really returning a list. Sneaky!

<img width="1249" alt="Screenshot 2023-03-22 at 11 03 19" src="https://user-images.githubusercontent.com/984817/226885069-909077e9-3de9-4c00-83a6-9534d4beabeb.png">

## Changes

Converts the return to a reasonable shape

<img width="1255" alt="Screenshot 2023-03-22 at 11 03 37" src="https://user-images.githubusercontent.com/984817/226885090-fbc00c1c-8e7d-4c97-9f37-06799915c6b2.png">

## How did you test this code?

👀  locally