### PR TITLE
fix(data-exploration): prevent leave confirmation safeguard

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -100,11 +100,11 @@ export const insightDataLogic = kea<insightDataLogicType>([
         ],
 
         queryChanged: [
-            (s) => [s.isQueryBasedInsight, s.query, s.insight, s.savedInsight],
-            (isQueryBasedInsight, query, insight, savedInsight) => {
+            (s) => [s.isQueryBasedInsight, s.isUsingDataExploration, s.query, s.insight, s.savedInsight],
+            (isQueryBasedInsight, isUsingDataExploration, query, insight, savedInsight) => {
                 if (isQueryBasedInsight) {
                     return !objectsEqual(query, insight.query)
-                } else {
+                } else if (isUsingDataExploration) {
                     const currentFilters = queryNodeToFilter((query as InsightVizNode).source)
                     const savedFilters =
                         savedInsight.filters ||
@@ -115,6 +115,8 @@ export const insightDataLogic = kea<insightDataLogicType>([
                     delete savedFilters.filter_test_accounts
 
                     return !compareFilters(currentFilters, savedFilters)
+                } else {
+                    return false
                 }
             },
         ],


### PR DESCRIPTION
## Problem

We have a couple of reports that the leave page confirmation triggers when saving an insight.

## Changes

A condition that is only relevant for data exploration triggers erroneously for non data-exploration users. The condition works as expected with data exploration. This PR adds a feature flag safeguard to the condition.

## How did you test this code?

Verified the page leave confirmation doesn't trigger when clicking save (non data-exploration), but still works correctly for data exploration.