### PR TITLE
feat: Add email verification fields to Django Admin

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -129,7 +129,7 @@ class UserAdmin(DjangoUserAdmin):
 
     inlines = [OrganizationMemberInline]
     fieldsets = (
-        (None, {"fields": ("email", "password", "current_organization")}),
+        (None, {"fields": ("email", "password", "current_organization", "is_email_verified", "pending_email")}),
         (_("Personal info"), {"fields": ("first_name", "last_name")}),
         (_("Permissions"), {"fields": ("is_active", "is_staff")}),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -445,7 +445,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 117,
+  SELECT 116,
          person_id,
          key,
          'random'
@@ -526,7 +526,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 117,
+  SELECT 116,
          person_id,
          key,
          'random'

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -286,8 +286,8 @@
                           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
                        WHERE team_id = 2
                          AND event IN ['$autocapture', 'user signed up', '$autocapture', '$autocapture']
-                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-29 00:00:00', 'UTC')
-                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-05 23:59:59', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-30 00:00:00', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-06 23:59:59', 'UTC')
                          AND notEmpty(e.person_id)
                          AND (step_0 = 1
                               OR step_1 = 1


### PR DESCRIPTION
## Problem

These two fields where added in migration 301 but are not visible or editable in Django Admin. It's useful to have them to investigate issues with verification.

<!-- Who are we building for, what are their needs, why is this important? -->

