### PR TITLE
feat(hogql): swap out toDateTime function

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -100,12 +100,11 @@ CLICKHOUSE_FUNCTIONS: Dict[str, Tuple[str, int | None, int | None]] = {
     "toFloat": ("toFloat64OrNull", 1, 1),
     "toDecimal": ("toDecimal64OrNull", 1, 1),
     "toDate": ("toDateOrNull", 1, 1),
-    "toDateTime": ("toDateTime64OrNull", 1, 1),
+    "toDateTime": ("parseDateTime64BestEffortOrNull", 1, 1),
     "toUUID": ("toUUIDOrNull", 1, 1),
     "toString": ("toString", 1, 1),
     "toJSONString": ("toJSONString", 1, 1),
     "parseDateTime": ("parseDateTimeOrNull", 2, 2),
-    "parseDateTimeBestEffort": ("parseDateTimeBestEffortOrNull", 2, 2),
     # dates and times
     "toTimeZone": ("toTimeZone", 2, 2),
     "timeZoneOf": ("timeZoneOf", 1, 1),
@@ -632,7 +631,7 @@ HOGQL_AGGREGATIONS = {
     "maxIntersectionsPosition": 2,
     "maxIntersectionsPositionIf": 3,
 }
-ADD_TIMEZONE_TO_FUNCTIONS = ("now", "NOW", "toDateTime")
+ADD_TIMEZONE_TO_FUNCTIONS = ("now", "NOW", "toDateTime", "parseDateTime")
 # Keywords passed to ClickHouse without transformation
 KEYWORDS = ["true", "false", "null"]
 

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -632,7 +632,7 @@ HOGQL_AGGREGATIONS = {
     "maxIntersectionsPosition": 2,
     "maxIntersectionsPositionIf": 3,
 }
-ADD_TIMEZONE_TO_FUNCTIONS = ("now", "NOW", "toDateTime", "parseDateTime")
+ADD_TIMEZONE_TO_FUNCTIONS = ("now", "NOW", "toDateTime", "parseDateTime", "parseDateTimeBestEffort")
 # Keywords passed to ClickHouse without transformation
 KEYWORDS = ["true", "false", "null"]
 

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -105,6 +105,7 @@ CLICKHOUSE_FUNCTIONS: Dict[str, Tuple[str, int | None, int | None]] = {
     "toString": ("toString", 1, 1),
     "toJSONString": ("toJSONString", 1, 1),
     "parseDateTime": ("parseDateTimeOrNull", 2, 2),
+    "parseDateTimeBestEffort": ("parseDateTime64BestEffortOrNull", 1, 1),
     # dates and times
     "toTimeZone": ("toTimeZone", 2, 2),
     "timeZoneOf": ("timeZoneOf", 1, 1),

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -457,7 +457,7 @@ class _Printer(Visitor):
 
             if self.dialect == "clickhouse":
                 if (clickhouse_name == "now64" and len(args) == 0) or (
-                    clickhouse_name == "toDateTime64OrNull" and len(args) == 1
+                    clickhouse_name == "parseDateTime64BestEffortOrNull" and len(args) == 1
                 ):
                     # must add precision if adding timezone in the next step
                     args.append("6")

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -524,7 +524,7 @@ class TestPrinter(BaseTest):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
         self.assertEqual(
             self._select("SELECT now(), toDateTime(timestamp), toDateTime('2020-02-02') FROM events", context),
-            f"SELECT now64(6, %(hogql_val_0)s), toDateTime64OrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), 6, %(hogql_val_2)s), toDateTime64OrNull(%(hogql_val_3)s, 6, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT now64(6, %(hogql_val_0)s), parseDateTime64BestEffortOrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), 6, %(hogql_val_2)s), parseDateTime64BestEffortOrNull(%(hogql_val_3)s, 6, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         self.assertEqual(
             context.values,
@@ -543,7 +543,7 @@ class TestPrinter(BaseTest):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
         self.assertEqual(
             self._select("SELECT now(), toDateTime(timestamp), toDateTime('2020-02-02') FROM events", context),
-            f"SELECT now64(6, %(hogql_val_0)s), toDateTime64OrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), 6, %(hogql_val_2)s), toDateTime64OrNull(%(hogql_val_3)s, 6, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
+            f"SELECT now64(6, %(hogql_val_0)s), parseDateTime64BestEffortOrNull(toTimeZone(events.timestamp, %(hogql_val_1)s), 6, %(hogql_val_2)s), parseDateTime64BestEffortOrNull(%(hogql_val_3)s, 6, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 65535",
         )
         self.assertEqual(
             context.values,

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -60,7 +60,7 @@ class TestPropertyTypes(BaseTest):
         )
         expected = (
             "SELECT toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', '')), "
-            "toDateTime64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
+            "parseDateTime64BestEffortOrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
             "replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_3)s), '^\"|\"$', '') "
             f"FROM person WHERE equals(person.team_id, {self.team.pk}) LIMIT 65535"
         )
@@ -72,7 +72,7 @@ class TestPropertyTypes(BaseTest):
         )
         expected = (
             "SELECT toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_0)s), '^\"|\"$', '')), "
-            "toDateTime64OrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
+            "parseDateTime64BestEffortOrNull(replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_1)s), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
             "replaceRegexpAll(JSONExtractRaw(person.properties, %(hogql_val_3)s), '^\"|\"$', '') "
             f"FROM person WHERE equals(person.team_id, {self.team.pk}) LIMIT 65535"
         )


### PR DESCRIPTION
## Problem

HogQL passed all string properties to `toDateTime64OrNull` when converting them to datetimes.

That function however accepts only one format of dates: `2018-10-23 10:12:12.123456`

This means it doesn't know what to do when a date string contains a timezone, such as `2018-10-23 10:12:12+00:00` and just returns `null`.

## Changes

Swapped out `toDateTime64OrNull` with `parseDateTime64BestEffortOrNull` as the function powering `toDateTime`.

## How did you test this code?

I updated the tests that changed, and I could actually query datetime properties in the event explorer interface.