### PR TITLE
chore(test): fix flaky poev2 functional test

### DIFF
--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -526,6 +526,11 @@ testIfPoEEmbraceJoinEnabled(`single merge results in all events resolving to the
     })
 
     await waitForExpect(async () => {
+        const result = await reloadDictionaries()
+        expect(result).toBe('')
+    })
+
+    await waitForExpect(async () => {
         const events = await fetchEvents(teamId)
         expect(events.length).toBe(4)
         expect(events[0].person_id).toBeDefined()


### PR DESCRIPTION
## Problem

`functional_tests/ingestion.test.ts` are very flaky. We use `person_overrides_dict` but it's default lifecycle is to refresh every 5 to 10 seconds, and the assertion timeout is 10 seconds

## Changes

- Make sure the dictionnary is freshed before we query the events, to avoid flakes
- I think https://github.com/PostHog/posthog/pull/15188 is a better solution, but it does break another test (investigating it)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
