### PR TITLE
fix(poe-v2): use argMax to get latest override

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -1998,10 +1998,11 @@
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
                  LEFT OUTER JOIN
-                   (SELECT override_person_id as person_id,
+                   (SELECT argMax(override_person_id, version) as person_id,
                            old_person_id
                     FROM person_overrides
-                    WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+                    WHERE team_id = 2
+                    GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
                  WHERE team_id = 2
                    AND (event = '$pageview'
                         OR event = '$screen'

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -669,10 +669,11 @@
                if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
-          (SELECT override_person_id as person_id,
+          (SELECT argMax(override_person_id, version) as person_id,
                   old_person_id
            FROM person_overrides
-           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         INNER JOIN
           (SELECT group_key,
                   argMax(group_properties, _timestamp) AS group_properties_0
@@ -700,10 +701,11 @@
                       ] as breakdown_values
         FROM events e
         LEFT OUTER JOIN
-          (SELECT override_person_id as person_id,
+          (SELECT argMax(override_person_id, version) as person_id,
                   old_person_id
            FROM person_overrides
-           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         INNER JOIN
           (SELECT group_key,
                   argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -490,10 +490,11 @@
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
-       (SELECT override_person_id as person_id,
+       (SELECT argMax(override_person_id, version) as person_id,
                old_person_id
         FROM person_overrides
-        WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+        GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
      WHERE team_id = 2
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -262,10 +262,11 @@
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
                        LEFT OUTER JOIN
-                         (SELECT override_person_id as person_id,
+                         (SELECT argMax(override_person_id, version) as person_id,
                                  old_person_id
                           FROM person_overrides
-                          WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+                          WHERE team_id = 2
+                          GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
                        WHERE team_id = 2
                          AND event IN ['$autocapture', 'user signed up', '$autocapture', '$autocapture']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-25 00:00:00', 'UTC')

--- a/posthog/queries/person_on_events_v2_sql.py
+++ b/posthog/queries/person_on_events_v2_sql.py
@@ -1,0 +1,7 @@
+PERSON_OVERRIDES_JOIN_SQL = """LEFT OUTER JOIN (
+    SELECT argMax(override_person_id, version) as person_id, old_person_id
+    FROM person_overrides
+    WHERE team_id = %(team_id)s
+    GROUP BY old_person_id
+) AS {person_overrides_table_alias}
+ON {event_table_alias}.person_id = {person_overrides_table_alias}.old_person_id"""

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -95,10 +95,11 @@
                if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
-          (SELECT override_person_id as person_id,
+          (SELECT argMax(override_person_id, version) as person_id,
                   old_person_id
            FROM person_overrides
-           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-10 00:00:00', 'UTC')
@@ -118,10 +119,11 @@
                       ] as breakdown_values
         FROM events e
         LEFT OUTER JOIN
-          (SELECT override_person_id as person_id,
+          (SELECT argMax(override_person_id, version) as person_id,
                   old_person_id
            FROM person_overrides
-           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-10 00:00:00', 'UTC')

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -1330,6 +1330,241 @@
      ORDER BY day_start)
   '
 ---
+# name: TestTrends.test_same_day_with_person_on_events_v2_
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE team_id = 2
+    AND distinct_id IN ('distinctid1',
+                        'distinctid2')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'distinctid1', -1, 0)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_.1
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC')), toDateTime('2020-01-03 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC'))
+        UNION ALL SELECT count(DISTINCT if(notEmpty(overrides.person_id), overrides.person_id, e.person_id)) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT argMax(override_person_id, version) as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'UTC')
+          AND notEmpty(e.person_id)
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_.2
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE team_id = 2
+    AND distinct_id IN ('distinctid1',
+                        'distinctid3')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'distinctid1', -1, 0)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_.3
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC')), toDateTime('2020-01-03 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC'))
+        UNION ALL SELECT count(DISTINCT if(notEmpty(overrides.person_id), overrides.person_id, e.person_id)) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT argMax(override_person_id, version) as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'UTC')
+          AND notEmpty(e.person_id)
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_latest_override
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE team_id = 2
+    AND distinct_id IN ('distinctid1',
+                        'distinctid2')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'distinctid1', -1, 0)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_latest_override.1
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC')), toDateTime('2020-01-03 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC'))
+        UNION ALL SELECT count(DISTINCT if(notEmpty(overrides.person_id), overrides.person_id, e.person_id)) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT argMax(override_person_id, version) as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'UTC')
+          AND notEmpty(e.person_id)
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_latest_override.2
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE team_id = 2
+    AND distinct_id IN ('distinctid1',
+                        'distinctid3')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'distinctid1', -1, 0)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_latest_override.3
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC')), toDateTime('2020-01-03 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC'))
+        UNION ALL SELECT count(DISTINCT if(notEmpty(overrides.person_id), overrides.person_id, e.person_id)) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT argMax(override_person_id, version) as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'UTC')
+          AND notEmpty(e.person_id)
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_latest_override.4
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE team_id = 2
+    AND distinct_id IN ('distinctid1',
+                        'distinctid2')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'distinctid1', -1, 0)
+  '
+---
+# name: TestTrends.test_same_day_with_person_on_events_v2_latest_override.5
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC')), toDateTime('2020-01-03 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC'))
+        UNION ALL SELECT count(DISTINCT if(notEmpty(overrides.person_id), overrides.person_id, e.person_id)) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        LEFT OUTER JOIN
+          (SELECT argMax(override_person_id, version) as person_id,
+                  old_person_id
+           FROM person_overrides
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'UTC')
+          AND notEmpty(e.person_id)
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
 # name: TestTrends.test_same_day_with_person_on_events_v2g
   '
   

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -681,10 +681,11 @@
                             replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') as breakdown_value
            FROM events e
            LEFT OUTER JOIN
-             (SELECT override_person_id as person_id,
+             (SELECT argMax(override_person_id, version) as person_id,
                      old_person_id
               FROM person_overrides
-              WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+              WHERE team_id = 2
+              GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
            INNER JOIN
              (SELECT group_key,
                      argMax(group_properties, _timestamp) AS group_properties_0
@@ -1316,10 +1317,11 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         LEFT OUTER JOIN
-          (SELECT override_person_id as person_id,
+          (SELECT argMax(override_person_id, version) as person_id,
                   old_person_id
            FROM person_overrides
-           WHERE team_id = 2 ) AS overrides ON e.person_id = overrides.old_person_id
+           WHERE team_id = 2
+           GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'UTC')

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -65,6 +65,7 @@ from posthog.queries.trends.util import (
 )
 from posthog.queries.util import PersonPropertiesMode
 from posthog.utils import PersonOnEventsMode, encode_get_request_params, generate_short_id
+from posthog.queries.person_on_events_v2_sql import PERSON_OVERRIDES_JOIN_SQL
 
 
 class TrendsBreakdown:
@@ -631,13 +632,11 @@ class TrendsBreakdown:
 
         if self.person_on_events_mode == PersonOnEventsMode.V2_ENABLED:
             return (
-                f"""LEFT OUTER JOIN (
-                SELECT override_person_id as person_id, old_person_id
-                FROM person_overrides
-                WHERE team_id = %(team_id)s
-            ) AS {self.PERSON_ID_OVERRIDES_TABLE_ALIAS}
-            ON {self.EVENT_TABLE_ALIAS}.person_id = {self.PERSON_ID_OVERRIDES_TABLE_ALIAS}.old_person_id""",
-                {},
+                PERSON_OVERRIDES_JOIN_SQL.format(
+                    person_overrides_table_alias=self.PERSON_ID_OVERRIDES_TABLE_ALIAS,
+                    event_table_alias=self.EVENT_TABLE_ALIAS,
+                ),
+                {"team_id": self.team_id},
             )
 
         person_query = PersonQuery(self.filter, self.team_id, self.column_optimizer, entity=self.entity)

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -777,7 +777,9 @@ def _create_insight(
 # for a person with a given distinct ID `distinct_id_from` to a given distinct ID
 # `distinct_id_to` such that with person_on_events_mode set to V2_ENABLED these
 # persons will both count as 1
-def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int, version: int = 0):
+def create_person_id_override_by_distinct_id(
+    distinct_id_from: str, distinct_id_to: str, team_id: int, version: int = 0
+):
     person_ids_result = sync_execute(
         f"""
         SELECT distinct_id, person_id

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -777,7 +777,7 @@ def _create_insight(
 # for a person with a given distinct ID `distinct_id_from` to a given distinct ID
 # `distinct_id_to` such that with person_on_events_mode set to V2_ENABLED these
 # persons will both count as 1
-def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int, version: int):
+def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int, version: int = 0g):
     person_ids_result = sync_execute(
         f"""
         SELECT distinct_id, person_id

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -777,7 +777,7 @@ def _create_insight(
 # for a person with a given distinct ID `distinct_id_from` to a given distinct ID
 # `distinct_id_to` such that with person_on_events_mode set to V2_ENABLED these
 # persons will both count as 1
-def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int):
+def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int, version: int):
     person_ids_result = sync_execute(
         f"""
         SELECT distinct_id, person_id
@@ -792,7 +792,7 @@ def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_
 
     sync_execute(
         f"""
-        INSERT INTO person_overrides (team_id, old_person_id, override_person_id)
-        VALUES ({team_id}, '{person_id_from}', '{person_id_to}')
+        INSERT INTO person_overrides (team_id, old_person_id, override_person_id, version)
+        VALUES ({team_id}, '{person_id_from}', '{person_id_to}', {version})
     """
     )

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -777,7 +777,7 @@ def _create_insight(
 # for a person with a given distinct ID `distinct_id_from` to a given distinct ID
 # `distinct_id_to` such that with person_on_events_mode set to V2_ENABLED these
 # persons will both count as 1
-def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int, version: int = 0g):
+def create_person_id_override_by_distinct_id(distinct_id_from: str, distinct_id_to: str, team_id: int, version: int = 0):
     person_ids_result = sync_execute(
         f"""
         SELECT distinct_id, person_id


### PR DESCRIPTION
We should use `argMax(override_person_id, version)` grouped by `old_person_id` to actually get the latest override.

Thanks @tiina303 and @xvello for pointing this out