### PR TITLE
feat: log when losing or creating session managers

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
@@ -76,14 +76,13 @@ export class OffsetManager {
         const key = `${topic}-${partition}`
         const inFlightOffsets = this.offsetsByPartitionTopic.get(key)
 
-        status.info('💾', `Current offsets: ${inFlightOffsets}`)
-        status.info('💾', `Removing offsets: ${offsets}`)
-
         if (!inFlightOffsets) {
             // TODO: Add a metric so that we can see if and when this happens
-            status.warn('💾', `No inflight offsets found for key: ${key}.`)
+            status.warn('💾', `No inflight offsets found to remove for key: ${key}.`)
             return
         }
+
+        status.info('💾', `Removing offsets`, { removing: offsetsToRemove, current: inFlightOffsets, partition })
 
         offsetsToRemove.forEach((offset) => {
             // Remove from the list. If it is the lowest value - set it

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -63,7 +63,7 @@ export class SessionRecordingBlobIngester {
             )
 
             this.sessions.set(key, sessionManager)
-            status.info('📦', 'blob_ingester_session_manager created', { key, partition, topic })
+            status.info('📦', 'Blob ingestion consumer started session manager', { key, partition, topic })
         }
 
         this.offsetManager?.addOffset(topic, partition, offset)

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -63,6 +63,7 @@ export class SessionRecordingBlobIngester {
             )
 
             this.sessions.set(key, sessionManager)
+            status.info('📦', 'blob_ingester_session_manager created', { key, partition, topic })
         }
 
         this.offsetManager?.addOffset(topic, partition, offset)
@@ -222,7 +223,10 @@ export class SessionRecordingBlobIngester {
                 // TODO we should not need to handle the assignment ourself since rebalance_cb = true
                 // this.batchConsumer?.consumer.assign(assignments)
             } else if (err.code === CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-                status.info('⚖️', 'Blob ingestion consumer has had assignments revoked', { assignments })
+                status.info('⚖️', 'Blob ingestion consumer has had assignments revoked', {
+                    assignments,
+                    trackedSessions: Array.from(this.sessions).map(([sessionId]) => sessionId),
+                })
                 /**
                  * The revoke_partitions event occurs when the Kafka Consumer is part of a consumer group and the group rebalances.
                  * As a result, some partitions previously assigned to a consumer might be taken away (revoked) and reassigned to another consumer.


### PR DESCRIPTION
## Problem

we can't easily identify sessions that might have been affected by a consumer rebalance to see what happens in S3

## Changes

Now we can!

## How did you test this code?

🙈 