### PR TITLE
feat(hogql): convert to a cloning resolver

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -63,7 +63,7 @@ def execute_hogql_query(
             print_columns.append(node.alias)
         else:
             print_columns.append(
-                print_ast(node=node, context=hogql_query_context, dialect="hogql", stack=[select_query_hogql])
+                print_prepared_ast(node=node, context=hogql_query_context, dialect="hogql", stack=[select_query_hogql])
             )
 
     # Print the ClickHouse SQL query

--- a/posthog/hogql/transforms/lazy_tables.py
+++ b/posthog/hogql/transforms/lazy_tables.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
@@ -170,7 +170,7 @@ class LazyTableResolver(TraversingVisitor):
         # For all the collected tables, create the subqueries, and add them to the table.
         for table_name, table_to_add in tables_to_add.items():
             subquery = table_to_add.lazy_table.lazy_select(table_to_add.fields_accessed)
-            resolve_types(subquery, self.context.database, select_type)
+            subquery = cast(ast.SelectQuery, resolve_types(subquery, self.context.database, [node]))
             old_table_type = select_type.tables[table_name]
             select_type.tables[table_name] = ast.SelectQueryAliasType(alias=table_name, select_query_type=subquery.type)
 
@@ -188,7 +188,7 @@ class LazyTableResolver(TraversingVisitor):
             join_to_add: ast.JoinExpr = join_scope.lazy_join.join_function(
                 join_scope.from_table, join_scope.to_table, join_scope.fields_accessed
             )
-            resolve_types(join_to_add, self.context.database, select_type)
+            join_to_add = cast(ast.JoinExpr, resolve_types(join_to_add, self.context.database, [node]))
             select_type.tables[to_table] = join_to_add.type
 
             join_ptr = node.select_from

--- a/posthog/hogql/transforms/test/test_asterisk.py
+++ b/posthog/hogql/transforms/test/test_asterisk.py
@@ -12,7 +12,7 @@ class TestAsteriskExpander(BaseTest):
 
     def test_asterisk_expander_table(self):
         node = parse_select("select * from events")
-        resolve_types(node, self.database)
+        node = resolve_types(node, self.database)
         expand_asterisks(node)
         events_table_type = ast.TableType(table=self.database.events)
         self.assertEqual(
@@ -32,7 +32,7 @@ class TestAsteriskExpander(BaseTest):
 
     def test_asterisk_expander_table_alias(self):
         node = parse_select("select * from events e")
-        resolve_types(node, self.database)
+        node = resolve_types(node, self.database)
         expand_asterisks(node)
         events_table_type = ast.TableType(table=self.database.events)
         events_table_alias_type = ast.TableAliasType(table_type=events_table_type, alias="e")
@@ -62,7 +62,7 @@ class TestAsteriskExpander(BaseTest):
 
     def test_asterisk_expander_subquery(self):
         node = parse_select("select * from (select 1 as a, 2 as b)")
-        resolve_types(node, self.database)
+        node = resolve_types(node, self.database)
         expand_asterisks(node)
         select_subquery_type = ast.SelectQueryType(
             aliases={
@@ -86,7 +86,7 @@ class TestAsteriskExpander(BaseTest):
 
     def test_asterisk_expander_subquery_alias(self):
         node = parse_select("select x.* from (select 1 as a, 2 as b) x")
-        resolve_types(node, self.database)
+        node = resolve_types(node, self.database)
         expand_asterisks(node)
         select_subquery_type = ast.SelectQueryAliasType(
             alias="x",
@@ -113,7 +113,7 @@ class TestAsteriskExpander(BaseTest):
 
     def test_asterisk_expander_from_subquery_table(self):
         node = parse_select("select * from (select * from events)")
-        resolve_types(node, self.database)
+        node = resolve_types(node, self.database)
         expand_asterisks(node)
 
         events_table_type = ast.TableType(table=self.database.events)
@@ -151,14 +151,14 @@ class TestAsteriskExpander(BaseTest):
     def test_asterisk_expander_multiple_table_error(self):
         node = parse_select("select * from (select 1 as a, 2 as b) x left join (select 1 as a, 2 as b) y on x.a = y.a")
         with self.assertRaises(ResolverException) as e:
-            resolve_types(node, self.database)
+            node = resolve_types(node, self.database)
         self.assertEqual(
             str(e.exception), "Cannot use '*' without table name when there are multiple tables in the query"
         )
 
     def test_asterisk_expander_select_union(self):
         node = parse_select("select * from (select * from events union all select * from events)")
-        resolve_types(node, self.database)
+        node = resolve_types(node, self.database)
         expand_asterisks(node)
 
         events_table_type = ast.TableType(table=self.database.events)

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -311,6 +311,7 @@ class CloningVisitor(Visitor):
         )
 
     def visit_join_expr(self, node: ast.JoinExpr):
+        # :TRICKY: when adding new fields, also add them to visit_join_expr of resolver.py
         return ast.JoinExpr(
             type=None if self.clear_types else node.type,
             table=self.visit(node.table),
@@ -326,8 +327,8 @@ class CloningVisitor(Visitor):
         return ast.SelectQuery(
             type=None if self.clear_types else node.type,
             macros={key: expr for key, expr in node.macros.items()} if node.macros else None,  # to not traverse
+            select_from=self.visit(node.select_from),  # keep "select_from" before "select" to resolve tables first
             select=[self.visit(expr) for expr in node.select] if node.select else None,
-            select_from=self.visit(node.select_from),
             where=self.visit(node.where),
             prewhere=self.visit(node.prewhere),
             having=self.visit(node.having),


### PR DESCRIPTION
## Problem

I'd like to support smoothly expanding "macros" as database fields in HogQL. However the current architecture is not set up for that.

## Changes

Converts the `Resolver` from using a `TraversingVisitor` to `CloningVisitor`. Instead of modifying the existing tree and adding types, it now returns a clean tree.

Follow up PRs will build on this and make the resolver also resolve and expand Macros, but I wanted to get this refactor out of the way first. Now I can just `return new_node` when the resolver finds a macro to expand. This was not possible with a TraversingVisitor.

The only tricky bit is duplicating the cloning logic from `CloningVisitor` inside `visit_join_expr`, as just calling `super().visit_join_expr(node)` would error --> certain fields need to be resolved in a certain order.

## How did you test this code?

All previous tests continue to work 