### PR TITLE
ci: make cypress use correct image on master branch pushes

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -141,9 +141,8 @@ jobs:
                       ${{ github.ref == 'refs/heads/master' && 'posthog/posthog' || 'ghcr.io/posthog/posthog/posthog' }}
                   # If we're on master, use the latest tag, if we are a
                   # GitHub Actions pull_request event, use the pr tag.
-                  flavor: |
-                      latest=${{ github.ref == 'refs/heads/master' }}
-                      pr=${{ github.event_name == 'pull_request' }}
+                  tags: |
+                      type=raw,value=${{ github.ref == 'refs/heads/master' && 'latest' || 'pr-${{ github.event.number }}' }}
 
             - name: Start PostHog
               run: |

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -27,10 +27,11 @@ jobs:
         steps:
             - name: Wait for the container image to be ready
               uses: lewagon/wait-on-check-action@v1.2.0
-              # if we are on master then we don't need to wait for the container image
-              if: github.event_name == 'pull_request'
+              # if we are on master then we use the CD image (GitHub Action Job
+              # "Build and push PostHog"), otherwise we use the CI image (GitHub
+              # Action Job "Build PostHog")
               with:
-                  check-name: Build PostHog
+                  check-name: ${{ github.ref == 'refs/heads/master' && 'Build and push PostHog' || 'Build PostHog' }}
                   ref: ${{ github.event.pull_request.head.sha }}
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   wait-interval: 10
@@ -128,7 +129,21 @@ jobs:
               id: meta
               uses: docker/metadata-action@v4
               with:
-                  images: ghcr.io/posthog/posthog/posthog
+                  # This runs on both PRs and pushes to master, so we need to
+                  # check the ref to know which image to use. If we are on
+                  # master then we use the DockerHub image that will have been
+                  # pushed by the "Build and push PostHog" job which will have
+                  # been pushed as posthog/posthog:latest, otherwise if we are
+                  # on a pull_request we use the image built by the "Build
+                  # PostHog" job, which are tagged with the pr and use the GHCR
+                  # repo e.g. ghcr.io/posthog/posthog/posthog:pr-1234.
+                  images: |
+                      ${{ github.ref == 'refs/heads/master' && 'posthog/posthog' || 'ghcr.io/posthog/posthog/posthog' }}
+                  # If we're on master, use the latest tag, if we are a
+                  # GitHub Actions pull_request event, use the pr tag.
+                  flavor: |
+                      latest=${{ github.ref == 'refs/heads/master' }}
+                      pr=${{ github.event_name == 'pull_request' }}
 
             - name: Start PostHog
               run: |

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -142,7 +142,8 @@ jobs:
                   # If we're on master, use the latest tag, if we are a
                   # GitHub Actions pull_request event, use the pr tag.
                   tags: |
-                      type=raw,value=${{ github.ref == 'refs/heads/master' && 'latest' || 'pr-${{ github.event.number }}' }}
+                      type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+                      type=pr,enable=${{ github.event_name == 'pull_request' }}
 
             - name: Start PostHog
               run: |

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -143,7 +143,7 @@ jobs:
                   # GitHub Actions pull_request event, use the pr tag.
                   tags: |
                       type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
-                      type=pr,enable=${{ github.event_name == 'pull_request' }}
+                      type=ref,event=pr,enable=${{ github.event_name == 'pull_request' }}
 
             - name: Start PostHog
               run: |

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -39,6 +39,11 @@ jobs:
               uses: docker/metadata-action@v4
               with:
                   images: ghcr.io/posthog/posthog/posthog
+                  tags: |
+                      type=schedule
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=ref,event=pr
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
We were pulling the `master` tagged image, now we pull the DockerHub
latest image on master branch. Maybe it will work 🤷 

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
