### PR TITLE
chore(recordings): reduce prefetch size to stay within memory limits

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -64,7 +64,7 @@ export const startBatchConsumer = async ({
         'fetch.wait.max.ms': consumerMaxWaitMs,
         'enable.partition.eof': true,
         'queued.min.messages': 100000, // 100000 is the default
-        'queued.max.messages.kbytes': 1048576, // 1048576 is the default
+        'queued.max.messages.kbytes': 102400, // 1048576 is the default, we go smaller to reduce mem usage.
         'partition.assignment.strategy': 'roundrobin', // KafkaJS uses round robin, and we need to be compatible with it.
         rebalance_cb: true,
         offset_commit_cb: true,


### PR DESCRIPTION
I was using defaults of 1G before, but we can probably reduce that a
little.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
