### PR TITLE
fix: undefined default for window select

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
@@ -87,11 +87,11 @@ export function PlayerInspectorControls(): JSX.Element {
                         <LemonSelect
                             size="small"
                             data-attr="player-window-select"
-                            value={windowIdFilter ?? undefined}
+                            value={windowIdFilter}
                             onChange={(val) => setWindowIdFilter(val || null)}
                             options={[
                                 {
-                                    value: undefined,
+                                    value: null,
                                     label: 'All windows',
                                     icon: <IconWindow size="small" value="A" className="text-muted" />,
                                 },


### PR DESCRIPTION
## Problem

I think something in the LemonSelect refactor changed the defaults in such a way that we saw "select a value" instead of the "All windows" if nothing is selected

## Changes

* Fixes this

|Before|After|
|----|----|
| <img width="195" alt="Screenshot 2023-04-26 at 09 06 28" src="https://user-images.githubusercontent.com/2536520/234496541-e4df9847-1acd-41c2-81aa-f2bd1382a199.png"> | <img width="246" alt="Screenshot 2023-04-26 at 09 06 18" src="https://user-images.githubusercontent.com/2536520/234496837-4b72ee1a-271a-4d66-a701-e89874ff3171.png"> |


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 