### PR TITLE
fix(async-deletion): Fixing Slow Cohort Queries and ClickHouse Memory Limit Issue

### DIFF
--- a/posthog/models/async_deletion/delete.py
+++ b/posthog/models/async_deletion/delete.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Tuple
 import structlog
 from django.utils import timezone
 
-from posthog.models import DeletionType
 from posthog.models.async_deletion import AsyncDeletion
 
 logger = structlog.get_logger(__name__)

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -6,6 +6,8 @@ from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
 
 
 class AsyncCohortDeletion(AsyncDeletionProcess):
+    DELETION_TYPES = [DeletionType.Cohort_full, DeletionType.Cohort_stale]
+
     def process(self, deletions: List[AsyncDeletion]):
         if len(deletions) == 0:
             logger.debug("No AsyncDeletion for cohorts to perform")

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -18,6 +18,8 @@ TABLES_TO_DELETE_TEAM_DATA_FROM = [
 
 
 class AsyncEventDeletion(AsyncDeletionProcess):
+    DELETION_TYPES = [DeletionType.Team, DeletionType.Group, DeletionType.Person]
+
     def process(self, deletions: List[AsyncDeletion]):
         if len(deletions) == 0:
             logger.debug("No AsyncDeletion to perform")


### PR DESCRIPTION
## Description

After upgrading my self-hosted PostHog instance to version 1.43.0, I noticed that cohort queries became very slow and some of them were exceeding the ClickHouse memory limit. After investigating for a couple of days, I discovered that the celery task `clickhouse_clear_removed_data` was no longer executing successfully. At that time, the `cohortpeople` table in ClickHouse had 670M records. I found that this issue was caused by a conflict between `AsyncEventDeletion` and `AsyncCohortDeletion`, as mentioned in issue [#15014](https://github.com/PostHog/posthog/issues/15014).

To fix this issue, I defined a static class variable `AsyncDeletionProcess.DELETION_TYPES` so that queued deletions are filtered with the proper deletion types, resolving the conflict.

Additionally, I identified another bug where the `posthog_asyncdeletion` table in PostgreSQL had 70K records with `delete_verified_at` set to null, causing a `max query size exceeded exception` in ClickHouse. To address this, I rewrote the queries with  `AsyncDeletionProcess.CLICKHOUSE_CHUNK_SIZE` (1000) chunks of `OR` statements in the ClickHouse query WHERE clause, effectively resolving the issue.

This pull request includes the necessary changes to fix these two issues and optimize cohort queries performance in self-hosted PostHog instances using ClickHouse as the data store.

## How did you test this code?
By running `clickhouse_clear_removed_data`  Celery task and checking the state of `cohortpeple` table in ClickHouse and `posthog_asyncdeletion` table in PostgreSQL.