### PR TITLE
fix: Properly bootstrap most property-based feature flags

### DIFF
--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import (
     Any,
     Callable,
@@ -150,7 +151,7 @@ class User(AbstractUser, UUIDClassicModel):
     def is_superuser(self) -> bool:  # type: ignore
         return self.is_staff
 
-    @property
+    @cached_property
     def teams(self):
         """
         All teams the user has access to on any organization, taking into account project based permissioning
@@ -182,7 +183,7 @@ class User(AbstractUser, UUIDClassicModel):
 
         return teams.order_by("access_control", "id")
 
-    @property
+    @cached_property
     def organization(self) -> Optional[Organization]:
         if self.current_organization is None:
             if self.current_team is not None:
@@ -191,7 +192,7 @@ class User(AbstractUser, UUIDClassicModel):
             self.save()
         return self.current_organization
 
-    @property
+    @cached_property
     def team(self) -> Optional[Team]:
         if self.current_team is None and self.organization is not None:
             self.current_team = self.teams.filter(organization=self.current_organization).first()

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -92,7 +92,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.base_app_num_queries = 43
+        cls.base_app_num_queries = 42
         if settings.MULTI_TENANCY:
             cls.base_app_num_queries += 2
         # Create another team that the user does have access to

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -53,6 +53,7 @@ from posthog.redis import get_client
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+    from posthog.models import User
 
 DATERANGE_MAP = {
     "minute": datetime.timedelta(minutes=1),
@@ -356,7 +357,7 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     # Set the frontend app context
     if not request.GET.get("no-preloaded-app-context"):
         from posthog.api.team import TeamSerializer
-        from posthog.api.user import User, UserSerializer
+        from posthog.api.user import UserSerializer
         from posthog.user_permissions import UserPermissions
         from posthog.views import preflight_check
 
@@ -370,7 +371,7 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
         }
 
         if request.user.pk:
-            user = cast(User, request.user)
+            user = cast("User", request.user)
             user_permissions = UserPermissions(user=user, team=user.team)
             user_serialized = UserSerializer(
                 request.user, context={"request": request, "user_permissions": user_permissions}, many=False
@@ -388,9 +389,26 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     if posthog_distinct_id:
         groups = {}
-        if request.user and request.user.is_authenticated and request.user.organization:
-            groups = {"organization": str(request.user.organization.id)}
-        feature_flags = posthoganalytics.get_all_flags(posthog_distinct_id, only_evaluate_locally=True, groups=groups)
+        group_properties = {}
+        person_properties = {}
+        if request.user and request.user.is_authenticated:
+            user = cast("User", request.user)
+            person_properties["email"] = user.email
+            person_properties["joined_at"] = user.date_joined.isoformat()
+            if user.organization:
+                groups["organization"] = str(user.organization.id)
+                group_properties["organization"] = {
+                    "name": user.organization.name,
+                    "created_at": user.organization.created_at.isoformat(),
+                }
+
+        feature_flags = posthoganalytics.get_all_flags(
+            posthog_distinct_id,
+            only_evaluate_locally=True,
+            person_properties=person_properties,
+            groups=groups,
+            group_properties=group_properties,
+        )
         # don't forcefully set distinctID, as this breaks the link for anonymous users coming from `posthog.com`.
         posthog_bootstrap["featureFlags"] = feature_flags
 


### PR DESCRIPTION
## Problem

We've only been bootstrapping rollout percentage-based feature flags, but most of feature flags we use in production are based on user emails. And for e.g. billing v2 we use the organizations's `created_at` value. This means that most of our flags are not ready at bootstrap-time and need to be loaded later, which results in flashing UI (like with PostHog 3000) or weird behavior when loading data for a scene in a feature flag-dependent way (for instance, [this insight](https://app.posthog.com/insights/5XqHliZE) doesn't load because the feature flag it relies on isn't available early enough).

## Changes

Added basic person and organization properties to the bootstrapping phase.