### PR TITLE
fix(person-query): don't query persons twice if we don't need to

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -11,12 +11,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))
-                  AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$another_prop'), '^"|"$', '')))))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))
@@ -47,11 +41,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ((has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))) as person
@@ -104,11 +93,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
@@ -169,11 +153,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -235,11 +235,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -319,11 +314,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -403,11 +393,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -487,11 +472,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -659,11 +639,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Positive'], person."pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Positive'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id
@@ -743,11 +718,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Positive'], person."pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Positive'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id
@@ -827,11 +797,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Negative'], person."pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Negative'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id
@@ -911,11 +876,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['Negative'], person."pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['Negative'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -436,11 +436,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -569,11 +564,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -700,11 +690,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2
-                              AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
                        AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -136,11 +136,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '') ILIKE '%test%')) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '') ILIKE '%test%'))) person ON pdi.person_id = person.id

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -32,11 +32,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -104,11 +99,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
@@ -146,11 +136,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))))) person ON person.person_id = behavior_query.person_id
@@ -334,11 +319,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
@@ -456,11 +436,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -477,14 +452,6 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND id IN
-      (SELECT id
-       FROM person
-       WHERE team_id = 2
-         AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))
-               OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))
-              OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
-                  AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))
@@ -519,12 +486,6 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND id IN
-      (SELECT id
-       FROM person
-       WHERE team_id = 2
-         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))
-              OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -34,11 +34,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -84,11 +79,6 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
-              AND id IN
-                (SELECT id
-                 FROM person
-                 WHERE team_id = 2
-                   AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))
@@ -155,11 +145,6 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
-              AND id IN
-                (SELECT id
-                 FROM person
-                 WHERE team_id = 2
-                   AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))
@@ -275,11 +260,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -20,12 +20,6 @@
               SELECT id
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -41,12 +35,6 @@
               SELECT id, argMax(properties, version) as person_props
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -62,12 +50,6 @@
               SELECT id
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_2)s), '^"|"$', '')))
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -99,12 +81,6 @@
               SELECT id
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -120,12 +96,6 @@
               SELECT id, argMax(pmat_email, version) as pmat_email , argMax(properties, version) as person_props
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -141,12 +111,6 @@
               SELECT id, argMax(properties, version) as person_props
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -162,12 +126,6 @@
               SELECT id, argMax(pmat_email, version) as pmat_email , argMax(properties, version) as person_props
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -183,12 +141,6 @@
               SELECT id, argMax(properties, version) as person_props
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  
@@ -204,12 +156,6 @@
               SELECT id, argMax(pmat_email, version) as pmat_email
               FROM person
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  AND (   person."pmat_email" ILIKE %(v_0)s)
-              )
               
               GROUP BY id
               HAVING max(is_deleted) = 0  

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -222,11 +222,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -258,11 +253,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -322,11 +312,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -358,11 +343,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -418,11 +398,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -454,11 +429,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -503,12 +503,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
-                    AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', '')))
@@ -580,12 +574,6 @@
                    (SELECT id
                     FROM person
                     WHERE team_id = 2
-                      AND id IN
-                        (SELECT id
-                         FROM person
-                         WHERE team_id = 2
-                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
-                                AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
                     GROUP BY id
                     HAVING max(is_deleted) = 0
                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', '')))
@@ -635,12 +623,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
-                    AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', ''))))

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -6,11 +6,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (has(['0', '1', '2', '3'], replaceRegexpAll(JSONExtractRaw(person.properties, 'group'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['0', '1', '2', '3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', ''))))
@@ -262,12 +257,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ((has(['none'], replaceRegexpAll(JSONExtractRaw(person.properties, 'group'), '^"|"$', ''))
-                  OR has(['1', '2', '3'], replaceRegexpAll(JSONExtractRaw(person.properties, 'group'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((has(['none'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', ''))

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -32,11 +32,6 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND id IN
-      (SELECT id
-       FROM person
-       WHERE team_id = 2
-         AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'some_prop'), '^"|"$', ''))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   and argMax(created_at, version) < now() + interval '1 day'

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -318,11 +318,6 @@
                                   (SELECT id
                                    FROM person
                                    WHERE team_id = 2
-                                     AND id IN
-                                       (SELECT id
-                                        FROM person
-                                        WHERE team_id = 2
-                                          AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%')) )
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
                                    AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
@@ -526,14 +521,6 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND id IN
-                              (SELECT id
-                               FROM person
-                               WHERE team_id = 2
-                                 AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                       AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                      OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                          OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -629,14 +616,6 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND id IN
-                              (SELECT id
-                               FROM person
-                               WHERE team_id = 2
-                                 AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                       AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                      OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                          OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -736,14 +715,6 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND id IN
-                              (SELECT id
-                               FROM person
-                               WHERE team_id = 2
-                                 AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                       AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                      OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                          OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -843,14 +814,6 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND id IN
-                              (SELECT id
-                               FROM person
-                               WHERE team_id = 2
-                                 AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                       AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                      OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                          OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,18 +102,19 @@ class PersonQuery:
         )
         updated_after_clause, updated_after_params = self._get_updated_after_clause()
 
+        cohort_subquery = f"""AND id IN (
+            SELECT id FROM person
+            {cohort_query}
+            WHERE team_id = %(team_id)s
+            {person_filters}
+        )
+        {cohort_filters}""" if cohort_query else ""
         return (
             f"""
             SELECT {fields}
             FROM person
             WHERE team_id = %(team_id)s
-            AND id IN (
-                SELECT id FROM person
-                {cohort_query}
-                WHERE team_id = %(team_id)s
-                {person_filters}
-            )
-            {cohort_filters}
+            {cohort_subquery}
             GROUP BY id
             HAVING max(is_deleted) = 0 {filter_future_persons_query} {updated_after_clause}
             {grouped_person_filters} {search_clause} {distinct_id_clause} {email_clause}

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -102,13 +102,17 @@ class PersonQuery:
         )
         updated_after_clause, updated_after_params = self._get_updated_after_clause()
 
-        cohort_subquery = f"""AND id IN (
+        cohort_subquery = (
+            f"""AND id IN (
             SELECT id FROM person
             {cohort_query}
             WHERE team_id = %(team_id)s
             {person_filters}
         )
-        {cohort_filters}""" if cohort_query else ""
+        {cohort_filters}"""
+            if cohort_query
+            else ""
+        )
         return (
             f"""
             SELECT {fields}

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
@@ -621,11 +621,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -1661,11 +1656,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -417,11 +417,6 @@
                     (SELECT id
                      FROM person
                      WHERE team_id = 2
-                       AND id IN
-                         (SELECT id
-                          FROM person
-                          WHERE team_id = 2
-                            AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                      GROUP BY id
                      HAVING max(is_deleted) = 0
                      AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))))
@@ -502,11 +497,6 @@
                                 (SELECT id
                                  FROM person
                                  WHERE team_id = 2
-                                   AND id IN
-                                     (SELECT id
-                                      FROM person
-                                      WHERE team_id = 2
-                                        AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
                                  AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))))
@@ -1024,11 +1014,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -1069,11 +1054,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -1141,11 +1121,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (has(['person1'], person."pmat_name")) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
@@ -1213,11 +1188,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (has(['person1'], person."pmat_name")) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
@@ -2660,12 +2630,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                     OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', ''))
@@ -2725,12 +2689,6 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND id IN
-                  (SELECT id
-                   FROM person
-                   WHERE team_id = 2
-                     AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                           OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', ''))
@@ -2772,13 +2730,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                      AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
-                    AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', ''))
@@ -2838,13 +2789,6 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND id IN
-                  (SELECT id
-                   FROM person
-                   WHERE team_id = 2
-                     AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                            AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
-                          AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', ''))
@@ -2920,11 +2864,6 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND id IN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                  AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -4169,11 +4108,6 @@
                 (SELECT id
                  FROM person
                  WHERE team_id = 2
-                   AND id IN
-                     (SELECT id
-                      FROM person
-                      WHERE team_id = 2
-                        AND (has(['person-1', 'person-2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
                  GROUP BY id
                  HAVING max(is_deleted) = 0
                  AND (has(['person-1', 'person-2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -4230,11 +4164,6 @@
                 (SELECT id
                  FROM person
                  WHERE team_id = 2
-                   AND id IN
-                     (SELECT id
-                      FROM person
-                      WHERE team_id = 2
-                        AND (has(['person-1', 'person-2'], person."pmat_name")) )
                  GROUP BY id
                  HAVING max(is_deleted) = 0
                  AND (has(['person-1', 'person-2'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -240,11 +240,6 @@
                      (SELECT id
                       FROM person
                       WHERE team_id = 2
-                        AND id IN
-                          (SELECT id
-                           FROM person
-                           WHERE team_id = 2
-                             AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', '')))) )
                       GROUP BY id
                       HAVING max(is_deleted) = 0
                       AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))))
@@ -309,11 +304,6 @@
                      (SELECT id
                       FROM person
                       WHERE team_id = 2
-                        AND id IN
-                          (SELECT id
-                           FROM person
-                           WHERE team_id = 2
-                             AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', '')))) )
                       GROUP BY id
                       HAVING max(is_deleted) = 0
                       AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))))


### PR DESCRIPTION
We were querying the persons table **twice** even if there was no cohort filter on a query!

Even then, there should still be a lot of optimizations we can make to this query, but this was the quickest to unblock a client with an urgent need