### PR TITLE
fix(trends): fix trend actors query with poe v2

### DIFF
--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -119,7 +119,7 @@ class TrendsActors(ActorBaseQuery):
             team=self._team,
             entity=self.entity,
             should_join_distinct_ids=not self.is_aggregating_by_groups
-            and self._team.person_on_events_mode == PersonOnEventsMode.DISABLED,
+            and self._team.person_on_events_mode != PersonOnEventsMode.V1_ENABLED,
             extra_event_properties=["$window_id", "$session_id"] if self._filter.include_recordings else [],
             extra_fields=extra_fields,
             person_on_events_mode=self._team.person_on_events_mode,


### PR DESCRIPTION
 Trends actors is currently not working on PoE v2, this fixes it.
