### PR TITLE
fix: show correct projected amount in old billing ui

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -439,10 +439,7 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
                                         Predicted bill
                                     </LemonLabel>
                                     <div className="font-bold text-muted text-2xl">
-                                        $
-                                        {product.projected_usage
-                                            ? convertUsageToAmount(product.projected_usage, product.tiers)
-                                            : '0.00'}
+                                        ${product.projected_amount_usd || '0.00'}
                                     </div>
                                 </div>
                                 {billing?.billing_period?.interval == 'month' && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1071,6 +1071,7 @@ export interface BillingProductV2Type {
     tiers?: BillingV2TierType[]
     tiered: boolean
     current_usage?: number
+    projected_amount_usd?: string
     projected_usage?: number
     percentage_usage: number
     current_amount_usd?: string


### PR DESCRIPTION
## Problem

After merging the new billing backend the projected amount wasn't calculating properly. We can just grab it from the products response.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Gets it from the billing products response instead.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
