### PR TITLE
fix: current_usage wrongly displayed

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -90,7 +90,7 @@ class BillingManager:
         # Extend the products with accurate usage_limit info
 
         for product in response["products"]:
-            usage_key = product["usage_key"] or None
+            usage_key = product.get("usage_key", None)
             if not usage_key:
                 continue
             usage = response.get("usage_summary", {}).get(usage_key, {})

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -90,16 +90,15 @@ class BillingManager:
         # Extend the products with accurate usage_limit info
 
         for product in response["products"]:
-            usage = response.get("usage_summary", {}).get(product["type"], {})
+            usage_key = product["usage_key"] or None
+            if not usage_key:
+                continue
+            usage = response.get("usage_summary", {}).get(usage_key, {})
             usage_limit = usage.get("limit")
             current_usage = usage.get("usage") or 0
 
-            if (
-                organization
-                and organization.usage
-                and organization.usage.get(product["type"], {}).get("todays_usage", None)
-            ):
-                todays_usage = organization.usage[product["type"]]["todays_usage"]
+            if organization and organization.usage and organization.usage.get(usage_key, {}).get("todays_usage", None):
+                todays_usage = organization.usage[usage_key]["todays_usage"]
                 current_usage = current_usage + todays_usage
 
             product["current_usage"] = current_usage


### PR DESCRIPTION
## Problem
We need to usage the `usage_key` to extract the correct usage from the billing response.

## Changes
Fixes that.

## How did you test this code?
Locally
