### PR TITLE
fix: eagerly load flags so we don't block decide

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -48,6 +48,10 @@ class PostHogConfig(AppConfig):
             else:
                 posthoganalytics.disabled = True
 
+        # load feature flag definitions if not already loaded
+        if posthoganalytics.feature_flag_definitions() is None:
+            posthoganalytics.default_client.load_feature_flags()
+
         if not settings.SKIP_SERVICE_VERSION_REQUIREMENTS:
             for service_version_requirement in settings.SERVICE_VERSION_REQUIREMENTS:
                 in_range, version = service_version_requirement.is_service_in_accepted_version()


### PR DESCRIPTION
## Problem

An issue with local dev vs prod is that decide is on a separate pod, which means these other `posthoganalytics.get_feature_flag()` calls aren't really called, which means we end up never loading flags.

This is a problem, because we're not sending decide analytics like we should be doing.

This PR ensures the default client starts the poller so flags can be downloaded frequently.

This _shouldn't_ affect anything else / other pods & how they work, because they were making blocking calls to get flags anyway.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
