### PR TITLE
chore(plugin-server): add context to KafkaJSProtocolError sentry capture

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -15,6 +15,7 @@ type ConsumerManagementPayload = {
 }
 
 type EachBatchFunction = (payload: EachBatchPayload, queue: IngestionConsumer) => Promise<void>
+
 export class IngestionConsumer {
     public pluginsServer: Hub
     public workerMethods: WorkerMethods
@@ -192,7 +193,9 @@ export const setupEventHandlers = (consumer: Consumer): void => {
         offsets = {}
         status.error('⚠️', `Kafka consumer group ${groupId} crashed:\n`, error)
         clearInterval(statusInterval)
-        Sentry.captureException(error)
+        Sentry.captureException(error, {
+            extra: { detected_at: `kafka-queue.ts on consumer crash` },
+        })
         killGracefully()
     })
     consumer.on(CONNECT, () => {
@@ -246,7 +249,9 @@ export const instrumentEachBatch = async (
                 }
             }
             if (logToSentry) {
-                Sentry.captureException(error)
+                Sentry.captureException(error, {
+                    extra: { detected_at: `kafka-queue.ts instrumentEachBatch` },
+                })
             }
         }
         throw error

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -148,6 +148,13 @@ export async function startPluginsServer(
         process.exit(0)
     })
 
+    // Code list in https://kafka.apache.org/0100/protocol.html
+    const kafkaJSIgnorableCodes = new Set([
+        22, // ILLEGAL_GENERATION
+        25, // UNKNOWN_MEMBER_ID
+        27, // REBALANCE_IN_PROGRESS
+    ])
+
     process.on('unhandledRejection', (error: Error) => {
         status.error('🤮', `Unhandled Promise Rejection: ${error.stack}`)
 
@@ -158,18 +165,14 @@ export async function startPluginsServer(
             })
 
             // Ignore some "business as usual" Kafka errors, send the rest to sentry
-            // Code list in https://kafka.apache.org/0100/protocol.html
-            switch (error.code) {
-                case 27: // REBALANCE_IN_PROGRESS
-                    hub!.statsd?.increment(`kafka_consumer_group_rebalancing`)
-                    return
-                case 22: // ILLEGAL_GENERATION
-                    hub!.statsd?.increment(`kafka_consumer_invalid_group_generation_id`)
-                    return
+            if (error.code in kafkaJSIgnorableCodes) {
+                return
             }
         }
 
-        Sentry.captureException(error)
+        Sentry.captureException(error, {
+            extra: { detected_at: `pluginServer.ts on unhandledRejection` },
+        })
     })
 
     process.on('uncaughtException', async (error: Error) => {


### PR DESCRIPTION
## Problem

Sentry reports thousands of kafkajs exceptions during rollouts, caused by rebalances. We want to filter these ones out, but `Sentry.captureException(error)` does not give us enough context.

## Changes

- Add context to the three `Sentry.captureException` that could catch kafkajs errors (hopefully I didn't miss one)
- Ignore `UNKNOWN_MEMBER_ID` too
- remove the statsd metrics replaced by `kafka_protocol_errors_total`

Let's not invest too much on this though, as we are in the process of moving away from kafkajs anyway.

## How did you test this code?

How did you chose what socks to wear today?