### PR TITLE
fix(dashboards): Load 1000 dashboards in one API page

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -94,7 +94,7 @@ export const dashboardsModel = kea<dashboardsModelType>({
                         return {}
                     }
                     const { results } = await api.get(
-                        `api/projects/${teamLogic.values.currentTeamId}/dashboards/?limit=300`
+                        `api/projects/${teamLogic.values.currentTeamId}/dashboards/?limit=1000`
                     )
                     return idToKey(results ?? [])
                 },


### PR DESCRIPTION
## Problem

We have more than 300 dashboards and are running into issues because of #9959.

## Changes

We will now load up to 1000 dashboards from the API. This is a hack and not a proper solution for #9959, but it mitigates the immediate issue of dashboards not loading beyond the 300th one.
