### PR TITLE
chore(tests): use PoE join instead of dict for functional_tests

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -138,14 +138,6 @@ export const reloadAction = async (teamId: number, actionId: number) => {
     await redis.publish('reload-action', JSON.stringify({ teamId, actionId }))
 }
 
-export const reloadDictionaries = async () => {
-    const queryResult = (await clickHouseClient.querying(
-        `SYSTEM RELOAD DICTIONARIES`
-    )) as unknown as ClickHouse.ObjectQueryResult<any>
-
-    return queryResult
-}
-
 export const fetchEvents = async (teamId: number, uuid?: string) => {
     const queryResult = (await clickHouseClient.querying(`
         SELECT *,

--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -152,10 +152,11 @@ export const fetchEvents = async (teamId: number, uuid?: string) => {
                if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as person_id
         FROM events e
                  LEFT OUTER JOIN
-             (SELECT override_person_id as person_id,
+             (SELECT argMax(override_person_id, version) as person_id,
                      old_person_id
               FROM person_overrides
-              WHERE team_id = ${teamId}) AS overrides ON e.person_id = overrides.old_person_id
+              WHERE team_id = ${teamId}
+              GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         WHERE team_id = ${teamId} ${uuid ? `AND uuid = '${uuid}'` : ``}
         ORDER BY timestamp ASC
     `)) as unknown as ClickHouse.ObjectQueryResult<RawClickHouseEvent>

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -1,13 +1,5 @@
 import { UUIDT } from '../src/utils/utils'
-import {
-    capture,
-    createOrganization,
-    createTeam,
-    fetchEvents,
-    fetchPersons,
-    getMetric,
-    reloadDictionaries,
-} from './api'
+import { capture, createOrganization, createTeam, fetchEvents, fetchPersons, getMetric } from './api'
 import { waitForExpect } from './expectations'
 
 let organizationId: string
@@ -573,11 +565,6 @@ testIfPoEEmbraceJoinEnabled(`chained merge results in all events resolving to th
     })
 
     await waitForExpect(async () => {
-        const result = await reloadDictionaries()
-        expect(result).toBe('')
-    })
-
-    await waitForExpect(async () => {
         const events = await fetchEvents(teamId)
         expect(events.length).toBe(5)
         expect(events[0].person_id).toBeDefined()
@@ -645,12 +632,6 @@ testIfPoEEmbraceJoinEnabled(
                 distinct_id: secondDistinctId,
                 alias: thirdDistinctId,
             },
-        })
-
-        await waitForExpect(async () => {
-            const result = await reloadDictionaries()
-            // This should return 'ok' according to ClickHouse JS docs but apparently it's empty string.
-            expect(result).toBe('')
         })
 
         await waitForExpect(async () => {


### PR DESCRIPTION
## Problem

`functional_tests/ingestion.test.ts` are very flaky. We use `person_overrides_dict` but it's default lifecycle is to refresh every 5 to 10 seconds, and the assertion timeout is 10 seconds

## Changes

- update the `fetchEvents` test helper to use a join instead of the dict, mirroring the changes in https://github.com/PostHog/posthog/pull/14830 and https://github.com/PostHog/posthog/pull/15264

We could try forcing a dict refresh or lowering its lifecycle, but ultimately it's better to align with how the app is querying.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
