### PR TITLE
use person_display_name_properties

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -137,7 +137,7 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
         group_type_index = request.GET.get("group_type_index")
         id = request.GET["id"]
 
-        results = RelatedActorsQuery(self.team.pk, group_type_index, id).run()
+        results = RelatedActorsQuery(self.team, group_type_index, id).run()
         return response.Response(results)
 
     @action(methods=["GET"], detail=False)

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -63,7 +63,7 @@ export const privilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
 
 // Persons
 export const PERSON_DISTINCT_ID_MAX_SIZE = 3
-// Sync with person.py
+// Sync with api/person.py
 export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     'email',
     'Email',

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -63,6 +63,7 @@ export const privilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
 
 // Persons
 export const PERSON_DISTINCT_ID_MAX_SIZE = 3
+// Sync with person.py
 export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     'email',
     'Email',

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -212,7 +212,7 @@ class ActionViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestro
         if request.accepted_renderer.format == "csv":
             content = [
                 {
-                    "Name": get_person_name(person),
+                    "Name": get_person_name(person, team),
                     "Distinct ID": person.distinct_ids[0] if person.distinct_ids else "",
                     "Internal ID": str(person.uuid),
                     "Email": person.properties.get("email"),

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -230,7 +230,7 @@ class CohortViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         raw_result = sync_execute(query, {**params, **filter.hogql_context.values})
         actor_ids = [row[0] for row in raw_result]
-        actors, serialized_actors = get_people(team.pk, actor_ids, distinct_id_limit=10 if is_csv_request else None)
+        actors, serialized_actors = get_people(team, actor_ids, distinct_id_limit=10 if is_csv_request else None)
 
         _should_paginate = len(actor_ids) >= filter.limit
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -99,8 +99,6 @@ class PersonLimitOffsetPagination(LimitOffsetPagination):
 def get_person_name(person: Person) -> str:
     if display_name := get_person_display_name(person):
         return display_name
-    if person.properties.get("email"):
-        return person.properties["email"]
     if len(person.distinct_ids) > 0:
         # Prefer non-UUID distinct IDs (presumably from user identification) over UUIDs
         return sorted(person.distinct_ids, key=is_anonymous_id)[0]
@@ -149,7 +147,6 @@ def get_funnel_actor_class(filter: Filter) -> Callable:
     funnel_actor_class: Type[ActorBaseQuery]
 
     if filter.correlation_person_entity and EE_AVAILABLE:
-
         if EE_AVAILABLE:
             from ee.clickhouse.queries.funnels.funnel_correlation_persons import FunnelCorrelationActors
 
@@ -288,7 +285,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         if key:
             result = self._get_person_property_values_for_key(key, value)
 
-            for (value, count) in result:
+            for value, count in result:
                 try:
                     # Try loading as json for dicts or arrays
                     flattened.append({"name": convert_property_value(json.loads(value)), "count": count})  # type: ignore

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -111,6 +111,7 @@ def get_person_display_name(person: Person) -> str | None:
     for property in person.team.person_display_name_properties or PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES:
         if person.properties.get(property):
             return person.properties.get(property)
+    return None
 
 
 class PersonsThrottle(ClickHouseSustainedRateThrottle):

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -419,6 +419,8 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         )
 
     def test_person_display_name(self) -> None:
+        self.team.person_display_name_properties = ["custom_name", "custom_email"]
+        self.team.save()
         _create_person(
             team=self.team,
             distinct_ids=["distinct_id1"],
@@ -440,12 +442,9 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-        self.team.person_display_name_properties = ["custom_name", "custom_email"]
-        self.team.save()
-
         response = self.client.get("/api/person/").json()
-        results = response["results"][::-1]  # results are in reverse order
 
+        results = response["results"][::-1]  # results are in reverse order
         self.assertEqual(results[0]["name"], "someone")
         self.assertEqual(results[1]["name"], "another_one@custom.com")
         self.assertEqual(results[2]["name"], "yet_another_one@gmail.com")
@@ -469,8 +468,8 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         response = self.client.get("/api/person/").json()
-        results = response["results"][::-1]  # results are in reverse order
 
+        results = response["results"][::-1]  # results are in reverse order
         self.assertEqual(results[0]["name"], "someone@gmail.com")
         self.assertEqual(results[1]["name"], "another_one")
         self.assertEqual(results[2]["name"], "distinct_id3")

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -92,7 +92,6 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
     @also_test_with_materialized_columns(event_properties=["email"], person_properties=["email"])
     @snapshot_clickhouse_queries
     def test_filter_person_email(self):
-
         _create_person(
             team=self.team,
             distinct_ids=["distinct_id", "another_one"],
@@ -114,7 +113,6 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     def test_filter_person_prop(self):
-
         _create_person(
             team=self.team,
             distinct_ids=["distinct_id", "another_one"],
@@ -140,7 +138,6 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.json()["results"][0]["uuid"], str(person2.uuid))
 
     def test_filter_person_list(self):
-
         person1: Person = _create_person(
             team=self.team,
             distinct_ids=["distinct_id", "another_one"],
@@ -181,7 +178,6 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(response.json()["results"]), 0)
 
     def test_cant_see_another_organization_pii_with_filters(self):
-
         # Completely different organization
         another_org: Organization = Organization.objects.create()
         another_team: Team = Team.objects.create(organization=another_org)
@@ -436,10 +432,6 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             distinct_ids=["distinct_id3"],
             properties={"email": "yet_another_one@gmail.com"},
         )
-        _create_person(
-            team=self.team,
-            distinct_ids=["distinct_id4"],
-        )
         flush_persons_and_events()
 
         response = self.client.get("/api/person/").json()
@@ -447,8 +439,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         results = response["results"][::-1]  # results are in reverse order
         self.assertEqual(results[0]["name"], "someone")
         self.assertEqual(results[1]["name"], "another_one@custom.com")
-        self.assertEqual(results[2]["name"], "yet_another_one@gmail.com")
-        self.assertEqual(results[3]["name"], "distinct_id4")
+        self.assertEqual(results[2]["name"], "distinct_id3")
 
     def test_person_display_name_defaults(self) -> None:
         _create_person(

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -26,6 +26,18 @@ from posthog.test.base import (
 
 
 class TestPerson(ClickhouseTestMixin, APIBaseTest):
+    def test_get_person_by_id(self) -> None:
+        person = _create_person(
+            team=self.team, distinct_ids=["distinct_id"], properties={"email": "someone@gmail.com"}, immediate=True
+        )
+        flush_persons_and_events()
+
+        with self.assertNumQueries(6):
+            response = self.client.get(f"/api/person/{person.pk}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], person.pk)
+
     def test_search(self) -> None:
         _create_person(team=self.team, distinct_ids=["distinct_id"], properties={"email": "someone@gmail.com"})
         _create_person(

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -10,7 +10,6 @@ from django.db.models.query import QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils.timezone import now
-from rest_framework import serializers
 
 from posthog.client import sync_execute
 from posthog.kafka_client.client import ClickhouseProducer
@@ -213,37 +212,3 @@ def _delete_ch_distinct_id(team_id: int, uuid: UUID, distinct_id: str, version: 
         is_deleted=True,
         sync=sync,
     )
-
-
-class ClickhousePersonSerializer(serializers.Serializer):
-    id = serializers.SerializerMethodField()
-    created_at = serializers.SerializerMethodField()
-    team_id = serializers.SerializerMethodField()
-    properties = serializers.SerializerMethodField()
-    is_identified = serializers.SerializerMethodField()
-    name = serializers.SerializerMethodField()
-    distinct_ids = serializers.SerializerMethodField()
-
-    def get_name(self, person):
-        props = json.loads(person[3])
-        email = props.get("email", None)
-        return email or person[0]
-
-    def get_id(self, person):
-        return person[0]
-
-    def get_created_at(self, person):
-        return person[1]
-
-    def get_team_id(self, person):
-        return person[2]
-
-    def get_properties(self, person):
-        return json.loads(person[3])
-
-    def get_is_identified(self, person):
-        return person[4]
-
-    # all queries might not retrieve distinct_ids
-    def get_distinct_ids(self, person):
-        return person[5] if len(person) > 5 else []

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -188,7 +188,7 @@ class ActorBaseQuery:
                 self._team.pk, cast(int, self.aggregation_group_type_index), actor_ids, value_per_actor_id
             )
         else:
-            actors, serialized_actors = get_people(self._team.pk, actor_ids, value_per_actor_id)
+            actors, serialized_actors = get_people(self._team, actor_ids, value_per_actor_id)
 
         if self.ACTOR_VALUES_INCLUDED:
             # We fetched actors from Postgres in get_groups/get_people, so `ORDER BY actor_value DESC` no longer holds
@@ -209,7 +209,7 @@ def get_groups(
 
 
 def get_people(
-    team_id: int, people_ids: List[Any], value_per_actor_id: Optional[Dict[str, float]] = None, distinct_id_limit=1000
+    team: Team, people_ids: List[Any], value_per_actor_id: Optional[Dict[str, float]] = None, distinct_id_limit=1000
 ) -> Tuple[QuerySet[Person], List[SerializedPerson]]:
     """Get people from raw SQL results in data model and dict formats"""
     distinct_id_subquery = Subquery(
@@ -218,7 +218,7 @@ def get_people(
         ]
     )
     persons: QuerySet[Person] = (
-        Person.objects.filter(team_id=team_id, uuid__in=people_ids)
+        Person.objects.filter(team_id=team.pk, uuid__in=people_ids)
         .prefetch_related(
             Prefetch(
                 "persondistinctid_set",
@@ -229,10 +229,12 @@ def get_people(
         .order_by("-created_at", "uuid")
         .only("id", "is_identified", "created_at", "properties", "uuid")
     )
-    return persons, serialize_people(persons, value_per_actor_id)
+    return persons, serialize_people(team, persons, value_per_actor_id)
 
 
-def serialize_people(data: QuerySet[Person], value_per_actor_id: Optional[Dict[str, float]]) -> List[SerializedPerson]:
+def serialize_people(
+    team: Team, data: QuerySet[Person], value_per_actor_id: Optional[Dict[str, float]]
+) -> List[SerializedPerson]:
     from posthog.api.person import get_person_name
 
     return [
@@ -243,7 +245,7 @@ def serialize_people(data: QuerySet[Person], value_per_actor_id: Optional[Dict[s
             created_at=person.created_at,
             properties=person.properties,
             is_identified=person.is_identified,
-            name=get_person_name(person),
+            name=get_person_name(person, team),
             distinct_ids=person.distinct_ids,
             matched_recordings=[],
             value_at_data_point=value_per_actor_id[str(person.uuid)] if value_per_actor_id else None,


### PR DESCRIPTION
## Problem

Builds upon https://github.com/PostHog/posthog/pull/15168 to take into account the `team.person_display_name_properties` setting for the name property.

## Changes

This PR adapts the `get_person_name` method to first check for any `team.person_display_name_properties`.

IMO this is a breaking change, as anyone relying on the old behaviour in api calls or exports will get unexpected results. Should we handle this in a special way e.g. some sort of announcement.

## How did you test this code?

Add tests and verified the `team.person_display_name_properties` take precedence over email and distinct ids in the UI.