### PR TITLE
fix: Single event loading from recording

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -453,7 +453,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
 
                     const { person } = values.sessionPlayerData
 
-                    // TODO: Somehow check whether or not we need to load more data.
+                    // TODO: Move this to an optimised HoqQL query when available...
                     try {
                         const res: any = await api.query({
                             kind: 'EventsQuery',


### PR DESCRIPTION
## Problem

HoqQL isn't rolled out yet for everyone so we can't use the nice optimised query. Instead we can use a boring old normal query that gets us the data albeit in a less optimised way.

## Changes

* Fixes this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀  🙈 