### PR TITLE
fix(lemon-switch): display with pointer cursor

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
@@ -7,7 +7,7 @@
     gap: 0.5rem;
 
     label[for] {
-        cursor: default; // A label with for=* also toggles the switch, so it shouldn't have the text select cursor
+        cursor: pointer; // A label with for=* also toggles the switch, so it shouldn't have the text select cursor
     }
 
     label {
@@ -36,12 +36,15 @@
     > .LemonIcon {
         font-size: 1.5rem;
         color: var(--muted-alt);
-        cursor: pointer;
     }
 
     &.LemonSwitch--disabled {
         cursor: not-allowed;
         opacity: var(--opacity-disabled);
+
+        label[for] {
+            cursor: not-allowed; // A label with for=* also toggles the switch, so it shouldn't have the text select cursor
+        }
     }
 }
 
@@ -54,7 +57,11 @@
     height: 1.25rem;
     background: none;
     border: none;
-    cursor: inherit;
+    cursor: pointer;
+
+    .LemonSwitch--disabled & {
+        cursor: not-allowed;
+    }
 }
 
 .LemonSwitch__slider {


### PR DESCRIPTION
## Problem

The lemon switch displays a pointer cursor for not clickable element i.e. icon and no pointer cursor for clickable elements i.e. handle, know and label.

## Changes

Now the lemon switch displays a pointer cursor for clickable elements (or a not-allowed one for disable switches) and a regular cursor for icons.

## How did you test this code?

Moving the mouse over the switch parts in storybook