### PR TITLE
fix: support inclusion only products on billing

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -235,7 +235,7 @@ export function Billing(): JSX.Element {
             </div>
 
             {(products || [])
-                .filter((x) => !x.contact_support)
+                .filter((x) => !x.inclusion_only)
                 .map((x) => (
                     <div key={x.type}>
                         <LemonDivider dashed className="my-2" />

--- a/frontend/src/scenes/billing/test/Billing.tsx
+++ b/frontend/src/scenes/billing/test/Billing.tsx
@@ -228,11 +228,13 @@ export function Billing(): JSX.Element {
             </div>
             <LemonDivider className="mt-2 mb-8" />
 
-            {products?.map((x) => (
-                <div key={x.type}>
-                    <BillingProduct product={x} />
-                </div>
-            ))}
+            {products
+                ?.filter((product) => !product.inclusion_only || product.contact_support)
+                ?.map((x) => (
+                    <div key={x.type}>
+                        <BillingProduct product={x} />
+                    </div>
+                ))}
         </div>
     )
 }

--- a/frontend/src/scenes/billing/test/Billing.tsx
+++ b/frontend/src/scenes/billing/test/Billing.tsx
@@ -81,7 +81,7 @@ export function Billing(): JSX.Element {
         }
         let url = '/api/billing-v2/activation?products='
         for (const product of products) {
-            if (product.subscribed || product.contact_support) {
+            if (product.subscribed || product.contact_support || product.inclusion_only) {
                 continue
             }
             const currentPlanIndex = product.plans.findIndex((plan) => plan.current_plan)

--- a/frontend/src/scenes/billing/test/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/test/BillingProduct.tsx
@@ -353,8 +353,8 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                     </p>
                                 )}
                                 <p className="m-0">
-                                    Need additional platform and support (aka enterprise) features like SSO and advanced
-                                    permissioning?{' '}
+                                    Need additional platform and support (aka enterprise) features like <b>SAML SSO</b>,{' '}
+                                    <b>advanced permissioning</b>, and more?{' '}
                                     <Link to="mailto:sales@posthog.com?subject=Enterprise%20plan%20request">
                                         Get in touch
                                     </Link>{' '}

--- a/frontend/src/scenes/billing/test/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/test/BillingProduct.tsx
@@ -105,7 +105,7 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
                                 }
                             />
                         </>
-                    ) : addon.included ? (
+                    ) : addon.included_with_main_product ? (
                         <LemonTag type="purple" icon={<IconCheckmark />}>
                             Included with plan
                         </LemonTag>

--- a/frontend/src/scenes/billing/test/PlanComparisonModal.scss
+++ b/frontend/src/scenes/billing/test/PlanComparisonModal.scss
@@ -5,11 +5,16 @@
         td {
             vertical-align: top;
             padding: 0.75rem 1.25rem;
+
+            &.PlanTable__td__upgradeButton {
+                padding-top: 1rem;
+                padding-bottom: 1rem;
+            }
         }
         th {
             vertical-align: top;
-            padding: 0.75rem 1.25rem;
-            font-weight: 800;
+            padding: 0.75rem 1.25rem 0.75rem;
+            font-weight: 600;
             text-align: left;
 
             &.PlanTable__th__section {
@@ -17,9 +22,13 @@
                 font-weight: 500;
             }
 
-            &.PlanTable__th__subfeature {
-                padding: 1rem 0 1rem 2rem;
+            &.PlanTable__th__feature {
+                padding: 0.75rem 1.25rem 0.75rem 3.25rem;
                 font-weight: 600;
+            }
+
+            &.PlanTable__th__last-feature {
+                padding-bottom: 2rem;
             }
 
             p {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1102,7 +1102,7 @@ export interface BillingProductV2Type {
     addons: BillingProductV2AddonType[]
 
     // addons-only: if this addon is included with the base product and not subscribed individually. for backwards compatibility.
-    included?: boolean
+    included_with_main_product?: boolean
 }
 
 export interface BillingProductV2AddonType {
@@ -1116,7 +1116,7 @@ export interface BillingProductV2AddonType {
     tiered: boolean
     subscribed: boolean
     // sometimes addons are included with the base product, but they aren't subscribed individually
-    included?: boolean
+    included_with_main_product?: boolean
     contact_support?: boolean
     unit: string | null
     unit_amount_usd: string | null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1092,6 +1092,7 @@ export interface BillingProductV2Type {
     unit_amount_usd: string | null
     plans: BillingV2PlanType[]
     contact_support: boolean
+    inclusion_only: any
     feature_groups: {
         // deprecated, remove after removing the billing plans table
         group: string
@@ -1099,7 +1100,8 @@ export interface BillingProductV2Type {
         features: BillingV2FeatureType[]
     }[]
     addons: BillingProductV2AddonType[]
-    // sometimes addons are included with the base product, but they aren't subscribed individually
+
+    // addons-only: if this addon is included with the base product and not subscribed individually. for backwards compatibility.
     included?: boolean
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1166,6 +1166,7 @@ export interface BillingV2PlanType {
     plan_key?: string
     current_plan?: any
     tiers?: BillingV2TierType[]
+    included_if?: 'no_active_subscription' | 'has_subscription' | null
 }
 
 export interface PlanInterface {


### PR DESCRIPTION
Should go out before https://github.com/PostHog/billing/pull/218

## Problem

We weren't showing which `inclusion_only` features (that is, product features that are included with subscription) you'd get when subscribing, but these are important features for getting people to subscribe.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

The plan comparison tables now show other included feature info:

![image](https://user-images.githubusercontent.com/18598166/235257400-cbf0622c-5c13-4d8e-89f9-6a6a72d07403.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Should add some storybook snapshots for this but I'm going to wait to do that until after we run some experiments on this.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
