### PR TITLE
fix(tests): make getEventsByPerson output stable to avoid flakes

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -746,7 +746,6 @@ export class DB {
                 GROUP BY team_id, id
                 HAVING max(is_deleted)=0
             )
-            ORDER BY created_at
             `
             return (await this.clickhouseQuery(query)).data.map((row) => {
                 const { 'person_max._timestamp': _discard1, 'person_max.id': _discard2, ...rest } = row

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -746,6 +746,7 @@ export class DB {
                 GROUP BY team_id, id
                 HAVING max(is_deleted)=0
             )
+            ORDER BY created_at
             `
             return (await this.clickhouseQuery(query)).data.map((row) => {
                 const { 'person_max._timestamp': _discard1, 'person_max.id': _discard2, ...rest } = row

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -69,17 +69,19 @@ export const getEventsByPerson = async (hub: Hub): Promise<EventsByPerson[]> => 
     const events = await hub.db.fetchEvents()
 
     return await Promise.all(
-        persons.map(async (person) => {
-            const distinctIds = await hub.db.fetchDistinctIdValues(person)
+        persons
+            .sort((p1, p2) => p1.created_at.diff(p2.created_at).toMillis())
+            .map(async (person) => {
+                const distinctIds = await hub.db.fetchDistinctIdValues(person)
 
-            return [
-                distinctIds,
-                (events as ClickHouseEvent[])
-                    .filter((event) => distinctIds.includes(event.distinct_id))
-                    .sort((e1, e2) => new Date(e1.timestamp).getTime() - new Date(e2.timestamp).getTime())
-                    .map((event) => event.event),
-            ] as EventsByPerson
-        })
+                return [
+                    distinctIds,
+                    (events as ClickHouseEvent[])
+                        .filter((event) => distinctIds.includes(event.distinct_id))
+                        .sort((e1, e2) => e1.timestamp.diff(e2.timestamp).toMillis())
+                        .map((event) => event.event),
+                ] as EventsByPerson
+            })
     )
 }
 


### PR DESCRIPTION
## Problem

`plugin-server/tests/main/process-event.test.ts` is flaky due to the order of persons not being stable in the output of `getEventsByPerson`. [[example run]](https://github.com/PostHog/posthog/actions/runs/4637082191/jobs/8205612726)

## Changes

Make sure persons are ordered by `created_at` to make the output stable and avoid flakes.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
