### PR TITLE
fix(billing): only show a free tier on the gauge if there is one

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -333,58 +333,63 @@ const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Ele
         700: 'medium',
     })
 
-    const freeTier = (billing?.has_active_subscription ? product.tiers?.[0]?.up_to : product.free_allocation) || 0
+    const freeTier =
+        (billing?.has_active_subscription
+            ? product.tiers?.[0].unit_amount_usd === '0'
+                ? product.tiers?.[0]?.up_to
+                : 0
+            : product.free_allocation) || 0
 
-    const billingGaugeItems: BillingGaugeProps['items'] = useMemo(
-        () =>
-            [
-                {
-                    tooltip: (
-                        <>
-                            <b>Free tier limit</b>
-                        </>
-                    ),
-                    color: 'success-light',
-                    value: freeTier,
-                    top: true,
-                },
-                {
-                    tooltip: (
-                        <>
-                            <b>Current</b>
-                        </>
-                    ),
-                    color: product.percentage_usage <= 1 ? 'success' : 'danger',
-                    value: product.current_usage || 0,
-                    top: false,
-                },
-                product.projected_usage && product.projected_usage > (product.current_usage || 0)
-                    ? {
-                          tooltip: (
-                              <>
-                                  <b>Projected</b>
-                              </>
-                          ),
-                          color: 'border',
-                          value: product.projected_usage || 0,
-                          top: false,
-                      }
-                    : undefined,
-                billingLimitAsUsage
-                    ? {
-                          tooltip: (
-                              <>
-                                  <b>Billing limit</b>
-                              </>
-                          ),
-                          color: 'primary-alt-light',
-                          top: true,
-                          value: billingLimitAsUsage || 0,
-                      }
-                    : (undefined as any),
-            ].filter(Boolean),
-        [product, billingLimitAsUsage, customLimitUsd]
-    )
+    const billingGaugeItems: BillingGaugeProps['items'] = useMemo(() => {
+        return [
+            freeTier
+                ? {
+                      tooltip: (
+                          <>
+                              <b>Free tier limit</b>
+                          </>
+                      ),
+                      color: 'success-light',
+                      value: freeTier,
+                      top: true,
+                  }
+                : undefined,
+            {
+                tooltip: (
+                    <>
+                        <b>Current</b>
+                    </>
+                ),
+                color: product.percentage_usage <= 1 ? 'success' : 'danger',
+                value: product.current_usage || 0,
+                top: false,
+            },
+            product.projected_usage && product.projected_usage > (product.current_usage || 0)
+                ? {
+                      tooltip: (
+                          <>
+                              <b>Projected</b>
+                          </>
+                      ),
+                      color: 'border',
+                      value: product.projected_usage || 0,
+                      top: false,
+                  }
+                : undefined,
+            billingLimitAsUsage
+                ? {
+                      tooltip: (
+                          <>
+                              <b>Billing limit</b>
+                          </>
+                      ),
+                      color: 'primary-alt-light',
+                      top: true,
+                      value: billingLimitAsUsage || 0,
+                  }
+                : (undefined as any),
+        ].filter(Boolean)
+    }, [product, billingLimitAsUsage, customLimitUsd])
 
     const tierDisplayOptions: LemonSelectOptions<string> = [
         { label: `Per ${productType.singular}`, value: 'individual' },


### PR DESCRIPTION
## Problem
The gauge UI was showing a free tier even if the first tier wasn't free. 

![image](https://user-images.githubusercontent.com/18598166/231584156-9b878a52-5346-452a-a2b2-bf43e9bf2c3c.png)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

This should correctly determine if there is actually a free tier and only include it if so.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
