### PR TITLE
fix(dashboards): do not display jumping jacks hog while loading insight

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -466,7 +466,7 @@ export function InsightViz({
                     : undefined
             }
         >
-            {loading && !timedOut && <SpinnerOverlay />}
+            {loading && <SpinnerOverlay />}
             {tooFewFunnelSteps ? (
                 <FunnelSingleStepState actionable={false} />
             ) : invalidFunnelExclusion ? (

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -473,9 +473,9 @@ export function InsightViz({
                 <FunnelInvalidExclusionState />
             ) : empty ? (
                 <InsightEmptyState />
-            ) : timedOut ? (
+            ) : !loading && timedOut ? (
                 <InsightTimeoutState
-                    isLoading={!!loading}
+                    isLoading={false}
                     insightProps={{ dashboardItemId: undefined }}
                     insightType={insight.filters.insight}
                 />


### PR DESCRIPTION
We would display the jumping jacks hog + the long notice about improving query speed (and the sampling button) on dashboards, and it just looks weird + doesn't fit in very well.

This was always there but now users are seeing it since we reduced the time to show the timeout state to 5s.

Rather, let's just show the spinner instead and then a proper timeout message once the query truly times out. 

P.S. Semantics in code are annoying because `timedOut` on a query doesn't mean it actually timed out.