### PR TITLE
feat(capture): remove team resolution code

### DIFF
--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -65,8 +65,8 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEquals(type(kafka_produce_call1["data"]["site_url"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["site_url"]), str)
 
-        self.assertEquals(type(kafka_produce_call1["data"]["team_id"]), int)
-        self.assertEquals(type(kafka_produce_call2["data"]["team_id"]), int)
+        self.assertEquals(type(kafka_produce_call1["data"]["token"]), str)
+        self.assertEquals(type(kafka_produce_call2["data"]["token"]), str)
 
         self.assertEquals(type(kafka_produce_call1["data"]["sent_at"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["sent_at"]), str)
@@ -76,51 +76,6 @@ class TestCaptureAPI(APIBaseTest):
 
         self.assertEquals(type(kafka_produce_call1["data"]["uuid"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["uuid"]), str)
-
-    @patch("posthog.api.utils.get_event_ingestion_context_for_token", side_effect=mocked_get_ingest_context_from_token)
-    @patch("posthog.api.capture.log_event_to_dead_letter_queue")
-    def test_unable_to_fetch_team(self, log_event_to_dead_letter_queue, _):
-        # In this situation we won't ingest the events, we'll add them to the dead letter queue
-
-        self.client.post(
-            "/track/",
-            {
-                "data": json.dumps(
-                    [
-                        {"event": "event1", "properties": {"distinct_id": "eeee", "token": self.team.api_token}},
-                        {"event": "event2", "properties": {"distinct_id": "aaaa", "token": self.team.api_token}},
-                    ]
-                ),
-                "api_key": self.team.api_token,
-            },
-        )
-
-        self.assertEqual(log_event_to_dead_letter_queue.call_count, 2)
-
-        log_event_to_dead_letter_queue_call1 = log_event_to_dead_letter_queue.call_args_list[0].args
-        log_event_to_dead_letter_queue_call2 = log_event_to_dead_letter_queue.call_args_list[1].args
-
-        self.assertEqual(type(log_event_to_dead_letter_queue_call1[0]), list)  # event
-        self.assertEqual(type(log_event_to_dead_letter_queue_call2[0]), list)  # event
-
-        self.assertEqual(log_event_to_dead_letter_queue_call1[1], "event1")  # event_name
-        self.assertEqual(log_event_to_dead_letter_queue_call2[1], "event2")  # event_name
-
-        self.assertEqual(type(log_event_to_dead_letter_queue_call1[2]), dict)  # event
-        self.assertEqual(type(log_event_to_dead_letter_queue_call2[2]), dict)  # event
-
-        self.assertEqual(
-            log_event_to_dead_letter_queue_call1[3],
-            "Unable to fetch team from Postgres. Error: Exception('test exception')",
-        )  # error_message
-
-        self.assertEqual(
-            log_event_to_dead_letter_queue_call2[3],
-            "Unable to fetch team from Postgres. Error: Exception('test exception')",
-        )  # error_message
-
-        self.assertEqual(log_event_to_dead_letter_queue_call1[4], "django_server_capture_endpoint")  # error_location
-        self.assertEqual(log_event_to_dead_letter_queue_call2[4], "django_server_capture_endpoint")  # error_location
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_capture_event_with_uuid_in_payload(self, kafka_produce):
@@ -174,7 +129,7 @@ class TestCaptureAPI(APIBaseTest):
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_partition_key_override(self, kafka_produce):
-        default_partition_key = f"{self.team.pk}:id1"
+        default_partition_key = f"{self.team.api_token}:id1"
 
         response = self.client.post(
             "/capture/",

--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -3,12 +3,10 @@ import json
 from typing import Any
 from unittest.mock import patch
 
-from django.http.request import HttpRequest
 from django.test.client import Client
 from kafka.errors import NoBrokersAvailable
 from rest_framework import status
 
-from posthog.api.utils import get_event_ingestion_context
 from posthog.settings.data_stores import KAFKA_EVENTS_PLUGIN_INGESTION
 from posthog.test.base import APIBaseTest
 
@@ -123,14 +121,6 @@ class TestCaptureAPI(APIBaseTest):
 
         self.assertEqual(log_event_to_dead_letter_queue_call1[4], "django_server_capture_endpoint")  # error_location
         self.assertEqual(log_event_to_dead_letter_queue_call2[4], "django_server_capture_endpoint")  # error_location
-
-    # unit test the underlying util that handles the DB being down
-    @patch("posthog.api.utils.get_event_ingestion_context_for_token", side_effect=mocked_get_ingest_context_from_token)
-    def test_determine_team_from_request_data_ch(self, _):
-        team, db_error, _ = get_event_ingestion_context(HttpRequest(), {}, "")
-
-        self.assertEqual(team, None)
-        self.assertEqual(db_error, "Exception('test exception')")
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_capture_event_with_uuid_in_payload(self, kafka_produce):

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -21,18 +21,15 @@ from statshog.defaults.django import statsd
 from token_bucket import Limiter, MemoryStorage
 
 from posthog.api.utils import (
-    EventIngestionContext,
     get_data,
-    get_event_ingestion_context,
     get_token,
     safe_clickhouse_string,
 )
 from posthog.exceptions import generate_exception_response
 from posthog.kafka_client.client import KafkaProducer
-from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE, KAFKA_SESSION_RECORDING_EVENTS
+from posthog.kafka_client.topics import KAFKA_SESSION_RECORDING_EVENTS
 from posthog.logging.timing import timed
-from posthog.metrics import LABEL_RESOURCE_TYPE, LABEL_TEAM_ID
-from posthog.models.feature_flag import get_all_feature_flags
+from posthog.metrics import LABEL_RESOURCE_TYPE
 from posthog.models.utils import UUIDT
 from posthog.session_recordings.session_recording_helpers import preprocess_session_recording_events_for_clickhouse
 from posthog.utils import cors_response, get_ip_address
@@ -58,7 +55,7 @@ SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
     "capture_events_dropped_over_quota",
     "Events dropped by capture due to quota-limiting, per resource_type, team_id and token.",
-    labelnames=[LABEL_RESOURCE_TYPE, LABEL_TEAM_ID, "token"],
+    labelnames=[LABEL_RESOURCE_TYPE, "token"],
 )
 
 PARTITION_KEY_CAPACITY_EXCEEDED_COUNTER = Counter(
@@ -74,25 +71,23 @@ TOKEN_SHAPE_INVALID_COUNTER = Counter(
 )
 
 
-def parse_kafka_event_data(
+def build_kafka_event_data(
     distinct_id: str,
     ip: Optional[str],
     site_url: str,
     data: Dict,
-    team_id: Optional[int],
     now: datetime,
     sent_at: Optional[datetime],
     event_uuid: UUIDT,
     token: str,
 ) -> Dict:
-    logger.debug("parse_kafka_event_data", token=token, team_id=team_id)
+    logger.debug("build_kafka_event_data", token=token)
     return {
         "uuid": str(event_uuid),
         "distinct_id": safe_clickhouse_string(distinct_id),
         "ip": safe_clickhouse_string(ip) if ip else ip,
         "site_url": safe_clickhouse_string(site_url),
         "data": json.dumps(data),
-        "team_id": team_id,
         "now": now.isoformat(),
         "sent_at": sent_at.isoformat() if sent_at else "",
         "token": token,
@@ -120,39 +115,6 @@ def log_event(data: Dict, event_name: str, partition_key: Optional[str]):
         statsd.incr("capture_endpoint_log_event_error")
         logger.exception("Failed to produce event to Kafka topic %s with error", kafka_topic)
         raise e
-
-
-def log_event_to_dead_letter_queue(
-    raw_payload: Dict,
-    event_name: str,
-    event: Dict,
-    error_message: str,
-    error_location: str,
-    topic: str = KAFKA_DEAD_LETTER_QUEUE,
-):
-    data = event.copy()
-
-    data["error_timestamp"] = datetime.now().isoformat()
-    data["error_location"] = safe_clickhouse_string(error_location)
-    data["error"] = safe_clickhouse_string(error_message)
-    data["elements_chain"] = ""
-    data["id"] = str(UUIDT())
-    data["event"] = safe_clickhouse_string(event_name)
-    data["raw_payload"] = json.dumps(raw_payload)
-    data["now"] = datetime.fromisoformat(data["now"]).replace(tzinfo=None).isoformat() if data["now"] else None
-    data["tags"] = ["django_server"]
-    data["event_uuid"] = event["uuid"]
-    del data["uuid"]
-
-    try:
-        KafkaProducer().produce(topic=topic, data=data)
-        statsd.incr(settings.EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC)
-    except Exception as e:
-        capture_exception(e)
-        statsd.incr("events_dead_letter_queue_produce_error")
-
-        if settings.DEBUG:
-            print("Failed to produce to events dead letter queue with error:", e)
 
 
 def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:
@@ -228,27 +190,7 @@ def get_distinct_id(data: Dict[str, Any]) -> str:
     return str(raw_value)[0:200]
 
 
-def _ensure_web_feature_flags_in_properties(
-    event: Dict[str, Any], ingestion_context: EventIngestionContext, distinct_id: str
-):
-    """If the event comes from web, ensure that it contains property $active_feature_flags."""
-    if event["properties"].get("$lib") == "web" and "$active_feature_flags" not in event["properties"]:
-        statsd.incr("active_feature_flags_missing")
-        all_flags, _, _, _ = get_all_feature_flags(team_id=ingestion_context.team_id, distinct_id=distinct_id)
-        active_flags = {key: value for key, value in all_flags.items() if value}
-        flag_keys = list(active_flags.keys())
-        event["properties"]["$active_feature_flags"] = flag_keys
-
-        if len(flag_keys) > 0:
-            statsd.incr("active_feature_flags_added")
-
-            for k, v in active_flags.items():
-                event["properties"][f"$feature/{k}"] = v
-
-
-def drop_events_over_quota(
-    token: str, events: List[Any], ingestion_context: Optional[EventIngestionContext]
-) -> List[Any]:
+def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     if not settings.EE_AVAILABLE:
         return events
 
@@ -257,17 +199,16 @@ def drop_events_over_quota(
     results = []
     limited_tokens_events = list_limited_team_tokens(QuotaResource.EVENTS)
     limited_tokens_recordings = list_limited_team_tokens(QuotaResource.RECORDINGS)
-    team_id = ingestion_context.team_id if ingestion_context else None
 
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             if token in limited_tokens_recordings:
-                EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="recordings", team_id=team_id, token=token).inc()
+                EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="recordings", token=token).inc()
                 if settings.QUOTA_LIMITING_ENABLED:
                     continue
 
         elif token in limited_tokens_events:
-            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="events", team_id=team_id, token=token).inc()
+            EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="events", token=token).inc()
             if settings.QUOTA_LIMITING_ENABLED:
                 continue
 
@@ -279,7 +220,6 @@ def drop_events_over_quota(
 @csrf_exempt
 @timed("posthog_cloud_event_endpoint")
 def get_event(request):
-    # At this point, we don't now which team_id we are working with, so unbind if set.
     structlog.contextvars.unbind_contextvars("team_id")
 
     # handle cors request
@@ -319,37 +259,21 @@ def get_event(request):
             invalid_token_reason = "exception"
             logger.warning("capture_token_shape_exception", token=token, reason="exception", exception=e)
 
-        ingestion_context = None
-        send_events_to_dead_letter_queue = False
+        if invalid_token_reason:
+            TOKEN_SHAPE_INVALID_COUNTER.labels(reason=invalid_token_reason).inc()
+            logger.warning("capture_token_shape_invalid", token=token, reason=invalid_token_reason)
+            return cors_response(
+                request,
+                generate_exception_response(
+                    "capture",
+                    f"Provided API key is not valid: {invalid_token_reason}",
+                    type="authentication_error",
+                    code=invalid_token_reason,
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                ),
+            )
 
-        if settings.LIGHTWEIGHT_CAPTURE_ENDPOINT_ALL or token in settings.LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS:
-            if invalid_token_reason:
-                TOKEN_SHAPE_INVALID_COUNTER.labels(reason=invalid_token_reason).inc()
-                logger.warning("capture_token_shape_invalid", token=token, reason=invalid_token_reason)
-                return cors_response(
-                    request,
-                    generate_exception_response(
-                        "capture",
-                        f"Provided API key is not valid: {invalid_token_reason}",
-                        type="authentication_error",
-                        code=invalid_token_reason,
-                        status_code=status.HTTP_401_UNAUTHORIZED,
-                    ),
-                )
-
-            logger.debug("lightweight_capture_endpoint_hit", token=token)
-            statsd.incr("lightweight_capture_endpoint_hit")
-        else:
-            ingestion_context, db_error, error_response = get_event_ingestion_context(request, data, token)
-
-            if error_response:
-                return error_response
-
-            if db_error:
-                send_events_to_dead_letter_queue = True
-
-    team_id = ingestion_context.team_id if ingestion_context else None
-    structlog.contextvars.bind_contextvars(team_id=team_id)
+    structlog.contextvars.bind_contextvars(token=token)
 
     with start_span(op="request.process"):
         if isinstance(data, dict):
@@ -365,7 +289,7 @@ def get_event(request):
             events = [data]
 
         try:
-            events = drop_events_over_quota(token, events, ingestion_context)
+            events = drop_events_over_quota(token, events)
         except Exception as e:
             # NOTE: Whilst we are testing this code we want to track exceptions but allow the events through if anything goes wrong
             capture_exception(e)
@@ -378,11 +302,10 @@ def get_event(request):
             )
 
         site_url = request.build_absolute_uri("/")[:-1]
-
-        ip = None if ingestion_context and ingestion_context.anonymize_ips else get_ip_address(request)
+        ip = get_ip_address(request)
 
         try:
-            processed_events = list(validate_events(events, ingestion_context))
+            processed_events = list(preprocess_events(events))
         except ValueError as e:
             return cors_response(
                 request, generate_exception_response("capture", f"Invalid payload: {e}", code="invalid_payload")
@@ -393,34 +316,8 @@ def get_event(request):
     with start_span(op="kafka.produce") as span:
         span.set_tag("event.count", len(processed_events))
         for event, event_uuid, distinct_id in processed_events:
-            if send_events_to_dead_letter_queue:
-                kafka_event = parse_kafka_event_data(
-                    distinct_id=distinct_id,
-                    ip=None,
-                    site_url=site_url,
-                    team_id=None,
-                    now=now,
-                    event_uuid=event_uuid,
-                    data=event,
-                    sent_at=sent_at,
-                    token=token,
-                )
-
-                log_event_to_dead_letter_queue(
-                    data,
-                    event["event"],
-                    kafka_event,
-                    f"Unable to fetch team from Postgres. Error: {db_error}",
-                    "django_server_capture_endpoint",
-                )
-                continue
-
             try:
-                futures.append(
-                    capture_internal(
-                        event, distinct_id, ip, site_url, now, sent_at, team_id, event_uuid, token
-                    )  # type: ignore
-                )
+                futures.append(capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid, token))
             except Exception as exc:
                 capture_exception(exc, {"data": data})
                 statsd.incr("posthog_cloud_raw_endpoint_failure", tags={"endpoint": "capture"})
@@ -463,10 +360,7 @@ def get_event(request):
     return cors_response(request, JsonResponse({"status": 1}))
 
 
-# TODO: Rename this function - it doesn't just validate events, it also processes them
-def validate_events(
-    events: List[Dict[str, Any]], ingestion_context: Optional[EventIngestionContext]
-) -> Iterator[Tuple[Dict[str, Any], UUIDT, str]]:
+def preprocess_events(events: List[Dict[str, Any]]) -> Iterator[Tuple[Dict[str, Any], UUIDT, str]]:
     for event in events:
         event_uuid = UUIDT()
         distinct_id = get_distinct_id(event)
@@ -481,10 +375,6 @@ def validate_events(
         event = parse_event(event)
         if not event:
             continue
-
-        if ingestion_context:
-            # TODO: Get rid of this code path after informing users about bootstrapping feature flags
-            _ensure_web_feature_flags_in_properties(event, ingestion_context, distinct_id)
 
         yield event, event_uuid, distinct_id
 
@@ -504,16 +394,15 @@ def parse_event(event):
     return event
 
 
-def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, event_uuid=None, token=None) -> None:
+def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=None, token=None):
     if event_uuid is None:
         event_uuid = UUIDT()
 
-    parsed_event = parse_kafka_event_data(
+    parsed_event = build_kafka_event_data(
         distinct_id=distinct_id,
         ip=ip,
         site_url=site_url,
         data=event,
-        team_id=team_id,
         now=now,
         sent_at=sent_at,
         event_uuid=event_uuid,
@@ -528,10 +417,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, ev
     if event["event"] in ("$snapshot", "$performance_event"):
         return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
 
-    if team_id:
-        candidate_partition_key = f"{team_id}:{distinct_id}"
-    else:
-        candidate_partition_key = f"{token}:{distinct_id}"
+    candidate_partition_key = f"{token}:{distinct_id}"
 
     if is_randomly_partitioned(candidate_partition_key) is False:
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -54,7 +54,7 @@ SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event")
 
 EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
     "capture_events_dropped_over_quota",
-    "Events dropped by capture due to quota-limiting, per resource_type, team_id and token.",
+    "Events dropped by capture due to quota-limiting, per resource_type and token.",
     labelnames=[LABEL_RESOURCE_TYPE, "token"],
 )
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -355,7 +355,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             distinct_id=person.distinct_ids[0],
             ip=None,
             site_url=None,
-            team_id=self.team_id,
+            token=self.team.api_token,
             now=datetime.now(),
             sent_at=None,
             event={
@@ -438,7 +438,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             distinct_id=instance.distinct_ids[0],
             ip=None,
             site_url=None,
-            team_id=instance.team_id,
+            token=instance.team.api_token,
             now=datetime.now(),
             sent_at=None,
             event={

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -102,24 +102,13 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -130,7 +119,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -141,7 +130,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -169,7 +158,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -189,6 +178,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -102,13 +102,24 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -119,7 +130,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -130,7 +141,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -158,7 +169,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -178,22 +189,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -7,7 +7,7 @@
          'a%sd',
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 70), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 68), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -23,7 +23,7 @@
          'a%sd',
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 70), equals(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), 'test_val3'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 68), equals(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), 'test_val3'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -39,7 +39,7 @@
          'a%sd',
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 70), ilike(replaceRegexpAll(JSONExtractRaw(events.properties, 'path'), '^"|"$', ''), '%/%'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 68), ilike(replaceRegexpAll(JSONExtractRaw(events.properties, 'path'), '^"|"$', ''), '%/%'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -55,7 +55,7 @@
          'a%sd',
          concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(events.team_id, 71), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 69), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -71,7 +71,7 @@
          'a%sd',
          concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(events.team_id, 71), equals(events.mat_key, 'test_val3'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 69), equals(events.mat_key, 'test_val3'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -87,7 +87,7 @@
          'a%sd',
          concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(events.team_id, 71), ilike(events.mat_path, '%/%'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 69), ilike(events.mat_path, '%/%'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -101,7 +101,7 @@
          events.distinct_id,
          replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '')
   FROM events
-  WHERE equals(events.team_id, 72)
+  WHERE equals(events.team_id, 70)
   ORDER BY events.timestamp ASC
   LIMIT 100 SETTINGS readonly=1,
                      max_execution_time=60
@@ -114,7 +114,7 @@
          events.distinct_id,
          events.mat_key
   FROM events
-  WHERE equals(events.team_id, 73)
+  WHERE equals(events.team_id, 71)
   ORDER BY events.timestamp ASC
   LIMIT 100 SETTINGS readonly=1,
                      max_execution_time=60
@@ -129,7 +129,7 @@
          'a%sd',
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 74), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 72), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -145,7 +145,7 @@
          'a%sd',
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 74), equals('a%sd', 'foo'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 72), equals('a%sd', 'foo'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -161,7 +161,7 @@
          'a%sd',
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 74), equals('a%sd', 'a%sd'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 72), equals('a%sd', 'a%sd'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -177,7 +177,7 @@
          'a%sd',
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 74), equals(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), 'test_val2'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 72), equals(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), 'test_val2'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -193,7 +193,7 @@
          'a%sd',
          concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(events.team_id, 75), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 73), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -209,7 +209,7 @@
          'a%sd',
          concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(events.team_id, 75), equals('a%sd', 'foo'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 73), equals('a%sd', 'foo'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -225,7 +225,7 @@
          'a%sd',
          concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(events.team_id, 75), equals('a%sd', 'a%sd'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 73), equals('a%sd', 'a%sd'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -241,7 +241,7 @@
          'a%sd',
          concat(events.event, ' ', events.mat_key)
   FROM events
-  WHERE and(equals(events.team_id, 75), equals(events.mat_key, 'test_val2'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 73), equals(events.mat_key, 'test_val2'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -261,17 +261,17 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 79)
+     WHERE equals(person_distinct_id2.team_id, 77)
      GROUP BY person_distinct_id2.distinct_id
      HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''), person.version) AS properties___email,
             person.id
      FROM person
-     WHERE equals(person.team_id, 79)
+     WHERE equals(person.team_id, 77)
      GROUP BY person.id
      HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(events.team_id, 79), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 77), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -291,17 +291,17 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 80)
+     WHERE equals(person_distinct_id2.team_id, 78)
      GROUP BY person_distinct_id2.distinct_id
      HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(person.pmat_email, person.version) AS properties___email,
             person.id
      FROM person
-     WHERE equals(person.team_id, 80)
+     WHERE equals(person.team_id, 78)
      GROUP BY person.id
      HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(events.team_id, 80), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 78), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -314,7 +314,7 @@
   SELECT replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 81), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 79), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '')
   ORDER BY count() DESC
   LIMIT 101
@@ -328,7 +328,7 @@
   SELECT replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 81), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 79), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '')
   HAVING and(greater(count(), 1))
   ORDER BY count() DESC
@@ -343,7 +343,7 @@
   SELECT events.mat_key,
          count()
   FROM events
-  WHERE and(equals(events.team_id, 82), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 80), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY events.mat_key
   ORDER BY count() DESC
   LIMIT 101
@@ -357,7 +357,7 @@
   SELECT events.mat_key,
          count()
   FROM events
-  WHERE and(equals(events.team_id, 82), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 80), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY events.mat_key
   HAVING and(greater(count(), 1))
   ORDER BY count() DESC
@@ -373,7 +373,7 @@
          events.distinct_id,
          events.distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 83), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 81), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -388,7 +388,7 @@
          events.distinct_id,
          concat(events.event, ' ', replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''))
   FROM events
-  WHERE and(equals(events.team_id, 84), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 82), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -401,7 +401,7 @@
   SELECT tuple(events.uuid, events.event, events.properties, events.timestamp, events.team_id, events.distinct_id, events.elements_chain, events.created_at),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 84), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 82), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   ORDER BY tuple(events.uuid, events.event, events.properties, events.timestamp, events.team_id, events.distinct_id, events.elements_chain, events.created_at) ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=1,
@@ -414,7 +414,7 @@
   SELECT count(),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 84), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 82), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY events.event
   ORDER BY count() DESC
   LIMIT 101
@@ -428,7 +428,7 @@
   SELECT count(),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 84), or(equals(events.event, 'sign up'), like(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), '%val2')), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
+  WHERE and(equals(events.team_id, 82), or(equals(events.event, 'sign up'), like(replaceRegexpAll(JSONExtractRaw(events.properties, 'key'), '^"|"$', ''), '%val2')), less(events.timestamp, '2020-01-10 12:14:05.000000'), greater(events.timestamp, '2020-01-09 12:00:00.000000'))
   GROUP BY events.event
   ORDER BY count() DESC, events.event ASC
   LIMIT 101

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -375,7 +375,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             distinct_id="some_distinct_id",
             ip=None,
             site_url=None,
-            team_id=self.team.id,
+            token=self.team.api_token,
             now=mock.ANY,
             sent_at=None,
             event={
@@ -401,7 +401,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             distinct_id="some_distinct_id",
             ip=None,
             site_url=None,
-            team_id=self.team.id,
+            token=self.team.api_token,
             now=mock.ANY,
             sent_at=None,
             event={

--- a/posthog/management/commands/plugin_server_load_test.py
+++ b/posthog/management/commands/plugin_server_load_test.py
@@ -13,6 +13,7 @@ from kafka import KafkaAdminClient, KafkaConsumer, TopicPartition
 
 from posthog.api.capture import capture_internal
 from posthog.demo.products.hedgebox import HedgeboxMatrix
+from posthog.models import Team
 from posthog.settings import KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
 
 logging.getLogger("kafka").setLevel(logging.WARNING)  # Hide kafka-python's logspam
@@ -56,6 +57,7 @@ class Command(BaseCommand):
 
         admin = KafkaAdminClient(bootstrap_servers=settings.KAFKA_HOSTS)
         consumer = KafkaConsumer(KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC, bootstrap_servers=settings.KAFKA_HOSTS)
+        token = Team.objects.filter(id=int(options["team_id"])).first().api_token
 
         logger.info(
             "creating_data",
@@ -92,7 +94,7 @@ class Command(BaseCommand):
                 distinct_id=event.distinct_id,
                 ip="",
                 site_url="",
-                team_id=options["team_id"],
+                token=token,
                 now=event.timestamp,
                 sent_at=event.timestamp,
             )

--- a/posthog/management/commands/plugin_server_load_test.py
+++ b/posthog/management/commands/plugin_server_load_test.py
@@ -57,7 +57,11 @@ class Command(BaseCommand):
 
         admin = KafkaAdminClient(bootstrap_servers=settings.KAFKA_HOSTS)
         consumer = KafkaConsumer(KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC, bootstrap_servers=settings.KAFKA_HOSTS)
-        token = Team.objects.filter(id=int(options["team_id"])).first().api_token
+        team = Team.objects.filter(id=int(options["team_id"])).first()
+        if not team:
+            logger.critical("Cannot find team with id: " + options["team_id"])
+            exit(1)
+        token = team.api_token
 
         logger.info(
             "creating_data",

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -286,8 +286,8 @@
                           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
                        WHERE team_id = 2
                          AND event IN ['$autocapture', 'user signed up', '$autocapture', '$autocapture']
-                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-27 00:00:00', 'UTC')
-                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-03 23:59:59', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-28 00:00:00', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-04 23:59:59', 'UTC')
                          AND notEmpty(e.person_id)
                          AND (step_0 = 1
                               OR step_1 = 1

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -14,9 +14,6 @@ BUFFER_CONVERSION_SECONDS = get_from_env("BUFFER_CONVERSION_SECONDS", default=60
 # This is a measure to handle hot partitions in ad-hoc cases.
 EVENT_PARTITION_KEYS_TO_OVERRIDE = get_list(os.getenv("EVENT_PARTITION_KEYS_TO_OVERRIDE", ""))
 
-LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS = get_list(os.getenv("LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS", ""))
-LIGHTWEIGHT_CAPTURE_ENDPOINT_ALL = "*" in LIGHTWEIGHT_CAPTURE_ENDPOINT_ENABLED_TOKENS
-
 # Keep in sync with plugin-server
 EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC = "events_added_to_dead_letter_queue"
 


### PR DESCRIPTION
## Problem

Lightweight capture has been running for a month now, so the team resolution path is now dead code. Let's remove it to make the real code path more explicit.

## Changes

- Remove all occurences of `team_id` from `capture.py` and the dead code branches, including: 
  - `log_event_to_dead_letter_queue`, as it was only used in case PG was down. Kafka being down generates 503s (service unavailable).
  - `EventIngestionContext` and its associated methods and tests from utils
  - `_ensure_web_feature_flags_in_properties` (deprecation was announced twice on Slack)
- Rename the misleadingly named functions
- Update `person.py` to submit events with a token instead of a team_id. This change ensures that these events will be co-located with the distinct_id's other events
- Update tests, and remove the ones testing removed features:
  - `test_capture_event_ip_anonymize` handled in plugin-server-ingestion now
  - `test_personal_api_key`, `test_personal_api_key_from_batch_request` and `test_batch_request_with_invalid_auth`: this auth method has been deprecated (used by old versions of the zapier integration)
  - `test_batch_incorrect_token` -> `test_batch_incorrect_token_shape`
  - `test_add_feature_flags_if_missing` feature flag value backfill has been deprecated
  - `test_database_unavailable`: we don't hit PG anymore

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

- Unit and e2e test coverage

- Manual tests:
  - local instance with autocapture works fine (both events and recordings)
  - adding and removing properties from the app (person.py) work fine