### PR TITLE
chore: Add analytics for language selection

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -521,6 +521,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportFlagsCodeExampleInteraction: (optionType: string) => ({
             optionType,
         }),
+        reportFlagsCodeExampleLanguage: (language: string) => ({
+            language,
+        }),
     },
     listeners: ({ values }) => ({
         reportAxisUnitsChanged: (properties) => {
@@ -1268,6 +1271,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportFlagsCodeExampleInteraction: ({ optionType }) => {
             posthog.capture('flags code example option selected', {
                 option_type: optionType,
+            })
+        },
+        reportFlagsCodeExampleLanguage: ({ language }) => {
+            posthog.capture('flags code example language selected', {
+                language,
             })
         },
     }),

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -64,7 +64,7 @@ export function CodeInstructions({
             ? groupTypes[featureFlag?.filters?.aggregation_group_type_index]
             : undefined
 
-    const { reportFlagsCodeExampleInteraction } = useActions(eventUsageLogic)
+    const { reportFlagsCodeExampleInteraction, reportFlagsCodeExampleLanguage } = useActions(eventUsageLogic)
     const getDocumentationLink = (): string => {
         const documentationLink = selectedOption.documentationLink
 
@@ -160,6 +160,7 @@ export function CodeInstructions({
                         onChange={(val) => {
                             if (val) {
                                 selectOption(val)
+                                reportFlagsCodeExampleLanguage(val)
                             }
                         }}
                         value={selectedOption.value}


### PR DESCRIPTION
## Problem

We want to know which languages people select in the code select options

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
