### PR TITLE
fix: Missing windowId from network events

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -27,6 +27,10 @@ export function loadPostHogJS(): void {
                 bootstrap: !!window.POSTHOG_USER_IDENTITY_WITH_FLAGS ? window.POSTHOG_USER_IDENTITY_WITH_FLAGS : {},
                 opt_in_site_apps: true,
                 loaded: (posthog) => {
+                    if (posthog.webPerformance) {
+                        posthog.webPerformance._forceAllowLocalhost = true
+                    }
+
                     if (window.IMPERSONATED_SESSION) {
                         posthog.opt_out_capturing()
                     } else {

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -272,10 +272,11 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             snapshot.data.plugin === NETWORK_PLUGIN_NAME
                         ) {
                             const properties = snapshot.data.payload as any
-                            const data = {
+
+                            const data: Partial<PerformanceEvent> = {
                                 timestamp: snapshot.timestamp,
-                                windowId: windowId,
-                            } as Partial<PerformanceEvent>
+                                window_id: windowId,
+                            }
 
                             Object.entries(PerformanceEventReverseMapping).forEach(([key, value]) => {
                                 if (key in properties) {


### PR DESCRIPTION
## Problem

I had a bad `as` type conversion which masked a bad property.

## Changes

* Fixes this so now the right window is associated again

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
