### PR TITLE
feat(admin): allow to search orgs and teams by token

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -59,7 +59,7 @@ class PluginAdmin(admin.ModelAdmin):
 @admin.register(Team)
 class TeamAdmin(admin.ModelAdmin):
     list_display = ("id", "name", "organization_link", "organization_id")
-    search_fields = ("id", "name", "organization__id", "organization__name")
+    search_fields = ("id", "name", "organization__id", "organization__name", "api_token")
     readonly_fields = ["primary_dashboard", "test_account_filters"]
     exclude = [
         "event_names",
@@ -207,7 +207,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         "usage_posthog",
         "usage",
     ]
-    search_fields = ("name", "members__email")
+    search_fields = ("name", "members__email", "team__api_token")
     list_display = (
         "name",
         "created_at",

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -445,7 +445,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 117,
+  SELECT 116,
          person_id,
          key,
          'random'
@@ -526,7 +526,7 @@
          (SELECT feature_flag_key
           FROM existing_overrides) )
   INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT 117,
+  SELECT 116,
          person_id,
          key,
          'random'

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -286,8 +286,8 @@
                           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
                        WHERE team_id = 2
                          AND event IN ['$autocapture', 'user signed up', '$autocapture', '$autocapture']
-                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-29 00:00:00', 'UTC')
-                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-05 23:59:59', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-03-30 00:00:00', 'UTC')
+                         AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-04-06 23:59:59', 'UTC')
                          AND notEmpty(e.person_id)
                          AND (step_0 = 1
                               OR step_1 = 1


### PR DESCRIPTION
## Problem

To investigate intake spikes and imbalances, we now have to resolve tokens to teams manually. Instead of running a PG query through metabase, this PR allows us to directly search the organization holding that token. From the org, we can quickly bounce to users.

Also added it to teams for least surprise, but org looks like the best entrypoint.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
