### PR TITLE
fix: Add missing script to start temporal worker

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -114,6 +114,12 @@ cat > compose/start <<EOF
 EOF
 chmod +x compose/start
 
+cat > compose/temporal-django-worker <<EOF
+#!/bin/bash
+./bin/temporal-django-worker
+EOF
+chmod +x compose/temporal-django-worker
+
 # write wait script
 cat > compose/wait <<EOF
 #!/usr/bin/env python3


### PR DESCRIPTION
## Problem

In #14658, we added the Temporal stack to hobby deployments. However, we forgot to include the script to start a Temporal Django worker. This is causing hobby deployments to fail, see #14865.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Create a `compose/temporal-django-worker` script to start a Temporal Django script, following what we do to start other services.

@fuziontech You may be interested in checking this one out to see if there's a better way.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Deployed hobby stack. Without changes I was able to reproduce the issue in #14865, with changes everything works.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
