### PR TITLE
fix: specify correct workspace folder

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
         "kafka:127.0.0.1"
     ],
 
-    "workspaceFolder": "/workspace",
+    "workspaceFolder": "/workspaces/posthog",
 
     // Set *default* container specific settings.json values on container create.
     "settings": {


### PR DESCRIPTION
For some reason it was /workspace :shrug:

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
