### PR TITLE
feat: Improve titles and links in bugs emails

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -17,7 +17,7 @@ function getSessionReplayLink(): string {
         0
     )
     const link = `https://app.posthog.com/recordings/${posthog?.sessionRecording?.sessionId}?t=${recordingStartTime}`
-    return `\nSession replay: ${link}`
+    return `[Session replay](${link})`
 }
 
 function getDjangoAdminLink(user: UserType | null): string {
@@ -25,8 +25,7 @@ function getDjangoAdminLink(user: UserType | null): string {
         return ''
     }
     const link = `${window.location.origin}/admin/posthog/user/?q=${user.email}`
-    console.log(`\nAdmin link: ${link} (Organization: '${user.organization?.name}'; Project: '${user.team?.name}')`)
-    return `\nAdmin link: ${link} (Organization: '${user.organization?.name}'; Project: '${user.team?.name}')`
+    return `[Admin](${link}) (Organization: '${user.organization?.name}'; Project: '${user.team?.name}')`
 }
 
 export const TARGET_AREA_TO_NAME = {
@@ -136,18 +135,21 @@ export const supportLogic = kea<supportLogicType>([
             const email = userLogic.values.user?.email
 
             const zendesk_ticket_uuid = uuid()
+            const subject = (kind == 'bug' ? 'Bug Report: ' : 'Feedback: ') + TargetAreaToName[target_area]
             const payload = {
                 request: {
                     requester: { name: name, email: email },
-                    subject: 'Help in-app',
+                    subject: subject,
                     comment: {
                         body:
                             message +
                             `\n\n-----` +
                             `\nKind: ${kind}` +
                             `\nTarget area: ${target_area}` +
-                            `\nInternal link: http://go/ticketByUUID/${zendesk_ticket_uuid}` +
+                            `\nInternal links: [Event](http://go/ticketByUUID/${zendesk_ticket_uuid})` +
+                            ' | ' +
                             getSessionReplayLink() +
+                            ' | ' +
                             getDjangoAdminLink(userLogic.values.user),
                     },
                 },

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -29,13 +29,12 @@ function getDjangoAdminLink(user: UserType | null): string {
 }
 
 function getSentryLinks(user: UserType | null): string {
-    const sentryProjectId = new URL(window.SENTRY_DSN).pathname.slice(1)
-    if (!user || !sentryProjectId) {
+    if (!user) {
         return ''
     }
-    const link = `https://posthog.sentry.io/issues/?project=${sentryProjectId}&query=user.email:${user.email}`
     const cloud = window.location.origin == 'https://eu.posthog.com' ? 'EU' : 'US'
-    const pluginServer = `http://go/pluginServerSentry/DEPLOYMENT:${cloud}+team_id:${user.team?.id}`
+    const link = `http://go/sentry${cloud}/${user.email}`
+    const pluginServer = `http://go/pluginServerSentry${cloud}/${user.team?.id}`
     return `[Sentry](${link}) | [Plugin Server Sentry](${pluginServer})`
 }
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -28,6 +28,17 @@ function getDjangoAdminLink(user: UserType | null): string {
     return `[Admin](${link}) (Organization: '${user.organization?.name}'; Project: ${user.team?.id}:'${user.team?.name}')`
 }
 
+function getSentryLinks(user: UserType | null): string {
+    const sentryProjectId = new URL(window.SENTRY_DSN).pathname.slice(1)
+    if (!user || !sentryProjectId) {
+        return ''
+    }
+    const link = `https://posthog.sentry.io/issues/?project=${sentryProjectId}&query=user.email:${user.email}`
+    const cloud = window.location.origin == 'https://eu.posthog.com' ? 'EU' : 'US'
+    const pluginServer = `http://go/pluginServerSentry/DEPLOYMENT:${cloud}+team_id:${user.team?.id}`
+    return `[Sentry](${link}) | [Plugin Server Sentry](${pluginServer})`
+}
+
 export const TARGET_AREA_TO_NAME = {
     app_performance: 'App Performance',
     apps: 'Apps',
@@ -161,7 +172,9 @@ export const supportLogic = kea<supportLogicType>([
                             '\n' +
                             getSessionReplayLink() +
                             '\n' +
-                            getDjangoAdminLink(userLogic.values.user),
+                            getDjangoAdminLink(userLogic.values.user) +
+                            '\n' +
+                            getSentryLinks(userLogic.values.user),
                     },
                 },
             }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Before the user would get an email always had a subject of "In-app help" and the links were visible fully. Additionally different support requests would be grouped together by email clients ... probably.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

Added the UUID to the email for better aggregation by email clients.

Now the email looks like this:
<img width="867" alt="Screenshot 2023-05-08 at 17 19 21" src="https://user-images.githubusercontent.com/890921/236863110-3fb07b8f-f5b7-4382-bcf1-ef2235997bd9.png">


Slack: https://posthog.slack.com/archives/C0460J93NBU/p1683559083555579



Alternative for the internal links would be to submit a public message first and then a follow-up that's the one sent to slack that has the links too, but that's more complex and sending two API requests isn't great, so visible links it is for now.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
