### PR TITLE
feat(data-exploration): add insight data timing

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -271,6 +271,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             () => [(_, props) => props.cachedResults ?? null],
             (cachedResults: AnyResponseType | null): boolean => !!cachedResults,
         ],
+        query: [(_, p) => [p.query], (query) => query],
         newQuery: [
             (s, p) => [p.query, s.response],
             (query, response): DataNode | null => {

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -15,6 +15,7 @@ import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { queryExportContext } from '~/queries/query'
 import { objectsEqual } from 'lib/utils'
 import { compareFilters } from './utils/compareFilters'
+import { insightDataTimingLogic } from './insightDataTimingLogic'
 
 const queryFromFilters = (filters: Partial<FilterType>): InsightVizNode => ({
     kind: NodeKind.InsightVizNode,
@@ -46,6 +47,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
             dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
             ['loadData', 'loadDataSuccess'],
         ],
+        logic: [insightDataTimingLogic(props)],
     })),
 
     actions({

--- a/frontend/src/scenes/insights/insightDataTimingLogic.ts
+++ b/frontend/src/scenes/insights/insightDataTimingLogic.ts
@@ -1,0 +1,116 @@
+import { kea, props, key, path, connect, listeners, reducers, actions } from 'kea'
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { DataNode } from '~/queries/schema'
+import { InsightLogicProps } from '~/types'
+import { keyForInsightLogicProps } from './sharedUtils'
+
+import type { insightDataTimingLogicType } from './insightDataTimingLogicType'
+import { teamLogic } from 'scenes/teamLogic'
+import { captureTimeToSeeData } from 'lib/internalMetrics'
+
+export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['scenes', 'insights', 'insightDataTimingLogic', key]),
+    connect((props: InsightLogicProps) => ({
+        values: [
+            teamLogic,
+            ['currentTeamId'],
+            dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
+            ['query', 'response'],
+        ],
+        actions: [
+            // TODO: need to pass empty query here, as otherwise dataNodeLogic will throw
+            dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
+            ['loadData', 'loadDataSuccess', 'loadDataFailure', 'abortQuery as loadDataCancellation'],
+        ],
+    })),
+    actions({
+        startQuery: (queryId: string) => ({ queryId }),
+        removeQuery: (queryId: string) => ({ queryId }),
+    }),
+    reducers({
+        queryStartTimes: [
+            {} as Record<string, number>,
+            {
+                startQuery: (state, { queryId }) => ({ ...state, [queryId]: performance.now() }),
+                removeQuery: (state, { queryId }) => {
+                    const { [queryId]: remove, ...rest } = state
+                    return rest
+                },
+            },
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        loadData: ({ queryId }) => {
+            console.debug('loadData', queryId)
+            actions.startQuery(queryId)
+        },
+        loadDataSuccess: ({ payload }) => {
+            // ignore initialization
+            if (!payload || !values.queryStartTimes[payload.queryId]) {
+                return
+            }
+
+            const duration = performance.now() - values.queryStartTimes[payload.queryId]
+
+            captureTimeToSeeData(values.currentTeamId, {
+                type: 'insight_load',
+                context: 'insight',
+                primary_interaction_id: payload.queryId,
+                query_id: payload.queryId,
+                status: 'success',
+                time_to_see_data_ms: Math.floor(duration),
+                insights_fetched: 1,
+                insights_fetched_cached: values.response?.is_cached ? 1 : 0,
+                // api_response_bytes: values.response?.apiResponseBytes, getResponseB
+                // api_url: values.response?.apiUrl,
+                insight: values.query.kind,
+                is_primary_interaction: true,
+            })
+            actions.removeQuery(payload.queryId)
+        },
+        loadDataFailure: ({ errorObject }) => {
+            // ignore unexpected errors without query id
+            if (!errorObject.queryId) {
+                return
+            }
+
+            const duration = performance.now() - values.queryStartTimes[errorObject.queryId]
+
+            captureTimeToSeeData(values.currentTeamId, {
+                type: 'insight_load',
+                context: 'insight',
+                primary_interaction_id: errorObject.queryId,
+                query_id: errorObject.queryId,
+                status: 'failure',
+                time_to_see_data_ms: Math.floor(duration),
+                insights_fetched: 1,
+                insights_fetched_cached: values.response?.is_cached ? 1 : 0,
+                // api_response_bytes: values.response?.apiResponseBytes, getResponseB
+                // api_url: values.response?.apiUrl,
+                insight: values.query.kind,
+                is_primary_interaction: true,
+            })
+            actions.removeQuery(errorObject.queryId)
+        },
+        loadDataCancellation: (payload) => {
+            const duration = performance.now() - values.queryStartTimes[payload.queryId]
+
+            captureTimeToSeeData(values.currentTeamId, {
+                type: 'insight_load',
+                context: 'insight',
+                primary_interaction_id: payload.queryId,
+                query_id: payload.queryId,
+                status: 'cancelled',
+                time_to_see_data_ms: Math.floor(duration),
+                insights_fetched: 0,
+                insights_fetched_cached: 0,
+                api_response_bytes: 0,
+                insight: values.query.kind,
+            })
+            actions.removeQuery(payload.queryId)
+        },
+    })),
+])


### PR DESCRIPTION
## Problem

Data exploration query nodes fetch data in another code path that wasn't instrumented w.r.t. time to see data.

## Changes

This PR adds time to see data capturing for insights.

## How did you test this code?

Setting up the instrumentation locally wasn't straight-forward so I tested with logging statements instead.