### PR TITLE
feat(admin): show PluginAttachment in PluginConfig pages

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -80,6 +80,9 @@ class TeamAdmin(admin.ModelAdmin):
         )
 
 
+ATTACHMENT_PREVIEW_SIZE_LIMIT_BYTES = 1024 * 1024
+
+
 class PluginAttachmentInline(admin.StackedInline):
     extra = 0
     model = PluginAttachment
@@ -88,19 +91,23 @@ class PluginAttachmentInline(admin.StackedInline):
 
     def raw_contents(self, attachment: PluginAttachment):
         try:
-            if attachment.file_size > 1024 * 1024:
-                raise ValueError("too big")
+            if attachment.file_size > ATTACHMENT_PREVIEW_SIZE_LIMIT_BYTES:
+                raise ValueError(
+                    f"file size {attachment.file_size} is larger than {ATTACHMENT_PREVIEW_SIZE_LIMIT_BYTES} bytes"
+                )
             return attachment.contents.tobytes()
         except Exception as err:
-            return format_html(f"cannot preview: {err=}")
+            return format_html(f"cannot preview: {err}")
 
     def json_contents(self, attachment: PluginAttachment):
         try:
-            if attachment.file_size > 1024 * 1024:
-                raise ValueError("too big")
+            if attachment.file_size > ATTACHMENT_PREVIEW_SIZE_LIMIT_BYTES:
+                raise ValueError(
+                    f"file size {attachment.file_size} is larger than {ATTACHMENT_PREVIEW_SIZE_LIMIT_BYTES} bytes"
+                )
             return json.loads(attachment.contents.tobytes())
         except Exception as err:
-            return format_html(f"cannot preview: {err=}")
+            return format_html(f"cannot preview: {err}")
 
     def has_add_permission(self, request, obj):
         return False

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
@@ -20,6 +22,7 @@ from posthog.models import (
     PluginConfig,
     Team,
     User,
+    PluginAttachment,
 )
 
 admin.site.register(Person)
@@ -77,6 +80,38 @@ class TeamAdmin(admin.ModelAdmin):
         )
 
 
+class PluginAttachmentInline(admin.StackedInline):
+    extra = 0
+    model = PluginAttachment
+    fields = ("key", "content_type", "file_size", "raw_contents", "json_contents")
+    readonly_fields = fields
+
+    def raw_contents(self, attachment: PluginAttachment):
+        try:
+            if attachment.file_size > 1024 * 1024:
+                raise ValueError("too big")
+            return attachment.contents.tobytes()
+        except Exception as err:
+            return format_html(f"cannot preview: {err=}")
+
+    def json_contents(self, attachment: PluginAttachment):
+        try:
+            if attachment.file_size > 1024 * 1024:
+                raise ValueError("too big")
+            return json.loads(attachment.contents.tobytes())
+        except Exception as err:
+            return format_html(f"cannot preview: {err=}")
+
+    def has_add_permission(self, request, obj):
+        return False
+
+    def has_change_permission(self, request, obj):
+        return False
+
+    def has_delete_permission(self, request, obj):
+        return False
+
+
 @admin.register(PluginConfig)
 class PluginConfigAdmin(admin.ModelAdmin):
     list_select_related = ("plugin", "team")
@@ -88,6 +123,7 @@ class PluginConfigAdmin(admin.ModelAdmin):
     )
     search_fields = ("team__name", "team__organization__name", "plugin__name")
     ordering = ("-created_at",)
+    inlines = [PluginAttachmentInline]
 
     def plugin_name(self, config: PluginConfig):
         return format_html(f"{config.plugin.name} ({config.plugin_id})")


### PR DESCRIPTION
## Problem

When debugging app issues, retrieving json configs is pretty difficult.

## Changes

Shows `PluginAttachment`s as a read-only view on the PluginConfig admin page. If the attachment is less than 1 MiB, we show its raw value and try to parse it as json to validate it:

## How did you test this code?

With a valid json attachment:
<img width="943" alt="image" src="https://user-images.githubusercontent.com/6241083/231183607-b1bd7459-c4c1-4e0b-b941-f66765a4e3ff.png">

With an invalid json attachment:

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/6241083/231183852-9eddcfab-76a9-4467-978d-9bff8354ef7e.png">

With a binary file: not very graceous but does not break:

<img width="1307" alt="image" src="https://user-images.githubusercontent.com/6241083/231186391-210e6e00-e0df-4000-a7fe-e7d031d84bf7.png">

With a file over 1Mib:

<img width="760" alt="image" src="https://user-images.githubusercontent.com/6241083/231188630-14539d01-0363-4f8a-89ca-58186db22b63.png">


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
