### PR TITLE
chore: don't read configs from file for Temporal Cloud

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -22,9 +22,9 @@ class Command(BaseCommand):
         )
         parser.add_argument("--namespace", default=settings.TEMPORAL_NAMESPACE, help="Namespace to connect to")
         parser.add_argument("--task-queue", default=settings.TEMPORAL_TASK_QUEUE, help="Task queue to service")
-        parser.add_argument("--server-root-ca-cert", help="Optional path to root server CA cert")
-        parser.add_argument("--client-cert", help="Optional path to client cert")
-        parser.add_argument("--client-key", help="Optional path to client key")
+        parser.add_argument("--server-root-ca-cert", help="Optional root server CA cert")
+        parser.add_argument("--client-cert", help="Optional client cert")
+        parser.add_argument("--client-key", help="Optional client key")
 
     def handle(self, *args, **options):
         logging.info(f"Starting Temporal Worker with options: {options}")
@@ -33,19 +33,9 @@ class Command(BaseCommand):
         temporal_port = options["temporal_port"]
         namespace = options["namespace"]
         task_queue = options["task_queue"]
-        server_root_ca_cert = None
-        client_cert = None
-        client_key = None
-
-        if options.get("server_root_ca_cert", False):
-            with open(options["server_root_ca_cert"], "rb") as f:
-                server_root_ca_cert = f.read()
-        if options.get("client_cert", False):
-            with open(options["client_cert"], "rb") as f:
-                client_cert = f.read()
-        if options.get("client_key", False):
-            with open(options["client_key"], "rb") as f:
-                client_key = f.read()
+        server_root_ca_cert = options.get("server_root_ca_cert", None)
+        client_cert = options.get("client_cert", None)
+        client_key = options.get("client_key", None)
 
         asyncio.run(
             start_worker(


### PR DESCRIPTION
## Problem

The way we are conveying these configs is not compatible with reading from individual files. Make it read from env vars directly.

## Changes

Read configs directly from env vars and not indirectly from files passed as configs.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
