### PR TITLE
docs(set/set_once): add $set/$set_once to docs

### DIFF
--- a/openapi/capture.yaml
+++ b/openapi/capture.yaml
@@ -245,9 +245,41 @@ components:
                     format: uuid
                 type:
                     type: string
+                $set:
+                    $ref: '#/components/schemas/SetPersonProperties'
+                $set_once:
+                    $ref: '#/components/schemas/SetOncePersonProperties'
                 properties:
                     type: object
+                    properties:
+                        $set:
+                            $ref: '#/components/schemas/SetPersonProperties'
+                        $set_once:
+                            $ref: '#/components/schemas/SetOncePersonProperties'
                     additionalProperties: true
+
+        SetPersonProperties:
+            type: object
+            description: |
+                Set person property to a given values. If the property does not 
+                exist, it will be set. If the property already exists, it
+                will be updated to the new value. The type of the property
+                will be inferred from the value.
+            additionalProperties: true
+            example:
+                $set:
+                    country: UK
+                    city: Cambridge
+
+        SetOncePersonProperties:
+            type: object
+            description: |
+                Set person property to a given value, but only if it is not
+                currently set. It will not override existing values. The type
+                of the property will be inferred from the value.
+            example:
+                $set_once:
+                    initial_referrer: https://google.com
 
         EventCaptureRequest:
             $ref: '#/components/schemas/Event'

--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -57,6 +57,8 @@ export const capture = async ({
     sentAt = new Date(),
     eventTime = new Date(),
     now = new Date(),
+    $set = undefined,
+    $set_once = undefined,
     topic = ['$performance_event', '$snapshot'].includes(event)
         ? 'session_recording_events'
         : 'events_plugin_ingestion',
@@ -71,6 +73,8 @@ export const capture = async ({
     eventTime?: Date
     now?: Date
     topic?: string
+    $set?: object
+    $set_once?: object
 }) => {
     // WARNING: this capture method is meant to simulate the ingestion of events
     // from the capture endpoint, but there is no guarantee that is is 100%
@@ -92,6 +96,8 @@ export const capture = async ({
                     properties: { ...properties, uuid },
                     team_id: teamId,
                     timestamp: eventTime,
+                    $set,
+                    $set_once,
                 }),
             })
         ),


### PR DESCRIPTION
This also adds a test to ensure we are capturing usage of $set/$set_once
at the top level of the event, as posthog-js uses this method.

This was initiated by the issue mentioned
[here](https://github.com/PostHog/posthog-js/issues/615).

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
