### PR TITLE
fix: capture insight undelete to the activity log

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -321,7 +321,12 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
     def update(self, instance: Insight, validated_data: Dict, **kwargs) -> Insight:
         dashboards_before_change: List[Union[str, Dict]] = []
         try:
-            before_update = Insight.objects.prefetch_related("tagged_items__tag", "dashboards").get(pk=instance.id)
+            # since it is possible to be undeleting a soft deleted insight
+            # the state captured before the update has to include soft deleted insights
+            # or we can't capture undeletes to the activity log
+            before_update = Insight.objects_including_soft_deleted.prefetch_related(
+                "tagged_items__tag", "dashboards"
+            ).get(pk=instance.id)
             dashboards_before_change = [describe_change(dt.dashboard) for dt in instance.dashboard_tiles.all()]
         except Insight.DoesNotExist:
             before_update = None

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -1497,24 +1497,6 @@
                                               5 /* ... */) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
   '
 ---
-# name: TestInsight.test_listing_insights_does_not_nplus1.33
-  '
-  SELECT "posthog_taggeditem"."id",
-         "posthog_taggeditem"."tag_id",
-         "posthog_taggeditem"."dashboard_id",
-         "posthog_taggeditem"."insight_id",
-         "posthog_taggeditem"."event_definition_id",
-         "posthog_taggeditem"."property_definition_id",
-         "posthog_taggeditem"."action_id",
-         "posthog_taggeditem"."feature_flag_id"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."insight_id" IN (1,
-                                              2,
-                                              3,
-                                              4,
-                                              5 /* ... */) /*controller='project_insights-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/insights/%3F%24'*/
-  '
----
 # name: TestInsight.test_listing_insights_does_not_nplus1.4
   '
   SELECT "posthog_team"."id",

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -2347,6 +2347,21 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             status.HTTP_200_OK,
         )
 
+        # assert that undeletes end up in the activity log
+        activity_response = self.dashboard_api.get_insight_activity(insight_id)
+
+        activity: List[Dict] = activity_response["results"]
+        # we will have three logged activities (in reverse order) undelete, delete, create
+        assert [a["activity"] for a in activity] == ["updated", "updated", "created"]
+        undelete_change_log = activity[0]["detail"]["changes"][0]
+        assert undelete_change_log == {
+            "action": "changed",
+            "after": False,
+            "before": True,
+            "field": "deleted",
+            "type": "Insight",
+        }
+
     def test_soft_delete_cannot_be_reversed_for_another_team(self) -> None:
         other_team = Team.objects.create(organization=self.organization, name="other team")
         other_insight = Insight.objects.create(


### PR DESCRIPTION
## Problem

We discovered that while the UI lets you undo deleting an insight (for a short time after deletion). It wasn't capturing the change to the activity log

When running the update we first load the model to capture its "before"state. Then when logging the change we compare the new state to the before state.

When the insight is soft deleted we can't load its before state. Since you can't compare current to previous if previous doesn't exist, so we log nothing :sanic:

## Changes

Allow the `before_update` state to capture soft deleted insights

<img width="417" alt="Screenshot 2023-04-27 at 20 42 11" src="https://user-images.githubusercontent.com/984817/234973885-12908eb9-68ff-49bc-b8e9-25471ce5df77.png">

## How did you test this code?

developer tests and 👀 locally