### PR TITLE
perf(recordings): allow to tune bytes per partitions

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -39,6 +39,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_SASL_MECHANISM: null,
         KAFKA_SASL_USER: null,
         KAFKA_SASL_PASSWORD: null,
+        KAFKA_CONSUMPTION_MAX_BYTES: 10_485_760, // Default value for kafkajs
+        KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: 1_048_576, // Default value for kafkajs, must be bigger than message size
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_CONSUMPTION_OVERFLOW_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv() ? 0 : 1000,

--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -17,10 +17,14 @@ export const startSessionRecordingEventsConsumer = async ({
     teamManager,
     kafka,
     partitionsConsumedConcurrently = 5,
+    maxBytes,
+    maxBytesPerPartition,
 }: {
     teamManager: TeamManager
     kafka: Kafka
     partitionsConsumedConcurrently: number
+    maxBytes: number
+    maxBytesPerPartition: number
 }) => {
     /*
         For Session Recordings we need to prepare the data for ClickHouse.
@@ -41,7 +45,12 @@ export const startSessionRecordingEventsConsumer = async ({
 
     const groupId = 'session-recordings'
     const sessionTimeout = 30000
-    const consumer = kafka.consumer({ groupId: groupId, sessionTimeout: sessionTimeout })
+    const consumer = kafka.consumer({
+        groupId: groupId,
+        sessionTimeout: sessionTimeout,
+        maxBytes: maxBytes,
+        maxBytesPerPartition: maxBytesPerPartition,
+    })
     setupEventHandlers(consumer)
 
     status.info('🔁', 'Starting session recordings consumer')

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -437,6 +437,8 @@ export async function startPluginsServer(
                 teamManager: teamManager,
                 kafka: kafka,
                 partitionsConsumedConcurrently: serverConfig.RECORDING_PARTITIONS_CONSUMED_CONCURRENTLY,
+                maxBytes: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES,
+                maxBytesPerPartition: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
             })
             sessionRecordingEventsConsumer = consumer
             healthChecks['session-recordings'] = isSessionRecordingsHealthy

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -100,6 +100,8 @@ export interface PluginsServerConfig {
     KAFKA_SASL_MECHANISM: KafkaSaslMechanism | null
     KAFKA_SASL_USER: string | null
     KAFKA_SASL_PASSWORD: string | null
+    KAFKA_CONSUMPTION_MAX_BYTES: number
+    KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: number
     KAFKA_CONSUMPTION_TOPIC: string | null
     KAFKA_CONSUMPTION_OVERFLOW_TOPIC: string | null
     KAFKA_PRODUCER_MAX_QUEUE_SIZE: number


### PR DESCRIPTION
## Problem

When upscaling posthog-recordings-ingestionto one partition per consumer, we see a drop in CPU usage (30% -> 15%) and the processing batch size [plateauing around 200 messages/batch](
http://grafana-prod-us/explore?orgId=1&left=%7B%22datasource%22:%22PBFA97CFB590B2093%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%28topic%29%20%28rate%28consumed_batch_size_sum%5B$__rate_interval%5D%29%29%20%2F%20sum%20by%28topic%29%20%28rate%28consumed_batch_size_count%5B$__rate_interval%5D%29%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-2d%22,%22to%22:%22now%22%7D%7D). The very low CPU usage indicates we spend too much time waiting on kafka reads & writes. Increasing the batch size on both ends should help increase the CPU usage.

kafkajs [default config values](https://kafka.js.org/docs/consuming#options) are:

- maxBytes 10MB
- maxBytesPerPartition 1MB

With these values, the batch size will drop when we upscale, which would be consistent with the efficiency drop we're observing. We should increase `maxBytesPerPartition` and measure the impact

## Changes

- Add KAFKA_CONSUMPTION_MAX_BYTES and KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION options
- Use them when configuring the kafka consumer for recordings. We'll want to use it for analytics too if it helps with recordings
- Set the default values to kafkajs's defaults, we'll tune through chart values

Setting maxBytesPerPartition == maxBytes would help us for peak hours, but might create imbalances when we downscale (as we'll read less evenly from the different partitions). Let's slowly increase it and see how it goes, but we can bump it to 10MB if we're falling back again.

## How did you test this code?

yolo