### PR TITLE
fix: debug geoip test failures

### DIFF
--- a/posthog/api/geoip.py
+++ b/posthog/api/geoip.py
@@ -51,7 +51,6 @@ def get_geoip_properties(ip_address: Optional[str]) -> Dict[str, str]:
         return {}
 
     properties = {}
-    print(geoip_properties, "geoip_properties")
     for key, value in geoip_properties.items():
         if value and key in VALID_GEOIP_PROPERTIES:
             properties[f"$geoip_{key}"] = value

--- a/posthog/api/geoip.py
+++ b/posthog/api/geoip.py
@@ -51,6 +51,7 @@ def get_geoip_properties(ip_address: Optional[str]) -> Dict[str, str]:
         return {}
 
     properties = {}
+    print(geoip_properties, "geoip_properties")
     for key, value in geoip_properties.items():
         if value and key in VALID_GEOIP_PROPERTIES:
             properties[f"$geoip_{key}"] = value

--- a/posthog/api/test/test_geoip.py
+++ b/posthog/api/test/test_geoip.py
@@ -19,7 +19,9 @@ local_ip = "127.0.0.1"
 def test_geoip_results(test_input, expected):
     properties = get_geoip_properties(test_input)
     assert properties["$geoip_country_name"] == expected
-    assert len(properties) >= 5
+    # The GeoIP2 database changed to remove the postal code for the uk_ip_v6 address, so for that one we only expect 5 properties.
+    # if this test starts to fail again in production, just assert len(properties) == 6
+    assert len(properties) == 5 if test_input == uk_ip_v6 else 6
 
 
 class TestGeoIPDBError(TestCase):

--- a/posthog/api/test/test_geoip.py
+++ b/posthog/api/test/test_geoip.py
@@ -19,7 +19,7 @@ local_ip = "127.0.0.1"
 def test_geoip_results(test_input, expected):
     properties = get_geoip_properties(test_input)
     assert properties["$geoip_country_name"] == expected
-    assert len(properties) == 6
+    assert len(properties) > 5
 
 
 class TestGeoIPDBError(TestCase):
@@ -31,7 +31,6 @@ class TestGeoIPDBError(TestCase):
         geoip.city = self.geoip_city_method  # type: ignore
 
     def test_geoip_with_invalid_database_file_returns_successfully(self):
-
         properties = get_geoip_properties(australia_ip)
 
         self.assertEqual(properties, {})
@@ -39,13 +38,11 @@ class TestGeoIPDBError(TestCase):
 
 class TestGeoIPError(TestCase):
     def test_geoip_on_local_ip_returns_successfully(self):
-
         properties = get_geoip_properties(local_ip)
 
         self.assertEqual(properties, {})
 
     def test_geoip_on_invalid_ip_returns_successfully(self):
-
         properties = get_geoip_properties(None)
 
         self.assertEqual(properties, {})

--- a/posthog/api/test/test_geoip.py
+++ b/posthog/api/test/test_geoip.py
@@ -9,19 +9,17 @@ from posthog.api.geoip import geoip, get_geoip_properties
 
 australia_ip = "13.106.122.3"
 uk_ip = "31.28.64.3"
-uk_ip_v6 = "2a01:4b00:875f:cf01:109e:dbfd:8cb9:a5d4"
+us_ip_v6 = "2600:6c52:7a00:11c:1b6:b7b0:ea19:6365"
 local_ip = "127.0.0.1"
 
 
 @pytest.mark.parametrize(
-    "test_input,expected", [(australia_ip, "Australia"), (uk_ip, "United Kingdom"), (uk_ip_v6, "United Kingdom")]
+    "test_input,expected", [(australia_ip, "Australia"), (uk_ip, "United Kingdom"), (us_ip_v6, "United States")]
 )
 def test_geoip_results(test_input, expected):
     properties = get_geoip_properties(test_input)
     assert properties["$geoip_country_name"] == expected
-    # The GeoIP2 database changed to remove the postal code for the uk_ip_v6 address, so for that one we only expect 5 properties.
-    # if this test starts to fail again in production, just assert len(properties) == 6
-    assert len(properties) == 5 if test_input == uk_ip_v6 else 6
+    assert len(properties) == 6
 
 
 class TestGeoIPDBError(TestCase):

--- a/posthog/api/test/test_geoip.py
+++ b/posthog/api/test/test_geoip.py
@@ -19,7 +19,7 @@ local_ip = "127.0.0.1"
 def test_geoip_results(test_input, expected):
     properties = get_geoip_properties(test_input)
     assert properties["$geoip_country_name"] == expected
-    assert len(properties) > 5
+    assert len(properties) >= 5
 
 
 class TestGeoIPDBError(TestCase):


### PR DESCRIPTION
## Problem

The geoIP tests were failing because the postal code data from MaxMind is no longer associated with the `uk_ip_v6` IP address. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Uses a different IP address that does return postal code data.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

🤔 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
