### PR TITLE
feat: Filtering person API by updated after

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -228,7 +228,7 @@
               WHERE team_id = %(team_id)s
               
               GROUP BY id
-              HAVING max(is_deleted) = 0  and max(_timestamp) > toDateTime(%(updated_after)s)
+              HAVING max(is_deleted) = 0  and max(_timestamp) > parseDateTimeBestEffort(%(updated_after)s)
                  
               
               
@@ -244,7 +244,7 @@
               WHERE team_id = %(team_id)s
               
               GROUP BY id
-              HAVING max(is_deleted) = 0  and max(_timestamp) > toDateTime(%(updated_after)s)
+              HAVING max(is_deleted) = 0  and max(_timestamp) > parseDateTimeBestEffort(%(updated_after)s)
                  
               
               

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -7,7 +7,7 @@
               WHERE team_id = %(team_id)s
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
                  
               
               
@@ -28,7 +28,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
@@ -49,7 +49,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND ((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
               
               
@@ -70,7 +70,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s  AND has(%(vpersonquery_grouped_filters__1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__1)s), '^"|"$', ''))  AND has(%(vpersonquery_grouped_filters__2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__2)s), '^"|"$', '')))   
               
               
@@ -86,7 +86,7 @@
               WHERE team_id = %(team_id)s
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
                  
               
               
@@ -107,7 +107,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
@@ -128,7 +128,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND ((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
               
               
@@ -149,7 +149,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND (((  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_0_1)s))AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_grouped_filters__1_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__1_1)s))   
               
               
@@ -170,7 +170,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
@@ -191,7 +191,7 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
@@ -212,8 +212,40 @@
               )
               
               GROUP BY id
-              HAVING max(is_deleted) = 0 
+              HAVING max(is_deleted) = 0  
               AND (  argMax(person."pmat_email", version) ILIKE %(vpersonquery_grouped_filters__0)s)   
+              
+              
+          
+  '
+---
+# name: test_person_query_with_updated_after
+  '
+  
+              SELECT id
+              FROM person
+              
+              WHERE team_id = %(team_id)s
+              
+              GROUP BY id
+              HAVING max(is_deleted) = 0  and max(_timestamp) > toDateTime(%(updated_after)s)
+                 
+              
+              
+          
+  '
+---
+# name: test_person_query_with_updated_after.1
+  '
+  
+              SELECT id
+              FROM person
+              
+              WHERE team_id = %(team_id)s
+              
+              GROUP BY id
+              HAVING max(is_deleted) = 0  and max(_timestamp) > toDateTime(%(updated_after)s)
+                 
               
               
           

--- a/ee/clickhouse/queries/test/test_person_query.py
+++ b/ee/clickhouse/queries/test/test_person_query.py
@@ -202,3 +202,15 @@ def test_person_query_with_entity_filters_and_property_group_filters(testdata, t
 
     assert person_query(team, filter, entity=filter.entities[0]) == snapshot
     assert run_query(team, filter, entity=filter.entities[0]) == {"rows": 2, "columns": 2}
+
+
+def test_person_query_with_updated_after(testdata, team, snapshot):
+    filter = Filter(data={"updated_after": "2023-04-04"})
+
+    assert person_query(team, filter) == snapshot
+    assert run_query(team, filter) == {"rows": 3, "columns": 1}
+
+    filter = Filter(data={"updated_after": "2055-04-04"})
+
+    assert person_query(team, filter) == snapshot
+    assert run_query(team, filter) == {"rows": 0}

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results
   '
-  /* user_id:48 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:49 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results
   '
-  /* user_id:53 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:54 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -140,7 +140,7 @@
 ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_and_events_out_of_time_range_timezones
   '
-  /* user_id:54 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:55 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -280,7 +280,7 @@
 ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:56 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -420,7 +420,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results
   '
-  /* user_id:57 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:58 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -619,7 +619,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:58 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:59 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -762,7 +762,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:60 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:61 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -31,6 +31,7 @@ from posthog.models.filters.mixins.common import (
     SelectorMixin,
     ShownAsMixin,
     SmoothingIntervalsMixin,
+    UpdatedAfterMixin,
 )
 from posthog.models.filters.mixins.funnel import (
     FunnelCorrelationActorsMixin,
@@ -89,6 +90,7 @@ class Filter(
     SearchMixin,
     DistinctIdMixin,
     EmailMixin,
+    UpdatedAfterMixin,
     ClientQueryIdMixin,
     SampleMixin,
     BaseFilter,

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -559,7 +559,7 @@ class EmailMixin(BaseParamMixin):
 
 class UpdatedAfterMixin(BaseParamMixin):
     """
-    Filter on updated after (parsable by CH toDateTime). Only used for person endpoint
+    Filter on updated after (parsable by CH parseDateTimeBestEffort). Only used for person endpoint
     """
 
     @cached_property

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -557,6 +557,17 @@ class EmailMixin(BaseParamMixin):
         return email
 
 
+class UpdatedAfterMixin(BaseParamMixin):
+    """
+    Filter on updated after (parsable by CH toDateTime). Only used for person endpoint
+    """
+
+    @cached_property
+    def updated_after(self) -> Optional[str]:
+        updated_after = self._data.get("updated_after", None)
+        return updated_after
+
+
 class SampleMixin(BaseParamMixin):
     """
     Sample factor for a query.

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -327,5 +327,7 @@ class PersonQuery:
             return "", {}
 
         if self._filter.updated_after:
-            return "and max(_timestamp) > toDateTime(%(updated_after)s)", {"updated_after": self._filter.updated_after}
+            return "and max(_timestamp) > parseDateTimeBestEffort(%(updated_after)s)", {
+                "updated_after": self._filter.updated_after
+            }
         return "", {}

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -100,6 +100,7 @@ class PersonQuery:
         filter_future_persons_query = (
             "and argMax(created_at, version) < now() + interval '1 day'" if filter_future_persons else ""
         )
+        updated_after_clause, updated_after_params = self._get_updated_after_clause()
 
         return (
             f"""
@@ -114,7 +115,7 @@ class PersonQuery:
             )
             {cohort_filters}
             GROUP BY id
-            HAVING max(is_deleted) = 0 {filter_future_persons_query}
+            HAVING max(is_deleted) = 0 {filter_future_persons_query} {updated_after_clause}
             {grouped_person_filters} {search_clause} {distinct_id_clause} {email_clause}
             {"ORDER BY max(created_at) DESC, id" if paginate else ""}
             {limit_offset}
@@ -127,12 +128,13 @@ class PersonQuery:
             WHERE team_id = %(team_id)s
             {cohort_filters}
             GROUP BY id
-            HAVING max(is_deleted) = 0 {filter_future_persons_query}
+            HAVING max(is_deleted) = 0 {filter_future_persons_query} {updated_after_clause}
             {grouped_person_filters} {search_clause} {distinct_id_clause} {email_clause}
             {"ORDER BY max(created_at) DESC, id" if paginate else ""}
             {limit_offset}
         """,
             {
+                **updated_after_params,
                 **person_params,
                 **grouped_person_params,
                 **cohort_params,
@@ -318,4 +320,12 @@ class PersonQuery:
             return prop_filter_json_extract(
                 Property(key="email", value=self._filter.email, type="person"), 0, prepend="_email"
             )
+        return "", {}
+
+    def _get_updated_after_clause(self) -> Tuple[str, Dict]:
+        if not isinstance(self._filter, Filter):
+            return "", {}
+
+        if self._filter.updated_after:
+            return "and max(_timestamp) > toDateTime(%(updated_after)s)", {"updated_after": self._filter.updated_after}
         return "", {}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

closes https://github.com/PostHog/posthog/issues/14169

Currently there's no easy way to sync persons and we don't want users to be rebuilding the ingestion properties update nor user merging logic nor querying full persons table frequently.

## Changes

This allows filtering on when the person was updated, so one can on a daily basis fetch only the persons that have been updated in the last day. 

Note: we're using the `_timestamp` field which is automatically added during ingestion time iff the person was updated.

Note that this option comes with limitations: 
- if distinct_ids are changed without the person properties or created_at changing, then `_timestamp` won't be updated
- if a person is deleted that won't show up (as currently API query filters out deleted persons, future consideration: make that optional to not filter them out).
- if two persons are merged, then both/either of the above might be relevant

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

added unittest
http://localhost:8000/api/projects/1/persons?distinct_id=test-id&updated_after=2023-04-10%2010:00:00 - showed a person 
http://localhost:8000/api/projects/1/persons?distinct_id=test-id&updated_after=2023-04-10%2020:00:00 - didn't


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
