### PR TITLE
fix(sampling): always show fast mode tooltip

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -251,11 +251,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         {!!featureFlags[FEATURE_FLAGS.SAMPLING] ? (
                             <>
                                 <Tooltip
-                                    title={
-                                        !!globalInsightFilters.sampling_factor
-                                            ? 'Turning on lightning mode will automatically enable 10% sampling for all insights you refresh, speeding up the calculation of results'
-                                            : ''
-                                    }
+                                    title="Turning on fast mode will automatically enable 10% sampling for all insights you refresh, speeding up the calculation of results"
                                     placement="bottom"
                                 >
                                     <div>


### PR DESCRIPTION
## Problem

We are displaying the fast mode tooltip only once it is switched on, which doesn't allow the user to understand the feature beforehand. While I'd be fine with that, the tooltip is also broken when the cursor is over the lemon switch knob and will only display when the cursor is somewhere else over the lemon switch.

## Changes

This PR removes the condition from the fast mode tooltip and adapts it's wording to be inline with the naming from docs.

Notes:
- Alternative: If we want to keep the conditional tooltip, we should set the lemon switch knob to `pointer-events: none;`, so that the tooltip consistently appears.
- I like the naming "lightning mode" better, but docs say "fast mode", so I'm assuming we've settled on that.

## How did you test this code?

Moving the mouse over the switch