### PR TITLE
fix(plugins): handle undefined plugin capabilties

### DIFF
--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -261,7 +261,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                     }
 
                     if (tab === AppMetricsTab.HistoricalExports) {
-                        return isExportEvents
+                        return !!isExportEvents
                     } else if (tab === AppMetricsTab.OnEvent && isExportEvents) {
                         // Hide onEvent tab for plugins using exportEvents
                         // :KLUDGE: if plugin has `onEvent` in source, that's called/tracked but we can't check that here.
@@ -273,11 +273,11 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                         return (
                             !isExportEvents &&
                             ['runEveryMinute', 'runEveryHour', 'runEveryDay'].some((method) =>
-                                capabilities.scheduled_tasks.includes(method)
+                                capabilities.scheduled_tasks?.includes(method)
                             )
                         )
                     } else {
-                        return capabilities.methods?.includes(tab)
+                        return !!capabilities.methods?.includes(tab)
                     }
                 },
         ],

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -33,7 +33,7 @@ function EnabledDisabledSwitch({
     return (
         <>
             <Switch checked={value} onChange={onChange} />
-            <strong style={{ paddingLeft: 10 }}>{value ? 'Enabled' : 'Disabled'}</strong>
+            <strong className="pl-2.5">{value ? 'Enabled' : 'Disabled'}</strong>
         </>
     )
 }
@@ -145,7 +145,7 @@ export function PluginDrawer(): JSX.Element {
                 title={editingPlugin?.name}
                 data-attr="plugin-drawer"
                 footer={
-                    <div style={{ display: 'flex' }}>
+                    <div className="flex">
                         <Space style={{ flexGrow: 1 }}>
                             {editingPlugin &&
                                 !editingPlugin.is_global &&
@@ -230,16 +230,16 @@ export function PluginDrawer(): JSX.Element {
                     {/* TODO: Rework as Kea form with Lemon UI components */}
                     {editingPlugin ? (
                         <div>
-                            <div style={{ display: 'flex', marginBottom: 16 }}>
+                            <div className="flex mb-4">
                                 <PluginImage
                                     pluginType={editingPlugin.plugin_type}
                                     url={editingPlugin.url}
                                     icon={editingPlugin.icon}
                                     size="large"
                                 />
-                                <div style={{ flexGrow: 1, paddingLeft: 16 }}>
+                                <div className="grow pl-4">
                                     {endWithPunctation(editingPlugin.description)}
-                                    <div style={{ marginTop: 5 }}>
+                                    <div className="mt-1.5">
                                         {editingPlugin?.plugin_type === 'local' && editingPlugin.url ? (
                                             <LocalPluginTag url={editingPlugin.url} title="Installed Locally" />
                                         ) : editingPlugin.plugin_type === 'source' ? (
@@ -251,7 +251,7 @@ export function PluginDrawer(): JSX.Element {
                                             </a>
                                         )}
                                     </div>
-                                    <div style={{ display: 'flex', alignItems: 'center', marginTop: 5 }}>
+                                    <div className="flex items-center mt-1.5">
                                         <Form.Item
                                             fieldKey="__enabled"
                                             name="__enabled"
@@ -279,14 +279,12 @@ export function PluginDrawer(): JSX.Element {
 
                             {editingPlugin.capabilities && Object.keys(editingPlugin.capabilities).length > 0 ? (
                                 <>
-                                    <h3 className="l3" style={{ marginTop: 32 }}>
-                                        Capabilities
-                                    </h3>
+                                    <h3 className="l3 mt-8">Capabilities</h3>
 
-                                    <div style={{ marginTop: 5 }}>
+                                    <div className="mt-1.5">
                                         {[
-                                            ...editingPlugin.capabilities.methods,
-                                            ...editingPlugin.capabilities.scheduled_tasks,
+                                            ...(editingPlugin.capabilities.methods || []),
+                                            ...(editingPlugin.capabilities.scheduled_tasks || []),
                                         ]
                                             .filter(
                                                 (capability) => !['setupPlugin', 'teardownPlugin'].includes(capability)
@@ -320,9 +318,7 @@ export function PluginDrawer(): JSX.Element {
                                 />
                             )}
 
-                            <h3 className="l3" style={{ marginTop: 32 }}>
-                                Configuration
-                            </h3>
+                            <h3 className="l3 mt-8">Configuration</h3>
                             {getConfigSchemaArray(editingPlugin.config_schema).length === 0 ? (
                                 <div>This app is not configurable.</div>
                             ) : null}
@@ -343,7 +339,7 @@ export function PluginDrawer(): JSX.Element {
                                             extra={
                                                 fieldConfig.hint && (
                                                     <small>
-                                                        <div style={{ height: 2 }} />
+                                                        <div className="h-0.5" />
                                                         <ReactMarkdown source={fieldConfig.hint} linkTarget="_blank" />
                                                     </small>
                                                 )
@@ -370,7 +366,7 @@ export function PluginDrawer(): JSX.Element {
                                     ) : (
                                         <>
                                             {fieldConfig.type ? (
-                                                <p style={{ color: 'var(--danger)' }}>
+                                                <p className="text-danger">
                                                     Invalid config field <i>{fieldConfig.name || fieldConfig.key}</i>.
                                                 </p>
                                             ) : null}

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -296,7 +296,7 @@ export function PluginDrawer(): JSX.Element {
                                                     <Tag className="plugin-capabilities-tag">{capability}</Tag>
                                                 </Tooltip>
                                             ))}
-                                        {editingPlugin.capabilities.jobs.map((jobName) => (
+                                        {(editingPlugin.capabilities?.jobs || []).map((jobName) => (
                                             <Tooltip title="Custom job" key={jobName}>
                                                 <Tag className="plugin-capabilities-tag">{jobName}</Tag>
                                             </Tooltip>

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -13,7 +13,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 interface PluginJobOptionsProps {
     pluginId: number
     pluginConfigId: number
-    capabilities: Record<'jobs' | 'methods' | 'scheduled_tasks', string[]>
+    capabilities: Record<'jobs' | 'methods' | 'scheduled_tasks', string[] | undefined>
     publicJobs: Record<string, JobSpec>
     onSubmit: () => void
 }
@@ -28,7 +28,7 @@ export function PluginJobOptions({
     const { featureFlags } = useValues(featureFlagLogic)
 
     const jobs = useMemo(() => {
-        return capabilities.jobs
+        return (capabilities?.jobs || [])
             .filter((jobName) => jobName in publicJobs)
             .filter((jobName) => {
                 // Hide either old or new export depending on the feature flag value

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -47,7 +47,7 @@ export function PluginJobOptions({
 
     return (
         <>
-            <h3 className="l3" style={{ marginTop: 32 }}>
+            <h3 className="l3 mt-8">
                 Jobs
                 <LemonTag type="warning" className="uppercase" style={{ verticalAlign: '0.125em', marginLeft: 6 }}>
                     BETA

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1346,7 +1346,7 @@ export interface PluginType {
     organization_id: string
     organization_name: string
     metrics?: Record<string, StoredMetricMathOperations>
-    capabilities?: Record<'jobs' | 'methods' | 'scheduled_tasks', string[]>
+    capabilities?: Record<'jobs' | 'methods' | 'scheduled_tasks', string[] | undefined>
     public_jobs?: Record<string, JobSpec>
 }
 


### PR DESCRIPTION
## Problem

<img width="1231" alt="Screenshot 2023-04-17 at 23 22 36" src="https://user-images.githubusercontent.com/1851359/232624551-cdcc057d-54cc-45fe-ae23-bd29b3eb2de0.png">

## Changes

This PR modifies plugin capabilities' jobs, methods and scheduled_tasks types to include undefined and handles these cases. In many cases we did already check for undefined for these values.

## How did you test this code?

`tsc` and verifying my issue above is gone