### PR TITLE
chore: Make Celery and Redis optional in preflight experimenting

### DIFF
--- a/frontend/src/scenes/PreflightCheck/preflightLogic.test.ts
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.test.ts
@@ -130,7 +130,8 @@ describe('preflightLogic', () => {
                         {
                             id: 'celery',
                             name: 'Background jobs · Celery',
-                            status: 'error',
+                            status: 'warning',
+                            caption: 'Required in production environments',
                         },
                         {
                             id: 'plugins',
@@ -179,8 +180,8 @@ describe('preflightLogic', () => {
                 .toDispatchActions(['loadPreflightSuccess'])
                 .toMatchValues({
                     checksSummary: {
-                        summaryString: '7 successful, 1 warning, 1 error, 1 optional',
-                        summaryStatus: 'error',
+                        summaryString: '7 successful, 2 warnings, 1 optional',
+                        summaryStatus: 'warning',
                     },
                 })
         })

--- a/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
@@ -92,12 +92,28 @@ export const preflightLogic = kea<preflightLogicType>([
                     {
                         id: 'redis',
                         name: 'Cache · Redis',
-                        status: preflight?.redis ? 'validated' : 'error',
+                        status: preflight?.redis
+                            ? 'validated'
+                            : preflightMode === 'experimentation'
+                            ? 'warning'
+                            : 'error',
+                        caption:
+                            !preflight?.redis && preflightMode === 'experimentation'
+                                ? 'Required in production environments'
+                                : undefined,
                     },
                     {
                         id: 'celery',
                         name: 'Background jobs · Celery',
-                        status: preflight?.celery ? 'validated' : 'error',
+                        status: preflight?.celery
+                            ? 'validated'
+                            : preflightMode === 'experimentation'
+                            ? 'warning'
+                            : 'error',
+                        caption:
+                            !preflight?.celery && preflightMode === 'experimentation'
+                                ? 'Required in production environments'
+                                : undefined,
                     },
                     {
                         id: 'plugins',


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

This check is only done the first time and Celery sometimes annoyingly doesn't start up properly. There's lots of times when we don't need it for testing our changes, so making it optional, similar to plugin-server which already is optional.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<img width="329" alt="Screenshot 2023-04-19 at 14 55 36" src="https://user-images.githubusercontent.com/890921/233082067-2f3be7b8-122e-43d4-a2db-e186ae5d472d.png">


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
