### PR TITLE
fix(insights): Fix undoing insight deletion

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -50,9 +50,11 @@ def api_not_found(request):
 router = DefaultRouterPlusPlus()
 
 # Legacy endpoints shared (to be removed eventually)
-router.register(r"dashboard", dashboard.LegacyDashboardsViewSet)  # Should be completely unused now
-router.register(r"dashboard_item", dashboard.LegacyInsightViewSet)  # To be deleted - unified into insight viewset
-router.register(r"plugin_config", plugin.LegacyPluginConfigViewSet)
+router.register(r"dashboard", dashboard.LegacyDashboardsViewSet, "legacy_dashboards")  # Should be completely unused now
+router.register(
+    r"dashboard_item", dashboard.LegacyInsightViewSet, "legacy_insights"
+)  # To be deleted - unified into insight viewset
+router.register(r"plugin_config", plugin.LegacyPluginConfigViewSet, "legacy_plugin_configs")
 
 router.register(r"feature_flag", feature_flag.LegacyFeatureFlagViewSet)  # Used for library side feature flag evaluation
 router.register(r"prompts", prompt.PromptSequenceViewSet, "user_prompts")  # User prompts

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -549,6 +549,8 @@ class InsightViewSet(
         else:
             queryset = Insight.objects.all()
 
+        # Optimize tag retrieval
+        queryset = self.prefetch_tagged_items_if_available(queryset)
         # Disallow access to other teams' insights
         queryset = self.filter_queryset_by_parents_lookups(queryset)
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -2326,20 +2326,40 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
     def test_soft_delete_can_be_reversed_by_patch(self) -> None:
         insight_id, _ = self.dashboard_api.create_insight({"name": "an insight"})
 
-        self.client.patch(f"/api/projects/{self.team.id}/insights/{insight_id}", {"deleted": True})
+        self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"deleted": True, "name": "an insight"},  # This request should work also if other fields are provided
+        )
 
         self.assertEqual(
             self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}").status_code,
             status.HTTP_404_NOT_FOUND,
         )
 
-        update_response = self.client.patch(f"/api/projects/{self.team.id}/insights/{insight_id}", {"deleted": False})
+        update_response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"deleted": False, "name": "an insight"},  # This request should work also if other fields are provided
+        )
         self.assertEqual(update_response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(
             self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}").status_code,
             status.HTTP_200_OK,
         )
+
+    def test_soft_delete_cannot_be_reversed_for_another_team(self) -> None:
+        other_team = Team.objects.create(organization=self.organization, name="other team")
+        other_insight = Insight.objects.create(
+            filters=Filter(data={"events": [{"id": "$pageview"}]}).to_dict(),
+            team=other_team,
+            short_id="abcabc",
+            deleted=True,
+        )
+
+        other_update_response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{other_insight.id}", {"deleted": False}
+        )
+        self.assertEqual(other_update_response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_cancel_running_query(self) -> None:
         # There is no good way of writing a test that tests this without it being very slow


### PR DESCRIPTION
## Problem

The "Undo" button on insight deletion toasts doesn't work, because the PATCH request that the frontend sends to undo deletion contains the whole of `insight`, while the API only allows undeletion if the request body is just `{ "deleted": false }`. This restriction is not really relevant, so we can just drop it.

<img width="560" alt="An undeletion request coming from the frontend" src="https://user-images.githubusercontent.com/4550621/234927974-edf5938f-f233-4273-bb89-da9e901e58f7.png">

Also see this extra context: [internal Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1682608861843399).

## Changes

Updated the insights endpoint to allow undeletion if the payload has other fields besides `"deleted": false`.
Also fixed filtering of the `Insight.objects_including_soft_deleted` queryset.

## How did you test this code?

API tests.