### PR TITLE
refactor: Execute temporal workers with name

### DIFF
--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -7,13 +7,13 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from posthog.temporal.client import connect
-from posthog.temporal.workflows import NoOpWorkflow
 
 
 class Command(BaseCommand):
     help = "Execute Temporal Workflow"
 
     def add_arguments(self, parser):
+        parser.add_argument("workflow", metavar="<WORKFLOW>", help="The name of the workflow to execute")
         parser.add_argument(
             "--temporal_host", default=settings.TEMPORAL_SCHEDULER_HOST, help="Hostname for Temporal Scheduler"
         )
@@ -61,5 +61,5 @@ class Command(BaseCommand):
                 client_key=client_key,
             )
         )
-        result = asyncio.run(client.execute_workflow(NoOpWorkflow.run, ts, id=workflow_id, task_queue=task_queue))
+        result = asyncio.run(client.execute_workflow(options["workflow"], ts, id=workflow_id, task_queue=task_queue))
         logging.warning(f"Workflow output: {result}")

--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -1,12 +1,12 @@
 import asyncio
 import logging
-from datetime import datetime
 from uuid import uuid4
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from posthog.temporal.client import connect
+from posthog.temporal.workflows import WORKFLOWS
 
 
 class Command(BaseCommand):
@@ -14,6 +14,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("workflow", metavar="<WORKFLOW>", help="The name of the workflow to execute")
+        parser.add_argument(
+            "inputs",
+            metavar="INPUTS",
+            nargs="*",
+            help="Inputs for the workflow to execute",
+        )
         parser.add_argument(
             "--temporal_host", default=settings.TEMPORAL_SCHEDULER_HOST, help="Hostname for Temporal Scheduler"
         )
@@ -39,7 +45,7 @@ class Command(BaseCommand):
         client_cert = None
         client_key = None
         workflow_id = str(uuid4())
-        ts = datetime.now().isoformat()
+        workflow_name = options["workflow"]
 
         if options.get("server_root_ca_cert", False):
             with open(options["server_root_ca_cert"], "rb") as f:
@@ -61,5 +67,19 @@ class Command(BaseCommand):
                 client_key=client_key,
             )
         )
-        result = asyncio.run(client.execute_workflow(options["workflow"], ts, id=workflow_id, task_queue=task_queue))
+
+        try:
+            workflow = [workflow for workflow in WORKFLOWS if workflow.is_named(workflow_name)][0]
+        except IndexError:
+            raise ValueError(f"No workflow with name '{workflow_name}'")
+        except AttributeError:
+            raise TypeError(
+                f"Workflow '{workflow_name}' is not a CommandableWorkflow that can invoked by execute_temporal_workflow."
+            )
+
+        result = asyncio.run(
+            client.execute_workflow(
+                workflow_name, workflow.parse_inputs(options["inputs"]), id=workflow_id, task_queue=task_queue
+            )
+        )
         logging.warning(f"Workflow output: {result}")

--- a/posthog/temporal/workflows/base.py
+++ b/posthog/temporal/workflows/base.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class CommandableWorkflow(ABC):
+    @classmethod
+    def is_named(cls, name: str) -> bool:
+        """Check if this workflow's name matches name.
+
+        All temporal workflows have the __temporal_workflow_definition attribute
+        injected into them by the defn decorator. We use it to access the name and
+        avoid having to define it twice. If this changes in the future, we can
+        update this method instead of changing every single workflow.
+        """
+        return getattr(cls, "__temporal_workflow_definition").name == name
+
+    @staticmethod
+    @abstractmethod
+    def parse_inputs(inputs: list[str]) -> Any:
+        """Parse inputs from the management command CLI.
+
+        If a workflow is to be executed via the CLI it must know how to parse its
+        own inputs.
+        """
+        return NotImplemented

--- a/posthog/temporal/workflows/noop.py
+++ b/posthog/temporal/workflows/noop.py
@@ -18,7 +18,7 @@ async def noop_activity(input: NoopActivityArgs) -> str:
     return output
 
 
-@workflow.defn
+@workflow.defn(name="no-op")
 class NoOpWorkflow:
     @workflow.run
     async def run(self, time: str) -> str:

--- a/posthog/temporal/workflows/noop.py
+++ b/posthog/temporal/workflows/noop.py
@@ -1,8 +1,11 @@
 import logging
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
+from typing import Any
 
 from temporalio import activity, workflow
+
+from posthog.temporal.workflows.base import CommandableWorkflow
 
 
 @dataclass
@@ -19,7 +22,18 @@ async def noop_activity(input: NoopActivityArgs) -> str:
 
 
 @workflow.defn(name="no-op")
-class NoOpWorkflow:
+class NoOpWorkflow(CommandableWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> Any:
+        """Parse inputs from the management command CLI.
+
+        We expect only one input, so we just return it and assume it's correct.
+        """
+        if not inputs:
+            # Preserving defaults from when this was the only workflow.
+            inputs = [datetime.now().isoformat()]
+        return inputs[0]
+
     @workflow.run
     async def run(self, time: str) -> str:
         workflow.logger.info(f"Running workflow with parameter {time}")


### PR DESCRIPTION
## Problem

* The `start_temporal_workflow` command was calling `execute_workflow`. Since the semantics of `start_workflow` and `execute_workflow` are different, the name of the command could be confusing.
* `start_temporal_workflow` only supported executing the `NoOpWorkflow`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Rename `start_temporal_workflow` to `execute_temporal_workflow` so that it lines up with the underlying call.
* Take in a str argument from the CLI with the name of the workflow to execute instead of supporting only `NoOpWorkflow`.

~TODO: Add support for workflow inputs.~

* Added support for workflow inputs. For this, I added a `CommandableWorkflow` interface for workflows that can be executed via the Django management command CLI. This interface has only one method `parse_inputs`. My reasoning was that if we want to execute any arbitrary workflow via the CLI, then these arbitrary workflows should be capable of parsing their own inputs. This allows us to add a "catch-all" 'INPUTS' CLI argument and pass it to the workflow to parse.

Tested no-op workflow by running locally:

With default:
```sh
$  DEBUG=1 python manage.py execute_temporal_workflow no-op
2023-03-24T13:09:17.185715Z [info     ] Executing Temporal Workflow with options: {'verbosity': 1, 'settings': None, 'pythonpath': None, 'traceback': False, 'no_color': False, 'force_color': False, 'skip_checks': False, 'workflow': 'no-op', 'inputs': [], 'temporal_host': '127.0.0.1', 'temporal_port': '7233', 'task_queue': 'no-sandbox-python-django', 'namespace': 'default', 'server_root_ca_cert': None, 'client_cert': None, 'client_key': None} [root] pid=1197686 tid=140304738934848
2023-03-24T13:09:17.249325Z [warning  ] Workflow output: OK - 2023-03-24T13:09:17.190058 [root] pid=1197686 tid=140304738934848
```

Passing a parameter:
```sh
$  DEBUG=1 python manage.py execute_temporal_workflow no-op wow-much-parameter
2023-03-24T13:13:25.955499Z [info     ] Executing Temporal Workflow with options: {'verbosity': 1, 'settings': None, 'pythonpath': None, 'traceback': False, 'no_color': False, 'force_color': False, 'skip_checks': False, 'workflow': 'no-op', 'inputs': ['wow-much-parameter'], 'temporal_host': '127.0.0.1', 'temporal_port': '7233', 'task_queue': 'no-sandbox-python-django', 'namespace': 'default', 'server_root_ca_cert': None, 'client_cert': None, 'client_key': None} [root] pid=1200288 tid=139819023962176
2023-03-24T13:13:26.012909Z [warning  ] Workflow output: OK - wow-much-parameter [root] pid=1200288 tid=139819023962176
```

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

