### PR TITLE
ci(backend): Always run conditional jobs to fix required checks

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -78,8 +78,6 @@ jobs:
     backend-code-quality:
         needs: changes
         timeout-minutes: 5
-        # Make sure we only run on backend changes
-        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Python code quality checks
         runs-on: ubuntu-latest
@@ -91,58 +89,68 @@ jobs:
                   path: 'current/'
 
             - name: Stop/Start stack with Docker Compose
+              # Make sure we only run on backend changes
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
+              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
+              if: needs.changes.outputs.backend == 'true'
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
 
             - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
 
             - name: Install SAML (python3-saml) dependencies
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
               run: |
                   cd current
                   python -m pip install -r requirements-dev.txt
                   python -m pip install -r requirements.txt
 
             - name: Check for syntax errors, import sort, and code style violations
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   ruff .
 
             - name: Check formatting
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   black --exclude posthog/hogql/grammar --check .
 
             - name: Check static typing
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   mypy .
 
             - name: Check if "schema.py" is up to date
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   npm run schema:build:python && git diff --exit-code
 
             - name: Check if antlr definitions are up to date
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   # Installing a version of ant compatible with what we use in development from homebrew (4.11)
                   # "apt-get install antlr" would install 4.7 which is incompatible with our grammar.
@@ -167,8 +175,6 @@ jobs:
         needs: changes
         timeout-minutes: 5
 
-        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
-
         name: Validate Django migrations
         runs-on: ubuntu-latest
 
@@ -176,40 +182,46 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Stop/Start stack with Docker Compose
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
+              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
+              if: needs.changes.outputs.backend == 'true'
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
 
             - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
 
             - name: Install SAML (python3-saml) dependencies
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
               run: |
                   python -m pip install -r requirements-dev.txt
                   python -m pip install -r requirements.txt
 
             - uses: actions/checkout@v3
+              if: needs.changes.outputs.backend == 'true'
               with:
                   ref: master
 
             - name: Run migrations up to master
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   # We need to ensure we have requirements for the master branch
                   # now also, so we can run migrations up to master.
@@ -218,8 +230,10 @@ jobs:
                   python manage.py migrate
 
             - uses: actions/checkout@v3
+              if: needs.changes.outputs.backend == 'true'
 
             - name: Check migrations
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   python manage.py makemigrations --check --dry-run
                   git fetch origin master
@@ -234,7 +248,6 @@ jobs:
     django:
         needs: changes
         timeout-minutes: 30
-        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' || github.event_name == 'workflow_dispatch' }}
 
         name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
         runs-on: ubuntu-latest
@@ -260,6 +273,7 @@ jobs:
                   token: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.POSTHOG_BOT_GITHUB_TOKEN || github.token }}
 
             - uses: ./.github/actions/run-backend-tests
+              if: needs.changes.outputs.backend == 'true'
               with:
                   segment: ${{ matrix.segment }}
                   person-on-events: ${{ matrix.person-on-events }}
@@ -272,7 +286,7 @@ jobs:
             - uses: EndBug/add-and-commit@v9
               # Skip on forks
               # Also skip for persons-on-events runs, as we want to ignore snapshots diverging there
-              if: ${{ !matrix.person-on-events && github.event.pull_request.head.repo.full_name == github.repository }}
+              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && github.event.pull_request.head.repo.full_name == github.repository }}
               with:
                   add: '["ee", "posthog/clickhouse/test/__snapshots__", "posthog/api/test/__snapshots__", "posthog/test/__snapshots__", "posthog/queries/", "posthog/migrations"]'
                   message: 'Update query snapshots'
@@ -281,7 +295,7 @@ jobs:
 
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
-              if: ${{ !matrix.person-on-events && github.event.pull_request.head.repo.full_name == github.repository }}
+              if: ${{ needs.changes.outputs.backend == 'true' && !matrix.person-on-events && github.event.pull_request.head.repo.full_name == github.repository }}
               run: |
                   if [[ -z $(git status -s | grep -v ".test_durations" | tr -d "\n") ]]
                   then
@@ -299,7 +313,7 @@ jobs:
 
             - name: Archive email renders
               uses: actions/upload-artifact@v3
-              if: matrix.segment == 'FOSS' && matrix.person-on-events == false
+              if: needs.changes.outputs.backend == 'true' && matrix.segment == 'FOSS' && matrix.person-on-events == false
               with:
                   name: email_renders
                   path: posthog/tasks/test/__emails__
@@ -308,7 +322,7 @@ jobs:
     cloud:
         needs: changes
         timeout-minutes: 30
-        if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
+        if: github.repository == 'PostHog/posthog'
 
         name: Django tests – Cloud
         runs-on: ubuntu-latest
@@ -318,12 +332,14 @@ jobs:
                   curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
 
             - name: Checkout master
+              if: needs.changes.outputs.backend == 'true'
               uses: actions/checkout@v3
               with:
                   ref: 'master'
                   path: 'master/'
 
             - name: Link posthog-cloud at master
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cp -r multi_tenancy master/
                   cp -r messaging master/
@@ -331,48 +347,56 @@ jobs:
                   cat requirements.txt >> master/requirements.txt
 
             - name: Stop/Start stack with Docker Compose
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   docker compose -f master/docker-compose.dev.yml down
                   docker compose -f master/docker-compose.dev.yml up -d
 
             - name: Set up Python
+              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
+              if: needs.changes.outputs.backend == 'true'
               id: cache-backend-tests
 
             - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
 
             - name: Install SAML (python3-saml) dependencies
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
               run: |
                   python -m pip install -r master/requirements-dev.txt
                   python -m pip install -r master/requirements.txt
 
             - name: Wait for Clickhouse & Kafka
+              if: needs.changes.outputs.backend == 'true'
               run: master/bin/check_kafka_clickhouse_up
 
             # The 2-step migration process (first master, then current branch) verifies that it'll always
             # be possible to migrate to the new version without problems in production
             - name: Run migration on master branch
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   python master/manage.py migrate
 
             - name: Checkout current branch
+              if: needs.changes.outputs.backend == 'true'
               uses: actions/checkout@v3
               with:
                   path: 'current/'
 
             - name: Install requirements.txt dependencies with pip at current branch
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   python -m pip install --upgrade pip
@@ -380,6 +404,7 @@ jobs:
                   python -m pip install freezegun fakeredis pytest pytest-mock pytest-django syrupy
 
             - name: Link posthog-cloud at current branch
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cp current/ee/conftest.py multi_tenancy/conftest.py
                   cp current/ee/conftest.py messaging/conftest.py
@@ -389,12 +414,14 @@ jobs:
                   cat requirements.txt >> current/requirements.txt
 
             - name: Check migrations
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   python manage.py makemigrations --check --dry-run
                   python manage.py migrate
 
             - name: Set up needed files
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   mkdir -p frontend/dist
@@ -404,6 +431,7 @@ jobs:
                   touch frontend/dist/exporter.html
 
             - name: Run cloud tests (posthog-cloud)
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   source .env.template
                   cd current
@@ -419,45 +447,47 @@ jobs:
                   fetch-depth: 1
 
             - name: Start stack with Docker Compose
-              shell: bash
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   export CLICKHOUSE_SERVER_IMAGE_VERSION=${{ inputs.clickhouse-server-image-version }}
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
+              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install SAML (python3-saml) dependencies
-              shell: bash
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - uses: syphar/restore-virtualenv@v1
+              if: needs.changes.outputs.backend == 'true'
               id: cache-async-migrations-tests
               with:
                   custom_cache_key_element: v1-${{ inputs.cache-id }}
 
             - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: steps.cache-backend-tests.outputs.cache-hit == 'false'
               shell: bash
               run: |
                   python -m pip install -r requirements-dev.txt
                   python -m pip install -r requirements.txt
 
             - name: Add kafka host to /etc/hosts for kafka connectivity
-              shell: bash
+              if: needs.changes.outputs.backend == 'true'
               run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
             - name: Set up needed files
-              shell: bash
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html
@@ -465,10 +495,10 @@ jobs:
                   touch frontend/dist/exporter.html
 
             - name: Wait for Clickhouse & Kafka
-              shell: bash
+              if: needs.changes.outputs.backend == 'true'
               run: bin/check_kafka_clickhouse_up
 
             - name: Run async migrations tests
-              shell: bash
+              if: needs.changes.outputs.backend == 'true'
               run: |
                   pytest -m "async_migrations"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -83,13 +83,13 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            # The first step is the only one that should always run. See the `django` job for details.
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 1
                   path: 'current/'
 
             - name: Stop/Start stack with Docker Compose
-              # Make sure we only run on backend changes
               if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
@@ -179,6 +179,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            # The first step is the only one that should always run. See the `django` job for details.
             - uses: actions/checkout@v3
 
             - name: Stop/Start stack with Docker Compose
@@ -264,6 +265,9 @@ jobs:
                 group: [1, 2, 3, 4, 5]
 
         steps:
+            # The first step is the only one that should run if `needs.changes.outputs.backend == 'false'`.
+            # All the other ones should rely on `needs.changes.outputs.backend` directly or indirectly, so that they're
+            # effectively skipped if backend code is unchanged. See https://github.com/PostHog/posthog/pull/15174.
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 1
@@ -322,7 +326,8 @@ jobs:
     cloud:
         needs: changes
         timeout-minutes: 30
-        if: github.repository == 'PostHog/posthog'
+        # This workflow may be skipped as a whole (as opposed to the other ones), as it's optional on forks anyway
+        if: github.repository == 'PostHog/posthog' && needs.changes.outputs.backend == 'true'
 
         name: Django tests – Cloud
         runs-on: ubuntu-latest
@@ -332,14 +337,12 @@ jobs:
                   curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
 
             - name: Checkout master
-              if: needs.changes.outputs.backend == 'true'
               uses: actions/checkout@v3
               with:
                   ref: 'master'
                   path: 'master/'
 
             - name: Link posthog-cloud at master
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cp -r multi_tenancy master/
                   cp -r messaging master/
@@ -347,27 +350,23 @@ jobs:
                   cat requirements.txt >> master/requirements.txt
 
             - name: Stop/Start stack with Docker Compose
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   docker compose -f master/docker-compose.dev.yml down
                   docker compose -f master/docker-compose.dev.yml up -d
 
             - name: Set up Python
-              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
-              if: needs.changes.outputs.backend == 'true'
               id: cache-backend-tests
 
             - uses: syphar/restore-pip-download-cache@v1
               if: steps.cache-backend-tests.outputs.cache-hit == 'false'
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
@@ -379,24 +378,20 @@ jobs:
                   python -m pip install -r master/requirements.txt
 
             - name: Wait for Clickhouse & Kafka
-              if: needs.changes.outputs.backend == 'true'
               run: master/bin/check_kafka_clickhouse_up
 
             # The 2-step migration process (first master, then current branch) verifies that it'll always
             # be possible to migrate to the new version without problems in production
             - name: Run migration on master branch
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   python master/manage.py migrate
 
             - name: Checkout current branch
-              if: needs.changes.outputs.backend == 'true'
               uses: actions/checkout@v3
               with:
                   path: 'current/'
 
             - name: Install requirements.txt dependencies with pip at current branch
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   python -m pip install --upgrade pip
@@ -404,7 +399,6 @@ jobs:
                   python -m pip install freezegun fakeredis pytest pytest-mock pytest-django syrupy
 
             - name: Link posthog-cloud at current branch
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cp current/ee/conftest.py multi_tenancy/conftest.py
                   cp current/ee/conftest.py messaging/conftest.py
@@ -414,14 +408,12 @@ jobs:
                   cat requirements.txt >> current/requirements.txt
 
             - name: Check migrations
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   python manage.py makemigrations --check --dry-run
                   python manage.py migrate
 
             - name: Set up needed files
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   mkdir -p frontend/dist
@@ -431,7 +423,6 @@ jobs:
                   touch frontend/dist/exporter.html
 
             - name: Run cloud tests (posthog-cloud)
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   source .env.template
                   cd current
@@ -441,6 +432,7 @@ jobs:
         name: Async migrations tests
         runs-on: ubuntu-latest
         steps:
+            # The first step is the only one that should always run. See the `django` job for details.
             - name: 'Checkout repo'
               uses: actions/checkout@v3
               with:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -83,28 +83,24 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            # The first step is the only one that should always run. See the `django` job for details.
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 1
                   path: 'current/'
 
             - name: Stop/Start stack with Docker Compose
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
-              if: needs.changes.outputs.backend == 'true'
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
@@ -113,7 +109,6 @@ jobs:
               if: steps.cache-backend-tests.outputs.cache-hit == 'false'
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
@@ -126,31 +121,26 @@ jobs:
                   python -m pip install -r requirements.txt
 
             - name: Check for syntax errors, import sort, and code style violations
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   ruff .
 
             - name: Check formatting
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   black --exclude posthog/hogql/grammar --check .
 
             - name: Check static typing
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   mypy .
 
             - name: Check if "schema.py" is up to date
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   cd current
                   npm run schema:build:python && git diff --exit-code
 
             - name: Check if antlr definitions are up to date
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   # Installing a version of ant compatible with what we use in development from homebrew (4.11)
                   # "apt-get install antlr" would install 4.7 which is incompatible with our grammar.
@@ -173,30 +163,27 @@ jobs:
 
     check-migrations:
         needs: changes
+        if: needs.changes.outputs.backend == 'true'
         timeout-minutes: 5
 
         name: Validate Django migrations
         runs-on: ubuntu-latest
 
         steps:
-            # The first step is the only one that should always run. See the `django` job for details.
             - uses: actions/checkout@v3
 
             - name: Stop/Start stack with Docker Compose
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
-              if: needs.changes.outputs.backend == 'true'
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
@@ -205,7 +192,6 @@ jobs:
               if: steps.cache-backend-tests.outputs.cache-hit == 'false'
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
@@ -217,12 +203,10 @@ jobs:
                   python -m pip install -r requirements.txt
 
             - uses: actions/checkout@v3
-              if: needs.changes.outputs.backend == 'true'
               with:
                   ref: master
 
             - name: Run migrations up to master
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   # We need to ensure we have requirements for the master branch
                   # now also, so we can run migrations up to master.
@@ -231,10 +215,8 @@ jobs:
                   python manage.py migrate
 
             - uses: actions/checkout@v3
-              if: needs.changes.outputs.backend == 'true'
 
             - name: Check migrations
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   python manage.py makemigrations --check --dry-run
                   git fetch origin master
@@ -430,36 +412,33 @@ jobs:
 
     async-migrations:
         name: Async migrations tests
+        needs: changes
+        if: needs.changes.outputs.backend == 'true'
         runs-on: ubuntu-latest
         steps:
-            # The first step is the only one that should always run. See the `django` job for details.
             - name: 'Checkout repo'
               uses: actions/checkout@v3
               with:
                   fetch-depth: 1
 
             - name: Start stack with Docker Compose
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   export CLICKHOUSE_SERVER_IMAGE_VERSION=${{ inputs.clickhouse-server-image-version }}
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              if: needs.changes.outputs.backend == 'true'
               uses: actions/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - uses: syphar/restore-virtualenv@v1
-              if: needs.changes.outputs.backend == 'true'
               id: cache-async-migrations-tests
               with:
                   custom_cache_key_element: v1-${{ inputs.cache-id }}
@@ -475,11 +454,9 @@ jobs:
                   python -m pip install -r requirements.txt
 
             - name: Add kafka host to /etc/hosts for kafka connectivity
-              if: needs.changes.outputs.backend == 'true'
               run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
             - name: Set up needed files
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   mkdir -p frontend/dist
                   touch frontend/dist/index.html
@@ -487,10 +464,8 @@ jobs:
                   touch frontend/dist/exporter.html
 
             - name: Wait for Clickhouse & Kafka
-              if: needs.changes.outputs.backend == 'true'
               run: bin/check_kafka_clickhouse_up
 
             - name: Run async migrations tests
-              if: needs.changes.outputs.backend == 'true'
               run: |
                   pytest -m "async_migrations"


### PR DESCRIPTION
## Problem

@github is somewhat dumb with conditional matrix checks (i.e. jobs that might be skipped under certain conditions), as those effectively can't be made required. The problem is that such a job's name appears with its matrix placeholders if skipped, and with actual matrix values if ran – and required checks purely rely on specific check names. There's no workflow matching logic to them. This is particularly a problem for Django tests, which only need to run if backend code has changed.

## Changes

To fix the above, let's always run those Django test jobs, and if there are no changes we can simply skip most of the constituent _steps_ – while still fulfilling the condition of the check having run.