### PR TITLE
feat: Handle perf events that are batched into one event

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -7,7 +7,7 @@ import { PipelineEvent, RawEventMessage, Team } from '../../types'
 import { DependencyUnavailableError } from '../../utils/db/error'
 import { KafkaProducerWrapper } from '../../utils/db/kafka-producer-wrapper'
 import { status } from '../../utils/status'
-import { createPerformanceEvent, createSessionRecordingEvent } from '../../worker/ingestion/process-event'
+import { createPerformanceEvents, createSessionRecordingEvent } from '../../worker/ingestion/process-event'
 import { TeamManager } from '../../worker/ingestion/team-manager'
 import { parseEventTimestamp } from '../../worker/ingestion/timestamps'
 import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
@@ -199,13 +199,11 @@ export const eachBatch =
                             producer
                         )
                     } else if (event.event === '$performance_event') {
-                        await createPerformanceEvent(
+                        await createPerformanceEvents(
                             messagePayload.uuid,
                             team.id,
                             messagePayload.distinct_id,
                             event.properties || {},
-                            event.ip,
-                            parseEventTimestamp(event as PluginEvent),
                             producer
                         )
                     } else {

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -28,7 +28,7 @@ import { posthog } from '../../src/utils/posthog'
 import { UUIDT } from '../../src/utils/utils'
 import { EventPipelineRunner } from '../../src/worker/ingestion/event-pipeline/runner'
 import {
-    createPerformanceEvent,
+    createPerformanceEvents,
     createSessionRecordingEvent,
     EventsProcessor,
 } from '../../src/worker/ingestion/process-event'
@@ -1222,7 +1222,7 @@ test('performance event stored as performance_event', async () => {
         queueSingleJsonMessage: jest.fn(),
     }
 
-    await createPerformanceEvent(
+    await createPerformanceEvents(
         'some-id',
         team.id,
         '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
@@ -1258,8 +1258,6 @@ test('performance event stored as performance_event', async () => {
             distinct_id: '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
             $current_url: 'http://localhost:8000/recordings/recent',
         },
-        '',
-        now,
         producer as any as KafkaProducerWrapper
     )
 


### PR DESCRIPTION
## Problem

Checks for a special property in the $performance_event that indicates it has been batched and unpacks it to write to kafka.

Related JS change https://github.com/PostHog/posthog-js/pull/605

## Changes

* Adds support for perf events that may be batched internally in the event. The idea here being that we have a low level of concern for individuality here so it is a potentially great saving to simply contain a bunch of perf events in one

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Still need to write some tests...