### PR TITLE
fix: Checkout git tag corresponding to Docker image

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -75,7 +75,23 @@ sudo apt install -y git
 # try to clone - if folder is already there pull latest for that branch
 git clone https://github.com/PostHog/posthog.git &> /dev/null || true
 cd posthog
-git pull
+
+if [ "$POSTHOG_APP_TAG" = "latest-release"]
+then
+    # Checkout the latest RELEASED version
+    git fetch --tags
+    git checkout $(git rev-list --tags --max-count=1)
+elif [ "$POSTHOG_APP_TAG" = "latest"]
+then
+    # Pull latest for current branch
+    git pull
+else
+    # Checkout a specific release tag
+    # Docker tags have the form release-X.Y.Z, but git tags don't have the prefix
+    git fetch --tags
+    git checkout "${POSTHOG_APP_TAG/release-/""}"
+fi
+
 cd ..
 
 if [ -n "$3" ]

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -76,20 +76,21 @@ sudo apt install -y git
 git clone https://github.com/PostHog/posthog.git &> /dev/null || true
 cd posthog
 
-if [ "$POSTHOG_APP_TAG" = "latest-release"]
+if [[ "$POSTHOG_APP_TAG" = "latest-release" ]]
 then
-    # Checkout the latest RELEASED version
     git fetch --tags
-    git checkout $(git rev-list --tags --max-count=1)
-elif [ "$POSTHOG_APP_TAG" = "latest"]
+    latestReleaseTag=$(git describe --tags `git rev-list --tags --max-count=1`)
+    echo "Checking out latest PostHog release: $latestReleaseTag"
+    git checkout $latestReleaseTag
+elif [[ "$POSTHOG_APP_TAG" = "latest" ]]
 then
-    # Pull latest for current branch
+    echo "Pulling latest from current branch: $(git branch --show-current)"
     git pull
 else
-    # Checkout a specific release tag
-    # Docker tags have the form release-X.Y.Z, but git tags don't have the prefix
+    releaseTag="${POSTHOG_APP_TAG/release-/""}"
     git fetch --tags
-    git checkout "${POSTHOG_APP_TAG/release-/""}"
+    echo "Checking out PostHog release: $releaseTag"
+    git checkout $releaseTag
 fi
 
 cd ..


### PR DESCRIPTION
## Problem

The `deploy-hobby` script requests a user for a version of PostHog (`POSTHOG_APP_TAG`) that is used to pull a PostHog Docker image. However, we then pull the `posthog` git repository in whatever branch it's currently in. This can cause a disparity between the image pulled and the current branch we are at.

For example, assuming we are starting from clean and with the default `latest-release`:

1. We will pull the latest image from Docker (version 1.43.0 as of writing).
2. We will pull the default git branch, `master` which is incompatible with version 1.43.0 (released 2 months ago).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Check for the image tag we are pulling from Docker and use that information to checkout the matching git tag.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Deployed to DO, checked logs.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
