### PR TITLE
fix: push the buffer files storage down a level

### DIFF
--- a/.run/Plugin Server.run.xml
+++ b/.run/Plugin Server.run.xml
@@ -10,8 +10,9 @@
       <env name="CLICKHOUSE_SECURE" value="False" />
       <env name="DATABASE_URL" value="postgres://posthog:posthog@localhost:5432/posthog" />
       <env name="KAFKA_HOSTS" value="localhost:9092" />
-      <env name="WORKER_CONCURRENCY" value="2" />
       <env name="OBJECT_STORAGE_ENABLED" value="True" />
+      <env name="WORKER_CONCURRENCY" value="2" />
+      <env name="SESSION_RECORDING_BLOB_PROCESSING_TEAMS" value="all" />
     </envs>
     <method v="2" />
   </configuration>

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -10,6 +10,7 @@ import * as zlib from 'zlib'
 import { PluginsServerConfig } from '../../../../types'
 import { status } from '../../../../utils/status'
 import { ObjectStorage } from '../../../services/object_storage'
+import { bufferFileDir } from '../session-recordings-blob-consumer'
 import { IncomingRecordingMessage } from './types'
 import { convertToPersistedMessage } from './utils'
 
@@ -175,7 +176,7 @@ export class SessionManager {
             size: 0,
             createdAt: new Date(),
             file: path.join(
-                this.serverConfig.SESSION_RECORDING_LOCAL_DIRECTORY,
+                bufferFileDir(this.serverConfig.SESSION_RECORDING_LOCAL_DIRECTORY),
                 `${this.teamId}.${this.sessionId}.${id}.jsonl`
             ),
             offsets: [],

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -183,6 +183,7 @@ export interface PluginsServerConfig {
     CLOUD_DEPLOYMENT: string
 
     SESSION_RECORDING_BLOB_PROCESSING_TEAMS: string
+    // local directory might be a volume mount or a directory on disk (e.g. in local dev)
     SESSION_RECORDING_LOCAL_DIRECTORY: string
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number


### PR DESCRIPTION
## Problem

We moved the session directory from being a local dir on the consumer to a volume mount.

And then the consumer couldn't start because it was trying to delete the mounted volume 🤦 

## Changes

Uses a directory created within the configured dir. This way we can clear it regardless of whether we're running with local or mounted storage

## How did you test this code?

running it locally and seeing files appear in the expected folder