### PR TITLE
feat: data management property activity log

### DIFF
--- a/ee/api/ee_event_definition.py
+++ b/ee/api/ee_event_definition.py
@@ -100,6 +100,7 @@ class EnterpriseEventDefinitionSerializer(TaggedItemSerializerMixin, serializers
             activity="changed",
             detail=Detail(name=str(event_definition.name), changes=changes),
         )
+
         return super().update(event_definition, validated_data)
 
     def to_representation(self, instance):

--- a/ee/api/ee_property_definition.py
+++ b/ee/api/ee_property_definition.py
@@ -3,6 +3,8 @@ from rest_framework import serializers
 from ee.models.property_definition import EnterprisePropertyDefinition
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
+from posthog.models import PropertyDefinition
+from posthog.models.activity_logging.activity_log import dict_changes_between, log_activity, Detail
 
 
 class EnterprisePropertyDefinitionSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
@@ -24,7 +26,7 @@ class EnterprisePropertyDefinitionSerializer(TaggedItemSerializerMixin, serializ
         )
         read_only_fields = ["id", "name", "is_numerical", "query_usage_30_day", "is_seen_on_filtered_events"]
 
-    def update(self, event_definition: EnterprisePropertyDefinition, validated_data):
+    def update(self, property_definition: EnterprisePropertyDefinition, validated_data):
         validated_data["updated_by"] = self.context["request"].user
         if "property_type" in validated_data:
             if validated_data["property_type"] == "Numeric":
@@ -32,4 +34,28 @@ class EnterprisePropertyDefinitionSerializer(TaggedItemSerializerMixin, serializ
             else:
                 validated_data["is_numerical"] = False
 
-        return super().update(event_definition, validated_data)
+        before_state = {
+            k: property_definition.__dict__[k] for k in validated_data.keys() if k in property_definition.__dict__
+        }
+        # KLUDGE: if we get a None value for tags, and we're not adding any
+        # then we get an activity log that we went from null to the empty array ¯\_(ツ)_/¯
+        if "tags" not in before_state or before_state["tags"] is None:
+            before_state["tags"] = []
+
+        changes = dict_changes_between("PropertyDefinition", before_state, validated_data, True)
+
+        log_activity(
+            organization_id=None,
+            team_id=self.context["team_id"],
+            user=self.context["request"].user,
+            item_id=str(property_definition.id),
+            scope="PropertyDefinition",
+            activity="changed",
+            detail=Detail(
+                name=str(property_definition.name),
+                type=PropertyDefinition.Type(property_definition.type).label,
+                changes=changes,
+            ),
+        )
+
+        return super().update(property_definition, validated_data)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -552,6 +552,10 @@ const api = {
                     // TODO allow someone to load _only_ event definitions?
                     return new ApiRequest().dataManagementActivity()
                 },
+                [ActivityScope.PROPERTY_DEFINITION]: () => {
+                    // TODO allow someone to load _only_ property definitions?
+                    return new ApiRequest().dataManagementActivity()
+                },
             }
 
             const pagingParameters = { page: page || 1, limit: ACTIVITY_PAGE_SIZE }

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -36,6 +36,7 @@ export const describerFor = (logItem?: ActivityLogItem): Describer | undefined =
         case ActivityScope.PERSON:
             return personActivityDescriber
         case ActivityScope.EVENT_DEFINITION:
+        case ActivityScope.PROPERTY_DEFINITION:
             return dataManagementActivityDescriber
         default:
             return undefined

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -27,6 +27,8 @@ export interface ActivityLogDetail {
     changes: ActivityChange[] | null
     name: string | null
     short_id?: InsightShortId | null
+    /** e.g. for property definition carries event, person, or group */
+    type?: string
 }
 
 export interface ActivityUser {
@@ -43,6 +45,7 @@ export enum ActivityScope {
     PLUGIN_CONFIG = 'PluginConfig',
     DATA_MANAGEMENT = 'DataManagement',
     EVENT_DEFINITION = 'EventDefinition',
+    PROPERTY_DEFINITION = 'PropertyDefinition',
 }
 
 export interface ActivityLogItem {

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -74,6 +74,7 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
 export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX.Element {
     const { showWarningsTab, showDatabaseTab, showHistoryTab } = useValues(eventsTabsLogic)
     const { setTab } = useActions(eventsTabsLogic)
+
     return (
         <>
             <LemonTabs

--- a/frontend/src/scenes/data-management/dataManagementDescribers.tsx
+++ b/frontend/src/scenes/data-management/dataManagementDescribers.tsx
@@ -77,15 +77,31 @@ function nameAndLink(logItem?: ActivityLogItem): JSX.Element {
     )
 }
 
+function DescribeType({ logItem }: { logItem: ActivityLogItem }): JSX.Element {
+    const typeDescription = logItem.scope === ActivityScope.EVENT_DEFINITION ? 'event' : 'property'
+    if (typeDescription === 'property') {
+        return (
+            <>
+                <span className="highlighted-activity">{logItem.detail?.type}</span> property definition
+            </>
+        )
+    }
+    return <>{typeDescription} definition</>
+}
+
 export function dataManagementActivityDescriber(logItem: ActivityLogItem): HumanizedChange {
-    if (logItem.scope !== ActivityScope.EVENT_DEFINITION) {
+    if (logItem.scope !== ActivityScope.EVENT_DEFINITION && logItem.scope !== ActivityScope.PROPERTY_DEFINITION) {
         console.error('data management describer received a non-data-management activity')
         return { description: null }
     }
 
     if (logItem.activity == 'changed') {
         let changes: Description[] = []
-        let changeSuffix: Description = <>on {nameAndLink(logItem)}</>
+        let changeSuffix: Description = (
+            <>
+                on <DescribeType logItem={logItem} /> {nameAndLink(logItem)}
+            </>
+        )
 
         for (const change of logItem.detail.changes || []) {
             if (!change?.field || !dataManagementActionsMapping[change.field]) {
@@ -126,7 +142,7 @@ export function dataManagementActivityDescriber(logItem: ActivityLogItem): Human
             description: (
                 <>
                     <strong>{logItem.user.first_name}</strong> <div className="highlighted-activity">deleted</div>{' '}
-                    {nameAndLink(logItem)}
+                    <DescribeType logItem={logItem} /> {nameAndLink(logItem)}
                 </>
             ),
         }

--- a/frontend/src/scenes/data-management/dataManagementDescribers.tsx
+++ b/frontend/src/scenes/data-management/dataManagementDescribers.tsx
@@ -141,8 +141,8 @@ export function dataManagementActivityDescriber(logItem: ActivityLogItem): Human
         return {
             description: (
                 <>
-                    <strong>{logItem.user.first_name}</strong> <div className="highlighted-activity">deleted</div>{' '}
-                    <DescribeType logItem={logItem} /> {nameAndLink(logItem)}
+                    <strong>{logItem.user.first_name}</strong> deleted <DescribeType logItem={logItem} />{' '}
+                    {nameAndLink(logItem)}
                 </>
             ),
         }

--- a/posthog/api/data_management.py
+++ b/posthog/api/data_management.py
@@ -15,6 +15,6 @@ class DataManagementViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
         limit = int(request.query_params.get("limit", "10"))
         page = int(request.query_params.get("page", "1"))
 
-        activity_page = load_all_activity(scope_list=["EventDefinition"], team_id=request.user.team.id, limit=limit, page=page)  # type: ignore
+        activity_page = load_all_activity(scope_list=["EventDefinition", "PropertyDefinition"], team_id=request.user.team.id, limit=limit, page=page)  # type: ignore
 
         return activity_page_response(activity_page, limit, page, request)

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -145,6 +145,7 @@ class TestExports(APIBaseTest):
                             }
                         ],
                         "trigger": None,
+                        "type": None,
                         "name": self.insight.name,
                         "short_id": self.insight.short_id,
                     },

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -199,6 +199,7 @@ class TestFeatureFlag(APIBaseTest):
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "alpha-feature",
                         "short_id": None,
                     },
@@ -498,6 +499,7 @@ class TestFeatureFlag(APIBaseTest):
                             },
                         ],
                         "trigger": None,
+                        "type": None,
                         "name": "a-feature-flag-that-is-updated",
                         "short_id": None,
                     },
@@ -511,6 +513,7 @@ class TestFeatureFlag(APIBaseTest):
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "a-feature-flag-that-is-updated",
                         "short_id": None,
                     },
@@ -580,6 +583,7 @@ class TestFeatureFlag(APIBaseTest):
                             }
                         ],
                         "trigger": None,
+                        "type": None,
                         "name": "feature_with_activity",
                         "short_id": None,
                     },
@@ -593,6 +597,7 @@ class TestFeatureFlag(APIBaseTest):
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "feature_with_activity",
                         "short_id": None,
                     },
@@ -648,7 +653,7 @@ class TestFeatureFlag(APIBaseTest):
                     "created_at": "2021-08-25T22:29:14.252000Z",
                     "scope": "FeatureFlag",
                     "item_id": str(second_flag_id),
-                    "detail": {"changes": None, "trigger": None, "name": "flag-two", "short_id": None},
+                    "detail": {"changes": None, "trigger": None, "type": None, "name": "flag-two", "short_id": None},
                 },
                 {
                     "user": {"first_name": new_user.first_name, "email": new_user.email},
@@ -667,6 +672,7 @@ class TestFeatureFlag(APIBaseTest):
                             }
                         ],
                         "trigger": None,
+                        "type": None,
                         "name": "feature_with_activity",
                         "short_id": None,
                     },
@@ -680,6 +686,7 @@ class TestFeatureFlag(APIBaseTest):
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "feature_with_activity",
                         "short_id": None,
                     },
@@ -2009,7 +2016,7 @@ class TestFeatureFlag(APIBaseTest):
 
         activity: List[Dict] = activity_response["results"]
         self.maxDiff = None
-        self.assertEqual(activity, expected)
+        assert activity == expected
 
     def test_patch_api_as_form_data(self):
         another_feature_flag = FeatureFlag.objects.create(

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -480,6 +480,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "a created dashboard",
                         "short_id": response_data["short_id"],
                     },
@@ -720,6 +721,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                         "name": "have to have a name to hit the activity log",
                         "short_id": insight_json["short_id"],
                         "trigger": None,
+                        "type": None,
                     },
                     "item_id": str(insight_id),
                     "scope": "Insight",
@@ -744,6 +746,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                         "name": "have to have a name to hit the activity log",
                         "short_id": insight_json["short_id"],
                         "trigger": None,
+                        "type": None,
                     },
                     "item_id": str(insight_id),
                     "scope": "Insight",
@@ -757,6 +760,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                         "name": "have to have a name to hit the activity log",
                         "short_id": insight_json["short_id"],
                         "trigger": None,
+                        "type": None,
                     },
                     "item_id": str(insight_id),
                     "scope": "Insight",
@@ -846,6 +850,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "pageview unique users",
                         "short_id": response_data["short_id"],
                     },
@@ -909,6 +914,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                                 },
                             ],
                             "trigger": None,
+                            "type": None,
                             "name": "insight new name",
                             "short_id": short_id,
                         },
@@ -922,6 +928,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                         "detail": {
                             "changes": None,
                             "trigger": None,
+                            "type": None,
                             "name": "insight name",
                             "short_id": short_id,
                         },
@@ -980,6 +987,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "a created dashboard",
                         "short_id": insight_short_id,
                     },
@@ -1001,6 +1009,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                             }
                         ],
                         "trigger": None,
+                        "type": None,
                         "name": "a created dashboard",
                         "short_id": insight_short_id,
                     },
@@ -1022,6 +1031,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                             }
                         ],
                         "trigger": None,
+                        "type": None,
                         "name": "a created dashboard",
                         "short_id": insight_short_id,
                     },

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -235,6 +235,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": str(person.uuid),
                         "short_id": None,
                     },
@@ -317,6 +318,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                         ],
                         "name": str(person1.uuid),
                         "trigger": None,
+                        "type": None,
                         "short_id": None,
                     },
                     "created_at": "2021-08-25T22:09:14.252000Z",
@@ -515,6 +517,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                             }
                         ],
                         "trigger": None,
+                        "type": None,
                         "name": None,
                         "short_id": None,
                     },

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -86,6 +86,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
                         "name": "helloworldplugin",
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "short_id": None,
                     },
                 }
@@ -296,6 +297,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
                         "name": "helloworldplugin",
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "short_id": None,
                     },
                 },
@@ -309,6 +311,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
                         "name": "helloworldplugin",
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "short_id": None,
                     },
                 },
@@ -1271,6 +1274,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
                     "detail": {
                         "changes": None,
                         "trigger": None,
+                        "type": None,
                         "name": "helloworldplugin",
                         "short_id": None,
                     },
@@ -1284,6 +1288,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
                     "detail": {
                         "changes": [],
                         "trigger": None,
+                        "type": None,
                         "name": "helloworldplugin",
                         "short_id": None,
                     },

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, patch
 from rest_framework import status
 
 from posthog.api.property_definition import PropertyDefinitionQuerySerializer
-from posthog.models import EventDefinition, EventProperty, Organization, PropertyDefinition, Team
+from posthog.models import EventDefinition, EventProperty, Organization, PropertyDefinition, Team, ActivityLog
 from posthog.test.base import APIBaseTest, BaseTest
 
 
@@ -326,6 +326,13 @@ class TestPropertyDefinitionAPI(APIBaseTest):
             properties={"name": "test_property", "type": "event"},
             groups={"instance": ANY, "organization": str(self.organization.id), "project": str(self.team.uuid)},
         )
+
+        activity_log: Optional[ActivityLog] = ActivityLog.objects.first()
+        assert activity_log is not None
+        assert activity_log.detail["type"] == "event"
+        assert activity_log.item_id == str(property_definition.id)
+        assert activity_log.detail["name"] == "test_property"
+        assert activity_log.activity == "deleted"
 
 
 class TestPropertyDefinitionQuerySerializer(BaseTest):

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -16,7 +16,14 @@ from posthog.models.utils import UUIDT, UUIDModel
 logger = structlog.get_logger(__name__)
 
 ActivityScope = Literal[
-    "FeatureFlag", "Person", "Insight", "Plugin", "PluginConfig", "SessionRecordingPlaylist", "EventDefinition"
+    "FeatureFlag",
+    "Person",
+    "Insight",
+    "Plugin",
+    "PluginConfig",
+    "SessionRecordingPlaylist",
+    "EventDefinition",
+    "PropertyDefinition",
 ]
 ChangeAction = Literal["changed", "created", "deleted", "merged", "split", "exported"]
 
@@ -43,6 +50,7 @@ class Detail:
     trigger: Optional[Trigger] = None
     name: Optional[str] = None
     short_id: Optional[str] = None
+    type: Optional[str] = None
 
 
 class ActivityDetailEncoder(json.JSONEncoder):
@@ -137,7 +145,7 @@ field_exclusions: Dict[ActivityScope, List[str]] = {
     "EventDefinition": [
         "eventdefinition_ptr_id",
         "id",
-        "creted_at",
+        "created_at",
         "_state",
         "deprecated_tags",
         "team_id",
@@ -148,6 +156,23 @@ field_exclusions: Dict[ActivityScope, List[str]] = {
         "verified_by",
         "updated_by",
         "post_to_slack",
+    ],
+    "PropertyDefinition": [
+        "propertydefinition_ptr_id",
+        "id",
+        "created_at",
+        "_state",
+        "deprecated_tags",
+        "team_id",
+        "updated_at",
+        "owner_id",
+        "query_usage_30_day",
+        "volume_30_day",
+        "verified_at",
+        "verified_by",
+        "updated_by",
+        "post_to_slack",
+        "property_type_format",
     ],
 }
 

--- a/posthog/models/activity_logging/serializers.py
+++ b/posthog/models/activity_logging/serializers.py
@@ -38,6 +38,7 @@ class DetailSerializer(serializers.Serializer):
     trigger = TriggerSerializer(required=False)
     name = serializers.CharField(read_only=True)
     short_id = serializers.CharField(read_only=True)
+    type = serializers.CharField(read_only=True)
 
 
 class ActivityLogSerializer(serializers.Serializer):


### PR DESCRIPTION
## Problem

adds property definition activity tracking

## Changes

adds history tracking for property definitions

<img width="871" alt="Screenshot 2023-03-24 at 15 37 55" src="https://user-images.githubusercontent.com/984817/227572552-e79d7ef3-c4fe-4e8a-8fa3-56f6a05b83da.png">

## How did you test this code?

👀 locally