### PR TITLE
fix: Use timezone friendly display for Last Event Ingested

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -1,7 +1,7 @@
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
-import { humanFriendlyDetailedTime } from 'lib/utils'
 import { InstanceSetting, SystemStatusRow } from '~/types'
 import { IconLock } from 'lib/lemon-ui/icons'
+import { TZLabel } from '@posthog/apps-common'
 
 const TIMESTAMP_VALUES = new Set(['last_event_ingested_timestamp'])
 
@@ -33,7 +33,7 @@ export function RenderMetricValue(
         if (new Date(value).getTime() === new Date('1970-01-01T00:00:00').getTime()) {
             return 'Never'
         }
-        return humanFriendlyDetailedTime(value)
+        return <TZLabel time={value} />
     }
 
     if (value_type === 'bool' || typeof value === 'boolean') {

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import timedelta
 from os.path import abspath, basename, dirname, join
 from typing import Dict, Generator, List, Tuple
+import pytz
 
 import sqlparse
 from clickhouse_driver import Client
@@ -105,12 +106,18 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
         "subrows": {"columns": ["Metric", "Value", "Description"], "rows": list(sorted(system_metrics))},
     }
 
+    # This timestamp is a naive timestamp (does not include a timezone)
+    # ClickHouse always stores timezone agnostic unix timestamp
+    # See https://clickhouse.com/docs/en/sql-reference/data-types/datetime#usage-remarks
     last_event_ingested_timestamp = sync_execute("SELECT max(_timestamp) FROM events")[0][0]
+
+    # Therefore we can confidently apply the UTC timezone
+    last_event_ingested_timestamp_utc = last_event_ingested_timestamp.replace(tzinfo=pytz.UTC)
 
     yield {
         "key": "last_event_ingested_timestamp",
         "metric": "Last event ingested",
-        "value": last_event_ingested_timestamp.astimezone(),
+        "value": last_event_ingested_timestamp_utc,
     }
 
     dead_letter_queue_size = get_dead_letter_queue_size()

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -110,7 +110,7 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
     yield {
         "key": "last_event_ingested_timestamp",
         "metric": "Last event ingested",
-        "value": last_event_ingested_timestamp,
+        "value": last_event_ingested_timestamp.astimezone(),
     }
 
     dead_letter_queue_size = get_dead_letter_queue_size()


### PR DESCRIPTION
## Problem
The Last event ingested was displaying a date that was not timezone aware. There was no indicator if this was local time or UTC or other, which caused confusion (in some cases it was even showing as a future datetime!)

Closes #9505

## Rationale 🧠 

- I initially checked the value that was being sent from the `/api/instance_status` endpoint. I noticed it was a naive datetime (it didn't include a timezone).
- I started examining the code responsible for saving events and considered modifying it to include timezone information from now on.
- However, further research revealed that ClickHouse does not store timezones together with the `datetimes`, but it stores them as timezone-agnostic Unix timestamps (which align with UTC). [Reference here](https://clickhouse.com/docs/en/sql-reference/data-types/datetime#usage-remarks)
- I then thought about modifying the value on the frontend so it included the UTC timezone, but if this endpoint were to be consumed in the future somewhere else in the application, then we would have to keep track of 2 different places, which would be error prone.
- The solution then was to apply the timezone to the `datetime` on the backend, right after retrieving from ClickHouse. Knowing that ClickHouse always stores `datetimes` as UTC, we can confidently attach the UTC timezone to our `datetime` and then leverage the existing `TZLabel` component to display the values consistently and accurately to the users.

## Changes
### Before ⚠️ 
![before_ingested_tz](https://user-images.githubusercontent.com/3190666/227399330-b1181f6f-ae20-4e37-9508-f736af1ae6fb.jpg)


### After ✅ 
![after_ingested_tz](https://user-images.githubusercontent.com/3190666/227399031-19110a11-f133-4d80-8d86-e2d6025f5227.gif)


## How did you test this code?
1. Go to `/instance/status`
2. Scroll down to Last Event Ingested
3. See how we are now using `TZLabel`
