### PR TITLE
fix: Don't mark recordings as viewed in debugging state

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -5,6 +5,7 @@ import structlog
 from dateutil import parser
 from django.db.models import Count, Prefetch
 from django.http import JsonResponse
+from loginas.utils import is_impersonated_session
 from rest_framework import exceptions, request, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -116,7 +117,9 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             raise exceptions.NotFound("Recording not found")
 
         recording.load_person()
-        recording.check_viewed_for_user(request.user, save_viewed=request.GET.get("save_view") is not None)
+
+        save_viewed = request.GET.get("save_view") is not None and not is_impersonated_session(request)
+        recording.check_viewed_for_user(request.user, save_viewed=save_viewed)
 
         serializer = SessionRecordingSerializer(recording)
 


### PR DESCRIPTION
## Problem

When we are troubleshooting we don't want to mark recordings as viewed (at least not persistently)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
