### PR TITLE
fix(cohorts): number cohort version arguments

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -142,12 +142,12 @@
   <class 'tuple'> (
     '
       AND ( pdi.person_id IN (
-      SELECT DISTINCT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %(global_cohort_id_0)s AND version = %(version)s
+      SELECT DISTINCT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %(global_cohort_id_0)s AND version = %(global_version_0)s
       ))
     ',
     <class 'dict'> {
       'global_cohort_id_0': 28,
-      'version': None,
+      'global_version_0': None,
     },
   )
 ---

--- a/posthog/models/cohort/sql.py
+++ b/posthog/models/cohort/sql.py
@@ -47,7 +47,7 @@ WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version < %(new_ve
 # Version filtering is not necessary as only positive rows of the latest version will be selected by sum(sign) > 0
 
 GET_PERSON_ID_BY_PRECALCULATED_COHORT_ID = """
-SELECT DISTINCT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %({prepend}_cohort_id_{index})s AND version = %(version)s
+SELECT DISTINCT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %({prepend}_cohort_id_{index})s AND version = %({prepend}_version_{index})s
 """
 
 GET_COHORTS_BY_PERSON_UUID = """

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -71,7 +71,7 @@ def format_static_cohort_query(cohort: Cohort, index: int, prepend: str) -> Tupl
 
 def format_precalculated_cohort_query(cohort: Cohort, index: int, prepend: str = "") -> Tuple[str, Dict[str, Any]]:
     filter_query = GET_PERSON_ID_BY_PRECALCULATED_COHORT_ID.format(index=index, prepend=prepend)
-    return (filter_query, {f"{prepend}_cohort_id_{index}": cohort.pk, "version": cohort.version})
+    return (filter_query, {f"{prepend}_cohort_id_{index}": cohort.pk, f"{prepend}_version_{index}": cohort.version})
 
 
 def get_count_operator(count_operator: Optional[str]) -> str:

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -4929,7 +4929,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             groups=[{"properties": [{"key": "key_2", "value": "value_2", "type": "person"}]}],
         )
 
-        cohort1.calculate_people_ch(pending_version=0)
+        # try different versions
+        cohort1.calculate_people_ch(pending_version=1)
         cohort2.calculate_people_ch(pending_version=0)
 
         with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):  # Normally this is False in tests


### PR DESCRIPTION
## Problem

- multiple cohorts breaks filtering because the argument introduced [here](https://github.com/PostHog/posthog/pull/15005) wasn't numbered
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- add numbering to arg

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
