### PR TITLE
fix: Set hobby deployments to 'latest' by default

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -2,7 +2,7 @@
 
 set -e
 
-export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest-release}"
+export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest}"
 export SENTRY_DSN="${SENTRY_DSN:-'https://public@sentry.example.com/1'}"
 
 POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
@@ -21,7 +21,7 @@ if ! [ -z "$1" ]
 then
 export POSTHOG_APP_TAG=$1
 else
-echo "What version of Posthog would you like to install? (We default to 'latest-release')"
+echo "What version of Posthog would you like to install? (We default to 'latest')"
 echo "You can check out available versions here: https://hub.docker.com/r/posthog/posthog/tags"
 read -r POSTHOG_APP_TAG_READ
 if [ -z "$POSTHOG_APP_TAG_READ" ]


### PR DESCRIPTION
## Problem

This issue was raised in #14865: As we are not publishing any more numbered releases, the `latest-release` Docker tag will get stuck at `1.43.0`. Hobby deployments are using `latest-release` by default, so they will not get the latest features of PostHog by default. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Users should have access to latest PostHog by default, so I've made `latest` the default version for hobby deployments by modifying the `deploy-hobby` script.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

`e2e - hobby smoke test` CI should catch any installation errors.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
