### PR TITLE
feat(capture): use date header instead of timestamp

### DIFF
--- a/openapi/capture.yaml
+++ b/openapi/capture.yaml
@@ -46,23 +46,9 @@ paths:
                 PostHog.
 
             parameters:
-                - in: query
-                  name: ip
-                  schema:
-                      type: string
-                      format: ipv4
-                      description: |
-                          The IP address of the user. This is used to geolocate the user.
-                - in: query
-                  name: compression
-                  description: |
-                      The compression method used to compress the request body.
-                  schema:
-                      type: string
-                      enum:
-                          - gzip-js
-                          - gzip
-                          - lz64
+                - $ref: '#/components/parameters/ipParameter'
+                - $ref: '#/components/parameters/compressionParameter'
+                - $ref: '#/components/parameters/dateHeader'
 
             responses:
                 '200':
@@ -134,23 +120,9 @@ paths:
                 be set to the current time.
 
             parameters:
-                - in: query
-                  name: ip
-                  schema:
-                      type: string
-                      format: ipv4
-                      description: |
-                          The IP address of the user. This is used to geolocate the user.
-                - in: query
-                  name: compression
-                  description: |
-                      The compression method used to compress the request body.
-                  schema:
-                      type: string
-                      enum:
-                          - gzip-js
-                          - gzip
-                          - lz64
+                - $ref: '#/components/parameters/ipParameter'
+                - $ref: '#/components/parameters/compressionParameter'
+                - $ref: '#/components/parameters/dateHeader'
 
             responses:
                 '200':
@@ -332,3 +304,54 @@ components:
                 detail:
                     type: string
                     example: 'Invalid API key'
+
+    parameters:
+        ipParameter:
+            in: query
+            name: ip
+            schema:
+                type: string
+                format: ipv4
+                description: |
+                    The IP address of the user. This is used to geolocate the user.
+        compressionParameter:
+            in: query
+            name: compression
+            description: |
+                The compression method used to compress the request body.
+            schema:
+                type: string
+                enum:
+                    - gzip-js
+                    - gzip
+                    - lz64
+        dateHeader:
+            in: header
+            name: Date
+            schema:
+                type: string
+                format: date-time
+            required: false
+            description: |
+                The date and time of the event. This is used to calculate
+                clock skew between the client and the server. It is
+                in the format as specified in
+                [RFC5322](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.3)
+                which looks like:
+
+                ```
+                Date: <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT
+                ```
+
+                For example:
+
+                ```
+                Date: Mon, 27 Jul 2009 12:28:53 GMT
+                ```
+
+                If you don't set this header, we'll use the `sent_at` in the JSON
+                payload, and finally the current time.
+
+                All browser HTTP clients will automatically set this
+                header for you, so you don't need to worry about it.
+                For other clients, you may need to set it manually.

--- a/openapi/capture.yaml
+++ b/openapi/capture.yaml
@@ -49,6 +49,7 @@ paths:
                 - $ref: '#/components/parameters/ipParameter'
                 - $ref: '#/components/parameters/compressionParameter'
                 - $ref: '#/components/parameters/dateHeader'
+                - $ref: '#/components/parameters/contentEncodingHeader'
 
             responses:
                 '200':
@@ -123,6 +124,7 @@ paths:
                 - $ref: '#/components/parameters/ipParameter'
                 - $ref: '#/components/parameters/compressionParameter'
                 - $ref: '#/components/parameters/dateHeader'
+                - $ref: '#/components/parameters/contentEncodingHeader'
 
             responses:
                 '200':
@@ -355,3 +357,14 @@ components:
                 All browser HTTP clients will automatically set this
                 header for you, so you don't need to worry about it.
                 For other clients, you may need to set it manually.
+        contentEncodingHeader:
+            in: header
+            name: Content-Encoding
+            schema:
+                type: string
+                enum:
+                    - gzip
+                    - lz64
+            required: false
+            description: |
+                The compression method used to compress the request body.

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -286,8 +286,8 @@
                           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
                        WHERE team_id = 2
                          AND event IN ['$autocapture', 'user signed up', '$autocapture', '$autocapture']
-                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-28 00:00:00', 'UTC')
-                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-04 23:59:59', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-29 00:00:00', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-05 23:59:59', 'UTC')
                          AND notEmpty(e.person_id)
                          AND (step_0 = 1
                               OR step_1 = 1


### PR DESCRIPTION
We're currently using a specific field in the payload, `sent_at`, or the
`_` query parameter to determine the client size timestamp of when an
HTTP request is made. This has the chance of introducing bugs in client
libraries, as these fields can be generated well before the HTTP request
is made, meaning when we compensate for clock skew, the resulting
timestamp can be wildly off.

HTTP already defines a `Date` header, which is the time the request was
made according to the client. See
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date for more
information. It is supported by pretty much all the browsers.

As for other HTTP clients, we'll need to check to see if they send this
by default for the ones we care about, and if not, we'll need to add it
ourselves.

Side quest: I added headers validation against OpenAPI specs, and did some 
refactoring there.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
