### PR TITLE
fix(insights): sampling button without data exploration

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
@@ -105,6 +105,10 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
             }
         },
         querySource: (querySource) => {
+            if (!values.isUsingDataExploration) {
+                return
+            }
+
             const newSamplingPercentage = querySource?.samplingFactor ? querySource.samplingFactor * 100 : null
             if (newSamplingPercentage !== values.samplingPercentage) {
                 actions.setSamplingPercentage(newSamplingPercentage)


### PR DESCRIPTION
## Problem

![2023-04-27 14 23 34](https://user-images.githubusercontent.com/53387/234860903-b45794d5-ffad-450b-9f8c-3c6255781377.gif)

## Changes

![2023-04-27 14 23 13](https://user-images.githubusercontent.com/53387/234860931-e5fb7852-71e7-43d5-bb36-2046282424e2.gif)

## How did you test this code?

Just by clicking in the interface. I think this is the right fix, though could `import` some context :).