### PR TITLE
perf(recordings): use consumerMaxWaitMs for new batch consumer

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -112,6 +112,7 @@ export const startBatchConsumer = async ({
     await ensureTopicExists(adminClient, topic)
     adminClient.disconnect()
 
+    consumer.setDefaultConsumeTimeout(consumerMaxWaitMs)
     consumer.subscribe([topic])
 
     const startConsuming = async () => {


### PR DESCRIPTION
## Problem

The librdkafka consumer as a default batch read timeout of 1s, we need to explicitly set a different value when we create it. Otherwise, low traffic creates lag, because we're waiting too much to fill the batches. We can be more aggressive here.

## Changes

- reuse the existing consumerMaxWaitMs, pass it to the consumer we instantiate.

## How did you test this code?

On prod