### PR TITLE
chore: remove unused cohort code

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -94,12 +94,6 @@ class CohortSerializer(serializers.ModelSerializer):
             if filter_data:
                 insert_cohort_from_insight_filter.delay(cohort.pk, filter_data)
 
-    def _handle_csv(self, file, cohort: Cohort) -> None:
-        decoded_file = file.read().decode("utf-8").splitlines()
-        reader = csv.reader(decoded_file)
-        distinct_ids_and_emails = [row[0] for row in reader if len(row) > 0 and row]
-        calculate_cohort_from_list.delay(cohort.pk, distinct_ids_and_emails)
-
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> Cohort:
         request = self.context["request"]
         Team.objects.get(pk=self.context["team_id"])


### PR DESCRIPTION
## Problem

Noticed we had a duplicate method to `def _calculate_static_by_csv(self, file, cohort: Cohort)` that is also unused anywhere

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
