### PR TITLE
chore(jobs): make graphile concurrency configurable

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -74,6 +74,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         JOB_QUEUE_GRAPHILE_URL: '',
         JOB_QUEUE_GRAPHILE_SCHEMA: 'graphile_worker',
         JOB_QUEUE_GRAPHILE_PREPARED_STATEMENTS: false,
+        JOB_QUEUE_GRAPHILE_CONCURRENCY: 1,
         JOB_QUEUE_S3_AWS_ACCESS_KEY: '',
         JOB_QUEUE_S3_AWS_SECRET_ACCESS_KEY: '',
         JOB_QUEUE_S3_AWS_REGION: 'us-west-1',

--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -160,7 +160,7 @@ export class GraphileWorker {
                 pgPool: this.consumerPool as Pool as any,
                 schema: this.hub.JOB_QUEUE_GRAPHILE_SCHEMA,
                 noPreparedStatements: !this.hub.JOB_QUEUE_GRAPHILE_PREPARED_STATEMENTS,
-                concurrency: 1,
+                concurrency: this.hub.JOB_QUEUE_GRAPHILE_CONCURRENCY,
                 // Do not install signal handlers, we are handled signals in
                 // higher level code. If we let graphile worker handle the signals it
                 // ends up sending another SIGTERM.

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -132,6 +132,7 @@ export interface PluginsServerConfig {
     JOB_QUEUE_GRAPHILE_URL: string // use a different postgres connection in the graphile worker
     JOB_QUEUE_GRAPHILE_SCHEMA: string // the postgres schema that the graphile worker
     JOB_QUEUE_GRAPHILE_PREPARED_STATEMENTS: boolean // enable this to increase job queue throughput if not using pgbouncer
+    JOB_QUEUE_GRAPHILE_CONCURRENCY: number // concurrent jobs per pod
     JOB_QUEUE_S3_AWS_ACCESS_KEY: string
     JOB_QUEUE_S3_AWS_SECRET_ACCESS_KEY: string
     JOB_QUEUE_S3_AWS_REGION: string


### PR DESCRIPTION
## Problem

plugin-server-jobs pods have a very low task throughput. They are not CPU or memory bound, but are waiting idle on IO. Having too many pods hurts PG, so we cannot scale-out a lot more.


## Changes

To better feed the pod's CPU, let's try increasing the graphile concurrency, to execute several tasks when the CPU can.

Default stays 1 unless an envvar is set

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
