### PR TITLE
fix(cohorts): Restrict distinct ID query

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -230,7 +230,7 @@ class CohortViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         raw_result = sync_execute(query, {**params, **filter.hogql_context.values})
         actor_ids = [row[0] for row in raw_result]
-        actors, serialized_actors = get_people(team.pk, actor_ids, distinct_id_limit=10 if is_csv_request else None)
+        actors, serialized_actors = get_people(team.pk, actor_ids, distinct_id_limit=10)
 
         _should_paginate = len(actor_ids) >= filter.limit
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None


### PR DESCRIPTION
## Problem

Earlier, there was no restriction on no. of distinct IDs being queried, which caused some queries to time out, specially when people had > 10k distinct ids.

This hopefully resolves errors like those.

It's also not the most optimised query, can be much better, but not doing that for now:

```
SELECT "posthog_persondistinctid"."id", "posthog_persondistinctid"."team_id", "posthog_persondistinctid"."person_id", 
            "posthog_persondistinctid"."distinct_id", "posthog_persondistinctid"."version"
    FROM "posthog_persondistinctid"
    WHERE (
        "posthog_persondistinctid"."id" IN (
            SELECT U0."id" FROM "posthog_persondistinctid" U0 WHERE U0."person_id" = "posthog_persondistinctid"."person_id" LIMIT X
        ) AND "posthog_persondistinctid"."person_id" IN (30, 29, 28, 27, 26))
```

See: https://posthoghelp.zendesk.com/agent/tickets/2593 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/5520)
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Create 10k distinct ids, see it slow down with old code, see it speed up massively with new code.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
