### PR TITLE
fix: handle quotes in the cookie value

### DIFF
--- a/cypress/e2e/auto-redirect.cy.ts
+++ b/cypress/e2e/auto-redirect.cy.ts
@@ -9,7 +9,7 @@ describe('Redirect to other subdomain if logged in', () => {
 
         cy.visit(`/login?next=${redirect_path}`)
 
-        cy.setCookie('ph_current_instance', `eu.posthog.com`)
+        cy.setCookie('ph_current_instance', `"eu.posthog.com"`)
         cy.setCookie('is-logged-in', '1')
         cy.reload()
 
@@ -29,7 +29,7 @@ describe('Redirect to other subdomain if logged in', () => {
 
         cy.visit(`/login?next=${redirect_path}`)
 
-        cy.setCookie('ph_current_instance', `app.posthog.com`)
+        cy.setCookie('ph_current_instance', `"app.posthog.com"`)
         cy.setCookie('is-logged-in', '1')
         cy.reload()
 

--- a/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
+++ b/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
@@ -13,7 +13,7 @@
  * 127.0.0.1 app.posthogtest.com
  *
  * Then set the following cookies locally:
- * document.cookie = "ph_current_instance=https://eu.posthog.com";
+ * document.cookie = "ph_current_instance=\"https://eu.posthog.com\"";
  * document.cookie = "is-logged-in=1";
  *
  * Then go to http://app.posthogtest.com:8000/login?next=/apps
@@ -38,7 +38,8 @@ export function redirectIfLoggedInOtherInstance(): (() => void) | undefined {
     const currentSubdomain = window.location.hostname.split('.')[0]
 
     const loggedInInstance = getCookie(PH_CURRENT_INSTANCE)
-    const loggedInSubdomain = loggedInInstance ? new URL(loggedInInstance).host.split('.')[0] : null
+    // replace '"' as for some reason the cookie value is wrapped in quotes e.g. "https://eu.posthog.com"
+    const loggedInSubdomain = loggedInInstance ? new URL(loggedInInstance.replace('"', '')).host.split('.')[0] : null
 
     if (!loggedInSubdomain) {
         return // not logged into another subdomain

--- a/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
+++ b/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
@@ -13,7 +13,7 @@
  * 127.0.0.1 app.posthogtest.com
  *
  * Then set the following cookies locally:
- * document.cookie = "ph_current_instance=\"https://eu.posthog.com\"";
+ * document.cookie = 'ph_current_instance="https://eu.posthog.com"';
  * document.cookie = "is-logged-in=1";
  *
  * Then go to http://app.posthogtest.com:8000/login?next=/apps


### PR DESCRIPTION
## Problem

The ph_current_instance has quotes in the value, this fixes it

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
