### PR TITLE
fix: updates some dependencies with "high" vulnerabiltiies

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -19,7 +19,7 @@ datamodel-code-generator==0.16.1
 djangorestframework-stubs==1.4.0
 django-stubs==1.8.0
 Faker==17.5.0
-fakeredis==1.9.1
+fakeredis==2.11.0
 freezegun==1.2.2
 packaging==21.3
 black==22.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -65,7 +65,7 @@ deprecated==1.2.13
     # via
     #   -c requirements.txt
     #   redis
-django==3.2.16
+django==3.2.18
     # via
     #   -c requirements.txt
     #   django-stubs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -61,10 +61,6 @@ cryptography==37.0.2
     #   urllib3
 datamodel-code-generator==0.16.1
     # via -r requirements-dev.in
-deprecated==1.2.13
-    # via
-    #   -c requirements.txt
-    #   redis
 django==3.2.18
     # via
     #   -c requirements.txt
@@ -88,7 +84,7 @@ email-validator==1.3.1
     # via pydantic
 faker==17.5.0
     # via -r requirements-dev.in
-fakeredis==1.9.1
+fakeredis==2.11.0
     # via -r requirements-dev.in
 flaky==3.7.0
     # via -r requirements-dev.in
@@ -146,12 +142,10 @@ openapi-spec-validator==0.5.1
     # via datamodel-code-generator
 packaging==21.3
     # via
-    #   -c requirements.txt
     #   -r requirements-dev.in
     #   datamodel-code-generator
     #   prance
     #   pytest
-    #   redis
 pathable==0.4.3
     # via jsonschema-spec
 pathspec==0.9.0
@@ -183,9 +177,7 @@ pyopenssl==22.0.0
     #   -c requirements.txt
     #   urllib3
 pyparsing==3.0.7
-    # via
-    #   -c requirements.txt
-    #   packaging
+    # via packaging
 pyrsistent==0.18.1
     # via
     #   -c requirements.txt
@@ -236,7 +228,7 @@ pyyaml==6.0
     #   -c requirements.txt
     #   jsonschema-spec
     #   openapi-spec-validator
-redis==4.3.4
+redis==4.5.4
     # via
     #   -c requirements.txt
     #   fakeredis
@@ -257,7 +249,6 @@ semver==2.13.0
 six==1.16.0
     # via
     #   -c requirements.txt
-    #   fakeredis
     #   prance
     #   python-dateutil
 sortedcontainers==2.4.0
@@ -321,10 +312,6 @@ watchdog==2.1.8
     # via pytest-watch
 wheel==0.38.1
     # via pip-tools
-wrapt==1.14.1
-    # via
-    #   -c requirements.txt
-    #   deprecated
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ clickhouse-driver==0.2.4
 clickhouse-pool==0.5.3
 defusedxml==0.6.0
 dj-database-url==0.5.0
-Django==3.2.16
+Django==3.2.18
 django-axes==5.9.0
 django-cors-headers==3.5.0
 django-deprecate-fields==0.1.1

--- a/requirements.in
+++ b/requirements.in
@@ -54,7 +54,7 @@ pyjwt==2.4.0
 python-dateutil>=2.8.2
 python3-saml==1.12.0
 pytz==2021.1
-redis==4.3.4
+redis==4.5.4
 requests==2.28.1
 requests-oauthlib==1.3.0
 selenium==4.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ deprecated==1.2.13
     # via redis
 dj-database-url==0.5.0
     # via -r requirements.in
-django==3.2.16
+django==3.2.18
     # via
     #   -r requirements.in
     #   django-axes

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,8 +78,6 @@ defusedxml==0.6.0
     #   -r requirements.in
     #   python3-openid
     #   social-auth-core
-deprecated==1.2.13
-    # via redis
 dj-database-url==0.5.0
     # via -r requirements.in
 django==3.2.18
@@ -226,8 +224,6 @@ oauthlib==3.1.0
     #   social-auth-core
 outcome==1.1.0
     # via trio
-packaging==21.3
-    # via redis
 parso==0.8.1
     # via -r requirements.in
 pexpect==4.7.0
@@ -258,8 +254,6 @@ pyjwt==2.4.0
     #   social-auth-core
 pyopenssl==22.0.0
     # via urllib3
-pyparsing==3.0.7
-    # via packaging
 pypng==0.20220715.0
     # via qrcode
 pyrsistent==0.18.1
@@ -293,7 +287,7 @@ pyyaml==6.0
     # via drf-spectacular
 qrcode==7.4.2
     # via django-two-factor-auth
-redis==4.3.4
+redis==4.5.4
     # via
     #   -r requirements.in
     #   celery-redbeat
@@ -392,8 +386,6 @@ webdriver-manager==3.8.4
     # via -r requirements.in
 whitenoise==5.2.0
     # via -r requirements.in
-wrapt==1.14.1
-    # via deprecated
 wsproto==1.1.0
     # via trio-websocket
 xmlsec==1.3.13


### PR DESCRIPTION
udpates to version of django 3 that is patched for vuln at https://github.com/PostHog/posthog/security/dependabot/150
updates to a version of redis py that is patched for this vuln report https://github.com/PostHog/posthog/security/dependabot/155

## How did you test this code?

* clicking around in the UI after upgrading
* opening this PR to see the test results