### PR TITLE
fix(insights): Fix formula with HogQL breakdown

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -146,7 +146,7 @@
       ))
     ',
     <class 'dict'> {
-      'global_cohort_id_0': 26,
+      'global_cohort_id_0': 28,
       'global_version_0': None,
     },
   )

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -39,7 +39,6 @@ export function BreakdownTag({
             className="taxonomic-breakdown-filter tag-pill"
             closable={!!setFilters && !isHistogramable && !isURLNormalizeable}
             onClose={onClose}
-            style={{ textTransform: 'capitalize' }}
             popover={{
                 overlay: isURLNormalizeable ? (
                     <>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -66,6 +66,7 @@ export function TaxonomicBreakdownButton({
                 data-attr="add-breakdown-button"
                 onClick={() => setOpen(!open)}
                 className="taxonomic-breakdown-filter tag-button"
+                sideIcon={null}
             >
                 <PropertyKeyInfo
                     value={

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -62,7 +62,7 @@ class Database(BaseModel):
         raise HogQLException(f'Table "{table_name}" not found in database')
 
 
-def create_hogql_database(team_id: Optional[int]) -> Database:
+def create_hogql_database(team_id: int) -> Database:
     from posthog.models import Team
 
     team = Team.objects.get(pk=team_id)

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -17,7 +17,10 @@ def translate_hogql(query: str, context: HogQLContext, dialect: Literal["hogql",
 
     try:
         # Create a fake query that selects from "events" to have fields to select from.
-        context.database = context.database or create_hogql_database(context.team_id)
+        if context.database is None:
+            if context.team_id is None:
+                raise ValueError("Cannot translate HogQL for a filter with no team specified")
+            context.database = create_hogql_database(context.team_id)
         node = parse_expr(query, no_placeholders=True)
         select_query = ast.SelectQuery(select=[node], select_from=ast.JoinExpr(table=ast.Field(chain=["events"])))
         prepared_select_query: ast.SelectQuery = cast(

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -21,6 +21,7 @@ class TrendsFormula:
         params: Dict[str, Any] = {}
         for idx, entity in enumerate(filter.entities):
             _, sql, entity_params, _ = self._get_sql_for_entity(filter, team, entity)  # type: ignore
+            entity_params.update(filter.hogql_context.values)
             sql = sql.replace("%(", f"%({idx}_")
             entity_params = {f"{idx}_{key}": value for key, value in entity_params.items()}
             queries.append(sql)
@@ -77,11 +78,10 @@ class TrendsFormula:
         with push_scope() as scope:
             scope.set_context("filter", filter.to_dict())
             scope.set_tag("team", team)
-            query_params = {**params, **filter.hogql_context.values}
-            scope.set_context("query", {"sql": sql, "params": query_params})
+            scope.set_context("query", {"sql": sql, "params": params})
             result = insight_sync_execute(
                 sql,
-                query_params,
+                params,
                 query_type="trends_formula",
                 filter=filter,
             )

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -1,5 +1,6 @@
 import math
 from itertools import accumulate
+import re
 from string import ascii_uppercase
 from typing import Any, Dict, List
 
@@ -13,6 +14,9 @@ from posthog.queries.breakdown_props import get_breakdown_cohort_name
 from posthog.queries.insight import insight_sync_execute
 from posthog.queries.trends.util import ensure_value_is_json_serializable, parse_response
 
+# Regex for adding the formula variable index to all params, except HogQL params
+PARAM_DISAMBIGUATION_REGEX = re.compile(r"%\((?!hogql_)")
+
 
 class TrendsFormula:
     def _run_formula_query(self, filter: Filter, team: Team):
@@ -21,11 +25,11 @@ class TrendsFormula:
         params: Dict[str, Any] = {}
         for idx, entity in enumerate(filter.entities):
             _, sql, entity_params, _ = self._get_sql_for_entity(filter, team, entity)  # type: ignore
-            entity_params.update(filter.hogql_context.values)
-            sql = sql.replace("%(", f"%({idx}_")
+            sql = PARAM_DISAMBIGUATION_REGEX.sub(f"%({idx}_", sql)
             entity_params = {f"{idx}_{key}": value for key, value in entity_params.items()}
             queries.append(sql)
-            params = {**params, **entity_params}
+            params.update(entity_params)
+        params.update(filter.hogql_context.values)
 
         breakdown_value = ""
         if filter.breakdown_type == "cohort":

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -327,6 +327,190 @@
      ORDER BY breakdown_value) as sub_B ON sub_A.breakdown_value = sub_B.breakdown_value
   '
 ---
+# name: TestFormula.test_breakdown_hogql
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT concat(replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''), ' : ', replaceRegexpAll(JSONExtractRaw(events.properties, 'location'), '^"|"$', '')) AS value,
+            sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+     WHERE team_id = 2
+       AND event = 'session start'
+       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFormula.test_breakdown_hogql.1
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT concat(replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''), ' : ', replaceRegexpAll(JSONExtractRaw(events.properties, 'location'), '^"|"$', '')) AS value,
+            avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     INNER JOIN
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+     WHERE team_id = 2
+       AND event = 'session start'
+       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFormula.test_breakdown_hogql.2
+  '
+  SELECT sub_A.date,
+         arrayMap((A, B) -> A + B, arrayResize(sub_A.total, max_length, 0), arrayResize(sub_B.total, max_length, 0)) ,
+         arrayFilter(x -> notEmpty(x), [replaceRegexpAll(sub_A.breakdown_value, '^"|"$', ''), replaceRegexpAll(sub_B.breakdown_value, '^"|"$', '')])[1] ,
+         arrayMax([length(sub_A.total), length(sub_B.total)]) as max_length
+  FROM
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT ['some_val : London', 'some_val : Paris'] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               concat(replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''), ' : ', replaceRegexpAll(JSONExtractRaw(events.properties, 'location'), '^"|"$', '')) as breakdown_value
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+              INNER JOIN
+                (SELECT id,
+                        argMax(properties, version) as person_props
+                 FROM person
+                 WHERE team_id = 2
+                 GROUP BY id
+                 HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              WHERE e.team_id = 2
+                AND event = 'session start'
+                AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+                AND concat(replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''), ' : ', replaceRegexpAll(JSONExtractRaw(events.properties, 'location'), '^"|"$', '')) in (['some_val : London', 'some_val : Paris'])
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_A
+  FULL OUTER JOIN
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total,
+            breakdown_value
+     FROM
+       (SELECT SUM(total) as count,
+               day_start,
+               breakdown_value
+        FROM
+          (SELECT *
+           FROM
+             (SELECT toUInt16(0) AS total,
+                     ticks.day_start as day_start,
+                     breakdown_value
+              FROM
+                (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - number * 86400) as day_start
+                 FROM numbers(8)
+                 UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+              CROSS JOIN
+                (SELECT breakdown_value
+                 FROM
+                   (SELECT ['some_val : London', 'some_val : Paris'] as breakdown_value) ARRAY
+                 JOIN breakdown_value) as sec
+              ORDER BY breakdown_value,
+                       day_start
+              UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
+                               toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                               concat(replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''), ' : ', replaceRegexpAll(JSONExtractRaw(events.properties, 'location'), '^"|"$', '')) as breakdown_value
+              FROM events e
+              INNER JOIN
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+              INNER JOIN
+                (SELECT id,
+                        argMax(properties, version) as person_props
+                 FROM person
+                 WHERE team_id = 2
+                 GROUP BY id
+                 HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              WHERE e.team_id = 2
+                AND event = 'session start'
+                AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+                AND concat(replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''), ' : ', replaceRegexpAll(JSONExtractRaw(events.properties, 'location'), '^"|"$', '')) in (['some_val : London', 'some_val : Paris'])
+              GROUP BY day_start,
+                       breakdown_value))
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY breakdown_value,
+                 day_start)
+     GROUP BY breakdown_value
+     ORDER BY breakdown_value) as sub_B ON sub_A.breakdown_value = sub_B.breakdown_value
+  '
+---
 # name: TestFormula.test_breakdown_with_different_breakdown_values_per_series
   '
   


### PR DESCRIPTION
## Problem

HogQL breakdowns didn't work with formulas, as HogQL SQL params aren't part of the param disambiguation scheme that's based on formula variable indices. See ZEN-2697.

## Changes

Now we don't attempt disambiguating HogQL params, as they should already be unique at the level of the whole query.

While doing this I ran into a cryptic error caused by `team` not being passed to the `Filter` constructor, so added some error handling for that. Also improved the UI of the breakdown button.

## How did you test this code?

Added a query test against this.