### PR TITLE
perf(recordings): lower kafka consumer max wait

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -41,6 +41,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_SASL_PASSWORD: null,
         KAFKA_CONSUMPTION_MAX_BYTES: 10_485_760, // Default value for kafkajs
         KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: 1_048_576, // Default value for kafkajs, must be bigger than message size
+        KAFKA_CONSUMPTION_MAX_WAIT_MS: 1_000, // Down from the 5s default for kafkajs
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_CONSUMPTION_OVERFLOW_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv() ? 0 : 1000,

--- a/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recordings-consumer.ts
@@ -17,14 +17,16 @@ export const startSessionRecordingEventsConsumer = async ({
     teamManager,
     kafka,
     partitionsConsumedConcurrently = 5,
-    maxBytes,
-    maxBytesPerPartition,
+    consumerMaxBytes,
+    consumerMaxBytesPerPartition,
+    consumerMaxWaitMs,
 }: {
     teamManager: TeamManager
     kafka: Kafka
     partitionsConsumedConcurrently: number
-    maxBytes: number
-    maxBytesPerPartition: number
+    consumerMaxBytes: number
+    consumerMaxBytesPerPartition: number
+    consumerMaxWaitMs: number
 }) => {
     /*
         For Session Recordings we need to prepare the data for ClickHouse.
@@ -48,8 +50,9 @@ export const startSessionRecordingEventsConsumer = async ({
     const consumer = kafka.consumer({
         groupId: groupId,
         sessionTimeout: sessionTimeout,
-        maxBytes: maxBytes,
-        maxBytesPerPartition: maxBytesPerPartition,
+        maxBytes: consumerMaxBytes,
+        maxBytesPerPartition: consumerMaxBytesPerPartition,
+        maxWaitTimeInMs: consumerMaxWaitMs,
     })
     setupEventHandlers(consumer)
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -439,6 +439,7 @@ export async function startPluginsServer(
                 partitionsConsumedConcurrently: serverConfig.RECORDING_PARTITIONS_CONSUMED_CONCURRENTLY,
                 consumerMaxBytes: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES,
                 consumerMaxBytesPerPartition: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
+                consumerMaxWaitMs: serverConfig.KAFKA_CONSUMPTION_MAX_WAIT_MS,
             })
             sessionRecordingEventsConsumer = consumer
             healthChecks['session-recordings'] = isSessionRecordingsHealthy

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -437,8 +437,8 @@ export async function startPluginsServer(
                 teamManager: teamManager,
                 kafka: kafka,
                 partitionsConsumedConcurrently: serverConfig.RECORDING_PARTITIONS_CONSUMED_CONCURRENTLY,
-                maxBytes: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES,
-                maxBytesPerPartition: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
+                consumerMaxBytes: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES,
+                consumerMaxBytesPerPartition: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
             })
             sessionRecordingEventsConsumer = consumer
             healthChecks['session-recordings'] = isSessionRecordingsHealthy

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -102,6 +102,7 @@ export interface PluginsServerConfig {
     KAFKA_SASL_PASSWORD: string | null
     KAFKA_CONSUMPTION_MAX_BYTES: number
     KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: number
+    KAFKA_CONSUMPTION_MAX_WAIT_MS: number
     KAFKA_CONSUMPTION_TOPIC: string | null
     KAFKA_CONSUMPTION_OVERFLOW_TOPIC: string | null
     KAFKA_PRODUCER_MAX_QUEUE_SIZE: number


### PR DESCRIPTION
## Problem

Increasing the maximum consumer batch size causes a higher low-traffic latency, because the kafka consumer waits up to 5 seconds by default, and low-traffic is not enough to reach the max batch sizes.

## Changes

Make the read wait time configurable, and set the default lower (5s -> 1s).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
