### PR TITLE
fix: Don't double send response data

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -163,15 +163,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.ViewSet):
         else:
             next_url = None
 
-        res = {
-            "next": next_url,
-            "snapshot_data_by_window_id": recording.snapshot_data_by_window_id,
-            # TODO: Remove this once the frontend is migrated to use the above values
-            "result": {
-                "next": next_url,
-                "snapshot_data_by_window_id": recording.snapshot_data_by_window_id,
-            },
-        }
+        res = {"next": next_url, "snapshot_data_by_window_id": recording.snapshot_data_by_window_id}
 
         # NOTE: We have seen some issues with encoding of emojis, specifically when there is a lone "surrogate pair". See #13272 for more details
         # The Django JsonResponse handles this case, but the DRF Response does not. So we fall back to the Django JsonResponse if we encounter an error

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -308,7 +308,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1/snapshots")
         response_data = response.json()
-        self.assertEqual(len(response_data["result"]["snapshot_data_by_window_id"][""]), DEFAULT_RECORDING_CHUNK_LIMIT)
+        self.assertEqual(len(response_data["snapshot_data_by_window_id"][""]), DEFAULT_RECORDING_CHUNK_LIMIT)
 
     def test_get_snapshots_is_compressed(self):
         base_time = now()
@@ -353,19 +353,19 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
                 response_data = response.json()
 
                 self.assertEqual(
-                    len(response_data["result"]["snapshot_data_by_window_id"]["1"]),
+                    len(response_data["snapshot_data_by_window_id"]["1"]),
                     snapshots_per_chunk * DEFAULT_RECORDING_CHUNK_LIMIT / 2,
                 )
                 self.assertEqual(
-                    len(response_data["result"]["snapshot_data_by_window_id"]["2"]),
+                    len(response_data["snapshot_data_by_window_id"]["2"]),
                     snapshots_per_chunk * DEFAULT_RECORDING_CHUNK_LIMIT / 2,
                 )
                 if i == expected_num_requests - 1:
-                    self.assertIsNone(response_data["result"]["next"])
+                    self.assertIsNone(response_data["next"])
                 else:
-                    self.assertIsNotNone(response_data["result"]["next"])
+                    self.assertIsNotNone(response_data["next"])
 
-                next_url = response_data["result"]["next"]
+                next_url = response_data["next"]
 
     def test_get_metadata_for_chunked_session_recording(self):
 


### PR DESCRIPTION
## Problem

We changed our API a while ago and kept the old format to support the swapover. Enough time has passed that we can remove this redundant data

Technically speaking this is breaking but we did a check before and there were no users other than us of this, and we didn't publicize the API format so we decided its safe to do.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
