### PR TITLE
fix(person): set default limit for get_people function

### DIFF
--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -209,7 +209,7 @@ def get_groups(
 
 
 def get_people(
-    team_id: int, people_ids: List[Any], value_per_actor_id: Optional[Dict[str, float]] = None, distinct_id_limit=None
+    team_id: int, people_ids: List[Any], value_per_actor_id: Optional[Dict[str, float]] = None, distinct_id_limit=1000
 ) -> Tuple[QuerySet[Person], List[SerializedPerson]]:
     """Get people from raw SQL results in data model and dict formats"""
     distinct_id_subquery = Subquery(


### PR DESCRIPTION
## Problem

A customer was complaining that the persons modal for a trends query doesn't open [here](https://posthog.slack.com/archives/C045L1VEG87/p1681979456093999).

Turns out they have a person with ~200k distinct ids.

## Changes

Too many is too many. This PR limits the distinct_ids we display to 1000 per default. 

<img width="354" alt="Screenshot 2023-04-20 at 16 09 45" src="https://user-images.githubusercontent.com/1851359/233392681-e76b5a87-291c-4eac-8c8d-e0e5555a61da.png">

As far as I can see we also don't need all the distinct_ids in the persons modal, so we might not want to include them there at all. Actually the only place I found where we display the distinct_ids is on the single person scene /persons/{distinct_id}. we might want to add an endpoint for showing a single person and only include the distinct ids there. Opinions?

## How did you test this code?

```
[...Array(200000).keys()].forEach(i => {posthog.alias('test_user_distinct_id', 'other_id_'+i)})
```

... and then observe where it breaks and verify that it's working fine again with the limit.