### PR TITLE
fix: Truncate preview deploy namespaces to 38 characters

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -60,6 +60,7 @@ jobs:
                   export BRANCH_NAME=${{ github.head_ref }}
                   export RELEASE_NAME=posthog
                   export NAMESPACE=pr-$PR_NUM-${BRANCH_NAME//\//-}
+                  export NAMESPACE=${NAMESPACE:0:38}
                   export HOSTNAME=$NAMESPACE
                   export TAILNET_NAME=hedgehog-kitefin
                   export TS_AUTHKEY=${{ secrets.TAILSCALE_SERVICE_AUTHKEY }}


### PR DESCRIPTION

## Problem
Including our tailscale suffix (.hedgehog-kitefin.ts.net) this is the limit before letsencrypt complains, it only allows DNS names of 64 characters or less

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
