### PR TITLE
chore: reverse pre-commit hook order

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,8 +270,8 @@
             "prettier --write"
         ],
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
-            "ruff",
-            "black"
+            "black",
+            "ruff"
         ],
         "*.png": [
             "optipng -clobber -o4 -strip all"


### PR DESCRIPTION
Running ruff first is annoying, because it complains about all these whitespace issues that black would've fixed.

Reverts part of https://github.com/PostHog/posthog/pull/14849

Edit: Ah, just saw there was a reason for this in the previous PR, failing fast. Eh, if you really want that, we could make it a ruff-sandwich, where ruff runs as not-blocking first, then black, then ruff-blocking but idk if it's worth it.

I just don't want to have to fuss myself with making whitespace changes 🤷 . If you do go the sandwich route, I'd _still_ like to get this in first so it doesn't affect others current workflow :P 

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
