### PR TITLE
feat: Zendesk widget

### DIFF
--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -37,3 +37,31 @@
     window.JS_CAPTURE_TIME_TO_SEE_DATA = {{js_capture_time_to_see_data | yesno:"true,false"}};
     window.JS_KEA_VERBOSE_LOGGING = {{js_kea_verbose_logging | yesno:"true,false"}};
 </script>
+{% if zendesk_key %}
+<script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key={{zendesk_key}}">
+    window.zESettings = {
+        cookies: false
+};
+</script>
+<script type="text/javascript">
+    zE('webWidget:on', 'open', function() {
+        zE('webWidget', 'prefill', {
+        name: {
+            value: 'Tiina testing',
+            readOnly: true // optional
+        },
+        email: {
+            value: 'testing@gmail.com',
+            readOnly: true // optional
+        }
+        });
+        posthog.capture('Zendesk form opened')
+    });
+    zE('webWidget:on', 'userEvent', function(event) {
+        // console.log(JSON.stringify(event))
+        if (event.action == "Contact Form Submitted") {
+            posthog.capture('Zendesk form submitted') // TODO: content sent + how to link these two
+        }
+    });
+</script>
+{% endif %}

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -315,6 +315,9 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     if os.environ.get("SENTRY_DSN"):
         context["sentry_dsn"] = os.environ["SENTRY_DSN"]
 
+    if os.environ.get("ZENDESK_KEY"):
+        context["zendesk_key"] = os.environ["ZENDESK_KEY"]
+
     if settings.DEBUG and not settings.TEST:
         context["debug"] = True
         context["git_rev"] = get_git_commit()


### PR DESCRIPTION
## Problem

Problems with using the widget:
- we can't get the content of what was written in the how can I help you box (I couldn't figure out how to get that at least)
- linking between the PostHog event and the Zendesk ticket is not that easy either (couldn't figure out how I could get the ticket id that was submitted, even though I do see the id in the response in the network panel in Chrome. Only idea to create  a uuid when the form is opened and then add that to the Zendesk ticket and PostHog event property (or using as PostHog event uuid)
- message in the end that we'll get back to you soon, which we might not want to for feedback for example

Alternative: using the API to build a custom form https://developer.zendesk.com/documentation/ticketing/managing-tickets/building-a-custom-ticket-form-with-the-zendesk-api/

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

We can get the key from https://posthoghelp.zendesk.com/admin/channels/classic/web-widget (in the setup tab)

`ZENDESK_KEY=<key> DEBUG=1 ./bin/start`

Would result in this showing up in the bottom corner
<img width="146" alt="Screenshot 2023-04-07 at 14 34 21" src="https://user-images.githubusercontent.com/890921/230610647-9e801398-4bd9-410f-9891-77ee0a3d6d10.png">

<img width="319" alt="Screenshot 2023-04-07 at 14 35 05" src="https://user-images.githubusercontent.com/890921/230610701-cf16c80c-9548-4866-8c6c-3682ecf474b4.png">

<img width="609" alt="Screenshot 2023-04-07 at 14 35 19" src="https://user-images.githubusercontent.com/890921/230610720-bc64ba59-37f9-4571-9154-f3f413bfcd47.png">

After submitting the form we see this (& that can't be changed per https://support.zendesk.com/hc/en-us/articles/4415270962842-Can-I-edit-the-Your-request-was-successfully-submitted-confirmation-message-in-the-Help-Center-), which isn't great as we're not planning to get back to everyone, but this sets the expectation that we will.

<img width="277" alt="Screenshot 2023-04-07 at 14 53 23" src="https://user-images.githubusercontent.com/890921/230612609-26279f4d-6a48-476d-a933-2be71312acd8.png">


