### PR TITLE
feat(data-exploration): improve toggle json ux

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -56,14 +56,6 @@ export const seriesToActionsAndEvents = (
         }
     })
 
-    if (actions.length + events.length + new_entity.length === 1) {
-        actions.length > 0
-            ? delete actions[0].order
-            : events.length > 0
-            ? delete events[0].order
-            : delete new_entity[0].order
-    }
-
     return { actions, events, new_entity }
 }
 

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -357,7 +357,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         setInsightMode(ItemMode.Edit, null)
 
                                         // exit early if query editor doesn't need to be toggled
-                                        if (showQueryEditor === false) {
+                                        if (showQueryEditor !== false) {
                                             return
                                         }
                                     }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -97,7 +97,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     return (
         <>
-            {insight.short_id !== 'new' && (
+            {hasDashboardItemId && (
                 <>
                     <SubscriptionsModal
                         isOpen={insightMode === ItemMode.Subscriptions}
@@ -288,23 +288,25 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 <LemonDivider vertical />
                             </>
                         ) : null}
-                        {insightMode === ItemMode.Edit && insight.saved && (
+                        {insightMode === ItemMode.Edit && hasDashboardItemId && (
                             <LemonButton type="secondary" onClick={() => setInsightMode(ItemMode.View, null)}>
                                 Cancel
                             </LemonButton>
                         )}
-                        {insightMode !== ItemMode.Edit && insight.short_id && (
+                        {insightMode !== ItemMode.Edit && hasDashboardItemId && (
                             <AddToDashboard insight={insight} canEditInsight={canEditInsight} />
                         )}
 
-                        {insightMode !== ItemMode.Edit && insight.short_id && featureFlags[FEATURE_FLAGS.NOTEBOOKS] && (
-                            <AddToNotebook
-                                node={NotebookNodeType.Insight}
-                                properties={{ shortId: insight.short_id }}
-                                type="secondary"
-                                size="medium"
-                            />
-                        )}
+                        {insightMode !== ItemMode.Edit &&
+                            hasDashboardItemId &&
+                            featureFlags[FEATURE_FLAGS.NOTEBOOKS] && (
+                                <AddToNotebook
+                                    node={NotebookNodeType.Insight}
+                                    properties={{ shortId: insight.short_id }}
+                                    type="secondary"
+                                    size="medium"
+                                />
+                            )}
 
                         {insightMode !== ItemMode.Edit ? (
                             canEditInsight && (
@@ -320,7 +322,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             <InsightSaveButton
                                 saveAs={saveAs}
                                 saveInsight={saveQueryBasedInsight}
-                                isSaved={insight.saved}
+                                isSaved={hasDashboardItemId}
                                 addingToDashboard={!!insight.dashboards?.length && !insight.id}
                                 insightSaving={insightSaving}
                                 insightChanged={insightChanged || queryChanged}
@@ -349,12 +351,17 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 tooltipPlacement="bottomRight"
                                 type={'secondary'}
                                 onClick={() => {
-                                    toggleQueryEditorPanel()
-                                    if (insightMode !== ItemMode.Edit) {
+                                    // for an existing insight in view mode
+                                    if (hasDashboardItemId && insightMode !== ItemMode.Edit) {
+                                        // enter edit mode
                                         setInsightMode(ItemMode.Edit, null)
-                                    } else if (insightMode === ItemMode.Edit && insight.saved) {
-                                        setInsightMode(ItemMode.View, null)
+
+                                        // exit early if query editor doesn't need to be toggled
+                                        if (showQueryEditor === false) {
+                                            return
+                                        }
                                     }
+                                    toggleQueryEditorPanel()
                                 }}
                                 icon={<IconDataObject fontSize="18" />}
                             />

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -63,6 +63,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         insight,
         insightChanged,
         insightSaving,
+        hasDashboardItemId,
         exporterResourceParams,
         isUsingDataExploration,
         isUsingDashboardQueries,
@@ -143,7 +144,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 }
                 buttons={
                     <div className="flex justify-between items-center gap-2">
-                        {insightMode === ItemMode.Edit ? (
+                        {!hasDashboardItemId ? (
                             <>
                                 <More
                                     overlay={
@@ -162,8 +163,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 />
                                 <LemonDivider vertical />
                             </>
-                        ) : null}
-                        {insightMode !== ItemMode.Edit && (
+                        ) : (
                             <>
                                 <More
                                     overlay={

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -348,7 +348,14 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 aria-label={showQueryEditor ? 'Hide source (BETA)' : 'View source (BETA)'}
                                 tooltipPlacement="bottomRight"
                                 type={'secondary'}
-                                onClick={toggleQueryEditorPanel}
+                                onClick={() => {
+                                    toggleQueryEditorPanel()
+                                    if (insightMode !== ItemMode.Edit) {
+                                        setInsightMode(ItemMode.Edit, null)
+                                    } else if (insightMode === ItemMode.Edit && insight.saved) {
+                                        setInsightMode(ItemMode.View, null)
+                                    }
+                                }}
                                 icon={<IconDataObject fontSize="18" />}
                             />
                         ) : null}

--- a/frontend/src/scenes/insights/utils/compareFilters.ts
+++ b/frontend/src/scenes/insights/utils/compareFilters.ts
@@ -3,7 +3,16 @@ import { objectCleanWithEmpty, objectsEqual } from 'lib/utils'
 
 import { cleanFilters } from './cleanFilters'
 
-const clean = (f: Partial<AnyFilterType>): Partial<AnyFilterType> => objectCleanWithEmpty(cleanFilters(f))
+const clean = (f: Partial<AnyFilterType>): Partial<AnyFilterType> => {
+    const cleanedFilters = objectCleanWithEmpty(cleanFilters(f))
+    cleanedFilters.events = cleanedFilters.events?.map((e) => {
+        if (e.math === 'total') {
+            delete e.math
+        }
+        return e
+    })
+    return cleanedFilters
+}
 
 /** compares to filter objects for semantical equality */
 export function compareFilters(a: Partial<AnyFilterType>, b: Partial<AnyFilterType>): boolean {


### PR DESCRIPTION
## Problem

Toggling the JSON editor for a saved insight wasn't very intuitive, as you'd also need to toggle editing an insight.

## Changes

This PR:
- toggles editing a saved insight with the json editor
- fixes an issue where the `queryChanged` selector would return true for semantically equal filters

## How did you test this code?

Manual testing