### PR TITLE
feat: Override partition key for likely anonymous IDs

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -442,7 +442,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
 
     candidate_partition_key = f"{token}:{distinct_id}"
 
-    if distinct_id.lower() not in LIKELY_ANONYMOUS_IDS or is_randomly_partitioned(candidate_partition_key) is False:
+    if distinct_id.lower() not in LIKELY_ANONYMOUS_IDS and is_randomly_partitioned(candidate_partition_key) is False:
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
 
     return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -72,7 +72,12 @@ TOKEN_SHAPE_INVALID_COUNTER = Counter(
     labelnames=["reason"],
 )
 
-
+# This is a heuristic of ids we have seen used as anonymous. As they frequently
+# have significantly more traffic than non-anonymous distinct_ids, and likely
+# don't refer to the same underlying person we prefer to partition them randomly
+# to distribute the load.
+# This list mimics the array used in the plugin-server, and should be kept in-sync. See:
+# https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L22-L33
 LIKELY_ANONYMOUS_IDS = {
     "0",
     "anon",

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -74,18 +74,19 @@ TOKEN_SHAPE_INVALID_COUNTER = Counter(
 
 
 LIKELY_ANONYMOUS_IDS = {
-    "anon_id",
     "anon",
+    "anon_id",
     "anonymous",
-    "guest",
-    "distinctid",
+    "anonymous_id",
     "distinct_id",
+    "distinctid",
+    "email",
+    "false",
+    "guest",
     "id",
     "not_authenticated",
-    "email",
-    "undefined",
     "true",
-    "false",
+    "undefined",
 }
 
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -472,7 +472,7 @@ def is_randomly_partitioned(candidate_partition_key: str) -> bool:
     if settings.PARTITION_KEY_AUTOMATIC_OVERRIDE_ENABLED:
         has_capacity = LIMITER.consume(candidate_partition_key)
 
-        if has_capacity is False or candidate_partition_key in LIKELY_ANONYMOUS_IDS:
+        if has_capacity is False or candidate_partition_key.rsplit(":")[1] in LIKELY_ANONYMOUS_IDS:
             if not LOG_RATE_LIMITER.consume(candidate_partition_key):
                 # Return early if we have logged this key already.
                 return True

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -74,6 +74,7 @@ TOKEN_SHAPE_INVALID_COUNTER = Counter(
 
 
 LIKELY_ANONYMOUS_IDS = {
+    "0",
     "anon",
     "anon_id",
     "anonymous",
@@ -84,7 +85,10 @@ LIKELY_ANONYMOUS_IDS = {
     "false",
     "guest",
     "id",
+    "nan",
+    "none",
     "not_authenticated",
+    "null",
     "true",
     "undefined",
 }

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -438,7 +438,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
 
     candidate_partition_key = f"{token}:{distinct_id}"
 
-    if is_randomly_partitioned(candidate_partition_key) is False:
+    if distinct_id.lower() not in LIKELY_ANONYMOUS_IDS or is_randomly_partitioned(candidate_partition_key) is False:
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
 
     return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
@@ -472,7 +472,7 @@ def is_randomly_partitioned(candidate_partition_key: str) -> bool:
     if settings.PARTITION_KEY_AUTOMATIC_OVERRIDE_ENABLED:
         has_capacity = LIMITER.consume(candidate_partition_key)
 
-        if has_capacity is False or candidate_partition_key.rsplit(":")[1] in LIKELY_ANONYMOUS_IDS:
+        if has_capacity is False:
             if not LOG_RATE_LIMITER.consume(candidate_partition_key):
                 # Return early if we have logged this key already.
                 return True

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -445,7 +445,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 116,
+  SELECT 117,
          person_id,
          key,
          'random'
@@ -526,7 +526,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 116,
+  SELECT 117,
          person_id,
          key,
          'random'


### PR DESCRIPTION
## Problem

We generally override partition keys once they go over ingestion limit. However, this override is sometimes too slow and too local. As a heuristic, we can rely on certain ids being anonymous, so they should be overriden.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

In capture, override list of IDs that are likely anonymous.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
