### PR TITLE
feat(query): rate limit to 120 requests/min

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -27,9 +27,14 @@ from posthog.models.event.events_query import run_events_query
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.queries.time_to_see_data.serializers import SessionEventsQuerySerializer, SessionsQuerySerializer
 from posthog.queries.time_to_see_data.sessions import get_session_events, get_sessions
-from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
+from posthog.rate_limit import TeamRateThrottle
 from posthog.schema import EventsQuery, HogQLQuery, RecentPerformancePageViewNode
 from posthog.utils import relative_date_parse
+
+
+class QueryThrottle(TeamRateThrottle):
+    scope = "query"
+    rate = "120/hour"
 
 
 def parse_as_date_or(date_string: str | None, default: datetime) -> datetime:
@@ -68,7 +73,7 @@ class QuerySchemaParser(JSONParser):
 
 class QueryViewSet(StructuredViewSetMixin, viewsets.ViewSet):
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
-    throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]
+    throttle_classes = [QueryThrottle]
 
     parser_classes = (QuerySchemaParser,)
 


### PR DESCRIPTION
## Problem

We want a separate set of rate limits to HogQL queries.

## Changes

Implements almost this. The `/api/projects/:id/query` endpoint now gets a `120 queries per hour` limit. This should be enough to block users who accidentally abuse the system, and also allow legit users to do things.

The previous rate limits were "4800/hour" (ClickHouseSustainedRateThrottle) and "240/minute" (ClickHouseBurstRateThrottle)

## How did you test this code?

I didn't really. Copied what I found under api/feature_flag.py and hoping for the best.