### PR TITLE
fix(feature-flag): format payloads when clicked from list

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -793,7 +793,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
     afterMount(({ props, actions }) => {
         const foundFlag = featureFlagsLogic.findMounted()?.values.featureFlags.find((flag) => flag.id === props.id)
         if (foundFlag) {
-            actions.setFeatureFlag(foundFlag)
+            const formatPayloads = variantKeyToIndexFeatureFlagPayloads(foundFlag)
+            actions.setFeatureFlag(formatPayloads)
             actions.loadRecentInsights()
             actions.loadAllInsightsForFlag()
         } else if (props.id !== 'new') {


### PR DESCRIPTION
## Problem

- the payloads returned directly from API don't have the right mapping that the UI components need. The keys need to be remapped to an integer related to the variant index
- values that were retrieved from the feature flag list call did not have this mapping so when users clicked into the flag detail page, the payload fields would be empty. This doesn't happen when the feature flag detail page itself is reloaded because the remapping is called in those corresponding selectors
- more context: https://posthoghelp.zendesk.com/agent/tickets/2406 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/5376)
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
