### PR TITLE
fix: Perf issue logging warnings

### DIFF
--- a/frontend/src/lib/utils/wrapConsole.ts
+++ b/frontend/src/lib/utils/wrapConsole.ts
@@ -1,4 +1,4 @@
-export function wrapConsole(level: 'log' | 'warn' | 'error', fn: (args: Array<unknown>) => void): () => void {
+export function wrapConsole(level: 'log' | 'warn' | 'error', fn: (args: Array<unknown>) => boolean): () => void {
     // Flag the handler to prevent max call stack errors (any code in this execution might retrigger the log)
     const wrappedFn = console[level]
     let inWrap = false
@@ -11,8 +11,9 @@ export function wrapConsole(level: 'log' | 'warn' | 'error', fn: (args: Array<un
             }
             inWrap = true
 
-            fn(args)
-            wrappedFn(...args)
+            if (fn(args)) {
+                wrappedFn(...args)
+            }
         } finally {
             inWrap = false
         }

--- a/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
@@ -179,17 +179,17 @@ export const seekbarLogic = kea<seekbarLogicType>({
             actions.handleSeek(newX, false)
         },
         handleUp: ({ event }) => {
+            document.removeEventListener('touchmove', actions.handleMove)
+            document.removeEventListener('touchend', actions.handleUp)
+            document.removeEventListener('mousemove', actions.handleMove)
+            document.removeEventListener('mouseup', actions.handleUp)
+
             if (!values.slider) {
                 return
             }
             const newX = getXPos(event) - values.cursorDiff - values.slider.getBoundingClientRect().left
             actions.handleSeek(newX)
             actions.endScrub()
-
-            document.removeEventListener('touchmove', actions.handleMove)
-            document.removeEventListener('touchend', actions.handleUp)
-            document.removeEventListener('mousemove', actions.handleMove)
-            document.removeEventListener('mouseup', actions.handleUp)
         },
         handleDown: ({ event }) => {
             if (!values.thumb) {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -755,18 +755,23 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
             const debouncedCounter = (): void => {
                 warningCount += 1
-                clearTimeout(cache.consoleWarnDebounceTimer)
 
-                cache.consoleWarnDebounceTimer = setTimeout(() => {
-                    actions.incrementWarningCount(warningCount)
-                    warningCount = 0
-                }, 1000)
+                if (!cache.consoleWarnDebounceTimer) {
+                    cache.consoleWarnDebounceTimer = setTimeout(() => {
+                        cache.consoleWarnDebounceTimer = null
+                        actions.incrementWarningCount(warningCount)
+                        warningCount = 0
+                    }, 1000)
+                }
             }
 
             cache.resetConsoleWarn = wrapConsole('warn', (args) => {
                 if (typeof args[0] === 'string' && args[0].includes('[replayer]')) {
                     debouncedCounter()
+                    return false
                 }
+
+                return true
             })
         },
     })),

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -768,7 +768,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             cache.resetConsoleWarn = wrapConsole('warn', (args) => {
                 if (typeof args[0] === 'string' && args[0].includes('[replayer]')) {
                     debouncedCounter()
-                    return false
                 }
 
                 return true

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -120,7 +120,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         checkBufferingCompleted: true,
         initializePlayerFromStart: true,
         incrementErrorCount: true,
-        incrementWarningCount: true,
+        incrementWarningCount: (count: number = 1) => ({ count }),
         setMatching: (matching: SessionRecordingType['matching_events']) => ({ matching }),
         updateFromMetadata: true,
         exportRecordingToFile: true,
@@ -173,7 +173,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         isScrubbing: [false, { startScrub: () => true, endScrub: () => false }],
 
         errorCount: [0, { incrementErrorCount: (prevErrorCount, {}) => prevErrorCount + 1 }],
-        warningCount: [0, { incrementWarningCount: (prevWarningCount, {}) => prevWarningCount + 1 }],
+        warningCount: [0, { incrementWarningCount: (prevWarningCount, { count }) => prevWarningCount + count }],
         matching: [
             props.matching ?? ([] as SessionRecordingType['matching_events']),
             {
@@ -722,6 +722,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
     events(({ values, actions, cache }) => ({
         beforeUnmount: () => {
             cache.resetConsoleWarn?.()
+            clearTimeout(cache.consoleWarnDebounceTimer)
             values.player?.replayer?.pause()
             actions.setPlayer(null)
             actions.reportRecordingViewedSummary({
@@ -748,9 +749,23 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
             cache.openTime = performance.now()
 
+            // NOTE: RRweb can log _alot_ of warnings so we debounce the count otherwise we just end up making the performance worse
+            let warningCount = 0
+            cache.consoleWarnDebounceTimer = null
+
+            const debouncedCounter = (): void => {
+                warningCount += 1
+                clearTimeout(cache.consoleWarnDebounceTimer)
+
+                cache.consoleWarnDebounceTimer = setTimeout(() => {
+                    actions.incrementWarningCount(warningCount)
+                    warningCount = 0
+                }, 1000)
+            }
+
             cache.resetConsoleWarn = wrapConsole('warn', (args) => {
                 if (typeof args[0] === 'string' && args[0].includes('[replayer]')) {
-                    actions.incrementWarningCount()
+                    debouncedCounter()
                 }
             })
         },


### PR DESCRIPTION
## Problem

Discovered an issue that can happen with recordings that have a lot of replayer warnings. We track these to get a sense of how common this but if there are a lot of warnings the way we currently do it can negatively impact peformance

**Perf of the recording when applying a mutation (during playback)**

<img width="1190" alt="Screenshot 2023-04-24 at 10 34 30" src="https://user-images.githubusercontent.com/2536520/233945668-908a5c44-23f4-406c-b819-3dd187e05ef9.png">

**Going deeper we find it is actually Kea work due to console warn wrapper**
<img width="470" alt="Screenshot 2023-04-24 at 10 34 37" src="https://user-images.githubusercontent.com/2536520/233945680-0b4a5a45-1a54-4989-aa10-75b87c8f5a75.png">



## Changes

* Adds a debounce to the function collecting this metric

Running this:
```
[...Array(1000).keys()].forEach(() => {
    console.warn("[replayer] wat")
});
```

|Before|After|
|----|----|
|<img width="1322" alt="Screenshot 2023-04-24 at 10 50 50" src="https://user-images.githubusercontent.com/2536520/233947597-4761ab42-52ca-4ae9-b3d2-337c9122f54b.png">|<img width="1008" alt="Screenshot 2023-04-24 at 10 51 28" src="https://user-images.githubusercontent.com/2536520/233947593-b89b4fc9-73f4-4648-a25d-e7245307fe32.png">|





👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Only manually by creating a big loop of logs