### PR TITLE
fix(insights): Allow refreshing insight without page reload

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -1,4 +1,4 @@
-import { dayjs, now } from 'lib/dayjs'
+import { dayjs } from 'lib/dayjs'
 import {
     kea,
     path,
@@ -369,26 +369,24 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                     : null
             },
         ],
-        insightRefreshButtonDisabledReason: [
+        getInsightRefreshButtonDisabledReason: [
             (s) => [s.nextAllowedRefresh, s.lastRefresh],
-            (nextAllowedRefresh: string | null, lastRefresh: string | null): string => {
+            (nextAllowedRefresh: string | null, lastRefresh: string | null) => (): string => {
+                const now = dayjs()
                 let disabledReason = ''
-
-                if (!!nextAllowedRefresh && now().isBefore(dayjs(nextAllowedRefresh))) {
+                if (!!nextAllowedRefresh && now.isBefore(dayjs(nextAllowedRefresh))) {
                     // If this is a saved insight, the result will contain nextAllowedRefresh, and we use that to disable the button
-                    disabledReason = `You can refresh this insight again ${dayjs(nextAllowedRefresh).fromNow()}`
+                    disabledReason = `You can refresh this insight again ${dayjs(nextAllowedRefresh).from(now)}`
                 } else if (
                     !!lastRefresh &&
-                    now()
-                        .subtract(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes')
-                        .isBefore(lastRefresh)
+                    now.subtract(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes').isBefore(lastRefresh)
                 ) {
                     // Unsaved insights don't get cached and get refreshed on every page load, but we avoid allowing users to click
                     // 'refresh' more than once every UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES. This can be bypassed by simply
                     // refreshing the page though, as there's no cache layer on the backend
                     disabledReason = `You can refresh this insight again ${dayjs(lastRefresh)
                         .add(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES, 'minutes')
-                        .fromNow()}`
+                        .from(now)}`
                 }
 
                 return disabledReason

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -47,6 +47,7 @@ import { posthog } from 'posthog-js'
 import { summarizeInsight } from 'scenes/insights/summarizeInsight'
 import { AddToNotebook } from 'scenes/notebooks/AddToNotebook/AddToNotebook'
 import { NotebookNodeType } from 'scenes/notebooks/Nodes/types'
+import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 
 export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
     // insightSceneLogic
@@ -65,7 +66,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         exporterResourceParams,
         isUsingDataExploration,
         isUsingDashboardQueries,
-        insightRefreshButtonDisabledReason,
+        getInsightRefreshButtonDisabledReason,
     } = useValues(logic)
     const { setInsightMetadata, saveAs, loadResults } = useActions(logic)
 
@@ -88,6 +89,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { featureFlags } = useValues(featureFlagLogic)
     const { globalInsightFilters } = useValues(globalInsightLogic)
     const { setGlobalInsightFilters } = useActions(globalInsightLogic)
+
+    usePeriodicRerender(30000) // Re-render every 30 seconds for up-to-date `insightRefreshButtonDisabledReason`
+
+    const insightRefreshButtonDisabledReason = getInsightRefreshButtonDisabledReason()
 
     return (
         <>

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -41,7 +41,6 @@ import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { urls } from 'scenes/urls'
 import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import { actionsModel } from '~/models/actionsModel'
-
 import { DashboardPrivilegeLevel, FEATURE_FLAGS } from 'lib/constants'
 import { groupsModel } from '~/models/groupsModel'
 import { cohortsModel } from '~/models/cohortsModel'
@@ -54,7 +53,7 @@ import { toLocalFilters } from './filters/ActionFilter/entityFilterLogic'
 import { loaders } from 'kea-loaders'
 import { legacyInsightQuery, queryExportContext } from '~/queries/query'
 import { tagsModel } from '~/models/tagsModel'
-import { dayjs, now } from 'lib/dayjs'
+import { dayjs } from 'lib/dayjs'
 import { isInsightVizNode } from '~/queries/utils'
 import { userLogic } from 'scenes/userLogic'
 import { globalInsightLogic } from './globalInsightLogic'
@@ -805,26 +804,24 @@ export const insightLogic = kea<insightLogicType>([
                 return !!featureFlags[FEATURE_FLAGS.HOGQL]
             },
         ],
-        insightRefreshButtonDisabledReason: [
+        getInsightRefreshButtonDisabledReason: [
             (s) => [s.nextAllowedRefresh, s.lastRefresh],
-            (nextAllowedRefresh: string | null, lastRefresh: string | null): string => {
+            (nextAllowedRefresh: string | null, lastRefresh: string | null) => (): string => {
+                const now = dayjs()
                 let disabledReason = ''
-
-                if (!!nextAllowedRefresh && now().isBefore(dayjs(nextAllowedRefresh))) {
+                if (!!nextAllowedRefresh && now.isBefore(dayjs(nextAllowedRefresh))) {
                     // If this is a saved insight, the result will contain nextAllowedRefresh and we use that to disable the button
-                    disabledReason = `You can refresh this insight again ${dayjs(nextAllowedRefresh).fromNow()}`
+                    disabledReason = `You can refresh this insight again ${dayjs(nextAllowedRefresh).from(now)}`
                 } else if (
                     !!lastRefresh &&
-                    now()
-                        .subtract(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes')
-                        .isBefore(lastRefresh)
+                    now.subtract(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes').isBefore(lastRefresh)
                 ) {
                     // Unsaved insights don't get cached and get refreshed on every page load, but we avoid allowing users to click
                     // 'refresh' more than once every UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES. This can be bypassed by simply
                     // refreshing the page though, as there's no cache layer on the backend
                     disabledReason = `You can refresh this insight again ${dayjs(lastRefresh)
                         .add(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES, 'minutes')
-                        .fromNow()}`
+                        .from(now)}`
                 }
 
                 return disabledReason


### PR DESCRIPTION
## Problem

A user reported:
> "You can refresh this insight again in 3 minutes" but my three minutes never comes unless I refresh the page.
> ![FukH5XsacAAZ-JJ](https://user-images.githubusercontent.com/4550621/234305374-0c89a3c1-869f-4ecf-8d68-47a8991e7c88.png)

[(See tweet.)](https://twitter.com/grhmc/status/1650859425282899968)

## Changes

We now update the `disabledReason` every 30 seconds, so that the button becomes enabled when it's time – no page reload needed.
