### PR TITLE
fix: move beta tag to the right of text

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -452,10 +452,10 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                             })}
                                                             type="secondary"
                                                         >
+                                                            View Recordings
                                                             <LemonTag type="warning" className="uppercase ml-2 mr-2">
                                                                 Beta
                                                             </LemonTag>
-                                                            View Recordings
                                                         </LemonButton>
                                                         <LemonDivider vertical />
                                                     </>


### PR DESCRIPTION
## Problem

Beta tag on the left hand side was driving me crazy sorry!

## Changes

before:

<img width="345" alt="Screen Shot 2023-03-23 at 10 19 35 AM" src="https://user-images.githubusercontent.com/25164963/227232655-d215b171-6151-4eb1-b03d-697b6eed7db3.png">

after:

<img width="457" alt="Screen Shot 2023-03-23 at 10 18 03 AM" src="https://user-images.githubusercontent.com/25164963/227232654-3446f3bf-9bf1-4953-afda-1902f73a317b.png">



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
