### PR TITLE
ci: Wait for world map to appear in world map UI snapshot

### DIFF
--- a/frontend/src/scenes/insights/Insights.stories.tsx
+++ b/frontend/src/scenes/insights/Insights.stories.tsx
@@ -85,6 +85,7 @@ export const TrendsPieBreakdown = createInsightStory(require('./__mocks__/trends
 TrendsPieBreakdown.parameters = { testOptions: { waitForLoadersToDisappear: '[data-attr=trend-pie-graph] > canvas' } }
 
 export const TrendsWorldMap = createInsightStory(require('./__mocks__/trendsWorldMap.json'))
+TrendsWorldMap.parameters = { testOptions: { waitForLoadersToDisappear: '.WorldMap' } }
 
 // Funnels
 


### PR DESCRIPTION
## Problem

We wait for loading to finish in all our insight UI snapshots, except world map for some reason. This has been leading to this flakiness: https://github.com/PostHog/posthog/pull/15278#pullrequestreview-1403925229

## Changes

World map is now flake-proof like other insights.