### PR TITLE
chore(capture): increase tracing rate on /s for a bit

### DIFF
--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -286,8 +286,8 @@
                           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
                        WHERE team_id = 2
                          AND event IN ['$autocapture', 'user signed up', '$autocapture', '$autocapture']
-                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-28 00:00:00', 'UTC')
-                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-04 23:59:59', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-29 00:00:00', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-05 23:59:59', 'UTC')
                          AND notEmpty(e.person_id)
                          AND (step_0 = 1
                               OR step_1 = 1

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -32,6 +32,9 @@ def traces_sampler(sampling_context: dict) -> float:
         if path.startswith("/batch"):
             return 0.00000001  # 0.000001%
         # Ingestion endpoints (high volume)
+        elif path.startswith("/s"):
+            return 0.00001  # 0.001%
+        # Ingestion endpoints (high volume)
         elif path.startswith(("/capture", "/decide", "/track", "/s", "/e")):
             return 0.0000001  # 0.00001%
         # Probes/monitoring endpoints


### PR DESCRIPTION
## Problem

p99 latency on `/s` (session recording) is a lot higher than `/e` (between 2 and 4 seconds, vs less than a second on /e). Let's collect more traces for a day to check whether the latency comes from processing or kafka production.

Will open the revert PR as soon as I merge this one.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
