### PR TITLE
chore(deps): Upgrade Fuse.js form 6.4.1 to 6.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "express": "^4.17.1",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^10.0.0",
-        "fuse.js": "^6.4.1",
+        "fuse.js": "^6.6.2",
         "husky": "^7.0.4",
         "image-blob-reduce": "^4.1.0",
         "kea": "^3.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ specifiers:
   file-loader: ^6.1.0
   fs-extra: ^10.0.0
   fsevents: ^2.1.2
-  fuse.js: ^6.4.1
+  fuse.js: ^6.6.2
   givens: ^1.3.6
   history: ^5.0.1
   html-webpack-harddisk-plugin: ^1.0.2


### PR DESCRIPTION
## Changes

We use Fuse.js for client-side fuzzy search of things like dashboards (see #15191). Let's stay on the latest version.