### PR TITLE
chore: increase poll interval for decide flags

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -20,6 +20,7 @@ class PostHogConfig(AppConfig):
     def ready(self):
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"
         posthoganalytics.personal_api_key = os.environ.get("POSTHOG_PERSONAL_API_KEY")
+        posthoganalytics.poll_interval = 90
 
         if settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
             posthoganalytics.disabled = True

--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -56,7 +56,7 @@ structlog.configure(
 # rendered either as pretty colored console lines or as single JSON lines.
 LOGGING = {
     "version": 1,
-    "disable_existing_loggers": False,
+    "disable_existing_loggers": True,
     "formatters": {
         "default": {
             "()": structlog.stdlib.ProcessorFormatter,

--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -56,7 +56,7 @@ structlog.configure(
 # rendered either as pretty colored console lines or as single JSON lines.
 LOGGING = {
     "version": 1,
-    "disable_existing_loggers": True,
+    "disable_existing_loggers": False,
     "formatters": {
         "default": {
             "()": structlog.stdlib.ProcessorFormatter,


### PR DESCRIPTION
## Problem

We're hitting the local eval endpoint too much, because lots of decide pods, all of which are making requests to get flags 😅 .

This should reduce the number of requests by 3 times. (default poll interval = 30s)
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Run locally, see requests come in 90 sec intervals

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
