### PR TITLE
feat(read-replica): Add database config for postgres read replicas

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -32,8 +32,10 @@ else:
 
 if DATABASE_URL:
     DATABASES = {"default": dj_database_url.config(default=DATABASE_URL, conn_max_age=0)}
+
     if DISABLE_SERVER_SIDE_CURSORS:
         DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
+
 elif os.getenv("POSTHOG_DB_NAME"):
     DATABASES = {
         "default": {
@@ -77,6 +79,26 @@ else:
     raise ImproperlyConfigured(
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'
     )
+
+if os.getenv("POSTHOG_POSTGRES_READ_HOST"):
+    DATABASES["replica"] = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": get_from_env("POSTHOG_DB_NAME"),
+            "USER": os.getenv("POSTHOG_DB_USER", "postgres"),
+            "PASSWORD": os.getenv("POSTHOG_DB_PASSWORD", ""),
+            "HOST": os.getenv("POSTHOG_POSTGRES_READ_HOST", "localhost"),
+            "PORT": os.getenv("POSTHOG_POSTGRES_PORT", "5432"),
+            "CONN_MAX_AGE": 0,
+            "DISABLE_SERVER_SIDE_CURSORS": DISABLE_SERVER_SIDE_CURSORS,
+            "SSL_OPTIONS": {
+                "sslmode": os.getenv("POSTHOG_POSTGRES_SSL_MODE", None),
+                "sslrootcert": os.getenv("POSTHOG_POSTGRES_CLI_SSL_CA", None),
+                "sslcert": os.getenv("POSTHOG_POSTGRES_CLI_SSL_CRT", None),
+                "sslkey": os.getenv("POSTHOG_POSTGRES_CLI_SSL_KEY", None),
+            },
+        }
+    }
 
 if JOB_QUEUE_GRAPHILE_URL:
     DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -99,7 +99,7 @@ else:
 # This should have all the same config as our main writer DB, just use a different host.
 # Our database router will point here.
 if os.getenv("POSTHOG_POSTGRES_READ_HOST"):
-    DATABASES["replica"] = postgres_config(os.getenv("POSTHOG_POSTGRES_READ_HOST", "localhost"))
+    DATABASES["replica"] = postgres_config(os.getenv("POSTHOG_POSTGRES_READ_HOST"))
 
 if JOB_QUEUE_GRAPHILE_URL:
     DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -98,8 +98,9 @@ else:
 # Configure the database which will be used as a read replica.
 # This should have all the same config as our main writer DB, just use a different host.
 # Our database router will point here.
-if os.getenv("POSTHOG_POSTGRES_READ_HOST"):
-    DATABASES["replica"] = postgres_config(os.getenv("POSTHOG_POSTGRES_READ_HOST"))
+read_host = os.getenv("POSTHOG_POSTGRES_READ_HOST")
+if read_host:
+    DATABASES["replica"] = postgres_config(read_host)
 
 if JOB_QUEUE_GRAPHILE_URL:
     DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -1,5 +1,4 @@
 import os
-from typing import Dict, Any
 from urllib.parse import urlparse
 
 import dj_database_url
@@ -22,7 +21,7 @@ SQLCOMMENTER_WITH_FRAMEWORK = False
 JOB_QUEUE_GRAPHILE_URL = os.getenv("JOB_QUEUE_GRAPHILE_URL")
 
 
-def postgres_config(host: str) -> Dict[str, Any]:
+def postgres_config(host: str) -> dict:
     """Generate the config map we need for a postgres database.
 
     Generally all our postgres databases will need the same config - replicas are identical other than host.
@@ -31,7 +30,7 @@ def postgres_config(host: str) -> Dict[str, Any]:
         host (str): The host to connect to
 
     Returns:
-        Dict[str, Any]: The config, to be set in django DATABASES
+        dict: The config, to be set in django DATABASES
     """
 
     return {

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -21,6 +21,7 @@ SQLCOMMENTER_WITH_FRAMEWORK = False
 
 JOB_QUEUE_GRAPHILE_URL = os.getenv("JOB_QUEUE_GRAPHILE_URL")
 
+
 def postgres_config(host: str) -> Dict[str, Any]:
     """Generate the config map we need for a postgres database.
 
@@ -50,6 +51,7 @@ def postgres_config(host: str) -> Dict[str, Any]:
         },
     }
 
+
 if TEST or DEBUG:
     PG_HOST = os.getenv("PGHOST", "localhost")
     PG_USER = os.getenv("PGUSER", "posthog")
@@ -67,9 +69,7 @@ if DATABASE_URL:
         DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
 
 elif os.getenv("POSTHOG_DB_NAME"):
-    DATABASES = {
-        "default": postgres_config(os.getenv("POSTHOG_POSTGRES_HOST", "localhost"))
-    }
+    DATABASES = {"default": postgres_config(os.getenv("POSTHOG_POSTGRES_HOST", "localhost"))}
 
     ssl_configurations = []
     for ssl_option, value in DATABASES["default"]["SSL_OPTIONS"].items():


### PR DESCRIPTION
## Problem

Allow for configuring a second postgres database, this time a
read-replica.

This is configured via the POSTHOG_POSTGRES_READ_HOST, introduced here: https://github.com/PostHog/charts-clickhouse/pull/722

Note that with our current setup, all replicas have the same port/db
name/creds etc - only the host differs.

This change will not actually change any behaviour until the following
are complete

1. Write a new database router to actually use this
2. Set the env var to add the config

I will follow up with those :)

## How did you test this code?
I couldn't find any testing for our settings stuff, so did not add to it + think starting one now would be a bit out of scope. We probably should though.