### PR TITLE
chore(plugin-server): collect prometheus metrics from piscina workers

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -74,7 +74,7 @@
         "pino": "^8.6.0",
         "posthog-node": "2.0.2",
         "pretty-bytes": "^5.6.0",
-        "prom-client": "^14.1.1",
+        "prom-client": "^14.2.0",
         "re2": "^1.17.7",
         "safe-stable-stringify": "^2.4.0",
         "snowflake-sdk": "^1.6.10",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -83,7 +83,7 @@ specifiers:
   posthog-node: 2.0.2
   prettier: ^2.7.1
   pretty-bytes: ^5.6.0
-  prom-client: ^14.1.1
+  prom-client: ^14.2.0
   re2: ^1.17.7
   safe-stable-stringify: ^2.4.0
   snowflake-sdk: ^1.6.10
@@ -133,7 +133,7 @@ dependencies:
   pino: 8.7.0
   posthog-node: 2.0.2
   pretty-bytes: 5.6.0
-  prom-client: 14.1.1
+  prom-client: 14.2.0
   re2: 1.17.7
   safe-stable-stringify: 2.4.1
   snowflake-sdk: 1.6.15_asn1.js@5.4.1
@@ -8141,8 +8141,8 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  /prom-client/14.1.1:
-    resolution: {integrity: sha512-hFU32q7UZQ59bVJQGUtm3I2PrJ3gWvoCkilX9sF165ks1qflhugVCeK+S1JjJYHvyt3o5kj68+q3bchormjnzw==}
+  /prom-client/14.2.0:
+    resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
     engines: {node: '>=10'}
     dependencies:
       tdigest: 0.1.2

--- a/plugin-server/src/main/ingestion-queues/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/metrics.ts
@@ -6,6 +6,7 @@ export const latestOffsetTimestampGauge = new Gauge({
     name: 'latest_processed_timestamp_ms',
     help: 'Timestamp of the latest offset that has been committed.',
     labelNames: ['topic', 'partition', 'groupId'],
+    aggregator: 'max',
 })
 
 export const eventDroppedCounter = new Counter({

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -443,7 +443,7 @@ export async function startPluginsServer(
         }
 
         if (capabilities.http) {
-            httpServer = createHttpServer(healthChecks, analyticsEventsIngestionConsumer)
+            httpServer = createHttpServer(healthChecks, analyticsEventsIngestionConsumer, piscina)
         }
 
         return serverInstance ?? { stop: closeJobs }

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -110,6 +110,15 @@ export function createHttpServer(
     return server
 }
 
+/**
+ * Collects the prometheus metrics to be exposed.
+ * If piscina is disabled, the global registry from the main thread is passed through.
+ * If piscina is enabled, metrics from all the workers are retrieved, then aggregated
+ * with the main thread's metrics before being returned.
+ *
+ * Metrics are summed by default, which is good for counters and histograms.
+ * For gauges, you should set each gauge's aggregator config to one of average, min, max, sum.
+ */
 async function collectMetrics(piscina?: Piscina): Promise<string> {
     if (piscina) {
         // Get metrics from worker threads through piscina

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,4 +1,5 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
+import { register } from 'prom-client'
 
 import { Action, EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType, PostIngestionEvent, Team } from '../types'
 import { convertToProcessedPluginEvent } from '../utils/event'
@@ -64,6 +65,9 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     resetAvailableFeaturesCache: (hub, args: { organization_id: string }) => {
         hub.organizationManager.resetAvailableFeatureCache(args.organization_id)
+    },
+    getPrometheusMetrics: async (_hub) => {
+        return register.getMetricsAsJSON()
     },
     // Exported only for tests
     _testsRunProcessEvent: async (hub, args: { event: PluginEvent }) => {


### PR DESCRIPTION
## Problem

We currently cannot retrieve the prometheus metrics emitted by piscina workers, which leaves a significant gap in our observability. 

## Changes

This PR uses prom-client's `AggregatorRegistry` to expose metrics from all the running threads. If piscina is disabled (eg posthog-recordings-ingestion), the main thread's registry is directly used. Worker thread metrics are collected through a broadcast call of a new `getPrometheusMetrics` task.

`AggregatorRegistry` uses the `cluster` multi-threading library, by it is lazy-loaded to support our use case: we're calling a static function here instead of initializing a new `AggregatorRegistry`.

## How did you test this code?
Works on my machine. The first metric is from the main thread, the second metric from piscina workers and currently [not queryable on prod-eu](http://grafana-prod-eu/explore?orgId=1&left=%7B%22datasource%22:%22PBFA97CFB590B2093%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22builder%22,%22expr%22:%22ingestion_event_hasauthinfo_total%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)

```
# HELP latest_processed_timestamp_ms Timestamp of the latest offset that has been committed.
# TYPE latest_processed_timestamp_ms gauge
latest_processed_timestamp_ms{partition="0",topic="events_plugin_ingestion",groupId="ingestion"} 1680859800053
latest_processed_timestamp_ms{partition="0",topic="clickhouse_events_json",groupId="async_handlers"} 1680859800065
latest_processed_timestamp_ms{partition="0",topic="session_recording_events",groupId="session-recordings"} 1680859827689
latest_processed_timestamp_ms{partition="0",topic="scheduled_tasks",groupId="scheduled-tasks-runner"} 1680859800044

# HELP ingestion_event_hasauthinfo_total Count of events by presence of the team_id and token field.
# TYPE ingestion_event_hasauthinfo_total counter
ingestion_event_hasauthinfo_total{team_id_present="false",token_present="true"} 66
ingestion_event_hasauthinfo_total{team_id_present="true",token_present="false"} 2
```