### PR TITLE
fix: pie tooltips with formulas and breakdown

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -112,8 +112,11 @@ export function InsightTooltip({
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     const title: ReactNode | null =
-        getTooltipTitle(seriesData, altTitle, date) ||
-        `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${timezone ? shortTimeZone(timezone) : 'UTC'})`
+        getTooltipTitle(seriesData, altTitle, date) || !!date
+            ? `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${
+                  timezone ? shortTimeZone(timezone) : 'UTC'
+              })`
+            : ''
     const rightTitle: ReactNode | null = getTooltipTitle(seriesData, altRightTitle, date) || null
 
     if (itemizeEntitiesAsColumns) {

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -193,7 +193,7 @@ export function PieChart({
 
                                 ReactDOM.render(
                                     <InsightTooltip
-                                        date={dataset?.days?.[tooltip.dataPoints?.[0]?.dataIndex]}
+                                        date={undefined} // pie chart values aren't timeseries
                                         timezone={timezone}
                                         seriesData={seriesData}
                                         hideColorCol={!!tooltipConfig?.hideColorCol}

--- a/frontend/src/scenes/insights/views/LineGraph/lineGraphLogic.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/lineGraphLogic.ts
@@ -29,7 +29,7 @@ export const lineGraphLogic = kea<lineGraphLogicType>({
                                     pointDataset?.compareLabels?.[dp.dataIndex] ??
                                     undefined,
                                 action: pointDataset?.action ?? pointDataset?.actions?.[dp.dataIndex] ?? undefined,
-                                label: pointDataset?.label ?? undefined,
+                                label: pointDataset?.label ?? pointDataset.labels?.[dp.dataIndex] ?? undefined,
                                 color: Array.isArray(pointDataset.borderColor)
                                     ? pointDataset.borderColor?.[dp.dataIndex]
                                     : pointDataset.borderColor,


### PR DESCRIPTION
## Problem

While fixing in #14890 I noticed that pie charts with formula and breakdown couldn't draw tooltips correctly

## Changes

Fixes that by looking up label in the labels array if it isn't present as a top level label property
Fly-by don't try and put a date time in tooltip title for non timeseries values

### before

![before-pie](https://user-images.githubusercontent.com/984817/227521652-6e495285-17a7-499e-8d24-04f4616f8bae.gif)

### after

![after-pie](https://user-images.githubusercontent.com/984817/227521670-c9eee801-ff0a-4b59-81cb-cb4408a0938b.gif)

## How did you test this code?

👀 locally
