### PR TITLE
fix: flags code example tracking and updated more info UX

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -518,6 +518,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             resourceType,
             rolesLength,
         }),
+        reportFlagsCodeExampleInteraction: (optionType: string) => ({
+            optionType,
+        }),
     },
     listeners: ({ values }) => ({
         reportAxisUnitsChanged: (properties) => {
@@ -1260,6 +1263,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             posthog.capture('role custom added to a resource', {
                 resource_type: resourceType,
                 roles_length: rolesLength,
+            })
+        },
+        reportFlagsCodeExampleInteraction: ({ optionType }) => {
+            posthog.capture('flags code example option selected', {
+                option_type: optionType,
             })
         },
     }),

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-
+import { useActions } from 'kea'
 import { Card, Row } from 'antd'
 import { IconFlag, IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
@@ -15,6 +15,7 @@ import {
     OPTIONS,
     PAYLOAD_OPTIONS,
 } from './FeatureFlagCodeOptions'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 function FeatureFlagInstructionsHeader({
     selectedOptionValue,
@@ -107,6 +108,8 @@ export function CodeInstructions({
     const [showLocalEvalCode, setShowLocalEvalCode] = useState(false)
     const [showBootstrapCode, setShowBootstrapCode] = useState(false)
 
+    const { reportFlagsCodeExampleInteraction } = useActions(eventUsageLogic)
+
     const selectOption = (selectedValue: string): void => {
         const option = options.find((option) => option.value === selectedValue)
 
@@ -193,7 +196,10 @@ export function CodeInstructions({
                         <div className="flex flex-col gap-1 max-w-60">
                             <LemonCheckbox
                                 label="Show payload option"
-                                onChange={() => setShowPayloadCode(!showPayloadCode)}
+                                onChange={() => {
+                                    setShowPayloadCode(!showPayloadCode)
+                                    reportFlagsCodeExampleInteraction({ optionType: 'payloads' })
+                                }}
                                 data-attr="flags-code-example-payloads-option"
                                 checked={showPayloadCode}
                                 disabled={
@@ -216,7 +222,10 @@ export function CodeInstructions({
                                     label="Show bootstrap option"
                                     data-attr="flags-code-example-bootstrap-option"
                                     checked={showBootstrapCode}
-                                    onChange={() => setShowBootstrapCode(!showBootstrapCode)}
+                                    onChange={() => {
+                                        setShowBootstrapCode(!showBootstrapCode)
+                                        reportFlagsCodeExampleInteraction({ optionType: 'bootstrap' })
+                                    }}
                                     disabled={
                                         !BOOTSTRAPPING_OPTIONS.map((bo) => bo.value).includes(selectedOption.value) ||
                                         !!featureFlag?.ensure_experience_continuity
@@ -234,7 +243,10 @@ export function CodeInstructions({
                                     label="Show local evaluation option"
                                     data-attr="flags-code-example-local-eval-option"
                                     checked={showLocalEvalCode}
-                                    onChange={() => setShowLocalEvalCode(!showLocalEvalCode)}
+                                    onChange={() => {
+                                        setShowLocalEvalCode(!showLocalEvalCode)
+                                        reportFlagsCodeExampleInteraction({ optionType: 'local evaluation' })
+                                    }}
                                     disabled={
                                         selectedOption.type !== LibraryType.Server ||
                                         selectedOption.value === 'API' ||

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -198,7 +198,7 @@ export function CodeInstructions({
                                 label="Show payload option"
                                 onChange={() => {
                                     setShowPayloadCode(!showPayloadCode)
-                                    reportFlagsCodeExampleInteraction({ optionType: 'payloads' })
+                                    reportFlagsCodeExampleInteraction('payloads')
                                 }}
                                 data-attr="flags-code-example-payloads-option"
                                 checked={showPayloadCode}
@@ -224,7 +224,7 @@ export function CodeInstructions({
                                     checked={showBootstrapCode}
                                     onChange={() => {
                                         setShowBootstrapCode(!showBootstrapCode)
-                                        reportFlagsCodeExampleInteraction({ optionType: 'bootstrap' })
+                                        reportFlagsCodeExampleInteraction('bootstrap')
                                     }}
                                     disabled={
                                         !BOOTSTRAPPING_OPTIONS.map((bo) => bo.value).includes(selectedOption.value) ||
@@ -245,7 +245,7 @@ export function CodeInstructions({
                                     checked={showLocalEvalCode}
                                     onChange={() => {
                                         setShowLocalEvalCode(!showLocalEvalCode)
-                                        reportFlagsCodeExampleInteraction({ optionType: 'local evaluation' })
+                                        reportFlagsCodeExampleInteraction('local evaluation')
                                     }}
                                     disabled={
                                         selectedOption.type !== LibraryType.Server ||

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react'
 
 import { Card, Row } from 'antd'
-import { IconFlag, IconInfo, IconOpenInNew } from 'lib/lemon-ui/icons'
+import { IconFlag, IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import './FeatureFlagInstructions.scss'
 import { LemonCheckbox, LemonSelect } from '@posthog/lemon-ui'
 import { FeatureFlagType } from '~/types'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import {
     BOOTSTRAPPING_OPTIONS,
     InstructionOption,
@@ -157,39 +156,41 @@ export function CodeInstructions({
         <>
             {newCodeExample ? (
                 <div>
-                    <div className="flex flex-row gap-4">
-                        <LemonSelect
-                            data-attr={'feature-flag-instructions-select' + (dataAttr ? `-${dataAttr}` : '')}
-                            options={[
-                                {
-                                    title: 'Client libraries',
-                                    options: OPTIONS.filter((option) => option.type == LibraryType.Client).map(
-                                        (option) => ({
-                                            value: option.value,
-                                            label: option.value,
-                                            'data-attr': `feature-flag-instructions-select-option-${option.value}`,
-                                        })
-                                    ),
-                                },
-                                {
-                                    title: 'Server libraries',
-                                    options: OPTIONS.filter((option) => option.type == LibraryType.Server).map(
-                                        (option) => ({
-                                            value: option.value,
-                                            label: option.value,
-                                            'data-attr': `feature-flag-instructions-select-option-${option.value}`,
-                                        })
-                                    ),
-                                },
-                            ]}
-                            onChange={(val) => {
-                                if (val) {
-                                    selectOption(val)
-                                }
-                            }}
-                            value={selectedOption.value}
-                        />
-                        <div className="flex items-center gap-1">
+                    <div className="flex flex-row gap-6">
+                        <div>
+                            <LemonSelect
+                                data-attr={'feature-flag-instructions-select' + (dataAttr ? `-${dataAttr}` : '')}
+                                options={[
+                                    {
+                                        title: 'Client libraries',
+                                        options: OPTIONS.filter((option) => option.type == LibraryType.Client).map(
+                                            (option) => ({
+                                                value: option.value,
+                                                label: option.value,
+                                                'data-attr': `feature-flag-instructions-select-option-${option.value}`,
+                                            })
+                                        ),
+                                    },
+                                    {
+                                        title: 'Server libraries',
+                                        options: OPTIONS.filter((option) => option.type == LibraryType.Server).map(
+                                            (option) => ({
+                                                value: option.value,
+                                                label: option.value,
+                                                'data-attr': `feature-flag-instructions-select-option-${option.value}`,
+                                            })
+                                        ),
+                                    },
+                                ]}
+                                onChange={(val) => {
+                                    if (val) {
+                                        selectOption(val)
+                                    }
+                                }}
+                                value={selectedOption.value}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-1 max-w-60">
                             <LemonCheckbox
                                 label="Show payload option"
                                 onChange={() => setShowPayloadCode(!showPayloadCode)}
@@ -201,20 +202,16 @@ export function CodeInstructions({
                                     )
                                 }
                             />
-                            <Tooltip
-                                title={
-                                    <>
-                                        {`Feature flag payloads are only available in these libraries: ${PAYLOAD_OPTIONS.map(
-                                            (payloadOption) => ` ${payloadOption.value}`
-                                        )}`}
-                                    </>
-                                }
-                            >
-                                <IconInfo className="text-xl text-muted-alt shrink-0" />
-                            </Tooltip>
+                            {!PAYLOAD_OPTIONS.map((payloadOption) => payloadOption.value).includes(
+                                selectedOption.value
+                            ) && (
+                                <span className="text-muted">{`Feature flag payloads are only available in these libraries: ${PAYLOAD_OPTIONS.map(
+                                    (payloadOption) => ` ${payloadOption.value}`
+                                )}`}</span>
+                            )}
                         </div>
                         <>
-                            <div className="flex items-center gap-1">
+                            <div className="flex flex-col gap-1 max-w-60">
                                 <LemonCheckbox
                                     label="Show bootstrap option"
                                     data-attr="flags-code-example-bootstrap-option"
@@ -225,15 +222,14 @@ export function CodeInstructions({
                                         !!featureFlag?.ensure_experience_continuity
                                     }
                                 />
-                                <Tooltip
-                                    title={
-                                        'If you need your flags available immediately, you can initialize the PostHog library with a distinct user ID and their feature flag values. This avoids the delay between the library loading and feature flags becoming available to use. Bootstrapping is only available client side in our JavaScript and ReactNative libraries.'
-                                    }
-                                >
-                                    <IconInfo className="text-xl text-muted-alt shrink-0" />
-                                </Tooltip>
+                                {!BOOTSTRAPPING_OPTIONS.map((bo) => bo.value).includes(selectedOption.value) && (
+                                    <span className="text-muted">
+                                        Bootstrapping is only available client side in our JavaScript and ReactNative
+                                        libraries.
+                                    </span>
+                                )}
                             </div>
-                            <div className="flex items-center gap-1">
+                            <div className="flex flex-col gap-1 max-w-60">
                                 <LemonCheckbox
                                     label="Show local evaluation option"
                                     data-attr="flags-code-example-local-eval-option"
@@ -245,13 +241,12 @@ export function CodeInstructions({
                                         !!featureFlag?.ensure_experience_continuity
                                     }
                                 />
-                                <Tooltip
-                                    title={
-                                        'Improve performance by evaluating feature flags without making API requests each time. Local evaluation is only available in server side libraries and without flag persistence across authentication steps.'
-                                    }
-                                >
-                                    <IconInfo className="text-xl text-muted-alt shrink-0" />
-                                </Tooltip>
+                                {selectedOption.type !== LibraryType.Server && (
+                                    <span className="text-muted">
+                                        Local evaluation is only available in server side libraries and without flag
+                                        persistence.
+                                    </span>
+                                )}
                             </div>
                         </>
                     </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -387,6 +387,7 @@ export function JSBootstrappingSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.JavaScript} wrap>
             {`// Initialise the posthog library with a distinct ID and feature flags for immediate loading
+// This avoids the delay between the library loading and feature flags becoming available to use.
 
 posthog.init('{project_api_key}', {
     api_host: 'https://app.posthog.com',


### PR DESCRIPTION
## Problem
Nobody likes long tooltips
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<img width="1034" alt="Screen Shot 2023-03-22 at 7 12 33 PM" src="https://user-images.githubusercontent.com/25164963/227059065-f9a0fad7-e542-4531-ac7e-faf3c7cc1008.png">

<img width="1189" alt="Screen Shot 2023-03-22 at 7 13 01 PM" src="https://user-images.githubusercontent.com/25164963/227059145-ac38abae-28ae-4802-9a6a-8f955d86daaa.png">



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
