### PR TITLE
fix(ch): stop running delete jobs while clickhouse is on an older version

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -96,10 +96,10 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         sender.add_periodic_task(crontab(hour=4, minute=0), verify_persons_data_in_sync.s())
 
     # if is_cloud() or settings.DEMO:
-        # Reset master project data every Monday at Thursday at 5 AM UTC. Mon and Thu because doing this every day
-        # would be too hard on ClickHouse, and those days ensure most users will have data at most 3 days old.
-        # TODO: Re-enable when we've upgraded ClickHouse and can use lightweight deletes
-        # sender.add_periodic_task(crontab(day_of_week="mon,thu", hour=5, minute=0), demo_reset_master_team.s())
+    # Reset master project data every Monday at Thursday at 5 AM UTC. Mon and Thu because doing this every day
+    # would be too hard on ClickHouse, and those days ensure most users will have data at most 3 days old.
+    # TODO: Re-enable when we've upgraded ClickHouse and can use lightweight deletes
+    # sender.add_periodic_task(crontab(day_of_week="mon,thu", hour=5, minute=0), demo_reset_master_team.s())
 
     sender.add_periodic_task(crontab(day_of_week="fri", hour=0, minute=0), clean_stale_partials.s())
 
@@ -151,7 +151,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
     #     sender.add_periodic_task(
     #         clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
     #     )
-    
+
     # TODO: Re-enable when we've upgraded ClickHouse and can use lightweight deletes
     # if clear_clickhouse_deleted_person_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON):
     #     sender.add_periodic_task(

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -95,10 +95,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         # Verify that persons data is in sync every day at 4 AM UTC
         sender.add_periodic_task(crontab(hour=4, minute=0), verify_persons_data_in_sync.s())
 
-    if is_cloud() or settings.DEMO:
+    # if is_cloud() or settings.DEMO:
         # Reset master project data every Monday at Thursday at 5 AM UTC. Mon and Thu because doing this every day
         # would be too hard on ClickHouse, and those days ensure most users will have data at most 3 days old.
-        sender.add_periodic_task(crontab(day_of_week="mon,thu", hour=5, minute=0), demo_reset_master_team.s())
+        # TODO: Re-enable when we've upgraded ClickHouse and can use lightweight deletes
+        # sender.add_periodic_task(crontab(day_of_week="mon,thu", hour=5, minute=0), demo_reset_master_team.s())
 
     sender.add_periodic_task(crontab(day_of_week="fri", hour=0, minute=0), clean_stale_partials.s())
 
@@ -145,17 +146,19 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
 
         sender.add_periodic_task(get_crontab("0 6 * * *"), count_teams_with_no_property_query_count.s())
 
-    if clear_clickhouse_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON):
-        sender.add_periodic_task(
-            clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
-        )
-
-    if clear_clickhouse_deleted_person_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON):
-        sender.add_periodic_task(
-            clear_clickhouse_deleted_person_crontab,
-            clear_clickhouse_deleted_person.s(),
-            name="clickhouse clear deleted person data",
-        )
+    # TODO: Re-enable when we've upgraded ClickHouse and can use lightweight deletes
+    # if clear_clickhouse_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON):
+    #     sender.add_periodic_task(
+    #         clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
+    #     )
+    
+    # TODO: Re-enable when we've upgraded ClickHouse and can use lightweight deletes
+    # if clear_clickhouse_deleted_person_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON):
+    #     sender.add_periodic_task(
+    #         clear_clickhouse_deleted_person_crontab,
+    #         clear_clickhouse_deleted_person.s(),
+    #         name="clickhouse clear deleted person data",
+    #     )
 
     if settings.EE_AVAILABLE:
         sender.add_periodic_task(


### PR DESCRIPTION
Deletes are putting a lot of load on our cluster. Let's upgrade CH to 23.3 so we can use lightweight deletes and then bring these back