### PR TITLE
chore: Add 500 page

### DIFF
--- a/posthog/templates/500.html
+++ b/posthog/templates/500.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        {% include "head.html" %}
+    </head>
+    <style>
+        html, body, iframe {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        body {
+            display: flex;
+        }
+        iframe {
+            border: none;
+        }
+    </style>
+    <body>
+        <iframe src="https://posthog.com/service-message"/>
+    </body>
+</html>


### PR DESCRIPTION
## Problem

Currently if web pods are up, but something else is down preventing the app from working (e.g. we're migrating between Postgres instances), users see this:

![err](https://user-images.githubusercontent.com/4550621/235171498-daf17ff3-a723-48d0-8d15-e9cabbb57c07.jpg)

## Changes

This makes it so that they see this:

<img width="781" alt="Screenshot 2023-04-28 at 16 11 49" src="https://user-images.githubusercontent.com/4550621/235171696-cc6f02c4-62a8-4ca0-9824-1cc858672281.png">

Relying on https://posthog.com/service-message, which we can update regardless of the app's status.