### PR TITLE
chore: bump posthoganalytics version, optimise decide

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -205,7 +205,9 @@ def get_decide(request: HttpRequest):
             # which ensures that decide doesn't error out when the database is down
 
             # Analytics for decide requests with feature flags
-            if posthoganalytics.feature_enabled(
+            # Only send once flag definitions are loaded
+            # don't block on loading flag definitions
+            if posthoganalytics.feature_flag_definitions() and posthoganalytics.feature_enabled(
                 "decide-analytics", distinct_id, only_evaluate_locally=True, send_feature_flag_events=False
             ):
                 posthoganalytics.capture(

--- a/requirements.in
+++ b/requirements.in
@@ -47,7 +47,7 @@ parso==0.8.1
 pexpect==4.7.0
 pickleshare==0.7.5
 Pillow==9.2.0
-posthoganalytics==2.3.1
+posthoganalytics==3.0.1
 psycopg2-binary==2.8.6
 pydantic==1.10.4
 pyjwt==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ attrs==21.4.0
     #   jsonschema
     #   outcome
     #   trio
-backoff==1.6.0
+backoff==2.2.1
     # via posthoganalytics
 billiard==3.6.3.0
     # via celery
@@ -238,7 +238,7 @@ pickleshare==0.7.5
     # via -r requirements.in
 pillow==9.2.0
     # via -r requirements.in
-posthoganalytics==2.3.1
+posthoganalytics==3.0.1
     # via -r requirements.in
 prometheus-client==0.14.1
     # via django-prometheus
@@ -369,9 +369,6 @@ typing-extensions==4.4.0
     #   pydantic
     #   qrcode
     #   temporalio
-    #   typing-inspect
-typing-inspect==0.7.1
-    # via dataclasses-json
 tzlocal==2.1
     # via clickhouse-driver
 unicodecsv==0.14.1


### PR DESCRIPTION
## Problem

Bump versions so I can better _decide_ when to track things. Right now, on every subsequent deploy, we block decide to load flag definitions, which is booo
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
