### PR TITLE
chore(recordings): revert: use node-librdkafka for ingester production

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -1,17 +1,11 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { EachBatchPayload, Kafka } from 'kafkajs'
-import { ClientMetrics, HighLevelProducer as RdKafkaProducer } from 'node-rdkafka'
-import { hostname } from 'os'
 import { exponentialBuckets, Histogram } from 'prom-client'
 
-import {
-    KAFKA_CLICKHOUSE_SESSION_RECORDING_EVENTS,
-    KAFKA_PERFORMANCE_EVENTS,
-    KAFKA_SESSION_RECORDING_EVENTS,
-    KAFKA_SESSION_RECORDING_EVENTS_DLQ,
-} from '../../config/kafka-topics'
-import { KafkaSecurityProtocol, PipelineEvent, RawEventMessage, Team } from '../../types'
-import { KafkaConfig } from '../../utils/db/hub'
+import { KAFKA_SESSION_RECORDING_EVENTS, KAFKA_SESSION_RECORDING_EVENTS_DLQ } from '../../config/kafka-topics'
+import { PipelineEvent, RawEventMessage, Team } from '../../types'
+import { DependencyUnavailableError } from '../../utils/db/error'
+import { KafkaProducerWrapper } from '../../utils/db/kafka-producer-wrapper'
 import { status } from '../../utils/status'
 import { createPerformanceEvent, createSessionRecordingEvent } from '../../worker/ingestion/process-event'
 import { TeamManager } from '../../worker/ingestion/team-manager'
@@ -23,12 +17,10 @@ export const startSessionRecordingEventsConsumer = async ({
     teamManager,
     kafka,
     partitionsConsumedConcurrently = 5,
-    kafkaConfig,
 }: {
     teamManager: TeamManager
     kafka: Kafka
     partitionsConsumedConcurrently: number
-    kafkaConfig: KafkaConfig
 }) => {
     /*
         For Session Recordings we need to prepare the data for ClickHouse.
@@ -43,24 +35,25 @@ export const startSessionRecordingEventsConsumer = async ({
     // band calls to the `flush` method via the KAFKA_FLUSH_FREQUENCY_MS option.
     // This ensures that we can handle Kafka Producer errors within the body of
     // the Kafka consumer handler.
+    const producer = kafka.producer()
+    await producer.connect()
+    const producerWrapper = new KafkaProducerWrapper(producer, undefined, { KAFKA_FLUSH_FREQUENCY_MS: 0 } as any)
+
     const groupId = 'session-recordings'
     const sessionTimeout = 30000
+    const consumer = kafka.consumer({ groupId: groupId, sessionTimeout: sessionTimeout })
+    setupEventHandlers(consumer)
 
     status.info('🔁', 'Starting session recordings consumer')
 
-    const producer = await createKafkaProducer(kafkaConfig)
-
-    const consumer = kafka.consumer({ groupId: groupId, sessionTimeout: sessionTimeout })
-    setupEventHandlers(consumer)
     await consumer.connect()
     await consumer.subscribe({ topic: KAFKA_SESSION_RECORDING_EVENTS })
-
     await consumer.run({
         partitionsConsumedConcurrently,
         eachBatch: async (payload) => {
             return await instrumentEachBatch(
                 KAFKA_SESSION_RECORDING_EVENTS,
-                eachBatch({ producer: producer, teamManager, groupId }),
+                eachBatch({ producer: producerWrapper, teamManager, groupId }),
                 payload
             )
         },
@@ -83,25 +76,26 @@ export const startSessionRecordingEventsConsumer = async ({
         // currently rebalancing.
         try {
             const { state } = await consumer.describeGroup()
-            status.warn('🔥', 'Consumer group state', { state })
+
             return ['CompletingRebalance', 'PreparingRebalance'].includes(state)
         } catch (error) {
-            status.error('🔥', 'Failed to describe consumer group', { error: error.message })
             return false
         }
     }
 
-    const stop = async () => {
-        status.info('🔁', 'Stopping session recordings consumer')
-        await Promise.all([consumer.disconnect(), disconnectProducer(producer)])
-        status.info('🔁', 'Stopped session recordings consumer')
-    }
-
-    return { consumer, isHealthy, stop }
+    return { consumer, isHealthy }
 }
 
 export const eachBatch =
-    ({ producer, teamManager, groupId }: { producer: RdKafkaProducer; teamManager: TeamManager; groupId: string }) =>
+    ({
+        producer,
+        teamManager,
+        groupId,
+    }: {
+        producer: KafkaProducerWrapper
+        teamManager: TeamManager
+        groupId: string
+    }) =>
     async ({ batch, heartbeat }: Pick<EachBatchPayload, 'batch' | 'heartbeat'>) => {
         status.debug('🔁', 'Processing batch', { size: batch.messages.length })
 
@@ -112,8 +106,6 @@ export const eachBatch =
             })
             .observe(batch.messages.length)
 
-        const pendingMessages: Promise<number | null | undefined>[] = []
-
         for (const message of batch.messages) {
             if (!message.value) {
                 status.warn('⚠️', 'invalid_message', {
@@ -121,7 +113,7 @@ export const eachBatch =
                     partition: batch.partition,
                     offset: message.offset,
                 })
-                pendingMessages.push(produce(producer, KAFKA_SESSION_RECORDING_EVENTS_DLQ, message.value, message.key))
+                await producer.queueMessage({ topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ, messages: [message] })
                 continue
             }
 
@@ -142,7 +134,7 @@ export const eachBatch =
                     partition: batch.partition,
                     offset: message.offset,
                 })
-                pendingMessages.push(produce(producer, KAFKA_SESSION_RECORDING_EVENTS_DLQ, message.value, message.key))
+                await producer.queueMessage({ topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ, messages: [message] })
                 continue
             }
 
@@ -197,38 +189,24 @@ export const eachBatch =
             if (team.session_recording_opt_in) {
                 try {
                     if (event.event === '$snapshot') {
-                        const clickHouseRecord = createSessionRecordingEvent(
+                        await createSessionRecordingEvent(
                             messagePayload.uuid,
                             team.id,
                             messagePayload.distinct_id,
                             parseEventTimestamp(event as PluginEvent),
                             event.ip,
-                            event.properties || {}
-                        )
-
-                        pendingMessages.push(
-                            produce(
-                                producer,
-                                KAFKA_CLICKHOUSE_SESSION_RECORDING_EVENTS,
-                                Buffer.from(JSON.stringify(clickHouseRecord)),
-                                message.key
-                            )
+                            event.properties || {},
+                            producer
                         )
                     } else if (event.event === '$performance_event') {
-                        const clickHouseRecord = createPerformanceEvent(
+                        await createPerformanceEvent(
                             messagePayload.uuid,
                             team.id,
                             messagePayload.distinct_id,
-                            event.properties || {}
-                        )
-
-                        pendingMessages.push(
-                            produce(
-                                producer,
-                                KAFKA_PERFORMANCE_EVENTS,
-                                Buffer.from(JSON.stringify(clickHouseRecord)),
-                                message.key
-                            )
+                            event.properties || {},
+                            event.ip,
+                            parseEventTimestamp(event as PluginEvent),
+                            producer
                         )
                     } else {
                         status.warn('⚠️', 'invalid_message', {
@@ -249,6 +227,25 @@ export const eachBatch =
                         eventId: event.uuid,
                         error: error,
                     })
+
+                    if (error instanceof DependencyUnavailableError) {
+                        // If it's an error that is transient, we want to
+                        // initiate the KafkaJS retry logic, which kicks in when
+                        // we throw.
+                        throw error
+                    }
+
+                    // On non-retriable errors, e.g. perhaps the produced message
+                    // was too large, push the original message to the DLQ. This
+                    // message should be as the original so we _should_ be able to
+                    // produce it successfully.
+                    // TODO: it is not guaranteed that only this message is the one
+                    // that failed to be produced. We will already be in the
+                    // situation with the existing implementation so I will leave as
+                    // is for now. An improvement would be to keep track of the
+                    // messages that we failed to produce and send them all to the
+                    // DLQ.
+                    await producer.queueMessage({ topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ, messages: [message] })
                 }
             } else {
                 eventDroppedCounter
@@ -270,19 +267,22 @@ export const eachBatch =
             // We want to make sure that we have flushed the previous batch
             // before we complete the batch handling, such that we do not commit
             // messages if Kafka production fails for a retriable reason.
-            await flushProducer(producer)
-            // Make sure that none of the messages failed to be produced. If
-            // there were then this will throw an error.
-            await Promise.all(pendingMessages)
+            await producer.flush()
         } catch (error) {
             status.error('⚠️', 'flush_error', { error: error, topic: batch.topic, partition: batch.partition })
 
-            // If we get a retriable Kafka error, throw and let KafkaJS
-            // handle it, otherwise we continue
-
-            if (error?.isRetriable) {
+            if (error instanceof DependencyUnavailableError) {
                 throw error
             }
+
+            // NOTE: for errors coming from `flush` we don't have much by the
+            // way of options at the moment for e.g. DLQing these messages as we
+            // don't know which they were.
+            // TODO: handle DLQ/retrying on flush errors. At the moment we don't
+            // know which messages failed as a result of this flush error. For
+            // now I am going to just going to rely on the producer wrapper
+            // having sent a Sentry exception, but we should ideally send these
+            // to the DLQ.
         }
 
         const lastBatchMessage = batch.messages[batch.messages.length - 1]
@@ -306,94 +306,3 @@ const consumedMessageSizeBytes = new Histogram({
     labelNames: ['topic', 'groupId', 'messageType'],
     buckets: exponentialBuckets(1, 8, 4).map((bucket) => bucket * 1024),
 })
-
-// Kafka production related functions using node-rdkafka.
-// TODO: when we roll out the rdkafka library to other workloads, we should
-// likely reuse these functions, and in which case we should move them to a
-// separate file.s
-
-const createKafkaProducer = async (kafkaConfig: KafkaConfig) => {
-    const producer = new RdKafkaProducer({
-        'client.id': hostname(),
-        'metadata.broker.list': kafkaConfig.KAFKA_HOSTS,
-        'security.protocol': kafkaConfig.KAFKA_SECURITY_PROTOCOL
-            ? (kafkaConfig.KAFKA_SECURITY_PROTOCOL.toLowerCase() as Lowercase<KafkaSecurityProtocol>)
-            : 'plaintext',
-        'sasl.mechanisms': kafkaConfig.KAFKA_SASL_MECHANISM,
-        'sasl.username': kafkaConfig.KAFKA_SASL_USER,
-        'sasl.password': kafkaConfig.KAFKA_SASL_PASSWORD,
-        'ssl.ca.pem': kafkaConfig.KAFKA_TRUSTED_CERT_B64
-            ? Buffer.from(kafkaConfig.KAFKA_TRUSTED_CERT_B64, 'base64').toString()
-            : undefined,
-        'ssl.key.pem': kafkaConfig.KAFKA_CLIENT_CERT_B64
-            ? Buffer.from(kafkaConfig.KAFKA_CLIENT_CERT_B64, 'base64').toString()
-            : undefined,
-        'ssl.certificate.pem': kafkaConfig.KAFKA_CLIENT_CERT_KEY_B64
-            ? Buffer.from(kafkaConfig.KAFKA_CLIENT_CERT_KEY_B64, 'base64').toString()
-            : undefined,
-        // milliseconds to wait before sending a batch. The default is 0, which
-        // means that messages are sent as soon as possible. This does not mean
-        // that there will only be one message per batch, as the producer will
-        // attempt to fill batches up to the batch size while the number of
-        // Kafka inflight requests is saturated, by default 5 inflight requests.
-        'linger.ms': 20,
-        // The default is 16kb. 1024kb also seems quite small for our use case
-        // but at least larger than the default.
-        'batch.size': 1024 * 1024, // bytes. The default
-        'compression.codec': 'snappy',
-        dr_cb: true,
-    })
-
-    producer.on('event.log', function (log) {
-        status.debug('📝', 'librdkafka log', { log: log })
-    })
-
-    await new Promise((resolve, reject) =>
-        producer.connect(undefined, (error, data) => {
-            status.info('🔌', 'Connected to Kafka', { error: error, brokers: data.brokers })
-            error ? reject(error) : resolve(data)
-        })
-    )
-
-    return producer
-}
-
-const produce = async (
-    producer: RdKafkaProducer,
-    topic: string,
-    value: Buffer | null,
-    key: Buffer | null
-): Promise<number | null | undefined> => {
-    status.debug('📤', 'Producing message', { topic: topic })
-    return await new Promise((resolve, reject) =>
-        producer.produce(topic, null, value, key, Date.now(), (error: any, offset: number | null | undefined) => {
-            if (error) {
-                status.error('⚠️', 'produce_error', { error: error, topic: topic })
-                reject(error)
-            } else {
-                status.debug('📤', 'Produced message', { topic: topic, offset: offset })
-                resolve(offset)
-            }
-        })
-    )
-}
-
-const disconnectProducer = async (producer: RdKafkaProducer) => {
-    status.debug('🔌', 'Disconnecting producer')
-    return await new Promise<ClientMetrics>((resolve, reject) =>
-        producer.disconnect((error: any, data: ClientMetrics) => {
-            status.debug('🔌', 'Disconnected producer')
-            if (error) {
-                reject(error)
-            } else {
-                resolve(data)
-            }
-        })
-    )
-}
-
-const flushProducer = async (producer: RdKafkaProducer) => {
-    return await new Promise((resolve, reject) =>
-        producer.flush(10000, (error) => (error ? reject(error) : resolve(null)))
-    )
-}

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -90,7 +90,7 @@ export async function startPluginsServer(
     // (default 60 seconds) to allow for the person to be created in the
     // meantime.
     let bufferConsumer: Consumer | undefined
-    let stopSessionRecordingEventsConsumer: (() => void) | undefined
+    let sessionRecordingEventsConsumer: Consumer | undefined
     let jobsConsumer: Consumer | undefined
     let schedulerTasksConsumer: Consumer | undefined
 
@@ -131,7 +131,7 @@ export async function startPluginsServer(
             onEventHandlerConsumer?.stop(),
             bufferConsumer?.disconnect(),
             jobsConsumer?.disconnect(),
-            stopSessionRecordingEventsConsumer?.(),
+            sessionRecordingEventsConsumer?.disconnect(),
             schedulerTasksConsumer?.disconnect(),
         ])
 
@@ -433,13 +433,12 @@ export async function startPluginsServer(
             const kafka = hub?.kafka ?? createKafkaClient(serverConfig as KafkaConfig)
             const postgres = hub?.postgres ?? createPostgresPool(serverConfig.DATABASE_URL)
             const teamManager = hub?.teamManager ?? new TeamManager(postgres, serverConfig)
-            const { stop, isHealthy: isSessionRecordingsHealthy } = await startSessionRecordingEventsConsumer({
+            const { consumer, isHealthy: isSessionRecordingsHealthy } = await startSessionRecordingEventsConsumer({
                 teamManager: teamManager,
                 kafka: kafka,
-                kafkaConfig: serverConfig as KafkaConfig,
                 partitionsConsumedConcurrently: serverConfig.RECORDING_PARTITIONS_CONSUMED_CONCURRENTLY,
             })
-            stopSessionRecordingEventsConsumer = stop
+            sessionRecordingEventsConsumer = consumer
             healthChecks['session-recordings'] = isSessionRecordingsHealthy
         }
 

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -65,7 +65,7 @@ export function createHttpServer(
             if (statusCode === 200) {
                 status.info('💚', 'Server liveness check succeeded')
             } else {
-                status.info('💔', 'Server liveness check failed', checkResultsMapping)
+                status.info('💔', 'Server liveness check failed', checkResults)
             }
 
             res.end(JSON.stringify({ status: statusCode === 200 ? 'ok' : 'error', checks: checkResultsMapping }))

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -270,7 +270,7 @@ export async function createHub(
 export type KafkaConfig = {
     KAFKA_HOSTS: string
     KAFKAJS_LOG_LEVEL: keyof typeof KAFKAJS_LOG_LEVEL_MAPPING
-    KAFKA_SECURITY_PROTOCOL: 'PLAINTEXT' | 'SSL' | 'SASL_PLAINTEXT' | 'SASL_SSL' | undefined
+    KAFKA_SECURITY_PROTOCOL: string
     KAFKA_CLIENT_CERT_B64?: string
     KAFKA_CLIENT_CERT_KEY_B64?: string
     KAFKA_TRUSTED_CERT_B64?: string

--- a/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recordings-consumer.test.ts
@@ -1,36 +1,58 @@
-import LibrdKafkaError from 'node-rdkafka/lib/error'
-import { Pool } from 'pg'
+import { Kafka, KafkaJSError, Partitioners, Producer } from 'kafkajs'
+import Broker from 'kafkajs/src/broker'
 
 import { defaultConfig } from '../../../src/config/config'
 import { eachBatch } from '../../../src/main/ingestion-queues/session-recordings-consumer'
+import { DB } from '../../../src/utils/db/db'
+import { DependencyUnavailableError } from '../../../src/utils/db/error'
+import { KafkaProducerWrapper } from '../../../src/utils/db/kafka-producer-wrapper'
+import { createPostgresPool } from '../../../src/utils/utils'
 import { TeamManager } from '../../../src/worker/ingestion/team-manager'
 import { createOrganization, createTeam } from '../../helpers/sql'
 
 describe('session-recordings-consumer', () => {
-    const producer = {
-        produce: jest.fn(),
-        flush: jest.fn(),
-    } as any
-    let postgres: Pool
+    // NOTE: at the time of adding this comment, the test only checks the case
+    // that we error at the time of producing to the ClickHouse ingestion Kafka
+    // topic. There are also other cases that can fail which we should also
+    // test.
+
+    let mockProduce: jest.SpyInstance
+    let kafka: Kafka
+    let producer: Producer
+    let producerWrapper: KafkaProducerWrapper
+    let db: DB
     let teamManager: TeamManager
     let eachBachWithDependencies: any
 
-    beforeEach(() => {
-        postgres = new Pool({ connectionString: defaultConfig.DATABASE_URL })
-        teamManager = new TeamManager(postgres, {} as any)
-        eachBachWithDependencies = eachBatch({ groupId: 'asdf', producer, teamManager })
+    beforeEach(async () => {
+        kafka = new Kafka({ brokers: ['localhost:9092'] })
+        producer = kafka.producer({ retry: { retries: 0 }, createPartitioner: Partitioners.LegacyPartitioner })
+        await producer.connect()
+
+        // To ensure we are catching and retrying on the correct error, we make
+        // sure to mock deep into the KafkaJS internals, otherwise we can get
+        // into inplaced confidence that we have covered this critical path.
+        mockProduce = jest.spyOn(Broker.prototype, 'produce')
+        producerWrapper = new KafkaProducerWrapper(producer, undefined, {
+            KAFKA_FLUSH_FREQUENCY_MS: 0,
+        } as any)
+        db = {
+            postgres: createPostgresPool(defaultConfig.DATABASE_URL),
+        } as DB
+        teamManager = new TeamManager(db.postgres, {} as any)
+        eachBachWithDependencies = eachBatch({ groupId: 'test', producer: producerWrapper, teamManager })
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+        await producer.disconnect()
         jest.clearAllMocks()
     })
 
     test('eachBatch throws on recoverable KafkaJS errors', async () => {
-        const organizationId = await createOrganization(postgres)
-        const teamId = await createTeam(postgres, organizationId)
-        const error = new LibrdKafkaError({ message: 'test', code: 1, errno: 1, origin: 'test', isRetriable: true })
-        producer.produce.mockImplementation((topic, partition, message, key, timestamp, cb) => cb(error))
-        producer.flush.mockImplementation((timeout, cb) => cb(null))
+        const organizationId = await createOrganization(db.postgres)
+        const teamId = await createTeam(db.postgres, organizationId)
+        const error = new KafkaJSError('test', { retriable: true })
+        mockProduce.mockRejectedValueOnce(error)
         await expect(
             eachBachWithDependencies({
                 batch: {
@@ -44,15 +66,17 @@ describe('session-recordings-consumer', () => {
                 } as any,
                 heartbeat: jest.fn(),
             })
-        ).rejects.toEqual(error)
+        ).rejects.toEqual(new DependencyUnavailableError('KafkaJSError', 'Kafka', error))
+
+        // Should _not_ have retried or sent to DLQ.
+        expect(mockProduce).toHaveBeenCalledTimes(1)
     })
 
     test('eachBatch emits to DLQ and returns on unrecoverable KafkaJS errors', async () => {
-        const organizationId = await createOrganization(postgres)
-        const teamId = await createTeam(postgres, organizationId)
-        const error = new LibrdKafkaError({ message: 'test', code: 1, errno: 1, origin: 'test', isRetriable: false })
-        producer.produce.mockImplementation((topic, partition, message, key, timestamp, cb) => cb(error))
-        producer.flush.mockImplementation((timeout, cb) => cb(null))
+        const organizationId = await createOrganization(db.postgres)
+        const teamId = await createTeam(db.postgres, organizationId)
+        const error = new KafkaJSError('test', { retriable: false })
+        mockProduce.mockRejectedValueOnce(error)
         await eachBachWithDependencies({
             batch: {
                 topic: 'test',
@@ -67,6 +91,6 @@ describe('session-recordings-consumer', () => {
         })
 
         // Should have send to the DLQ.
-        expect(producer.produce).toHaveBeenCalledTimes(1)
+        expect(mockProduce).toHaveBeenCalledTimes(2)
     })
 })

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -22,6 +22,7 @@ import {
     Team,
 } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
+import { KafkaProducerWrapper } from '../../src/utils/db/kafka-producer-wrapper'
 import { personInitialAndUTMProperties } from '../../src/utils/db/utils'
 import { posthog } from '../../src/utils/posthog'
 import { UUIDT } from '../../src/utils/utils'
@@ -1187,15 +1188,22 @@ test('capture first team event', async () => {
     expect(elements.length).toEqual(1)
 })
 
-test('snapshot event stored as session_recording_event', () => {
-    const data = createSessionRecordingEvent(
+test('snapshot event stored as session_recording_event', async () => {
+    const producer = {
+        queueSingleJsonMessage: jest.fn(),
+    }
+
+    await createSessionRecordingEvent(
         'some-id',
         team.id,
         '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
         now,
         '',
-        { $session_id: 'abcf-efg', $snapshot_data: { timestamp: 123 } } as any as Properties
+        { $session_id: 'abcf-efg', $snapshot_data: { timestamp: 123 } } as any as Properties,
+        producer as any as KafkaProducerWrapper
     )
+
+    const [_topic, _uuid, data] = producer.queueSingleJsonMessage.mock.calls[0]
 
     expect(data).toEqual({
         created_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2} [\d\s:]+/),
@@ -1209,39 +1217,53 @@ test('snapshot event stored as session_recording_event', () => {
     })
 })
 
-test('performance event stored as performance_event', () => {
-    const data = createPerformanceEvent('some-id', team.id, '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4', {
-        // Taken from a real event from the JS
-        '0': 'resource',
-        '1': 1671723295836,
-        '2': 'http://localhost:8000/api/projects/1/session_recordings',
-        '3': 10737.89999999106,
-        '4': 0,
-        '5': 0,
-        '6': 0,
-        '7': 10737.89999999106,
-        '8': 10737.89999999106,
-        '9': 10737.89999999106,
-        '10': 10737.89999999106,
-        '11': 0,
-        '12': 10737.89999999106,
-        '13': 10745.09999999404,
-        '14': 11121.70000000298,
-        '15': 11122.20000000298,
-        '16': 73374,
-        '17': 1767,
-        '18': 'fetch',
-        '19': 'http/1.1',
-        '20': 'non-blocking',
-        '22': 2067,
-        '39': 384.30000001192093,
-        '40': 1671723306573,
-        token: 'phc_234',
-        $session_id: '1853a793ad26c1-0eea05631cbeff-17525635-384000-1853a793ad31dd2',
-        $window_id: '1853a793ad424a5-017f7473b057f1-17525635-384000-1853a793ad524dc',
-        distinct_id: '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
-        $current_url: 'http://localhost:8000/recordings/recent',
-    })
+test('performance event stored as performance_event', async () => {
+    const producer = {
+        queueSingleJsonMessage: jest.fn(),
+    }
+
+    await createPerformanceEvent(
+        'some-id',
+        team.id,
+        '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
+        {
+            // Taken from a real event from the JS
+            '0': 'resource',
+            '1': 1671723295836,
+            '2': 'http://localhost:8000/api/projects/1/session_recordings',
+            '3': 10737.89999999106,
+            '4': 0,
+            '5': 0,
+            '6': 0,
+            '7': 10737.89999999106,
+            '8': 10737.89999999106,
+            '9': 10737.89999999106,
+            '10': 10737.89999999106,
+            '11': 0,
+            '12': 10737.89999999106,
+            '13': 10745.09999999404,
+            '14': 11121.70000000298,
+            '15': 11122.20000000298,
+            '16': 73374,
+            '17': 1767,
+            '18': 'fetch',
+            '19': 'http/1.1',
+            '20': 'non-blocking',
+            '22': 2067,
+            '39': 384.30000001192093,
+            '40': 1671723306573,
+            token: 'phc_234',
+            $session_id: '1853a793ad26c1-0eea05631cbeff-17525635-384000-1853a793ad31dd2',
+            $window_id: '1853a793ad424a5-017f7473b057f1-17525635-384000-1853a793ad524dc',
+            distinct_id: '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
+            $current_url: 'http://localhost:8000/recordings/recent',
+        },
+        '',
+        now,
+        producer as any as KafkaProducerWrapper
+    )
+
+    const [_topic, _uuid, data] = producer.queueSingleJsonMessage.mock.calls[0]
 
     expect(data).toEqual({
         connect_end: 10737.89999999106,

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -49,7 +49,6 @@ RUN apt-get update && \
     "g++" \
     "gcc" \
     "python3" \
-    "libssl-dev" \
     && \
     rm -rf /var/lib/apt/lists/* && \
     corepack enable && \


### PR DESCRIPTION
Reverts PostHog/posthog#14460

It was not rolled out due to helm issues. Let's deploy it tomorrow morning outside of peak hours.