### PR TITLE
fix: handle rrweb timestamps if they are strings

### DIFF
--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -345,8 +345,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
-                                                     '2')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -378,8 +378,8 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
-                                                      'user2')
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
+                                                      'user')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---
@@ -569,9 +569,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
                                                      '3',
-                                                     '2')
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -614,9 +614,9 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
                                                       'user3',
-                                                      'user2')
+                                                      'user')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -345,8 +345,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
-                                                     '1')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -378,8 +378,8 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user')
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
+                                                      'user2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---
@@ -569,9 +569,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
                                                      '3',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -614,68 +614,13 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
                                                       'user3',
-                                                      'user')
+                                                      'user2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.32
-  '
-  SELECT "posthog_persondistinctid"."id",
-         "posthog_persondistinctid"."team_id",
-         "posthog_persondistinctid"."person_id",
-         "posthog_persondistinctid"."distinct_id",
-         "posthog_persondistinctid"."version"
-  FROM "posthog_persondistinctid"
-  WHERE "posthog_persondistinctid"."person_id" IN (1,
-                                                   2,
-                                                   3,
-                                                   4,
-                                                   5 /* ... */) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
-  '
----
-# name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.33
-  '
-  SELECT "posthog_persondistinctid"."id",
-         "posthog_persondistinctid"."team_id",
-         "posthog_persondistinctid"."person_id",
-         "posthog_persondistinctid"."distinct_id",
-         "posthog_persondistinctid"."version"
-  FROM "posthog_persondistinctid"
-  WHERE "posthog_persondistinctid"."person_id" IN (1,
-                                                   2,
-                                                   3,
-                                                   4,
-                                                   5 /* ... */) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
-  '
----
-# name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.34
-  '
-  SELECT "posthog_persondistinctid"."id",
-         "posthog_persondistinctid"."team_id",
-         "posthog_persondistinctid"."person_id",
-         "posthog_persondistinctid"."distinct_id",
-         "posthog_persondistinctid"."version",
-         "posthog_person"."id",
-         "posthog_person"."created_at",
-         "posthog_person"."properties_last_updated_at",
-         "posthog_person"."properties_last_operation",
-         "posthog_person"."team_id",
-         "posthog_person"."properties",
-         "posthog_person"."is_user_id",
-         "posthog_person"."is_identified",
-         "posthog_person"."uuid",
-         "posthog_person"."version"
-  FROM "posthog_persondistinctid"
-  INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user3',
-                                                      'user')
-         AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
-  '
----
-# name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.35
   '
   SELECT "posthog_persondistinctid"."id",
          "posthog_persondistinctid"."team_id",

--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -478,9 +478,19 @@ def test_get_events_summary_from_snapshot_data():
                 },
             },
         },
+        # payload has iso string timestamp instead of number and is out of order by timestamp sort
+        # in https://posthog.sentry.io/issues/4089255349/?project=1899813&referrer=slack we saw a client
+        # send this event, which caused the backend sorting to fail because we treat the rrweb timestamp
+        # as if it is always a number
+        {
+            "type": 1,
+            "timestamp": "1987-04-28T17:17:17.590Z",
+            "data": {"source": 3},
+        },
     ]
 
     assert get_events_summary_from_snapshot_data(snapshot_events) == [
+        {"data": {"source": 3}, "timestamp": 546628637590, "type": 1},
         {"timestamp": timestamp, "type": 2, "data": {}},
         {"timestamp": timestamp, "type": 1, "data": {"source": 3}},
         {"timestamp": timestamp, "type": 1, "data": {"source": 3}},

--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -487,6 +487,12 @@ def test_get_events_summary_from_snapshot_data():
             "timestamp": "1987-04-28T17:17:17.590Z",
             "data": {"source": 3},
         },
+        # safely ignore string timestamps that aren't timestamps
+        {
+            "type": 1,
+            "timestamp": "it was about a hundred years ago, that I remember this happening",
+            "data": {"source": 3},
+        },
     ]
 
     assert get_events_summary_from_snapshot_data(snapshot_events) == [

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, DefaultDict, Dict, Generator, List, Optional
 
+from dateutil.parser import parse
 from sentry_sdk.api import capture_exception, capture_message
 
 from posthog.models import utils
@@ -309,6 +310,10 @@ def get_active_segments_from_event_list(
     return active_recording_segments
 
 
+def convert_to_timestamp(source: str) -> int:
+    return int(parse(source).timestamp() * 1000)
+
+
 def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> List[SessionRecordingEventSummary]:
     """
     Extract a minimal representation of the snapshot data events for easier querying.
@@ -339,13 +344,15 @@ def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> 
 
         events_summary.append(
             SessionRecordingEventSummary(
-                timestamp=event["timestamp"],
+                timestamp=event["timestamp"]
+                if isinstance(event["timestamp"], int)
+                else convert_to_timestamp(event["timestamp"]),
                 type=event["type"],
                 data=data,
             )
         )
 
-    # No guarantees are made about order so we sort here to be sure
+    # No guarantees are made about order so, we sort here to be sure
     events_summary.sort(key=lambda x: x["timestamp"])
 
     return events_summary

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -346,8 +346,8 @@ def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> 
         try:
             events_summary.append(
                 SessionRecordingEventSummary(
-                    timestamp=event["timestamp"]
-                    if isinstance(event["timestamp"], int)
+                    timestamp=int(event["timestamp"])
+                    if isinstance(event["timestamp"], (int, float))
                     else convert_to_timestamp(event["timestamp"]),
                     type=event["type"],
                     data=data,


### PR DESCRIPTION
## Problem

In https://posthog.sentry.io/issues/4089255349/?project=1899813&referrer=slack we saw a client send some rrweb events whose timestamps were ISO strings. 

We treat them as numbers not strings and this broke sorting

## Changes

* convert string timestamps to a timestamp
* ignore events with invalid string timestamps but capture them to Sentry

## How did you test this code?

added developer tests
