### PR TITLE
fix: Added missing value for blob ingestion

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -153,6 +153,7 @@ export function overrideWithEnv(
             'ingestion-overflow',
             'analytics-ingestion',
             'recordings-ingestion',
+            'recordings-blob-ingestion',
             null,
         ].includes(newConfig.PLUGIN_SERVER_MODE)
     ) {


### PR DESCRIPTION
## Problem

We missed one more place for the plugin server mode

## Changes

* Fixes it 

For the future - we should make this better and derive it from the type instead...

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
