### PR TITLE
chore: add SECRET_KEY env var to codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,11 @@
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
     "name": "PostHog codespaces development environment",
-
     "build": {
         "dockerfile": "Dockerfile",
         "context": "../",
         "cacheFrom": "ghcr.io/posthog/posthog/codespaces:master"
     },
-
     "remoteUser": "vscode",
     "remoteEnv": {
         "DEBUG": "1",
@@ -20,10 +18,13 @@
         "CLICKHOUST_HOST": "localhost",
         "CLICKHOUSE_DATABASE": "posthog_test",
         "CLICKHOUSE_VERIFY": "False",
-        "REDIS_URL": "redis://localhost:6379"
+        "REDIS_URL": "redis://localhost:6379",
+        "SECRET_KEY": "<randomly generated secret key>"
     },
     "overrideCommand": false,
-    "mounts": ["source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"],
+    "mounts": [
+        "source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"
+    ],
     "runArgs": [
         "--cap-add=SYS_PTRACE",
         "--security-opt",
@@ -33,32 +34,26 @@
         "--add-host",
         "kafka:127.0.0.1"
     ],
-
     "workspaceFolder": "/workspaces/posthog",
-
     // Set *default* container specific settings.json values on container create.
     "settings": {
         /*
           Python settings
         */
         "python.defaultInterpreterPath": "/usr/local/bin/python",
-
         // Configure linting
         "python.linting.enabled": true,
         "python.linting.pylintEnabled": false, // We use flake8, disable pylint
         "python.linting.flake8Enabled": true,
         "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
         "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-
         // Configure formatting
         "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
         "python.formatting.provider": "black",
-
         // Configure testing
         "python.testing.pytestEnabled": true,
         "python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
     },
-
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
         "ms-python.python",
@@ -75,7 +70,16 @@
         "mtxr.sqltools",
         "ultram4rine.sqltools-clickhouse-driver"
     ],
-
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [8000, 5432, 6379, 8123, 8234, 9000, 9092, 9440, 9009]
+    "forwardPorts": [
+        8000,
+        5432,
+        6379,
+        8123,
+        8234,
+        9000,
+        9092,
+        9440,
+        9009
+    ]
 }

--- a/.github/workflows/customer-data-pipeline.yml
+++ b/.github/workflows/customer-data-pipeline.yml
@@ -37,8 +37,6 @@ jobs:
               id: meta
               with:
                   images: ghcr.io/${{ github.repository }}/cdp
-                  flavor: |
-                      latest=${{ github.ref == 'refs/heads/master' }}
 
             # Make the image tags used for docker cache. We use this rather than
             # ${{ github.repository }} directly because the repository
@@ -126,3 +124,18 @@ jobs:
 
                   # Run the functional tests.
                   pnpm jest
+
+            - name: Generate docker latest tag
+              if: github.ref == 'refs/heads/master'
+              uses: docker/metadata-action@v4
+              id: meta
+              with:
+                  images: ghcr.io/${{ github.repository }}/cdp
+                  tags: |
+                      type=raw,value=latest
+
+            - name: Push image as latest on master
+              if: github.ref == 'refs/heads/master'
+              run: |
+                  docker tag ${{ needs.build.outputs.tags }} ${{ steps.meta.outputs.tags }}
+                  docker push ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Now that I'm sharing the key between the Django app and the CDP work, we
want it to be set as a global env var.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
