### PR TITLE
fix: player skip buttons only ever showed right

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerControllerTime.tsx
@@ -34,6 +34,9 @@ export function SeekSkip({ direction }: { direction: 'forward' | 'backward' }): 
     const jumpTimeSeconds = altKeyHeld ? 1 : jumpTimeMs / 1000
     const altKeyName = navigator.platform.includes('Mac') ? '⌥' : 'Alt'
 
+    const arrowSymbol = direction === 'forward' ? '→' : '←'
+    const arrowName = direction === 'forward' ? 'right' : 'left'
+
     return (
         <Tooltip
             placement="top"
@@ -42,10 +45,18 @@ export function SeekSkip({ direction }: { direction: 'forward' | 'backward' }): 
                 <div className="text-center">
                     {!altKeyHeld ? (
                         <>
-                            {capitalizeFirstLetter(direction)} {jumpTimeSeconds}s (<kbd>→ right arrow</kbd>) <br />
+                            {capitalizeFirstLetter(direction)} {jumpTimeSeconds}s (
+                            <kbd>
+                                {arrowSymbol} {arrowName} arrow
+                            </kbd>
+                            ) <br />
                         </>
                     ) : null}
-                    {capitalizeFirstLetter(direction)} 1 frame ({ONE_FRAME_MS}ms) (<kbd>{altKeyName} + →</kbd>)
+                    {capitalizeFirstLetter(direction)} 1 frame ({ONE_FRAME_MS}ms) (
+                    <kbd>
+                        {altKeyName} + {arrowSymbol}
+                    </kbd>
+                    )
                 </div>
             }
         >


### PR DESCRIPTION
## Problem

player skip buttons were always right

![2023-04-26 22 54 39](https://user-images.githubusercontent.com/984817/234705609-987a0511-1704-4ecc-a743-a391675c89ce.gif)

## Changes

Well, not anymore!

## How did you test this code?

![2023-04-26 22 22 02](https://user-images.githubusercontent.com/984817/234705752-a003670d-20c5-47d5-98f8-0f46335f971b.gif)
