### PR TITLE
feat(metrics): Add team ID labels to specific metrics

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -446,7 +446,12 @@ class PrometheusAfterMiddlewareWithTeamIds(PrometheusAfterMiddleware):
     def label_metric(self, metric, request, response=None, **labels):
         new_labels = labels
         if metric._name in PROMETHEUS_EXTENDED_METRICS:
-            if request and getattr(request, "user", None) and request.user.is_authenticated:
+            if (
+                request
+                and getattr(request, "user", None)
+                and request.user.is_authenticated
+                and hasattr(request.user, "current_team_id")
+            ):
                 team_id = request.user.current_team_id
             else:
                 team_id = None

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -51,7 +51,7 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
-    "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "posthog.middleware.PrometheusBeforeMiddlewareWithTeamIds",
     "posthog.gzip_middleware.ScopedGZipMiddleware",
     "posthog.middleware.per_request_logging_context_middleware",
     "django_structlog.middlewares.RequestMiddleware",
@@ -80,7 +80,7 @@ MIDDLEWARE = [
     "axes.middleware.AxesMiddleware",
     "posthog.middleware.AutoProjectMiddleware",
     "posthog.middleware.CHQueries",
-    "django_prometheus.middleware.PrometheusAfterMiddleware",
+    "posthog.middleware.PrometheusAfterMiddlewareWithTeamIds",
 ]
 
 if STATSD_HOST is not None:


### PR DESCRIPTION
## Problem

Add label to specific metrics that power [this grafana board](http://grafana-prod-us/d/http-by-application-endpoint/http-by-application-endpoint?orgId=1&var-view=featureflag-local-evaluation&from=now-6h&to=now). To be a bit more conservative with resources, haven't added it to all series, just three, to keep the active time series explosion in check (somewhat).

Context: https://posthog.slack.com/archives/C02E3BKC78F/p1682332677153889

This should be very helpful in debugging which teams specifically have high request counts, or high latency.
 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

See things work via `/_metrics` for both anonymous and logged in users

<img width="1202" alt="image" src="https://user-images.githubusercontent.com/7115141/234018778-a8af96d3-2abf-46ef-aa24-d82dd24a36c1.png">

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
