### PR TITLE
fix(exports): retention people name in csvs

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -115,10 +115,7 @@ def _convert_response_to_csv_data(data: Any) -> List[Any]:
             # RETENTION PERSONS LIKE
             csv_rows = []
             for item in items:
-                line = {
-                    "person": item["person"].get("properties").get("email")
-                    or item["person"].get("properties").get("id")
-                }
+                line = {"person": item["person"]["name"]}
                 for index, data in enumerate(item["appearances"]):
                     line[f"Day {index}"] = data
 

--- a/posthog/tasks/exports/test/csv_renders/persons_modal_retention.json
+++ b/posthog/tasks/exports/test/csv_renders/persons_modal_retention.json
@@ -1,0 +1,52 @@
+{
+    "csv_rows": [
+        "person,Day 0,Day 1,Day 2,Day 3,Day 4,Day 5,Day 6,Day 7,Day 8,Day 9,Day 10",
+        "talent1974@yahoo.com,1,1,1,1,1,1,1,1,1,1,0",
+        "few2035@protonmail.com,1,1,1,1,1,1,1,1,1,0,0",
+        ""
+    ],
+    "response": {
+        "result": [
+            {
+                "person": {
+                    "type": "person",
+                    "id": "018768a9-a830-0000-b9f8-ae480a10ca90",
+                    "uuid": "018768a9-a830-0000-b9f8-ae480a10ca90",
+                    "created_at": "2023-04-19T12:40:29.833305Z",
+                    "properties": {
+                        "name": "Shaunta Owen",
+                        "email": "talent1974@yahoo.com",
+                        "$geoip_country_code": "US"
+                    },
+                    "is_identified": false,
+                    "name": "talent1974@yahoo.com",
+                    "distinct_ids": ["3tLhzgJQWLIsWLNl", "c37443ea-fe72-597f-05c5-92ce5fb03a43"],
+                    "matched_recordings": [],
+                    "value_at_data_point": null
+                },
+                "appearances": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+            },
+            {
+                "person": {
+                    "type": "person",
+                    "id": "018769ce-05e5-0000-48b0-9bf78c97f1fc",
+                    "uuid": "018769ce-05e5-0000-48b0-9bf78c97f1fc",
+                    "created_at": "2023-04-19T12:40:29.823227Z",
+                    "properties": {
+                        "name": "Phylicia Valenzuela",
+                        "email": "few2035@protonmail.com",
+                        "$geoip_country_code": "SM"
+                    },
+                    "is_identified": false,
+                    "name": "few2035@protonmail.com",
+                    "distinct_ids": ["83db23d7-8520-e01a-f7db-8f96bf135755", "RPQRbF8NmsBd8uIs"],
+                    "matched_recordings": [],
+                    "value_at_data_point": null
+                },
+                "appearances": [1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]
+            }
+        ],
+        "next": null,
+        "missing_persons": 0
+    }
+}


### PR DESCRIPTION
## Problem

People names come up blank in retention modal export. See [here](https://posthog.slack.com/archives/C04UGBUARDG/p1681909516707269) for a customer reported issue.

## Changes

This PR replaces the code for extracting the person identifier with the [name property](https://github.com/PostHog/posthog/blob/c18931e7ff7482d7f6b99518e068a094a6805801/posthog/api/person.py#L90) of the [serialized person](https://github.com/PostHog/posthog/blob/c18931e7ff7482d7f6b99518e068a094a6805801/posthog/queries/actor_base_query.py#L246).

## How did you test this code?

Verified that the first column matches the name displayed in the retention modal.