### PR TITLE
chore(recordings): use teamid and session_id as Kafka key

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -443,6 +443,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
     kafka_partition_key = None
 
     if event["event"] in ("$snapshot", "$performance_event"):
+        kafka_partition_key = f"{token}:{event['properties']['$session_id']}"
         return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
 
     candidate_partition_key = f"{token}:{distinct_id}"

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -443,7 +443,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
     kafka_partition_key = None
 
     if event["event"] in ("$snapshot", "$performance_event"):
-        kafka_partition_key = f"{token}:{event['properties']['$session_id']}"
+        kafka_partition_key = event["properties"]["$session_id"]
         return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
 
     candidate_partition_key = f"{token}:{distinct_id}"

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1162,7 +1162,7 @@ class TestCapture(BaseTest):
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
         self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, f"{self.team.pk}:{session_id}")
+        self.assertEqual(key, session_id)
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_performance_events_go_to_session_recording_events_topic(self, kafka_produce):
@@ -1195,7 +1195,7 @@ class TestCapture(BaseTest):
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
         self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, f"{self.team.pk}:{session_id}")
+        self.assertEqual(key, session_id)
 
     @patch("posthog.models.utils.UUIDT", return_value="fake-uuid")
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
@@ -1221,7 +1221,7 @@ class TestCapture(BaseTest):
         self.assertEqual(kafka_produce.call_count, 1)
         self.assertEqual(kafka_produce.call_args_list[0][1]["topic"], KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, None)
+        self.assertEqual(key, session_id)
         data_sent_to_kafka = json.loads(kafka_produce.call_args_list[0][1]["data"]["data"])
 
         # Decompress the data sent to kafka to compare it to the original data

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1156,12 +1156,13 @@ class TestCapture(BaseTest):
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_recording_data_sent_to_kafka(self, kafka_produce) -> None:
-        self._send_session_recording_event()
+        session_id = "some_session_id"
+        self._send_session_recording_event(session_id=session_id)
         self.assertEqual(kafka_produce.call_count, 1)
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
         self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, None)
+        self.assertEqual(key, f"{self.team.pk}:{session_id}")
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_performance_events_go_to_session_recording_events_topic(self, kafka_produce):
@@ -1194,7 +1195,7 @@ class TestCapture(BaseTest):
         kafka_topic_used = kafka_produce.call_args_list[0][1]["topic"]
         self.assertEqual(kafka_topic_used, KAFKA_SESSION_RECORDING_EVENTS)
         key = kafka_produce.call_args_list[0][1]["key"]
-        self.assertEqual(key, None)
+        self.assertEqual(key, f"{self.team.pk}:{session_id}")
 
     @patch("posthog.models.utils.UUIDT", return_value="fake-uuid")
     @patch("posthog.kafka_client.client._KafkaProducer.produce")


### PR DESCRIPTION
This is so we can rely on all events for a session being in the same
partition, and handle events in order on one consumer member. Needed for
the S3 storage PR.

Discuss

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
