### PR TITLE
fix: Recording share button

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
@@ -17,8 +17,10 @@ export function PlayerMetaLinks(): JSX.Element {
 
     const onShare = (): void => {
         setPause()
+        // NOTE: We pull this value at call time as otherwise it would trigger rerenders if pulled from the hook
+        const currentPlayerTime = sessionRecordingPlayerLogic.findMounted(logicProps)?.values.currentPlayerTime || 0
         openPlayerShareDialog({
-            seconds: Math.floor((sessionRecordingPlayerLogic.values.currentPlayerTime || 0) / 1000),
+            seconds: Math.floor(currentPlayerTime / 1000),
             id: sessionRecordingId,
         })
     }


### PR DESCRIPTION
## Problem

The swap to the bound logic broke the share modal.

## Changes

* Fixes it and adds a note about why we do this 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 