### PR TITLE
fix: player component rendering

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -21,6 +21,57 @@ import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { PlayerMetaLinks } from './PlayerMetaLinks'
 import { SessionRecordingPlayerProps } from 'scenes/session-recordings/player/SessionRecordingPlayer'
 
+function SessionPropertyMeta(props: {
+    fullScreen: boolean
+    iconProperties: Record<string, any>
+    predicate: (x: string) => boolean
+}): JSX.Element {
+    return (
+        <div className="flex flex-row flex-nowrap shrink-0 gap-2 text-muted-alt">
+            <span className="flex items-center gap-1 whitespace-nowrap">
+                <PropertyIcon
+                    noTooltip={!props.fullScreen}
+                    property="$browser"
+                    value={props.iconProperties['$browser']}
+                />
+                {!props.fullScreen ? props.iconProperties['$browser'] : null}
+            </span>
+            <span className="flex items-center gap-1 whitespace-nowrap">
+                <PropertyIcon
+                    noTooltip={!props.fullScreen}
+                    property="$device_type"
+                    value={props.iconProperties['$device_type'] || props.iconProperties['$initial_device_type']}
+                />
+                {!props.fullScreen
+                    ? props.iconProperties['$device_type'] || props.iconProperties['$initial_device_type']
+                    : null}
+            </span>
+            <span className="flex items-center gap-1 whitespace-nowrap">
+                <PropertyIcon noTooltip={!props.fullScreen} property="$os" value={props.iconProperties['$os']} />
+                {!props.fullScreen ? props.iconProperties['$os'] : null}
+            </span>
+            {props.iconProperties['$geoip_country_code'] && (
+                <span className="flex items-center gap-1 whitespace-nowrap">
+                    <PropertyIcon
+                        noTooltip={!props.fullScreen}
+                        property="$geoip_country_code"
+                        value={props.iconProperties['$geoip_country_code']}
+                    />
+                    {
+                        props.fullScreen &&
+                            [
+                                props.iconProperties['$geoip_city_name'],
+                                props.iconProperties['$geoip_subdivision_1_code'],
+                            ]
+                                .filter(props.predicate)
+                                .join(', ') /* [city, state] */
+                    }
+                </span>
+            )}
+        </div>
+    )
+}
+
 export function PlayerMeta(props: SessionRecordingPlayerProps): JSX.Element {
     const {
         sessionPerson,
@@ -94,52 +145,11 @@ export function PlayerMeta(props: SessionRecordingPlayerProps): JSX.Element {
                         {sessionPlayerMetaDataLoading ? (
                             <LemonSkeleton className="w-1/4 my-1" />
                         ) : iconProperties ? (
-                            <div className="flex flex-row flex-nowrap shrink-0 gap-2 text-muted-alt">
-                                <span className="flex items-center gap-1 whitespace-nowrap">
-                                    <PropertyIcon
-                                        noTooltip={!isFullScreen}
-                                        property="$browser"
-                                        value={iconProperties['$browser']}
-                                    />
-                                    {!isFullScreen ? iconProperties['$browser'] : null}
-                                </span>
-                                <span className="flex items-center gap-1 whitespace-nowrap">
-                                    <PropertyIcon
-                                        noTooltip={!isFullScreen}
-                                        property="$device_type"
-                                        value={iconProperties['$device_type'] || iconProperties['$initial_device_type']}
-                                    />
-                                    {!isFullScreen
-                                        ? iconProperties['$device_type'] || iconProperties['$initial_device_type']
-                                        : null}
-                                </span>
-                                <span className="flex items-center gap-1 whitespace-nowrap">
-                                    <PropertyIcon
-                                        noTooltip={!isFullScreen}
-                                        property="$os"
-                                        value={iconProperties['$os']}
-                                    />
-                                    {!isFullScreen ? iconProperties['$os'] : null}
-                                </span>
-                                {iconProperties['$geoip_country_code'] && (
-                                    <span className="flex items-center gap-1 whitespace-nowrap">
-                                        <PropertyIcon
-                                            noTooltip={!isFullScreen}
-                                            property="$geoip_country_code"
-                                            value={iconProperties['$geoip_country_code']}
-                                        />
-                                        {
-                                            isFullScreen &&
-                                                [
-                                                    iconProperties['$geoip_city_name'],
-                                                    iconProperties['$geoip_subdivision_1_code'],
-                                                ]
-                                                    .filter((x) => x)
-                                                    .join(', ') /* [city, state] */
-                                        }
-                                    </span>
-                                )}
-                            </div>
+                            <SessionPropertyMeta
+                                fullScreen={isFullScreen}
+                                iconProperties={iconProperties}
+                                predicate={(x) => !!x}
+                            />
                         ) : null}
                     </div>
                 </div>

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, reducers, path, connect, props, key, selectors, listeners } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import {
     MatchedRecordingEvent,
     PerformanceEvent,
@@ -221,7 +221,8 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     const timestamp = dayjs(event.timestamp)
                     const responseStatus = event.response_status || 200
 
-                    // NOTE: Navigtion events are missing the first contentful paint info so we find the relevant first contentful paint event and add it to the navigation event
+                    // NOTE: Navigation events are missing the first contentful paint info
+                    // so, we find the relevant first contentful paint event and add it to the navigation event
                     if (event.entry_type === 'navigation' && !event.first_contentful_paint) {
                         const firstContentfulPaint = performanceEventsArr.find(
                             (x) =>
@@ -562,9 +563,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 }
 
                 const timeSeconds = Math.floor(playerTime / 1000)
-                const startIndex = items.findIndex((x) => Math.floor(x.timeInRecording / 1000) >= timeSeconds)
-
-                return startIndex
+                return items.findIndex((x) => Math.floor(x.timeInRecording / 1000) >= timeSeconds)
             },
         ],
 
@@ -591,9 +590,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 if (searchQuery === '') {
                     return filteredItems
                 }
-                const items = fuse.search(searchQuery).map((x: any) => x.item)
-
-                return items
+                return fuse.search(searchQuery).map((x: any) => x.item)
             },
         ],
     })),

--- a/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
@@ -7,7 +7,7 @@ import {
 } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { eventWithTime } from 'rrweb/typings/types'
 import { PersonType } from '~/types'
-import { ceilMsToClosestSecond, findLastIndex } from 'lib/utils'
+import { ceilMsToClosestSecond, findLastIndex, objectsEqual } from 'lib/utils'
 import { getEpochTimeFromPlayerPosition } from './playerUtils'
 
 export const playerMetaLogic = kea<playerMetaLogicType>({
@@ -57,6 +57,13 @@ export const playerMetaLogic = kea<playerMetaLogicType>({
                     width: snapshot.data['width'],
                     height: snapshot.data['height'],
                 }
+            },
+            {
+                resultEqualityCheck: (prev, next) => {
+                    // Only update if the resolution values have changed (not the object reference)
+                    // stops PlayerMeta from re-rendering on every player position
+                    return objectsEqual(prev, next)
+                },
             },
         ],
         recordingStartTime: [


### PR DESCRIPTION
## Problem

The player is struggling with large recordings (maybe) because it renders the page way more than it needs to

## Changes

* a little gentle refactoring
* better equality checking in a kea selector to stop the player meta rendering on every player position
* some react memoising to stop the tick marks rendering on every tick on every player position

|before|after|
|-|-|
|![player-render-before](https://user-images.githubusercontent.com/984817/229286810-7558f158-2fca-4579-890c-156c14116508.gif)|![player-render-after](https://user-images.githubusercontent.com/984817/229286842-e6ea1a62-57c4-4bf6-b955-ea984d5e311d.gif)|

## How did you test this code?

👀 locally
