### PR TITLE
feat: Improve naming of $time property

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -464,9 +464,10 @@ export const keyMapping: KeyMappingInterface = {
             hide: true,
         },
         $time: {
-            label: 'Time',
-            description: 'Time as given by the client.',
+            label: 'Timestamp (seconds)',
+            description: 'Time as given by the client, seconds since epoch.',
             hide: true,
+            examples: ['1681211521.345'],
         },
         $device_id: {
             label: 'Device ID',


### PR DESCRIPTION
## Problem

We have both $timestamp and $time (for some reason...). $time is confusing users as it sounds like "time spent on page" which trips people up.

I'm not sure why we have both but I think we should name this more clearly.

## Changes

* Changes the displayed name of the property to be `Timestamp (seconds)`

<img width="583" alt="Screenshot 2023-04-11 at 13 18 25" src="https://user-images.githubusercontent.com/2536520/231145117-a942e75d-d7d6-48fd-a055-07fd3d469f62.png">

**NOTE:** this could now be confusing with the $timestamp property. I'm open to suggestions of alternatives but figured a PR was a good starting point. I don't actually think you can filter on the $timestamp property anyways...

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
