### PR TITLE
fix(data-exploration): add safeguard to query when feature flag is off

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -77,12 +77,14 @@ export const insightDataLogic = kea<insightDataLogicType>([
 
     selectors({
         query: [
-            (s) => [s.insight, s.internalQuery, s.filterTestAccountsDefault],
-            (insight, internalQuery, filterTestAccountsDefault) =>
+            (s) => [s.insight, s.internalQuery, s.filterTestAccountsDefault, s.isUsingDataExploration],
+            (insight, internalQuery, filterTestAccountsDefault, isUsingDataExploration) =>
                 internalQuery ||
                 insight.query ||
-                (insight.filters && insight.filters.insight ? queryFromFilters(insight.filters) : undefined) ||
-                queryFromKind(NodeKind.TrendsQuery, filterTestAccountsDefault),
+                (isUsingDataExploration
+                    ? (insight.filters && insight.filters.insight ? queryFromFilters(insight.filters) : undefined) ||
+                      queryFromKind(NodeKind.TrendsQuery, filterTestAccountsDefault)
+                    : null),
         ],
 
         isQueryBasedInsight: [


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog/pull/15279.

## Changes

This PR adds a feature flag check to the `insightDataLogic.query` selector to not transform a filters based insight into a query when data exploration is off.

## How did you test this code?

Clicking arond