### PR TITLE
chore: align prettier versions to fix CI

### DIFF
--- a/frontend/src/lib/api.mock.ts
+++ b/frontend/src/lib/api.mock.ts
@@ -27,7 +27,7 @@ type APIMockReturnType = {
     [K in keyof Pick<
         typeof apiReal,
         'create' | 'createResponse' | 'get' | 'getResponse' | 'update' | 'delete'
-    >]: jest.Mock<ReturnType<typeof apiReal[K]>, Parameters<typeof apiReal[K]>>
+    >]: jest.Mock<ReturnType<(typeof apiReal)[K]>, Parameters<(typeof apiReal)[K]>>
 }
 
 export const api = apiReal as any as APIMockReturnType

--- a/frontend/src/lib/components/DateFilter/rollingDateRangeFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/rollingDateRangeFilterLogic.ts
@@ -11,7 +11,7 @@ const dateOptionsMap = {
     d: 'days',
 } as const
 
-export type DateOption = typeof dateOptionsMap[keyof typeof dateOptionsMap]
+export type DateOption = (typeof dateOptionsMap)[keyof typeof dateOptionsMap]
 
 export type RollingDateFilterLogicPropsType = {
     selected?: boolean

--- a/frontend/src/lib/components/FlaggedFeature.tsx
+++ b/frontend/src/lib/components/FlaggedFeature.tsx
@@ -3,7 +3,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export type PostHogFeatureProps = {
-    flag: typeof FEATURE_FLAGS[keyof typeof FEATURE_FLAGS]
+    flag: (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
     match?: string | boolean
     children: React.ReactNode | ((payload: any) => React.ReactNode)
 }

--- a/frontend/src/lib/components/HedgehogBuddy/sprites/sprites.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/sprites/sprites.tsx
@@ -46,7 +46,7 @@ export const accessoryGroups = ['headwear', 'eyewear', 'other'] as const
 export type AccessoryInfo = {
     /** Path to the img */
     img: string
-    group: typeof accessoryGroups[number]
+    group: (typeof accessoryGroups)[number]
     topOffset?: number
 }
 

--- a/frontend/src/mocks/utils.ts
+++ b/frontend/src/mocks/utils.ts
@@ -2,20 +2,20 @@ import { rest } from 'msw'
 
 export type MockSignature =
     | ((
-          req: Parameters<Parameters<typeof rest['get']>[1]>[0],
-          res: Parameters<Parameters<typeof rest['get']>[1]>[1],
-          ctx: Parameters<Parameters<typeof rest['get']>[1]>[2]
+          req: Parameters<Parameters<(typeof rest)['get']>[1]>[0],
+          res: Parameters<Parameters<(typeof rest)['get']>[1]>[1],
+          ctx: Parameters<Parameters<(typeof rest)['get']>[1]>[2]
       ) => [number, any] | [number])
     | Record<string, any>
 export type Mocks = Partial<Record<keyof typeof rest, Record<string, MockSignature>>>
 
-export const mocksToHandlers = (mocks: Mocks): ReturnType<typeof rest['get']>[] => {
-    const response: ReturnType<typeof rest['get']>[] = []
+export const mocksToHandlers = (mocks: Mocks): ReturnType<(typeof rest)['get']>[] => {
+    const response: ReturnType<(typeof rest)['get']>[] = []
     Object.entries(mocks).map(([method, mockHandlers]) => {
         Object.entries(mockHandlers).map(([path, handler]) => {
             const pathWithoutTrailingSlash = path.replace(/\/$/, '')
             response.push(
-                (rest[method] as typeof rest['get'])(pathWithoutTrailingSlash, async (req, res, ctx) => {
+                (rest[method] as (typeof rest)['get'])(pathWithoutTrailingSlash, async (req, res, ctx) => {
                     if (typeof handler === 'function') {
                         const responseArray = await handler(req, res, ctx)
                         if (responseArray.length === 2 && typeof responseArray[0] === 'number') {

--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -6,7 +6,7 @@ import { CohortEdit } from 'scenes/cohorts/CohortEdit'
 export const scene: SceneExport = {
     component: Cohort,
     logic: cohortLogic,
-    paramsToProps: ({ params: { id } }): typeof cohortLogic['props'] => ({
+    paramsToProps: ({ params: { id } }): (typeof cohortLogic)['props'] => ({
         id: id && id !== 'new' ? parseInt(id) : 'new',
     }),
 }

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -40,7 +40,7 @@ import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 export const scene: SceneExport = {
     component: DefinitionView,
     logic: definitionLogic,
-    paramsToProps: ({ params: { id } }): typeof definitionLogic['props'] => ({
+    paramsToProps: ({ params: { id } }): (typeof definitionLogic)['props'] => ({
         id,
     }),
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -81,7 +81,7 @@ import { billingLogic } from 'scenes/billing/billingLogic'
 export const scene: SceneExport = {
     component: FeatureFlag,
     logic: featureFlagLogic,
-    paramsToProps: ({ params: { id } }): typeof featureFlagLogic['props'] => ({
+    paramsToProps: ({ params: { id } }): (typeof featureFlagLogic)['props'] => ({
         id: id && id !== 'new' ? parseInt(id) : 'new',
     }),
 }

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -3,7 +3,7 @@ import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/util
 import { ChartDisplayType, TrendsFilterType } from '~/types'
 
 const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled'] as const
-export type AggregationAxisFormat = typeof formats[number]
+export type AggregationAxisFormat = (typeof formats)[number]
 
 export const INSIGHT_UNIT_OPTIONS: LemonSelectOptionLeaf<AggregationAxisFormat>[] = [
     { value: 'numeric', label: 'None' },

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -41,7 +41,7 @@ const { TabPane } = Tabs
 export const scene: SceneExport = {
     component: Person,
     logic: personsLogic,
-    paramsToProps: ({ params: { _: rawUrlId } }): typeof personsLogic['props'] => ({
+    paramsToProps: ({ params: { _: rawUrlId } }): (typeof personsLogic)['props'] => ({
         syncWithUrl: true,
         urlId: decodeURIComponent(rawUrlId),
     }),

--- a/frontend/src/scenes/session-recordings/detail/SessionRecordingDetail.tsx
+++ b/frontend/src/scenes/session-recordings/detail/SessionRecordingDetail.tsx
@@ -15,7 +15,7 @@ import { RecordingNotFound } from 'scenes/session-recordings/player/RecordingNot
 export const scene: SceneExport = {
     logic: sessionRecordingDetailLogic,
     component: SessionRecordingDetail,
-    paramsToProps: ({ params: { id } }): typeof sessionRecordingDetailLogic['props'] => ({
+    paramsToProps: ({ params: { id } }): (typeof sessionRecordingDetailLogic)['props'] => ({
         id,
     }),
 }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "monaco-editor": "^0.23.0",
         "posthog-js": "1.54.0",
         "posthog-js-lite": "2.0.0-alpha5",
-        "prettier": "^2.3.1",
+        "prettier": "^2.8.8",
         "prop-types": "^15.7.2",
         "query-selector-shadow-dom": "^1.0.0",
         "rc-field-form": "~1.21.0",

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -126,7 +126,7 @@
         "jest": "^28.1.1",
         "parse-prometheus-text-format": "^1.1.1",
         "pino-pretty": "^9.1.0",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.8",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.7.4"

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -83,7 +83,7 @@ specifiers:
   pino: ^8.6.0
   pino-pretty: ^9.1.0
   posthog-node: 2.0.2
-  prettier: ^2.7.1
+  prettier: ^2.8.8
   pretty-bytes: ^5.6.0
   prom-client: ^14.2.0
   re2: ^1.17.7

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -155,10 +155,10 @@ const getTasksFromBatch = async (batch: Batch, producer: Producer) => {
     // In any one batch, we only want to run one task per plugin config id.
     // Hence here we dedupe the tasks by plugin config id and task type.
     const tasksbyTypeAndPluginConfigId = {} as Record<
-        typeof taskTypes[number],
+        (typeof taskTypes)[number],
         Record<
             number,
-            { taskType: typeof taskTypes[number]; pluginConfigId: number; message: typeof batch.messages[number] }
+            { taskType: (typeof taskTypes)[number]; pluginConfigId: number; message: (typeof batch.messages)[number] }
         >
     >
 
@@ -172,7 +172,7 @@ const getTasksFromBatch = async (batch: Batch, producer: Producer) => {
         }
 
         let task: {
-            taskType: typeof taskTypes[number]
+            taskType: (typeof taskTypes)[number]
             pluginConfigId: number
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ specifiers:
   postcss-loader: ^4.3.0
   posthog-js: 1.54.0
   posthog-js-lite: 2.0.0-alpha5
-  prettier: ^2.3.1
+  prettier: ^2.8.8
   prop-types: ^15.7.2
   query-selector-shadow-dom: ^1.0.0
   raw-loader: ^4.0.2
@@ -255,7 +255,7 @@ dependencies:
   monaco-editor: 0.23.0
   posthog-js: 1.54.0
   posthog-js-lite: 2.0.0-alpha5
-  prettier: 2.7.1
+  prettier: 2.8.8
   prop-types: 15.8.1
   query-selector-shadow-dom: 1.0.0
   rc-field-form: 1.21.2_wcqkhtmu7mswc6yz4uyexck3ty
@@ -361,7 +361,7 @@ devDependencies:
   eslint-plugin-cypress: 2.12.1_eslint@7.32.0
   eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
   eslint-plugin-no-only-tests: 3.1.0
-  eslint-plugin-prettier: 3.4.1_hv3zp2mmlduuje4zq4gkyksija
+  eslint-plugin-prettier: 3.4.1_wbjvq5l5nilmuxvc4ylcjwialu
   eslint-plugin-react: 7.32.2_eslint@7.32.0
   eslint-plugin-storybook: 0.6.11_jofidmxrjzhj7l6vknpw5ecvfe
   file-loader: 6.2.0_webpack@4.46.0
@@ -9548,7 +9548,7 @@ packages:
     engines: {node: '>=5.0.0'}
     dev: true
 
-  /eslint-plugin-prettier/3.4.1_hv3zp2mmlduuje4zq4gkyksija:
+  /eslint-plugin-prettier/3.4.1_wbjvq5l5nilmuxvc4ylcjwialu:
     resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -9561,7 +9561,7 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-prettier: 8.8.0_eslint@7.32.0
-      prettier: 2.7.1
+      prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -13204,7 +13204,7 @@ packages:
       '@babel/preset-env': 7.20.2_@babel+core@7.20.2
       '@babel/preset-typescript': 7.21.0_@babel+core@7.20.2
       '@wessberg/ts-clone-node': 0.3.19_typescript@4.9.5
-      prettier: 2.7.1
+      prettier: 2.8.8
       recast: 0.20.5
       typescript: 4.9.5
       yargs: 16.2.0
@@ -15437,8 +15437,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier/2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+  /prettier/2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/15268 broke the CI by mis-aligning the prettier versions in the two modules: the pre-commit hook uses the prettier version from the frontend module, while the CI uses the one from the plugin-server module for p-s code.

## Changes

Upgrade prettier to 2.8.8 on both modules.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
