### PR TITLE
feat: Add send_all_org_usage_reports workflow (WIP)

### DIFF
--- a/posthog/temporal/tests/test_usage_report.py
+++ b/posthog/temporal/tests/test_usage_report.py
@@ -1,0 +1,659 @@
+from typing import Any, Dict, List
+from unittest.mock import ANY, MagicMock, Mock, call, patch
+from uuid import uuid4
+
+import pytest
+import structlog
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.utils.timezone import now
+from freezegun import freeze_time
+from temporalio.client import Client
+
+# from temporalio.testing import ActivityEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from ee.api.test.base import LicensedTestMixin
+from ee.billing.billing_manager import build_billing_token
+from ee.models.license import License
+from ee.settings import BILLING_SERVICE_URL
+from posthog.models import Organization, Plugin, Team
+from posthog.models.dashboard import Dashboard
+from posthog.models.feature_flag import FeatureFlag
+from posthog.models.group.util import create_group
+from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models.plugin import PluginConfig
+from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.session_recordings.test.test_factory import create_snapshot
+from posthog.temporal.workflows.usage_report import (
+    SendAllOrgUsageReportsInputs,
+    SendAllOrgUsageReportsWorkflow,
+    send_report_to_billing_service,
+    capture_report,
+)
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseDestroyTablesMixin,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+    flush_persons_and_events,
+)
+from posthog.utils import get_machine_id
+
+logger = structlog.get_logger(__name__)
+
+
+@freeze_time("2022-01-10T00:01:00Z")
+class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.expected_properties: dict = {}
+
+    def _create_sample_usage_data(self) -> None:
+        """
+        For this test, we create a lot of data around the current date 2022-01-01
+        so that we can test the report overall
+        """
+        self.org_internal = Organization.objects.create(name="Internal metrics org", for_internal_metrics=True)
+        self.org_1 = self.organization
+        self.org_2 = Organization.objects.create(name="Org 2")
+        self.org_internal_team_0 = Team.objects.create(organization=self.org_internal, name="Team 0 org internal")
+        self.org_1_team_1 = self.team  # self.organization already has a team
+        self.org_1_team_2 = Team.objects.create(organization=self.org_1, name="Team 2 org 1")
+        self.org_2_team_3 = Team.objects.create(organization=self.org_2, name="Team 3 org 2")
+
+        with self.settings(USE_TZ=False):
+
+            # Events for internal org
+            distinct_id = str(uuid4())
+            _create_person(distinct_ids=[distinct_id], team=self.org_internal_team_0)
+
+            for _ in range(0, 10):
+                _create_event(
+                    distinct_id=distinct_id,
+                    event="$event1",
+                    properties={"$lib": "$web"},
+                    timestamp=now() - relativedelta(hours=12),
+                    team=self.org_internal_team_0,
+                )
+
+            # Events for org 1 team 1
+            distinct_id = str(uuid4())
+            _create_person(distinct_ids=[distinct_id], team=self.org_1_team_1)
+
+            Dashboard.objects.create(team=self.org_1_team_1, name="Dash one", created_by=self.user)
+
+            dashboard = Dashboard.objects.create(
+                team=self.org_1_team_1,
+                name="Dash public",
+                created_by=self.user,
+            )
+            SharingConfiguration.objects.create(
+                team=self.org_1_team_1, dashboard=dashboard, access_token="testtoken", enabled=True
+            )
+
+            FeatureFlag.objects.create(
+                team=self.org_1_team_1,
+                rollout_percentage=30,
+                name="Disabled",
+                key="disabled-flag",
+                created_by=self.user,
+                active=False,
+            )
+
+            FeatureFlag.objects.create(
+                team=self.org_1_team_1,
+                rollout_percentage=30,
+                name="Enabled",
+                key="enabled-flag",
+                created_by=self.user,
+                active=True,
+            )
+
+            for _ in range(0, 10):
+                _create_event(
+                    distinct_id=distinct_id,
+                    event="$event1",
+                    properties={"$lib": "$web"},
+                    timestamp=now() - relativedelta(hours=12),
+                    team=self.org_1_team_1,
+                )
+
+            # Events before the period
+            for _ in range(0, 10):
+                _create_event(
+                    distinct_id=distinct_id,
+                    event="$out-of-range",
+                    properties={"$lib": "$mobile"},
+                    timestamp=now() - relativedelta(hours=48),
+                    team=self.org_1_team_1,
+                )
+
+            # Events after the period
+            for _ in range(0, 10):
+                _create_event(
+                    distinct_id=distinct_id,
+                    event="$out-of-range",
+                    properties={"$lib": "$mobile"},
+                    timestamp=now() + relativedelta(hours=48),
+                    team=self.org_1_team_1,
+                )
+
+            # Some groups
+            GroupTypeMapping.objects.create(team=self.org_1_team_1, group_type="organization", group_type_index=0)
+            GroupTypeMapping.objects.create(team=self.org_1_team_1, group_type="company", group_type_index=1)
+            create_group(
+                team_id=self.org_1_team_1.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"}
+            )
+            create_group(
+                team_id=self.org_1_team_1.pk,
+                group_type_index=0,
+                group_key="org:6",
+                properties={"industry": "technology"},
+            )
+
+            _create_event(
+                event="event",
+                lib="web",
+                distinct_id=distinct_id,
+                team=self.team,
+                timestamp=now() - relativedelta(hours=12),
+                properties={"$group_0": "org:5"},
+            )
+            _create_event(
+                event="event",
+                lib="web",
+                distinct_id=distinct_id,
+                team=self.team,
+                timestamp=now() - relativedelta(hours=12),
+                properties={"$group_0": "org:6"},
+            )
+
+            # Events for org 1 team 2
+            distinct_id = str(uuid4())
+            _create_person(distinct_ids=[distinct_id], team=self.org_1_team_2)
+
+            for _ in range(0, 10):
+                _create_event(
+                    distinct_id=distinct_id,
+                    event="$event1",
+                    properties={"$lib": "$web"},
+                    timestamp=now() - relativedelta(hours=12),
+                    team=self.org_1_team_2,
+                )
+
+            # recordings in period  - 5 sessions with 5 snapshots each
+            for i in range(0, 5):
+                for _ in range(0, 5):
+                    create_snapshot(
+                        has_full_snapshot=True,
+                        distinct_id=distinct_id,
+                        session_id=i,
+                        timestamp=now() - relativedelta(hours=12),
+                        team_id=self.org_1_team_2.id,
+                    )
+
+            # recordings out of period  - 5 sessions with 5 snapshots each
+            for i in range(0, 10):
+                for _ in range(0, 5):
+                    create_snapshot(
+                        has_full_snapshot=True,
+                        distinct_id=distinct_id,
+                        session_id=i + 10,
+                        timestamp=now() - relativedelta(hours=48),
+                        team_id=self.org_1_team_2.id,
+                    )
+
+            # Events for org 2 team 3
+            distinct_id = str(uuid4())
+            _create_person(distinct_ids=[distinct_id], team=self.org_2_team_3)
+
+            for _ in range(0, 10):
+                _create_event(
+                    distinct_id=distinct_id,
+                    event="$event1",
+                    properties={"$lib": "$web"},
+                    timestamp=now() - relativedelta(hours=12),
+                    team=self.org_2_team_3,
+                )
+
+            flush_persons_and_events()
+
+    def _select_report_by_org_id(self, org_id: str, reports: List[Dict]) -> Dict:
+        return [report for report in reports if report["organization_id"] == org_id][0]
+
+    def _create_plugin(self, name: str, enabled: bool) -> None:
+        plugin = Plugin.objects.create(organization_id=self.team.organization.pk, name=name)
+        PluginConfig.objects.create(plugin=plugin, enabled=enabled, order=1)
+
+    def _test_usage_report(self) -> List[dict]:
+
+        with self.settings(SITE_URL="http://test.posthog.com"):
+            self._create_sample_usage_data()
+            self._create_plugin("Installed but not enabled", False)
+            self._create_plugin("Installed and enabled", True)
+
+            all_reports = SendAllOrgUsageReportsWorkflow(dry_run=False)
+
+            report = all_reports[0]
+            assert report["table_sizes"]
+            assert report["table_sizes"]["posthog_event"] < 10**7  # <10MB
+            assert report["table_sizes"]["posthog_sessionrecordingevent"] < 10**7  # <10MB
+
+            assert len(all_reports) == 2
+
+            expectation = [
+                {
+                    "posthog_version": all_reports[0]["posthog_version"],
+                    "deployment_infrastructure": "tests",
+                    "realm": "hosted-clickhouse",
+                    "period": {
+                        "start_inclusive": "2022-01-09T00:00:00+00:00",
+                        "end_inclusive": "2022-01-09T23:59:59.999999+00:00",
+                    },
+                    "site_url": "http://test.posthog.com",
+                    "product": "open source",
+                    "helm": {},
+                    "clickhouse_version": all_reports[0]["clickhouse_version"],
+                    "users_who_logged_in": [],
+                    "users_who_logged_in_count": 0,
+                    "users_who_signed_up": [],
+                    "users_who_signed_up_count": 0,
+                    "table_sizes": all_reports[0]["table_sizes"],
+                    "plugins_installed": {"Installed and enabled": 1, "Installed but not enabled": 1},
+                    "plugins_enabled": {"Installed and enabled": 1},
+                    "instance_tag": "none",
+                    "event_count_lifetime": 42,
+                    "event_count_in_period": 22,
+                    "event_count_in_month": 32,
+                    "event_count_with_groups_in_period": 2,
+                    "recording_count_in_period": 5,
+                    "recording_count_total": 15,
+                    "group_types_total": 2,
+                    "dashboard_count": 2,
+                    "dashboard_template_count": 0,
+                    "dashboard_shared_count": 1,
+                    "dashboard_tagged_count": 0,
+                    "ff_count": 2,
+                    "ff_active_count": 1,
+                    "date": "2022-01-09",
+                    "organization_id": str(self.organization.id),
+                    "organization_name": "Test",
+                    "organization_created_at": "2022-01-10T00:01:00+00:00",
+                    "organization_user_count": 1,
+                    "team_count": 2,
+                    "teams": {
+                        str(self.org_1_team_1.id): {
+                            "event_count_lifetime": 32,
+                            "event_count_in_period": 12,
+                            "event_count_in_month": 22,
+                            "event_count_with_groups_in_period": 2,
+                            "recording_count_in_period": 0,
+                            "recording_count_total": 0,
+                            "group_types_total": 2,
+                            "dashboard_count": 2,
+                            "dashboard_template_count": 0,
+                            "dashboard_shared_count": 1,
+                            "dashboard_tagged_count": 0,
+                            "ff_count": 2,
+                            "ff_active_count": 1,
+                        },
+                        str(self.org_1_team_2.id): {
+                            "event_count_lifetime": 10,
+                            "event_count_in_period": 10,
+                            "event_count_in_month": 10,
+                            "event_count_with_groups_in_period": 0,
+                            "recording_count_in_period": 5,
+                            "recording_count_total": 15,
+                            "group_types_total": 0,
+                            "dashboard_count": 0,
+                            "dashboard_template_count": 0,
+                            "dashboard_shared_count": 0,
+                            "dashboard_tagged_count": 0,
+                            "ff_count": 0,
+                            "ff_active_count": 0,
+                        },
+                    },
+                },
+                {
+                    "posthog_version": all_reports[1]["posthog_version"],
+                    "deployment_infrastructure": "tests",
+                    "realm": "hosted-clickhouse",
+                    "period": {
+                        "start_inclusive": "2022-01-09T00:00:00+00:00",
+                        "end_inclusive": "2022-01-09T23:59:59.999999+00:00",
+                    },
+                    "site_url": "http://test.posthog.com",
+                    "product": "open source",
+                    "helm": {},
+                    "clickhouse_version": all_reports[1]["clickhouse_version"],
+                    "users_who_logged_in": [],
+                    "users_who_logged_in_count": 0,
+                    "users_who_signed_up": [],
+                    "users_who_signed_up_count": 0,
+                    "table_sizes": all_reports[1]["table_sizes"],
+                    "plugins_installed": {"Installed and enabled": 1, "Installed but not enabled": 1},
+                    "plugins_enabled": {"Installed and enabled": 1},
+                    "instance_tag": "none",
+                    "event_count_lifetime": 10,
+                    "event_count_in_period": 10,
+                    "event_count_in_month": 10,
+                    "event_count_with_groups_in_period": 0,
+                    "recording_count_in_period": 0,
+                    "recording_count_total": 0,
+                    "group_types_total": 0,
+                    "dashboard_count": 0,
+                    "dashboard_template_count": 0,
+                    "dashboard_shared_count": 0,
+                    "dashboard_tagged_count": 0,
+                    "ff_count": 0,
+                    "ff_active_count": 0,
+                    "date": "2022-01-09",
+                    "organization_id": str(self.org_2.id),
+                    "organization_name": "Org 2",
+                    "organization_created_at": "2022-01-10T00:01:00+00:00",
+                    "organization_user_count": 0,
+                    "team_count": 1,
+                    "teams": {
+                        str(self.org_2_team_3.id): {
+                            "event_count_lifetime": 10,
+                            "event_count_in_period": 10,
+                            "event_count_in_month": 10,
+                            "event_count_with_groups_in_period": 0,
+                            "recording_count_in_period": 0,
+                            "recording_count_total": 0,
+                            "group_types_total": 0,
+                            "dashboard_count": 0,
+                            "dashboard_template_count": 0,
+                            "dashboard_shared_count": 0,
+                            "dashboard_tagged_count": 0,
+                            "ff_count": 0,
+                            "ff_active_count": 0,
+                        }
+                    },
+                },
+            ]
+
+            for item in expectation:
+                item.update(**self.expected_properties)
+
+            # tricky: list could be in different order
+            assert len(all_reports) == 2
+            for report in all_reports:
+                if report["organization_id"] == expectation[0]["organization_id"]:
+                    assert report == expectation[0]
+                elif report["organization_id"] == expectation[1]["organization_id"]:
+                    assert report == expectation[1]
+
+            return all_reports
+
+    @patch("os.environ", {"DEPLOYMENT": "tests"})
+    @patch("posthog.tasks.usage_report.Client")
+    @patch("requests.post")
+    def test_unlicensed_usage_report(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+        self.expected_properties = {}
+        mockresponse = Mock()
+        mock_post.return_value = mockresponse
+        mockresponse.status_code = 200
+        mockresponse.json = lambda: {}
+        mock_posthog = MagicMock()
+        mock_client.return_value = mock_posthog
+
+        all_reports = self._test_usage_report()
+
+        # Check calls to other services
+        mock_post.assert_not_called()
+
+        calls = [
+            call(
+                get_machine_id(),
+                "organization usage report",
+                {**all_reports[0], "scope": "machine"},
+                groups={"instance": ANY},
+                timestamp=None,
+            ),
+            call(
+                get_machine_id(),
+                "organization usage report",
+                {**all_reports[1], "scope": "machine"},
+                groups={"instance": ANY},
+                timestamp=None,
+            ),
+        ]
+
+        assert mock_posthog.capture.call_count == 2
+        mock_posthog.capture.assert_has_calls(calls, any_order=True)
+
+
+class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.team2 = Team.objects.create(organization=self.organization)
+
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(
+            event="$$internal_metrics_shouldnt_be_billed",
+            team=self.team,
+            distinct_id=1,
+            timestamp="2021-10-09T13:01:01Z",
+        )
+        _create_event(event="$pageview", team=self.team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+        flush_persons_and_events()
+
+    def _usage_report_response(self) -> Any:
+        # A roughly correct billing response
+        return {
+            "customer": {
+                "billing_period": {
+                    "current_period_start": "2021-10-01T00:00:00Z",
+                    "current_period_end": "2021-10-31T00:00:00Z",
+                },
+                "usage_summary": {
+                    "events": {"usage": 10000, "limit": None},
+                    "recordings": {
+                        "usage": 1000,
+                        "limit": None,
+                    },
+                },
+            }
+        }
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("posthog.tasks.usage_report.Client")
+    @patch("requests.post")
+    async def test_send_usage_workflow(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+        mockresponse = Mock()
+        mock_post.return_value = mockresponse
+        mockresponse.status_code = 200
+        mockresponse.json = lambda: self._usage_report_response()
+        mock_posthog = MagicMock()
+        mock_client.return_value = mock_posthog
+
+        client = await Client.connect(
+            f"{settings.TEMPORAL_SCHEDULER_HOST}:{settings.TEMPORAL_SCHEDULER_PORT}",
+            namespace=settings.TEMPORAL_NAMESPACE,
+        )
+
+        workflow_id = str(uuid4())
+        inputs = SendAllOrgUsageReportsInputs(
+            dry_run=False,
+        )
+
+        logger.info("Blah 1")
+        async with Worker(
+            client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[SendAllOrgUsageReportsWorkflow],
+            activities=[
+                send_report_to_billing_service,
+                capture_report,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            all_reports = await client.execute_workflow(
+                SendAllOrgUsageReportsWorkflow.run,
+                inputs,
+                id=workflow_id,
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+        logger.info("Blah 2")
+        license = License.objects.first()
+        assert license
+        token = build_billing_token(license, self.organization)
+        mock_post.assert_called_once_with(
+            f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
+        )
+
+        logger.info("Blah 3")
+        mock_posthog.capture.assert_any_call(
+            get_machine_id(),
+            "organization usage report",
+            {**all_reports[0], "scope": "machine"},
+            groups={"instance": ANY},
+            timestamp=None,
+        )
+        logger.info("Blah 4")
+        return
+
+    # @freeze_time("2021-10-10T23:01:00Z")
+    # @patch("posthog.tasks.usage_report.Client")
+    # @patch("requests.post")
+    # def test_send_usage(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+    #     mockresponse = Mock()
+    #     mock_post.return_value = mockresponse
+    #     mockresponse.status_code = 200
+    #     mockresponse.json = lambda: self._usage_report_response()
+    #     mock_posthog = MagicMock()
+    #     mock_client.return_value = mock_posthog
+
+    #     all_reports = SendAllOrgUsageReportsWorkflow(dry_run=False)
+    #     license = License.objects.first()
+    #     assert license
+    #     token = build_billing_token(license, self.organization)
+    #     mock_post.assert_called_once_with(
+    #         f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
+    #     )
+
+    #     mock_posthog.capture.assert_any_call(
+    #         get_machine_id(),
+    #         "organization usage report",
+    #         {**all_reports[0], "scope": "machine"},
+    #         groups={"instance": ANY},
+    #         timestamp=None,
+    #     )
+
+
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthog.tasks.usage_report.Client")
+#     @patch("requests.post")
+#     def test_send_usage_cloud(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+#         with self.is_cloud(True):
+#             mockresponse = Mock()
+#             mock_post.return_value = mockresponse
+#             mockresponse.status_code = 200
+#             mockresponse.json = lambda: self._usage_report_response()
+#             mock_posthog = MagicMock()
+#             mock_client.return_value = mock_posthog
+
+#             all_reports = SendAllOrgUsageReportsWorkflow(dry_run=False)
+#             license = License.objects.first()
+#             assert license
+#             token = build_billing_token(license, self.organization)
+#             mock_post.assert_called_once_with(
+#                 f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
+#             )
+
+#             mock_posthog.capture.assert_any_call(
+#                 self.user.distinct_id,
+#                 "organization usage report",
+#                 {**all_reports[0], "scope": "user"},
+#                 groups={"instance": "http://localhost:8000", "organization": str(self.organization.id)},
+#                 timestamp=None,
+#             )
+
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthog.tasks.usage_report.Client")
+#     @patch("requests.post")
+#     def test_send_usage_billing_service_not_reachable(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+#         mockresponse = Mock()
+#         mock_post.return_value = mockresponse
+#         mockresponse.status_code = 404
+#         mockresponse.ok = False
+#         mockresponse.json = lambda: {"code": "not_found"}
+#         mockresponse.content = ""
+
+#         mock_posthog = MagicMock()
+#         mock_client.return_value = mock_posthog
+
+#         SendAllOrgUsageReportsWorkflow(dry_run=False)
+#         mock_posthog.capture.assert_any_call(
+#             get_machine_id(),
+#             "organization usage report to billing service failure",
+#             {"err": ANY, "scope": "machine"},
+#             groups={"instance": ANY},
+#             timestamp=None,
+#         )
+
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthog.tasks.usage_report.Client")
+#     @patch("requests.post")
+#     def test_org_usage_updated_correctly(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+
+#         mockresponse = Mock()
+#         mock_post.return_value = mockresponse
+#         mockresponse.status_code = 200
+#         usage_report_response = self._usage_report_response()
+#         mockresponse.json = lambda: usage_report_response
+#         mock_posthog = MagicMock()
+#         mock_client.return_value = mock_posthog
+
+#         SendAllOrgUsageReportsWorkflow(dry_run=False)
+
+#         self.team.organization.refresh_from_db()
+#         assert self.team.organization.usage == {
+#             "events": {"limit": None, "usage": 10000, "todays_usage": 0},
+#             "recordings": {"limit": None, "usage": 1000, "todays_usage": 0},
+#             "period": ["2021-10-01T00:00:00Z", "2021-10-31T00:00:00Z"],
+#         }
+
+
+# class SendNoUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthog.tasks.usage_report.Client")
+#     @patch("requests.post")
+#     def test_usage_not_sent_if_zero(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+
+#         mock_posthog = MagicMock()
+#         mock_client.return_value = mock_posthog
+
+#         SendAllOrgUsageReportsWorkflow(dry_run=False)
+
+#         mock_post.assert_not_called()
+
+
+# class SendUsageNoLicenseTest(APIBaseTest):
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthog.tasks.usage_report.Client")
+#     @patch("requests.post")
+#     def test_no_license(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
+#         # Same test, we just don't include the LicensedTestMixin so no license
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+
+#         flush_persons_and_events()
+
+#         SendAllOrgUsageReportsWorkflow()
+
+#         mock_post.assert_not_called()

--- a/posthog/temporal/workflows/__init__.py
+++ b/posthog/temporal/workflows/__init__.py
@@ -1,4 +1,9 @@
 from posthog.temporal.workflows.noop import *
+from typing import Callable, Sequence
 
-WORKFLOWS = [NoOpWorkflow]
-ACTIVITIES = [noop_activity]
+from posthog.temporal.workflows.usage_report import *
+
+WORKFLOWS = [NoOpWorkflow, SendAllOrgUsageReportsWorkflow]
+ACTIVITIES: Sequence[Callable] = [
+    noop_activity,
+]

--- a/posthog/temporal/workflows/usage_report.py
+++ b/posthog/temporal/workflows/usage_report.py
@@ -1,15 +1,415 @@
-from dataclasses import dataclass
+import dataclasses
+import os
+from collections import Counter
+from datetime import datetime
 from typing import (
+    Any,
+    Dict,
+    List,
     Optional,
+    Sequence,
+    Tuple,
+    TypedDict,
+    Union,
+    cast,
 )
 
-from temporalio import workflow
+import dateutil
+import requests
+import structlog
+from django.conf import settings
+from django.db import connection
+from django.db.models import Count, Q
+from posthoganalytics.client import Client
+from psycopg2 import sql
+from sentry_sdk import capture_exception
+from temporalio import activity, workflow
 
+from posthog import version_requirement
+from posthog.client import sync_execute
+from posthog.cloud_utils import is_cloud
+from posthog.models import GroupTypeMapping, OrganizationMembership, User
+from posthog.models.dashboard import Dashboard
+from posthog.models.feature_flag import FeatureFlag
+from posthog.models.organization import Organization
+from posthog.models.plugin import PluginConfig
+from posthog.models.team.team import Team
+from posthog.models.utils import namedtuplefetchall
+from posthog.settings import INSTANCE_TAG
 from posthog.temporal.workflows.base import CommandableWorkflow
+from posthog.utils import get_helm_info_env, get_instance_realm, get_machine_id, get_previous_day
+from posthog.version import VERSION
 
 
-@dataclass
-class SendAllOrgUsageReportsArgs:
+logger = structlog.get_logger(__name__)
+
+Period = TypedDict("Period", {"start_inclusive": str, "end_inclusive": str})
+TableSizes = TypedDict("TableSizes", {"posthog_event": int, "posthog_sessionrecordingevent": int})
+
+
+@dataclasses.dataclass
+class UsageReportCounters:
+    event_count_lifetime: int
+    event_count_in_period: int
+    event_count_in_month: int
+    event_count_with_groups_in_period: int
+    # event_count_by_lib: Dict
+    # event_count_by_name: Dict
+    # Recordings
+    recording_count_in_period: int
+    recording_count_total: int
+    # Persons and Groups
+    group_types_total: int
+    # person_count_total: int
+    # person_count_in_period: int
+    # Dashboards
+    dashboard_count: int
+    dashboard_template_count: int
+    dashboard_shared_count: int
+    dashboard_tagged_count: int
+    # Feature flags
+    ff_count: int
+    ff_active_count: int
+
+
+# Instance metadata to be included in oveall report
+@dataclasses.dataclass
+class InstanceMetadata:
+    posthog_version: str
+    deployment_infrastructure: str
+    realm: str
+    period: Period
+    site_url: str
+    product: str
+    helm: Optional[dict]
+    clickhouse_version: Optional[str]
+    users_who_logged_in: Optional[List[Dict[str, Union[str, int]]]]
+    users_who_logged_in_count: Optional[int]
+    users_who_signed_up: Optional[List[Dict[str, Union[str, int]]]]
+    users_who_signed_up_count: Optional[int]
+    table_sizes: Optional[TableSizes]
+    plugins_installed: Optional[Dict]
+    plugins_enabled: Optional[Dict]
+    instance_tag: str
+
+
+@dataclasses.dataclass
+class OrgReport(UsageReportCounters):
+    date: str
+    organization_id: str
+    organization_name: str
+    organization_created_at: str
+    organization_user_count: int
+    team_count: int
+    teams: Dict[str, UsageReportCounters]
+
+
+@dataclasses.dataclass
+class FullUsageReport(OrgReport, InstanceMetadata):
+    pass
+
+
+def fetch_table_size(table_name: str) -> int:
+    return fetch_sql("SELECT pg_total_relation_size(%s) as size", (table_name,))[0].size
+
+
+def fetch_sql(sql_: str, params: Tuple[Any, ...]) -> List[Any]:
+    with connection.cursor() as cursor:
+        cursor.execute(sql.SQL(sql_), params)
+        return namedtuplefetchall(cursor)
+
+
+def get_product_name(realm: str, has_license: bool) -> str:
+    if realm == "cloud":
+        return "cloud"
+    elif realm in {"hosted", "hosted-clickhouse"}:
+        return "scale" if has_license else "open source"
+    else:
+        return "unknown"
+
+
+def get_instance_metadata(period: Tuple[datetime, datetime]) -> InstanceMetadata:
+    has_license = False
+
+    if settings.EE_AVAILABLE:
+        from ee.models.license import License
+
+        license = License.objects.first_valid()
+        has_license = license is not None
+
+    period_start, period_end = period
+
+    realm = get_instance_realm()
+    metadata = InstanceMetadata(
+        posthog_version=VERSION,
+        deployment_infrastructure=os.getenv("DEPLOYMENT", "unknown"),
+        realm=realm,
+        period={"start_inclusive": period_start.isoformat(), "end_inclusive": period_end.isoformat()},
+        site_url=settings.SITE_URL,
+        product=get_product_name(realm, has_license),
+        # Non-cloud vars
+        helm=None,
+        clickhouse_version=None,
+        users_who_logged_in=None,
+        users_who_logged_in_count=None,
+        users_who_signed_up=None,
+        users_who_signed_up_count=None,
+        table_sizes=None,
+        plugins_installed=None,
+        plugins_enabled=None,
+        instance_tag=INSTANCE_TAG,
+    )
+
+    if realm != "cloud":
+        metadata.helm = get_helm_info_env()
+        metadata.clickhouse_version = str(version_requirement.get_clickhouse_version())
+
+        metadata.users_who_logged_in = [
+            {"id": user.id, "distinct_id": user.distinct_id}
+            if user.anonymize_data
+            else {"id": user.id, "distinct_id": user.distinct_id, "first_name": user.first_name, "email": user.email}
+            for user in User.objects.filter(is_active=True, last_login__gte=period_start, last_login__lte=period_end)
+        ]
+        metadata.users_who_logged_in_count = len(metadata.users_who_logged_in)
+
+        metadata.users_who_signed_up = [
+            {"id": user.id, "distinct_id": user.distinct_id}
+            if user.anonymize_data
+            else {"id": user.id, "distinct_id": user.distinct_id, "first_name": user.first_name, "email": user.email}
+            for user in User.objects.filter(is_active=True, date_joined__gte=period_start, date_joined__lte=period_end)
+        ]
+        metadata.users_who_signed_up_count = len(metadata.users_who_signed_up)
+
+        metadata.table_sizes = {
+            "posthog_event": fetch_table_size("posthog_event"),
+            "posthog_sessionrecordingevent": fetch_table_size("posthog_sessionrecordingevent"),
+        }
+
+        plugin_configs = PluginConfig.objects.select_related("plugin").all()
+
+        metadata.plugins_installed = dict(Counter(plugin_config.plugin.name for plugin_config in plugin_configs))
+        metadata.plugins_enabled = dict(
+            Counter(plugin_config.plugin.name for plugin_config in plugin_configs if plugin_config.enabled)
+        )
+
+    return metadata
+
+
+def get_org_user_count(organization_id: str) -> int:
+    return OrganizationMembership.objects.filter(organization_id=organization_id).count()
+
+
+def get_org_owner_or_first_user(organization_id: str) -> Optional[User]:
+    # Find the membership object for the org owner
+    user = None
+    membership = OrganizationMembership.objects.filter(
+        organization_id=organization_id, level=OrganizationMembership.Level.OWNER
+    ).first()
+    if not membership:
+        # If no owner membership is present, pick the first membership association we can find
+        membership = OrganizationMembership.objects.filter(organization_id=organization_id).first()
+    if hasattr(membership, "user"):
+        membership = cast(OrganizationMembership, membership)
+        user = membership.user
+    else:
+        capture_exception(
+            Exception("No user found for org while generating report"), {"org": {"organization_id": organization_id}}
+        )
+    return user
+
+
+@activity.defn
+def send_report_to_billing_service(org_id: str, report: Dict[str, Any]) -> None:
+    if not settings.EE_AVAILABLE:
+        return
+
+    from ee.billing.billing_manager import BillingManager, build_billing_token
+    from ee.billing.billing_types import BillingStatus
+    from ee.models.license import License
+    from ee.settings import BILLING_SERVICE_URL
+
+    try:
+        license = License.objects.first_valid()
+        if not license or not license.is_v2_license:
+            return
+
+        organization = Organization.objects.get(id=org_id)
+        if not organization:
+            return
+
+        token = build_billing_token(license, organization)
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        response = requests.post(f"{BILLING_SERVICE_URL}/api/usage", json=report, headers=headers)
+        if response.status_code != 200:
+            raise Exception(
+                f"Failed to send usage report to billing service code:{response.status_code} response:{response.text}"
+            )
+
+        logger.info(f"UsageReport sent to Billing for organization: {organization.id}")
+
+        response_data: BillingStatus = response.json()
+        BillingManager(license).update_org_details(organization, response_data)
+
+    except Exception as err:
+        logger.error(f"UsageReport failed sending to Billing for organization: {organization.id}: {err}")
+        capture_exception(err)
+        pha_client = Client("sTMFPsFhdP1Ssg")
+        capture_event(pha_client, f"organization usage report to billing service failure", org_id, {"err": str(err)})
+
+
+def capture_event(
+    pha_client: Client,
+    name: str,
+    organization_id: str,
+    properties: Dict[str, Any],
+    timestamp: Optional[datetime] = None,
+) -> None:
+    if is_cloud():
+        org_owner = get_org_owner_or_first_user(organization_id)
+        distinct_id = org_owner.distinct_id if org_owner and org_owner.distinct_id else f"org-{organization_id}"
+        pha_client.capture(
+            distinct_id,
+            name,
+            {**properties, "scope": "user"},
+            groups={"organization": organization_id, "instance": settings.SITE_URL},
+            timestamp=timestamp,
+        )
+        pha_client.group_identify("organization", organization_id, properties)
+    else:
+        pha_client.capture(
+            get_machine_id(),
+            name,
+            {**properties, "scope": "machine"},
+            groups={"instance": settings.SITE_URL},
+            timestamp=timestamp,
+        )
+        pha_client.group_identify("instance", settings.SITE_URL, properties)
+
+
+def get_teams_with_event_count_lifetime() -> List[Tuple[int, int]]:
+    result = sync_execute(
+        """
+        SELECT team_id, count(1) as count
+        FROM events
+        GROUP BY team_id
+    """
+    )
+    return result
+
+
+def get_teams_with_event_count_in_period(begin: datetime, end: datetime) -> List[Tuple[int, int]]:
+    result = sync_execute(
+        """
+        SELECT team_id, count(1) as count
+        FROM events
+        WHERE timestamp between %(begin)s AND %(end)s
+        GROUP BY team_id
+    """,
+        {"begin": begin, "end": end},
+    )
+    return result
+
+
+def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datetime) -> List[Tuple[int, int]]:
+    result = sync_execute(
+        """
+        SELECT team_id, count(1) as count
+        FROM events
+        WHERE timestamp between %(begin)s AND %(end)s
+        AND ($group_0 != '' OR $group_1 != '' OR $group_2 != '' OR $group_3 != '' OR $group_4 != '')
+        GROUP BY team_id
+    """,
+        {"begin": begin, "end": end},
+    )
+    return result
+
+
+def get_teams_with_event_count_by_lib(begin: datetime, end: datetime) -> List[Tuple[int, str, int]]:
+    results = sync_execute(
+        """
+        SELECT team_id, JSONExtractString(properties, '$lib') as lib, COUNT(1) as count
+        FROM events
+        WHERE timestamp between %(begin)s AND %(end)s
+        GROUP BY lib, team_id
+    """,
+        {"begin": begin, "end": end},
+    )
+    return results
+
+
+def get_teams_with_event_count_by_name(begin: datetime, end: datetime) -> List[Tuple[int, str, int]]:
+    results = sync_execute(
+        """
+        SELECT team_id, event, COUNT(1) as count
+        FROM events
+        WHERE timestamp between %(begin)s AND %(end)s
+        GROUP BY event, team_id
+    """,
+        {"begin": begin, "end": end},
+    )
+    return results
+
+
+def get_teams_with_recording_count_in_period(begin: datetime, end: datetime) -> List[Tuple[int, int]]:
+    result = sync_execute(
+        """
+        SELECT team_id, count(distinct session_id) as count
+        FROM session_recording_events
+        WHERE timestamp between %(begin)s AND %(end)s
+        GROUP BY team_id
+    """,
+        {"begin": begin, "end": end},
+    )
+    return result
+
+
+def get_teams_with_recording_count_total() -> List[Tuple[int, int]]:
+    result = sync_execute(
+        """
+        SELECT team_id, count(distinct session_id) as count
+        FROM session_recording_events
+        GROUP BY team_id
+    """
+    )
+    return result
+
+
+def find_count_for_team_in_rows(team_id: int, rows: list) -> int:
+    for row in rows:
+        if "team_id" in row:
+            if row["team_id"] == team_id:
+                return row["total"]
+        elif row[0] == team_id:
+            return row[1]
+    return 0
+
+
+@activity.defn
+def capture_report(
+    capture_event_name: str, org_id: str, full_report_dict: Dict[str, Any], at_date: Optional[datetime] = None
+) -> None:
+    pha_client = Client("sTMFPsFhdP1Ssg")
+    try:
+        capture_event(pha_client, capture_event_name, org_id, full_report_dict, timestamp=at_date)
+        logger.info(f"UsageReport sent to PostHog for organization {org_id}")
+    except Exception as err:
+        logger.error(
+            f"UsageReport sent to PostHog for organization {org_id} failed: {str(err)}",
+        )
+        capture_event(pha_client, f"{capture_event_name} failure", org_id, {"error": str(err)})
+    pha_client.flush()
+
+
+# extend this with future usage based products
+def has_non_zero_usage(report: FullUsageReport) -> bool:
+    return report.event_count_in_period > 0 or report.recording_count_in_period > 0
+
+
+@dataclasses.dataclass
+class SendAllOrgUsageReportsInputs:
     dry_run: bool = False
     at: Optional[str] = None
     capture_event_name: Optional[str] = None
@@ -20,12 +420,171 @@ class SendAllOrgUsageReportsArgs:
 @workflow.defn(name="send-all-org-usage-reports")
 class SendAllOrgUsageReportsWorkflow(CommandableWorkflow):
     @staticmethod
-    def parse_inputs(inputs: list[str]) -> SendAllOrgUsageReportsArgs:
+    def parse_inputs(inputs: list[str]) -> SendAllOrgUsageReportsInputs:
         """Parse inputs from the management command CLI."""
         # todo: parse inputs
         return inputs[0]
 
     @workflow.run
-    async def run(self, time: str):
-        # todo: migrate logic here
+    async def run(self, inputs: SendAllOrgUsageReportsInputs) -> List[dict]:  # Dict[str, OrgReport]:
+        dry_run, at, capture_event_name, skip_capture_event, only_organization_id = (
+            inputs.dry_run,
+            inputs.at,
+            inputs.capture_event_name,
+            inputs.skip_capture_event,
+            inputs.only_organization_id,
+        )
+
+        capture_event_name = capture_event_name or "organization usage report"
+
+        at_date = dateutil.parser.parse(at) if at else None
+        period = get_previous_day(at=at_date)
+        period_start, period_end = period
+
+        instance_metadata = get_instance_metadata(period)
+
+        # Clickhouse is good at counting things so we count across all teams rather than doing it one by one
+        all_data = dict(
+            teams_with_event_count_lifetime=get_teams_with_event_count_lifetime(),
+            teams_with_event_count_in_period=get_teams_with_event_count_in_period(period_start, period_end),
+            teams_with_event_count_in_month=get_teams_with_event_count_in_period(
+                period_start.replace(day=1), period_end
+            ),
+            teams_with_event_count_with_groups_in_period=get_teams_with_event_count_with_groups_in_period(
+                period_start, period_end
+            ),
+            # teams_with_event_count_by_lib=get_teams_with_event_count_by_lib(period_start, period_end),
+            # teams_with_event_count_by_name=get_teams_with_event_count_by_name(period_start, period_end),
+            teams_with_recording_count_in_period=get_teams_with_recording_count_in_period(period_start, period_end),
+            teams_with_recording_count_total=get_teams_with_recording_count_total(),
+            teams_with_group_types_total=list(
+                GroupTypeMapping.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            ),
+            teams_with_dashboard_count=list(
+                Dashboard.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            ),
+            teams_with_dashboard_template_count=list(
+                Dashboard.objects.filter(creation_mode="template")
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+            teams_with_dashboard_shared_count=list(
+                Dashboard.objects.filter(sharingconfiguration__enabled=True)
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+            teams_with_dashboard_tagged_count=list(
+                Dashboard.objects.filter(tagged_items__isnull=False)
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+            teams_with_ff_count=list(
+                FeatureFlag.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            ),
+            teams_with_ff_active_count=list(
+                FeatureFlag.objects.filter(active=True)
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+        )
+
+        teams: Sequence[Team] = list(
+            Team.objects.select_related("organization").exclude(
+                Q(organization__for_internal_metrics=True) | Q(is_demo=True)
+            )
+        )
+
+        org_reports: Dict[str, OrgReport] = {}
+
+        for team in teams:
+            team_report = UsageReportCounters(
+                event_count_lifetime=find_count_for_team_in_rows(team.id, all_data["teams_with_event_count_lifetime"]),
+                event_count_in_period=find_count_for_team_in_rows(
+                    team.id, all_data["teams_with_event_count_in_period"]
+                ),
+                event_count_in_month=find_count_for_team_in_rows(team.id, all_data["teams_with_event_count_in_month"]),
+                event_count_with_groups_in_period=find_count_for_team_in_rows(
+                    team.id, all_data["teams_with_event_count_with_groups_in_period"]
+                ),
+                # event_count_by_lib: Difind_count_for_team_in_rows(team.id, all_data["teams_with_#"]),
+                # event_count_by_name: Difind_count_for_team_in_rows(team.id, all_data["teams_with_#"]),
+                recording_count_in_period=find_count_for_team_in_rows(
+                    team.id, all_data["teams_with_recording_count_in_period"]
+                ),
+                recording_count_total=find_count_for_team_in_rows(
+                    team.id, all_data["teams_with_recording_count_total"]
+                ),
+                group_types_total=find_count_for_team_in_rows(team.id, all_data["teams_with_group_types_total"]),
+                dashboard_count=find_count_for_team_in_rows(team.id, all_data["teams_with_dashboard_count"]),
+                dashboard_template_count=find_count_for_team_in_rows(
+                    team.id, all_data["teams_with_dashboard_template_count"]
+                ),
+                dashboard_shared_count=find_count_for_team_in_rows(
+                    team.id, all_data["teams_with_dashboard_shared_count"]
+                ),
+                dashboard_tagged_count=find_count_for_team_in_rows(
+                    team.id, all_data["teams_with_dashboard_tagged_count"]
+                ),
+                ff_count=find_count_for_team_in_rows(team.id, all_data["teams_with_ff_count"]),
+                ff_active_count=find_count_for_team_in_rows(team.id, all_data["teams_with_ff_active_count"]),
+            )
+
+            org_id = str(team.organization.id)
+
+            if org_id not in org_reports:
+                org_report = OrgReport(
+                    date=period_start.strftime("%Y-%m-%d"),
+                    organization_id=org_id,
+                    organization_name=team.organization.name,
+                    organization_created_at=team.organization.created_at.isoformat(),
+                    organization_user_count=get_org_user_count(org_id),
+                    team_count=1,
+                    teams={str(team.id): team_report},
+                    **dataclasses.asdict(team_report),  # Clone the team report as the basis
+                )
+                org_reports[org_id] = org_report
+            else:
+                org_report = org_reports[org_id]
+                org_report.teams[str(team.id)] = team_report
+                org_report.team_count += 1
+
+                # Iterate on all fields of the UsageReportCounters and add the values from the team report to the org report
+                for field in dataclasses.fields(UsageReportCounters):
+                    if hasattr(team_report, field.name):
+                        setattr(
+                            org_report,
+                            field.name,
+                            getattr(org_report, field.name) + getattr(team_report, field.name),
+                        )
+
+        all_reports = []
+
+        for org_report in org_reports.values():
+            org_id = org_report.organization_id
+
+            if only_organization_id and only_organization_id != org_id:
+                continue
+
+            full_report = FullUsageReport(
+                **dataclasses.asdict(org_report),
+                **dataclasses.asdict(instance_metadata),
+            )
+            full_report_dict = dataclasses.asdict(full_report)
+            all_reports.append(full_report_dict)
+
+            if dry_run:
+                continue
+
+            # First capture the events to PostHog
+            if not skip_capture_event:
+                capture_report.delay(capture_event_name, org_id, full_report_dict, at_date)
+
+            # Then capture the events to Billing
+            if has_non_zero_usage(full_report):
+                send_report_to_billing_service.delay(org_id, full_report_dict)
+        return all_reports
         workflow.logger.info("Done 🎉")

--- a/posthog/temporal/workflows/usage_report.py
+++ b/posthog/temporal/workflows/usage_report.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import (
+    Optional,
+)
+
+from temporalio import workflow
+
+from posthog.temporal.workflows.base import CommandableWorkflow
+
+
+@dataclass
+class SendAllOrgUsageReportsArgs:
+    dry_run: bool = False
+    at: Optional[str] = None
+    capture_event_name: Optional[str] = None
+    skip_capture_event: bool = False
+    only_organization_id: Optional[str] = None
+
+
+@workflow.defn(name="send-all-org-usage-reports")
+class SendAllOrgUsageReportsWorkflow(CommandableWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> SendAllOrgUsageReportsArgs:
+        """Parse inputs from the management command CLI."""
+        # todo: parse inputs
+        return inputs[0]
+
+    @workflow.run
+    async def run(self, time: str):
+        # todo: migrate logic here
+        workflow.logger.info("Done 🎉")


### PR DESCRIPTION
## Problem
We have a Celery task that periodically (every night) runs `send_all_org_usage_reports`. If there's a failure midway through: 
 - we lose all of the work we've done so far and have to re-run from scratch
 - we don't have a record of successful/failed runs
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
Implement a Temporal workflow for `send_all_org_usage_reports`.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
