### PR TITLE
fix(hogql): toDateTime64OrNull precision

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -456,7 +456,9 @@ class _Printer(Visitor):
                 )
 
             if self.dialect == "clickhouse":
-                if clickhouse_name == "now64" and len(args) == 0:
+                if (clickhouse_name == "now64" and len(args) == 0) or (
+                    clickhouse_name == "toDateTime64OrNull" and len(args) == 1
+                ):
                     # must add precision if adding timezone in the next step
                     args.append("6")
                 if node.name in ADD_TIMEZONE_TO_FUNCTIONS:

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -524,7 +524,7 @@ class TestPrinter(BaseTest):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
         self.assertEqual(
             self._select("SELECT now(), toDateTime(timestamp), toDateTime('2020-02-02') FROM events", context),
-            f"SELECT now64(6, %(hogql_val_0)s), toDateTime64OrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s), toDateTime64OrNull(%(hogql_val_3)s, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT now64(6, %(hogql_val_0)s), toDateTime64OrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), 6, %(hogql_val_2)s), toDateTime64OrNull(%(hogql_val_3)s, 6, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         self.assertEqual(
             context.values,
@@ -543,7 +543,7 @@ class TestPrinter(BaseTest):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
         self.assertEqual(
             self._select("SELECT now(), toDateTime(timestamp), toDateTime('2020-02-02') FROM events", context),
-            f"SELECT now64(6, %(hogql_val_0)s), toDateTime64OrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s), toDateTime64OrNull(%(hogql_val_3)s, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT now64(6, %(hogql_val_0)s), toDateTime64OrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), 6, %(hogql_val_2)s), toDateTime64OrNull(%(hogql_val_3)s, 6, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         self.assertEqual(
             context.values,

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -60,7 +60,7 @@ class TestPropertyTypes(BaseTest):
         )
         expected = (
             "SELECT toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', '')), "
-            "toDateTime64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), %(hogql_val_2)s), "
+            "toDateTime64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
             "replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_3)s), '^\"|\"$', '') "
             f"FROM person WHERE equals(person.team_id, {self.team.pk}) LIMIT 65535"
         )
@@ -72,7 +72,7 @@ class TestPropertyTypes(BaseTest):
         )
         expected = (
             "SELECT toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', '')), "
-            "toDateTime64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), %(hogql_val_2)s), "
+            "toDateTime64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
             "replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_3)s), '^\"|\"$', '') "
             f"FROM person WHERE equals(person.team_id, {self.team.pk}) LIMIT 65535"
         )


### PR DESCRIPTION
## Problem

I forgot to add the precision argument to `toDateTime64OrNull` when adding the timezone

## Changes

Now datetimes don't crash.

## How did you test this code?

Saw the argument in a test. Verified by running a SQL query myself that it works.