### PR TITLE
feat: handle pricing & features better for addons in ingestion flow

### DIFF
--- a/frontend/src/scenes/billing/PlanTable.tsx
+++ b/frontend/src/scenes/billing/PlanTable.tsx
@@ -125,9 +125,11 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
     const { billing } = useValues(billingLogic)
     const { reportBillingUpgradeClicked } = useActions(eventUsageLogic)
 
+    const plans = billing?.available_plans?.filter((plan) => plan.name !== 'Enterprise')
+
     const excludedFeatures: string[] = [AvailableFeature.DASHBOARD_COLLABORATION]
 
-    const upgradeButtons = billing?.available_plans?.map((plan) => (
+    const upgradeButtons = plans?.map((plan) => (
         <td key={`${plan.name}-cta`}>
             <LemonButton
                 to={`/api/billing-v2/activation?plan=${plan.key}&redirect_path=${redirectPath}`}
@@ -147,7 +149,7 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
         </td>
     ))
 
-    return !billing?.available_plans?.length ? (
+    return !plans?.length ? (
         <Spinner />
     ) : (
         <div className="PlanTable space-x-4">
@@ -155,7 +157,7 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                 <thead>
                     <tr>
                         <td />
-                        {billing?.available_plans?.map((plan) => (
+                        {plans?.map((plan) => (
                             <td key={plan.name}>
                                 <h3 className="font-bold">{plan.name}</h3>
                                 <p className="ml-0 text-xs">{plan.description}</p>
@@ -166,7 +168,7 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                 <tbody>
                     <tr>
                         <th
-                            colSpan={4}
+                            colSpan={3}
                             className="PlanTable__th__section bg-muted-light text-muted justify-left rounded text-left mb-2"
                         >
                             <span>Pricing</span>
@@ -174,21 +176,20 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                     </tr>
                     <tr className="PlanTable__tr__border">
                         <td className="font-bold">Monthly base price</td>
-                        {billing?.available_plans?.map((plan) => (
+                        {plans?.map((plan) => (
                             <td key={`${plan.name}-basePrice`} className="text-sm font-bold">
                                 {getPlanBasePrice(plan)}
                             </td>
                         ))}
                     </tr>
-                    {billing?.available_plans
-                        ? billing?.available_plans[billing?.available_plans.length - 1].products
+                    {plans
+                        ? plans[plans.length - 1].products
                               .filter((product) => product.type !== 'base')
                               .map((product, i) => (
                                   <tr
                                       key={product.type}
                                       className={
-                                          billing?.available_plans?.[0].products.length &&
-                                          i !== billing?.available_plans?.[0].products.length - 1
+                                          plans?.[0].products.length && i !== plans?.[0].products.length - 1
                                               ? 'PlanTable__tr__border'
                                               : ''
                                       }
@@ -199,7 +200,7 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                                               Priced per {product.type === 'events' ? 'event' : 'recording'}
                                           </p>
                                       </th>
-                                      {billing?.available_plans?.map((plan) => (
+                                      {plans?.map((plan) => (
                                           <td key={`${plan.key}-${product}`}>{getProductTiers(plan, product.type)}</td>
                                       ))}
                                   </tr>
@@ -211,15 +212,15 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                     </tr>
                     <tr>
                         <th
-                            colSpan={4}
+                            colSpan={3}
                             className="PlanTable__th__section bg-muted-light text-muted justify-left rounded text-left mb-2"
                         >
                             <span>Features</span>
                         </th>
                     </tr>
 
-                    {billing?.available_plans?.length > 0
-                        ? billing.available_plans[billing.available_plans.length - 1].products.map((product) =>
+                    {plans?.length > 0
+                        ? plans[plans.length - 1].products.map((product) =>
                               product.feature_groups?.map((feature_group) => (
                                   <>
                                       <tr
@@ -228,7 +229,7 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                                       >
                                           <th>{feature_group.name}</th>
                                           {(product.type === 'events' || product.type === 'recordings') &&
-                                              billing?.available_plans?.map((plan) => (
+                                              plans?.map((plan) => (
                                                   <td key={`${plan.name}-${feature_group.name}`}>
                                                       <PlanIcon
                                                           feature={{
@@ -260,7 +261,7 @@ export function PlanTable({ redirectPath }: { redirectPath: string }): JSX.Eleme
                                                   <th className="PlanTable__th__subfeature text-muted text-xs">
                                                       <Tooltip title={feature.description}>{feature.name}</Tooltip>
                                                   </th>
-                                                  {billing?.available_plans?.map((plan) => (
+                                                  {plans?.map((plan) => (
                                                       <td key={`${plan.name}-${feature.name}`}>
                                                           <PlanIcon
                                                               feature={plan?.products

--- a/frontend/src/scenes/billing/test/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/test/BillingProduct.tsx
@@ -3,7 +3,14 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { IconChevronRight, IconCheckmark, IconExpandMore, IconPlus, IconArticle } from 'lib/lemon-ui/icons'
+import {
+    IconChevronRight,
+    IconCheckmark,
+    IconExpandMore,
+    IconPlus,
+    IconArticle,
+    IconCheckCircleOutline,
+} from 'lib/lemon-ui/icons'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { BillingProductV2AddonType, BillingProductV2Type, BillingV2PlanType, BillingV2TierType } from '~/types'
@@ -344,7 +351,8 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                     </p>
                                 )}
                                 <p className="m-0">
-                                    Need additional platform and support (aka enterprise) features?{' '}
+                                    Need additional platform and support (aka enterprise) features like SSO and advanced
+                                    permissioning?{' '}
                                     <Link to="mailto:sales@posthog.com?subject=Enterprise%20plan%20request">
                                         Get in touch
                                     </Link>{' '}
@@ -475,19 +483,41 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                             <h4 className={`${product.subscribed ? 'text-success-dark' : 'text-warning-dark'}`}>
                                 You're on the {product.subscribed ? 'paid' : 'free'} plan for {product.name}.
                             </h4>
-                            <p className="m-0 max-w-200">
-                                {product.subscribed ? 'You now' : 'Upgrade to'} get sweet features such as{' '}
+                            <p className="ml-0 max-w-200">
+                                {product.subscribed ? 'You now' : 'Upgrade to'} get sweet features such as:
+                            </p>
+                            <div>
                                 {additionalFeaturesOnUpgradedPlan?.map((feature, i) => {
                                     return (
                                         i < 3 && (
-                                            <Tooltip key={feature.key} title={feature.description}>
-                                                <b>{feature.name}, </b>
-                                            </Tooltip>
+                                            <div className="flex gap-x-2 items-center mb-2">
+                                                <IconCheckCircleOutline className="text-success" />
+                                                <Tooltip key={feature.key} title={feature.description}>
+                                                    <b>{feature.name} </b>
+                                                </Tooltip>
+                                            </div>
                                         )
                                     )
                                 })}
-                                and more{!billing?.has_active_subscription && ', plus upgraded platform features'}.
-                            </p>
+                                {!billing?.has_active_subscription && (
+                                    <div className="flex gap-x-2 items-center mb-2">
+                                        <IconCheckCircleOutline className="text-success" />
+                                        <Tooltip
+                                            title={
+                                                'Multiple projects, Feature flags, Experiments, Integrations, Apps, and more'
+                                            }
+                                        >
+                                            <b>Upgraded platform features</b>
+                                        </Tooltip>
+                                    </div>
+                                )}
+                                <div className="flex gap-x-2 items-center mb-2">
+                                    <IconCheckCircleOutline className="text-success" />
+                                    <Link onClick={toggleIsPlanComparisonModalOpen}>
+                                        <b>And more...</b>
+                                    </Link>
+                                </div>
+                            </div>
                             {upgradePlan?.tiers?.[0].unit_amount_usd &&
                                 parseInt(upgradePlan?.tiers?.[0].unit_amount_usd) === 0 && (
                                     <p className="ml-0 mb-0 mt-4">
@@ -507,6 +537,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                         type="secondary"
                                         onClick={toggleIsPlanComparisonModalOpen}
                                         className="grow"
+                                        center
                                     >
                                         Compare plans
                                     </LemonButton>
@@ -533,6 +564,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                             reportBillingUpgradeClicked(product.type)
                                         }}
                                         className="grow"
+                                        center
                                     >
                                         Upgrade
                                     </LemonButton>

--- a/frontend/src/scenes/billing/test/PlanComparisonModal.tsx
+++ b/frontend/src/scenes/billing/test/PlanComparisonModal.tsx
@@ -196,7 +196,7 @@ export const PlanComparisonModal = ({
                                                         </p>
                                                     </td>
                                                 ) : (
-                                                    <td key={`${addon.plan_key}-tiers-td`}>
+                                                    <td key={`${addon.type}-tiers-td`}>
                                                         {getProductTiers(addon.plans?.[0], addon)}
                                                     </td>
                                                 )

--- a/frontend/src/scenes/billing/test/PlanComparisonModal.tsx
+++ b/frontend/src/scenes/billing/test/PlanComparisonModal.tsx
@@ -184,9 +184,6 @@ export const PlanComparisonModal = ({
                                                 </p>
                                                 <p className="ml-0 text-xs text-muted mt-1">Priced per {addon.unit}</p>
                                             </th>
-                                            {/* There should only be one plan for an addon. It should be available on any paid plan of its parent product. 
-                                                So, we need to count the number of plans for the parent, count the paid plans, and work backwards.
-                                            */}
                                             {plans?.map((plan) =>
                                                 // If the plan is free, the addon isn't available
                                                 plan.free_allocation && !plan.tiers ? (


### PR DESCRIPTION
## Problem

The ingestion flow didn't include addon pricing, but would still subscribe someone to the Group Analytics addon if they sub'd to Product Analytics. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Plan comparison modal on ingestion now shows pricing for the main product and its addons:

![image](https://user-images.githubusercontent.com/18598166/234120401-7398ea81-d3be-4275-89ab-13fafaa82a19.png)

_The pricing is wrong in the above screenshot - I'll look into that and fix in a PR in the billing service, this is just for the UI._

And the ingestion screen lists features out better:

![image](https://user-images.githubusercontent.com/18598166/234130563-7a99d64a-7d11-4d1e-9d49-7891f76c9edd.png)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
