### PR TITLE
fix(subscriptions): Fix monthly subs' "nth day" option

### DIFF
--- a/frontend/src/lib/components/Subscriptions/utils.tsx
+++ b/frontend/src/lib/components/Subscriptions/utils.tsx
@@ -39,7 +39,12 @@ export const targetTypeOptions: LemonSelectOptions<'email' | 'slack'> = [
 
 export const intervalOptions: LemonSelectOptions<number> = range(1, 13).map((x) => ({ value: x, label: x.toString() }))
 
-export const frequencyOptions: LemonSelectOptions<'daily' | 'weekly' | 'monthly'> = [
+export const frequencyOptionsSingular: LemonSelectOptions<'daily' | 'weekly' | 'monthly'> = [
+    { value: 'daily', label: 'day' },
+    { value: 'weekly', label: 'week' },
+    { value: 'monthly', label: 'month' },
+]
+export const frequencyOptionsPlural: LemonSelectOptions<'daily' | 'weekly' | 'monthly'> = [
     { value: 'daily', label: 'days' },
     { value: 'weekly', label: 'weeks' },
     { value: 'monthly', label: 'months' },

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -394,7 +394,7 @@ export function EditSubscription({
                                                     // "day" is a special case where it is a list of all available days
                                                     value={value ? (value.length === 1 ? value[0] : 'day') : null}
                                                     onChange={(val) =>
-                                                        onChange(val === 'day' ? Object.keys(weekdayOptions) : [val])
+                                                        onChange(val === 'day' ? Object.values(weekdayOptions) : [val])
                                                     }
                                                 />
                                             )}

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -13,7 +13,8 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { subscriptionsLogic } from '../subscriptionsLogic'
 import {
     bysetposOptions,
-    frequencyOptions,
+    frequencyOptionsSingular,
+    frequencyOptionsPlural,
     getSlackChannelOptions,
     intervalOptions,
     monthlyWeekdayOptions,
@@ -347,7 +348,13 @@ export function EditSubscription({
                                     <LemonSelect options={intervalOptions} />
                                 </Field>
                                 <Field name={'frequency'}>
-                                    <LemonSelect options={frequencyOptions} />
+                                    <LemonSelect
+                                        options={
+                                            subscription.interval === 1
+                                                ? frequencyOptionsSingular
+                                                : frequencyOptionsPlural
+                                        }
+                                    />
                                 </Field>
 
                                 {subscription.frequency === 'weekly' && (

--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -45,7 +45,7 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
             <>
                 <PayGateMini feature={AvailableFeature.DASHBOARD_PERMISSIONING}>
                     {(!canEditDashboard || !canRestrictDashboard) && (
-                        <LemonBanner type="info">
+                        <LemonBanner type="info" className="mb-4">
                             {canEditDashboard
                                 ? "You aren't allowed to change the restriction level – only the dashboard owner and project admins can."
                                 : "You aren't allowed to change sharing settings – only dashboard collaborators with edit settings can."}


### PR DESCRIPTION
## Problem

ZEN-2689. See this related Sentry error: [POSTHOG-8NQ](https://posthog.sentry.io/issues/3804286892/)
For the "send on nth day of the month" option of dashboard subscriptions (i.e. not a particular nth _weekday_ of the month), we sent that preference as `byweekday: ["0", "1", "2", "3", "4", "5", "6"]`, when it should be `byweekday: ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]`. So such subscriptions couldn't actually be saved.

## Changes

Fixes the issue to send the right payload.
