### PR TITLE
fix(flags): Make overrides work irrespective of person merging

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,8 +270,8 @@
             "prettier --write"
         ],
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
-            "ruff",
-            "black"
+            "black",
+            "ruff"
         ],
         "*.png": [
             "optipng -clobber -o4 -strip all"

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -102,68 +102,35 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
-  '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -191,7 +158,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -211,6 +178,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -102,35 +102,68 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+  '
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -158,7 +191,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -178,22 +211,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -454,10 +454,7 @@
      WHERE team_id = 2
        AND person_id IN
          (SELECT person_id
-          FROM posthog_persondistinctid
-          WHERE team_id = 2
-            AND distinct_id IN ('example_id',
-                                'random') ) ),
+          FROM target_person_ids) ),
        flags_to_override AS
     (SELECT key
      FROM posthog_featureflag

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -445,7 +445,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 2,
+  SELECT 117,
          person_id,
          key,
          'random'
@@ -521,7 +521,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 2,
+  SELECT 117,
          person_id,
          key,
          'random'

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -428,13 +428,56 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.1
   '
-  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key"
-  FROM "posthog_featureflaghashkeyoverride"
-  WHERE ("posthog_featureflaghashkeyoverride"."person_id" = 2
-         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
+  SELECT "posthog_persondistinctid"."person_id"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('example_id',
+                                                      'random')
+         AND "posthog_persondistinctid"."team_id" = 2)
+  ORDER BY "posthog_persondistinctid"."id" ASC
+  LIMIT 1
   '
 ---
 # name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.2
+  '
+  WITH target_person_ids AS
+    (SELECT person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('example_id',
+                           'random') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM posthog_persondistinctid
+          WHERE team_id = 2
+            AND distinct_id IN ('example_id',
+                                'random') ) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT 117,
+         person_id,
+         key,
+         'random'
+  FROM flags_to_override,
+       target_person_ids ON CONFLICT DO NOTHING
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.3
   '
   SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
          "posthog_featureflaghashkeyoverride"."hash_key"
@@ -443,7 +486,7 @@
          AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
-# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.3
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.4
   '
   SELECT (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
           AND "posthog_person"."properties" ? 'email'
@@ -456,7 +499,7 @@
          AND "posthog_person"."team_id" = 2)
   '
 ---
-# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.4
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.5
   '
   SELECT pg_sleep(1);
   
@@ -468,7 +511,7 @@
   LIMIT 1
   '
 ---
-# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.5
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.6
   '
   SELECT pg_sleep(1);
   

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -418,27 +418,6 @@
 ---
 # name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db
   '
-  SELECT "posthog_persondistinctid"."person_id"
-  FROM "posthog_persondistinctid"
-  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
-         AND "posthog_persondistinctid"."team_id" = 2)
-  ORDER BY "posthog_persondistinctid"."id" ASC
-  LIMIT 1
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.1
-  '
-  SELECT "posthog_persondistinctid"."person_id"
-  FROM "posthog_persondistinctid"
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('example_id',
-                                                      'random')
-         AND "posthog_persondistinctid"."team_id" = 2)
-  ORDER BY "posthog_persondistinctid"."id" ASC
-  LIMIT 1
-  '
----
-# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.2
-  '
   WITH target_person_ids AS
     (SELECT person_id
      FROM posthog_persondistinctid
@@ -466,7 +445,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 117,
+  SELECT 2,
          person_id,
          key,
          'random'
@@ -474,16 +453,31 @@
        target_person_ids ON CONFLICT DO NOTHING
   '
 ---
-# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.3
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.1
+  '
+  SELECT "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('example_id',
+                                                      'random')
+         AND "posthog_persondistinctid"."team_id" = 2)
+  '
+---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.2
   '
   SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
-         "posthog_featureflaghashkeyoverride"."hash_key"
+         "posthog_featureflaghashkeyoverride"."hash_key",
+         "posthog_featureflaghashkeyoverride"."person_id"
   FROM "posthog_featureflaghashkeyoverride"
-  WHERE ("posthog_featureflaghashkeyoverride"."person_id" = 2
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
+                                                              2,
+                                                              3,
+                                                              4,
+                                                              5 /* ... */)
          AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
-# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.4
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.3
   '
   SELECT (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
           AND "posthog_person"."properties" ? 'email'
@@ -496,28 +490,66 @@
          AND "posthog_person"."team_id" = 2)
   '
 ---
+# name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.4
+  '
+  SELECT pg_sleep(1);
+  
+  WITH target_person_ids AS
+    (SELECT person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('example_id',
+                           'random') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT 2,
+         person_id,
+         key,
+         'random'
+  FROM flags_to_override,
+       target_person_ids ON CONFLICT DO NOTHING
+  '
+---
 # name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.5
   '
   SELECT pg_sleep(1);
   
-  SELECT "posthog_persondistinctid"."person_id"
+  SELECT "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id"
   FROM "posthog_persondistinctid"
-  WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('example_id',
+                                                      'random')
          AND "posthog_persondistinctid"."team_id" = 2)
-  ORDER BY "posthog_persondistinctid"."id" ASC
-  LIMIT 1
   '
 ---
 # name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db.6
   '
   SELECT pg_sleep(1);
   
-  SELECT "posthog_persondistinctid"."person_id"
+  SELECT "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id"
   FROM "posthog_persondistinctid"
-  WHERE ("posthog_persondistinctid"."distinct_id" = 'random'
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('random')
          AND "posthog_persondistinctid"."team_id" = 2)
-  ORDER BY "posthog_persondistinctid"."id" ASC
-  LIMIT 1
   '
 ---
 # name: TestResiliency.test_feature_flags_v3_with_group_properties_and_slow_db

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -576,7 +576,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         )
 
         # caching flag definitions mean fewer queries
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             response = self._post_decide(api_version=2)
             self.assertTrue(response.json()["featureFlags"]["beta-feature"])
             self.assertTrue(response.json()["featureFlags"]["default-flag"])
@@ -589,7 +589,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         # person2 = Person.objects.create(team=self.team, distinct_ids=["example_id", "other_id"], properties={"email": "tim@posthog.com"})
         person.add_distinct_id("other_id")
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(9):
             response = self._post_decide(
                 api_version=2,
                 data={"token": self.team.api_token, "distinct_id": "other_id", "$anon_distinct_id": "example_id"},
@@ -704,7 +704,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         )
 
         # caching flag definitions mean fewer queries
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             response = self._post_decide(api_version=2)
             self.assertTrue(response.json()["featureFlags"]["beta-feature"])
             self.assertTrue(response.json()["featureFlags"]["default-flag"])
@@ -720,7 +720,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         )
 
         # caching flag definitions in the above mean fewer queries
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(9):
             response = self._post_decide(
                 api_version=2,
                 data={"token": self.team.api_token, "distinct_id": "other_id", "$anon_distinct_id": "example_id"},
@@ -732,11 +732,11 @@ class TestDecide(BaseTest, QueryMatchingTest):
             )  # different hash, overridden by distinct_id, same variant assigned
 
         # now let's say a merge happens with a call like: identify(distinct_id='example_id', anon_distinct_id='other_id')
-        # that is, person2 is going to get merged into person!
+        # that is, person2 is going to get merged into person. (Could've been vice versa, but the following code assumes this, it's symmetric.)
         new_person_id = person.id
         old_person_id = person2.id
         # this happens in the plugin server
-        # https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L696
+        # https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L696 (addFeatureFlagHashKeysForMergedPerson)
         # at which point we run the query
         query = f"""
             WITH deletions AS (
@@ -755,7 +755,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         person.add_distinct_id("other_id")
 
         # caching flag definitions in the above mean fewer queries
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             response = self._post_decide(api_version=2, data={"token": self.team.api_token, "distinct_id": "other_id"})
             self.assertTrue(response.json()["featureFlags"]["beta-feature"])
             self.assertTrue(response.json()["featureFlags"]["default-flag"])
@@ -804,7 +804,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         )
 
         # caching flag definitions mean fewer queries
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             response = self._post_decide(api_version=2)
             self.assertTrue(response.json()["featureFlags"]["beta-feature"])
             self.assertTrue(response.json()["featureFlags"]["default-flag"])
@@ -815,7 +815,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         # new person with "other_id" is yet to be created
 
         # caching flag definitions in the above mean fewer queries
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(9):
             # one extra query to find person_id for $anon_distinct_id
             response = self._post_decide(
                 api_version=2,
@@ -831,6 +831,8 @@ class TestDecide(BaseTest, QueryMatchingTest):
         # In this case, we are over our grace period for ingestion, and there's
         # no quick decent way to find how 'other_id' is to be treated.
         # So, things appear like a completely new person with distinct-id = other_id.
+        # And this person can't have any hash key overrides (since the person doesn't yet exist)
+        # So one fewer query to not get overrides.
         with self.assertNumQueries(4):
             # caching flag definitions in the above mean fewer queries
 
@@ -843,7 +845,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         # Finally, 'other_id' is merged. The result goes back to its overridden values
 
         # caching flag definitions in the above mean fewer queries
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             response = self._post_decide(api_version=2, data={"token": self.team.api_token, "distinct_id": "other_id"})
             self.assertTrue(response.json()["featureFlags"]["beta-feature"])
             self.assertTrue(response.json()["featureFlags"]["default-flag"])
@@ -1211,19 +1213,17 @@ class TestDecide(BaseTest, QueryMatchingTest):
             ensure_experience_continuity=True,
         )
         # make sure caches are populated
-        # TODO: change this to whatever function is used to populate the cache on startup
         response = self._post_decide(api_version=3)
 
-        with self.assertNumQueries(8):
-            # effectively 2 queries, wrapped around by an atomic transaction
-            # E   1. SAVEPOINT "s8609641984_x94"
-            # E   2. SET LOCAL statement_timeout = 3000
-            # E   3. SELECT "posthog_persondistinctid"."person_id" FROM "posthog_persondistinctid" WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id' AND "posthog_persondistinctid"."team_id" = 4) ORDER BY "posthog_persondistinctid"."id" ASC LIMIT 1
-            # E   4. RELEASE SAVEPOINT "s8609641984_x94"
-            # E   5. SAVEPOINT "s8609641984_x95"
-            # E   6. SET LOCAL statement_timeout = 3000
-            # E   7. SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key", "posthog_featureflaghashkeyoverride"."hash_key" FROM "posthog_featureflaghashkeyoverride" WHERE ("posthog_featureflaghashkeyoverride"."person_id" = 86 AND "posthog_featureflaghashkeyoverride"."team_id" = 4)
-            # E   8. RELEASE SAVEPOINT "s8609641984_x95"
+        with self.assertNumQueries(5):
+            # effectively 3 queries, wrapped around by an atomic transaction
+            # E   1. SAVEPOINT "s4379526528_x103"
+            # E   2. SET LOCAL statement_timeout = 1000
+            # E   3. SELECT "posthog_persondistinctid"."person_id", "posthog_persondistinctid"."distinct_id" FROM "posthog_persondistinctid"
+            #           WHERE ("posthog_persondistinctid"."distinct_id" IN ('example_id') AND "posthog_persondistinctid"."team_id" = 1)
+            # E   4. SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key", "posthog_featureflaghashkeyoverride"."hash_key", "posthog_featureflaghashkeyoverride"."person_id" FROM "posthog_featureflaghashkeyoverride"
+            #            WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (7) AND "posthog_featureflaghashkeyoverride"."team_id" = 1)
+            # E   5. RELEASE SAVEPOINT "s4379526528_x103"
             response = self._post_decide(api_version=3)
             self.assertTrue(response.json()["featureFlags"]["beta-feature"])
             self.assertTrue(response.json()["featureFlags"]["default-flag"])

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3092,7 +3092,7 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
         self.assertTrue(serialized_data.is_valid())
         serialized_data.save()
 
-        with snapshot_postgres_queries_context(self), self.assertNumQueries(9):
+        with snapshot_postgres_queries_context(self), self.assertNumQueries(7):
             all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id", hash_key_override="random")
 
             self.assertTrue(all_flags["property-flag"])

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -391,7 +391,7 @@ class FeatureFlagMatcher:
         return current_match, current_index
 
 
-def hash_key_overrides(team_id: int, distinct_ids: List[str]) -> Dict[str, str]:
+def get_feature_flag_hash_key_overrides(team_id: int, distinct_ids: List[str]) -> Dict[str, str]:
     feature_flag_to_key_overrides = {}
 
     # Priority to the first distinctID's values, to keep this function deterministic
@@ -513,7 +513,7 @@ def get_all_feature_flags(
             target_distinct_ids = [distinct_id]
             if hash_key_override is not None:
                 target_distinct_ids.append(hash_key_override)
-            person_overrides = hash_key_overrides(team_id, target_distinct_ids)
+            person_overrides = get_feature_flag_hash_key_overrides(team_id, target_distinct_ids)
 
     except Exception:
         # database is down, we can't handle experience continuity flags at all.

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -546,9 +546,7 @@ def set_feature_flag_hash_key_overrides(
         ),
         existing_overrides AS (
             SELECT team_id, person_id, feature_flag_key, hash_key FROM posthog_featureflaghashkeyoverride
-            WHERE team_id = %(team_id)s AND person_id IN (
-                SELECT person_id FROM posthog_persondistinctid WHERE team_id = %(team_id)s AND distinct_id IN %(distinct_ids)s
-            )
+            WHERE team_id = %(team_id)s AND person_id IN (SELECT person_id FROM target_person_ids)
         ),
         flags_to_override AS (
             SELECT key FROM posthog_featureflag WHERE team_id = %(team_id)s AND ensure_experience_continuity = TRUE AND active = TRUE AND deleted = FALSE

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -551,7 +551,7 @@ def set_feature_flag_hash_key_overrides(
             )
         ),
         flags_to_override AS (
-            SELECT key FROM posthog_featureflag WHERE team_id = %(team_id)s AND ensure_experience_continuity = TRUE
+            SELECT key FROM posthog_featureflag WHERE team_id = %(team_id)s AND ensure_experience_continuity = TRUE AND active = TRUE AND deleted = FALSE
             AND key NOT IN (SELECT feature_flag_key FROM existing_overrides)
         )
         INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -5,9 +5,10 @@ from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from random import Random, choice
 from time import time
-from typing import Any, Callable, Dict, Optional, Set, Type, TypeVar
+from typing import Any, Callable, Dict, Iterator, Optional, Set, Type, TypeVar
 
 from django.db import IntegrityError, connection, models, transaction
+from django.db.backends.utils import CursorWrapper
 from django.db.backends.ddl_references import Statement
 from django.db.models.constraints import BaseConstraint
 from django.utils.text import slugify
@@ -258,11 +259,11 @@ class UniqueConstraintByExpression(BaseConstraint):
 
 
 @contextmanager
-def execute_with_timeout(timeout: int):
+def execute_with_timeout(timeout: int) -> Iterator[CursorWrapper]:
     """
     Sets a transaction local timeout for the current transaction.
     """
     with transaction.atomic():
         with connection.cursor() as cursor:
             cursor.execute("SET LOCAL statement_timeout = %s", [timeout])
-            yield
+            yield cursor

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1846,17 +1846,17 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
                 cursor, team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
             )
 
-        hash_keys = hash_key_overrides(self.team.pk, [self.person.id])
+        hash_keys = hash_key_overrides(self.team.pk, ["example_id"])
 
         self.assertEqual(hash_keys, {"beta-feature": "other_id", "multivariate-flag": "other_id"})
 
     def test_hash_key_overrides_for_multiple_ids_when_people_are_not_merged(self):
 
-        person1 = Person.objects.create(
+        Person.objects.create(
             team=self.team, distinct_ids=["1"], properties={"email": "beuk@posthog.com", "team": "posthog"}
         )
 
-        person2 = Person.objects.create(
+        Person.objects.create(
             team=self.team, distinct_ids=["2"], properties={"email": "beuk2@posthog.com", "team": "posthog"}
         )
 
@@ -1868,7 +1868,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
                 cursor, team_id=self.team.pk, distinct_ids=["2"], hash_key_override="aother_id2"
             )
 
-        hash_keys = hash_key_overrides(self.team.pk, [person1.id, person2.id])
+        hash_keys = hash_key_overrides(self.team.pk, ["1", "2"])
 
         self.assertEqual(hash_keys, {"beta-feature": "other_id1", "multivariate-flag": "other_id1"})
 

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1826,11 +1826,10 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
 
     def test_setting_overrides(self):
 
-        all_feature_flags = list(FeatureFlag.objects.filter(team_id=self.team.pk))
-
-        set_feature_flag_hash_key_overrides(
-            all_feature_flags, team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
-        )
+        with connection.cursor() as cursor:
+            set_feature_flag_hash_key_overrides(
+                cursor, team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
+            )
 
         with connection.cursor() as cursor:
             cursor.execute(
@@ -1842,11 +1841,10 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
 
     def test_retrieving_hash_key_overrides(self):
 
-        all_feature_flags = list(FeatureFlag.objects.filter(team_id=self.team.pk))
-
-        set_feature_flag_hash_key_overrides(
-            all_feature_flags, team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
-        )
+        with connection.cursor() as cursor:
+            set_feature_flag_hash_key_overrides(
+                cursor, team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
+            )
 
         hash_keys = hash_key_overrides(self.team.pk, self.person.id)
 
@@ -1868,9 +1866,10 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
         )
 
         # and now we come to get new overrides
-        set_feature_flag_hash_key_overrides(
-            all_feature_flags, team_id=self.team.pk, person_id=self.person.id, hash_key_override="other_id"
-        )
+        with connection.cursor() as cursor:
+            set_feature_flag_hash_key_overrides(
+                cursor, team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
+            )
 
         with connection.cursor() as cursor:
             cursor.execute(

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -15,7 +15,7 @@ from posthog.models.feature_flag.flag_matching import (
     FeatureFlagMatchReason,
     FlagsMatcherCache,
     get_all_feature_flags,
-    hash_key_overrides,
+    get_feature_flag_hash_key_overrides,
     set_feature_flag_hash_key_overrides,
 )
 from posthog.models.group import Group
@@ -1846,7 +1846,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
                 cursor, team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
             )
 
-        hash_keys = hash_key_overrides(self.team.pk, ["example_id"])
+        hash_keys = get_feature_flag_hash_key_overrides(self.team.pk, ["example_id"])
 
         self.assertEqual(hash_keys, {"beta-feature": "other_id", "multivariate-flag": "other_id"})
 
@@ -1868,7 +1868,7 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
                 cursor, team_id=self.team.pk, distinct_ids=["2"], hash_key_override="aother_id2"
             )
 
-        hash_keys = hash_key_overrides(self.team.pk, ["1", "2"])
+        hash_keys = get_feature_flag_hash_key_overrides(self.team.pk, ["1", "2"])
 
         self.assertEqual(hash_keys, {"beta-feature": "other_id1", "multivariate-flag": "other_id1"})
 

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -1846,9 +1846,31 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
                 cursor, team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
             )
 
-        hash_keys = hash_key_overrides(self.team.pk, self.person.id)
+        hash_keys = hash_key_overrides(self.team.pk, [self.person.id])
 
         self.assertEqual(hash_keys, {"beta-feature": "other_id", "multivariate-flag": "other_id"})
+
+    def test_hash_key_overrides_for_multiple_ids_when_people_are_not_merged(self):
+
+        person1 = Person.objects.create(
+            team=self.team, distinct_ids=["1"], properties={"email": "beuk@posthog.com", "team": "posthog"}
+        )
+
+        person2 = Person.objects.create(
+            team=self.team, distinct_ids=["2"], properties={"email": "beuk2@posthog.com", "team": "posthog"}
+        )
+
+        with connection.cursor() as cursor:
+            set_feature_flag_hash_key_overrides(
+                cursor, team_id=self.team.pk, distinct_ids=["1"], hash_key_override="other_id1"
+            )
+            set_feature_flag_hash_key_overrides(
+                cursor, team_id=self.team.pk, distinct_ids=["2"], hash_key_override="aother_id2"
+            )
+
+        hash_keys = hash_key_overrides(self.team.pk, [person1.id, person2.id])
+
+        self.assertEqual(hash_keys, {"beta-feature": "other_id1", "multivariate-flag": "other_id1"})
 
     def test_setting_overrides_doesnt_balk_with_existing_overrides(self):
 
@@ -1878,6 +1900,20 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             res = cursor.fetchall()
             self.assertEqual(len(res), 3)
             self.assertEqual({var[0] for var in res}, {hash_key})
+
+    def test_setting_overrides_when_persons_dont_exist(self):
+
+        with connection.cursor() as cursor:
+            set_feature_flag_hash_key_overrides(
+                cursor, team_id=self.team.pk, distinct_ids=["1", "2", "3", "4"], hash_key_override="other_id"
+            )
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT hash_key FROM posthog_featureflaghashkeyoverride WHERE team_id = {self.team.pk} AND person_id={self.person.id}"
+            )
+            res = cursor.fetchall()
+            self.assertEqual(len(res), 0)
 
     def test_entire_flow_with_hash_key_override(self):
         # get feature flags for 'other_id', with an override for 'example_id'


### PR DESCRIPTION
## Problem



See: https://posthog.slack.com/archives/C0185UNBSJZ/p1679506896978849.

We were facing issues because the merging logic can sometimes choose persons that don't exist yet, or have already been deleted. This PR attempts to make those race conditions go away, and refactor things to be simpler.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

When overrides are present, we add them to all persons who exist for these personIDs. And we do it in a single query.

When persons are merged, the ones on the old person get deleted, and moved to the new person if one doesn't already exist for the new person.

This way:

1. We never get stale info.
2. We're agnostic to which person gets merged into whom
3. We future-proof ourselves from however ingestion wants to implement merging.

All tests pass (or should 😅 ), so we're not introducing any unintended behaviour.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
