### PR TITLE
fix: series color is being recalculated after sort for series letter

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -85,6 +85,7 @@ export function InsightTooltip({
                     className="mr-2"
                     hasBreakdown={hasBreakdown}
                     seriesIndex={datum?.action?.order ?? datum.id}
+                    seriesColor={datum.color}
                 />
                 {value}
             </div>


### PR DESCRIPTION
## Problem

A [customer reported that the colors on the line graph tooltip were out of sync](https://twitter.com/grhmc/status/1638270981683793931) with each other

On investigation if the `SeriesLetter` component is not provided a color (which it wasn't being) then it was recalculating the series color... but it was doing that _after_ the dataset had been sorted. 

Whereas other components were calculating the color _before_ sorting

## Changes

Passes the color to the series letter

|before|after|
|--|--|
|![Screenshot 2023-03-24 at 11 16 20](https://user-images.githubusercontent.com/984817/227507775-8c66ebd7-36a5-4d7b-bf79-625b9c1c40f6.png)|![Screenshot 2023-03-24 at 11 16 00](https://user-images.githubusercontent.com/984817/227507806-be376200-1e66-4ae1-86b1-93ad7e778e9d.png)|

## How did you test this code?

👀 locally