### PR TITLE
chore: send error and warning toasts to posthog

### DIFF
--- a/frontend/src/lib/lemon-ui/lemonToast.tsx
+++ b/frontend/src/lib/lemon-ui/lemonToast.tsx
@@ -78,7 +78,7 @@ export const lemonToast = {
         posthog.capture('toast warning', {
             message: message.toString(),
             button: button?.label,
-            id: toastOptions.toastId,
+            toastId: toastOptions.toastId,
         })
         toastOptions = ensureToastId(toastOptions)
         toast.warning(<ToastContent type="warning" message={message} button={button} id={toastOptions.toastId} />, {
@@ -90,7 +90,7 @@ export const lemonToast = {
         posthog.capture('toast error', {
             message: message.toString(),
             button: button?.label,
-            id: toastOptions.toastId,
+            toastId: toastOptions.toastId,
         })
         toastOptions = ensureToastId(toastOptions)
         toast.error(

--- a/frontend/src/lib/lemon-ui/lemonToast.tsx
+++ b/frontend/src/lib/lemon-ui/lemonToast.tsx
@@ -2,6 +2,7 @@ import { toast, ToastContentProps as ToastifyRenderProps, ToastOptions } from 'r
 import { IconCheckmark, IconClose, IconErrorOutline, IconInfo, IconWarning } from 'lib/lemon-ui/icons'
 import { LemonButton } from './LemonButton'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import posthog from 'posthog-js'
 
 export function ToastCloseButton({ closeToast }: { closeToast?: () => void }): JSX.Element {
     return <LemonButton type="tertiary" icon={<IconClose />} onClick={closeToast} data-attr="toast-close-button" />
@@ -74,6 +75,11 @@ export const lemonToast = {
         })
     },
     warning(message: string | JSX.Element, { button, ...toastOptions }: ToastOptionsWithButton = {}): void {
+        posthog.capture('toast warning', {
+            message: message.toString(),
+            button: button?.label,
+            id: toastOptions.toastId,
+        })
         toastOptions = ensureToastId(toastOptions)
         toast.warning(<ToastContent type="warning" message={message} button={button} id={toastOptions.toastId} />, {
             icon: <IconWarning />,
@@ -81,6 +87,11 @@ export const lemonToast = {
         })
     },
     error(message: string | JSX.Element, { button, ...toastOptions }: ToastOptionsWithButton = {}): void {
+        posthog.capture('toast error', {
+            message: message.toString(),
+            button: button?.label,
+            id: toastOptions.toastId,
+        })
         toastOptions = ensureToastId(toastOptions)
         toast.error(
             <ToastContent


### PR DESCRIPTION
## Problem

We often see error or warning toasts popup but don't have a good sense of which are the most common and how often they occur

## Changes

adds posthog tracking for this

## How did you test this code?

Ran it locally
