### PR TITLE
fix(events-explorer): comment with person

### DIFF
--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -289,7 +289,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
-            query = EventsQuery(select=["event", "person", "person"])
+            query = EventsQuery(select=["event", "person", "person -- P"])
             response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 4)
             self.assertEqual(response["results"][0][1], {"distinct_id": "4"})

--- a/posthog/models/event/events_query.py
+++ b/posthog/models/event/events_query.py
@@ -50,7 +50,8 @@ def run_events_query(
     # columns & group_by
     select_input_raw = ["*"] if len(query.select) == 0 else query.select
     select_input: List[str] = []
-    for col in select_input_raw:
+    person_indices: List[int] = []
+    for index, col in enumerate(select_input_raw):
         # Selecting a "*" expands the list of columns, resulting in a table that's not what we asked for.
         # Instead, ask for a tuple with all the columns we want. Later transform this back into a dict.
         if col == "*":
@@ -58,6 +59,7 @@ def run_events_query(
         elif col.split("--")[0].strip() == "person":
             # This will be expanded into a followup query
             select_input.append("distinct_id")
+            person_indices.append(index)
         else:
             select_input.append(col)
 
@@ -152,9 +154,9 @@ def run_events_query(
                 ).data
             query_result.results[index][star_idx] = new_result
 
-    if "person" in select_input_raw and len(query_result.results) > 0:
+    if len(person_indices) > 0 and len(query_result.results) > 0:
         # Make a query into postgres to fetch person
-        person_idx = select_input_raw.index("person")
+        person_idx = person_indices[0]
         distinct_ids = list(set(event[person_idx] for event in query_result.results))
         persons = get_persons_by_distinct_ids(team.pk, distinct_ids)
         persons = persons.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
@@ -165,9 +167,7 @@ def run_events_query(
                     distinct_to_person[person_distinct_id] = person
 
         # Loop over all columns in case there is more than one "person" column
-        for column_index, column in enumerate(select_input_raw):
-            if column != "person":
-                continue
+        for column_index in person_indices:
             for index, result in enumerate(query_result.results):
                 distinct_id: str = result[column_index]
                 query_result.results[index] = list(result)

--- a/posthog/models/event/events_query.py
+++ b/posthog/models/event/events_query.py
@@ -55,7 +55,7 @@ def run_events_query(
         # Instead, ask for a tuple with all the columns we want. Later transform this back into a dict.
         if col == "*":
             select_input.append(f"tuple({', '.join(SELECT_STAR_FROM_EVENTS_FIELDS)})")
-        elif col == "person":
+        elif col.split("--")[0].strip() == "person":
             # This will be expanded into a followup query
             select_input.append("distinct_id")
         else:


### PR DESCRIPTION
## Problem

Queries like these would fail:

```json
{
  "kind": "DataTableNode",
  "full": true,
  "source": {
    "kind": "EventsQuery",
    "select": [
      "*",
      "event",
      "person -- P",
      "coalesce(properties.$current_url, properties.$screen_name) -- Url / Screen",
      "properties.$lib",
      "timestamp"
    ],
    "orderBy": [
      "timestamp DESC"
    ],
    "after": "-24h",
    "limit": 100
  },
  "propertiesViaUrl": true,
  "showSavedQueries": true
}
```

## Changes

Fixes the special person handling in EventsQuery.

## How did you test this code?

Added a tweak to a test that broke before but works now.