### PR TITLE
fix: Add autopurge to zookeeper to prevent snapshot bloat

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -32,6 +32,8 @@ services:
     zookeeper:
         image: zookeeper:3.7.0
         restart: on-failure
+        environment:
+            ZOO_AUTOPURGE_PURGEINTERVAL: 12
 
     kafka:
         image: bitnami/kafka:2.8.1-debian-10-r99


### PR DESCRIPTION

## Problem
By default zookeeper doesn't automatically clean up after itself and will bloat forever, set autopurge to happen every 12 hours to keep it under control

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
