### PR TITLE
fix(person): use display name setting

### DIFF
--- a/ee/api/session_recording_playlist.py
+++ b/ee/api/session_recording_playlist.py
@@ -208,7 +208,7 @@ class SessionRecordingPlaylistViewSet(StructuredViewSetMixin, ForbidDestroyModel
             {SESSION_RECORDINGS_FILTER_IDS: json.dumps([x.recording_id for x in playlist_items])}
         )
 
-        return response.Response(list_recordings(filter, request, self.team))
+        return response.Response(list_recordings(filter, request, context=self.get_serializer_context()))
 
     # As of now, you can only "update" a session recording by adding or removing a recording from a static playlist
     @action(methods=["POST", "DELETE"], detail=True, url_path="recordings/(?P<session_recording_id>[^/.]+)")

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -137,7 +137,7 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
         group_type_index = request.GET.get("group_type_index")
         id = request.GET["id"]
 
-        results = RelatedActorsQuery(self.team.pk, group_type_index, id).run()
+        results = RelatedActorsQuery(self.team, group_type_index, id).run()
         return response.Response(results)
 
     @action(methods=["GET"], detail=False)

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -63,6 +63,7 @@ export const privilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
 
 // Persons
 export const PERSON_DISTINCT_ID_MAX_SIZE = 3
+// Sync with api/person.py
 export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     'email',
     'Email',

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -212,7 +212,7 @@ class ActionViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestro
         if request.accepted_renderer.format == "csv":
             content = [
                 {
-                    "Name": get_person_name(person),
+                    "Name": get_person_name(team, person),
                     "Distinct ID": person.distinct_ids[0] if person.distinct_ids else "",
                     "Internal ID": str(person.uuid),
                     "Email": person.properties.get("email"),

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -228,7 +228,7 @@ class CohortViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         raw_result = sync_execute(query, {**params, **filter.hogql_context.values})
         actor_ids = [row[0] for row in raw_result]
-        actors, serialized_actors = get_people(team.pk, actor_ids, distinct_id_limit=10)
+        actors, serialized_actors = get_people(team, actor_ids, distinct_id_limit=10)
 
         _should_paginate = len(actor_ids) >= filter.limit
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -89,6 +89,7 @@ class PersonLimitOffsetPagination(LimitOffsetPagination):
 
 
 def get_person_name(person: Person) -> str:
+    raise Exception("get_person_name called")
     if person.properties.get("email"):
         return person.properties["email"]
     if len(person.distinct_ids) > 0:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -64,6 +64,15 @@ from posthog.tasks.split_person import split_person
 from posthog.utils import convert_property_value, format_query_params_absolute_url, is_anonymous_id, relative_date_parse
 
 DEFAULT_PAGE_LIMIT = 100
+PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
+    "email",
+    "Email",
+    "name",
+    "Name",
+    "username",
+    "Username",
+    "UserName",
+]
 
 
 class PersonLimitOffsetPagination(LimitOffsetPagination):
@@ -89,12 +98,19 @@ class PersonLimitOffsetPagination(LimitOffsetPagination):
 
 
 def get_person_name(team: Team, person: Person) -> str:
-    if person.properties.get("email"):
-        return person.properties["email"]
+    if display_name := get_person_display_name(person, team):
+        return display_name
     if len(person.distinct_ids) > 0:
         # Prefer non-UUID distinct IDs (presumably from user identification) over UUIDs
         return sorted(person.distinct_ids, key=is_anonymous_id)[0]
     return person.pk
+
+
+def get_person_display_name(person: Person, team: Team) -> str | None:
+    for property in team.person_display_name_properties or PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES:
+        if person.properties.get(property):
+            return person.properties.get(property)
+    return None
 
 
 class PersonsThrottle(ClickHouseSustainedRateThrottle):

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -120,8 +120,8 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         read_only_fields = ("id", "name", "distinct_ids", "created_at", "uuid")
 
     def get_name(self, person: Person) -> str:
-        raise Exception("get_name called")
-        return get_person_name(person)
+        team = self.context["get_team"]()
+        return get_person_name(team, person)
 
     def to_representation(self, instance: Person) -> Dict[str, Any]:
         representation = super().to_representation(instance)

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -89,7 +89,6 @@ class PersonLimitOffsetPagination(LimitOffsetPagination):
 
 
 def get_person_name(person: Person) -> str:
-    raise Exception("get_person_name called")
     if person.properties.get("email"):
         return person.properties["email"]
     if len(person.distinct_ids) > 0:
@@ -121,6 +120,7 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         read_only_fields = ("id", "name", "distinct_ids", "created_at", "uuid")
 
     def get_name(self, person: Person) -> str:
+        raise Exception("get_name called")
         return get_person_name(person)
 
     def to_representation(self, instance: Person) -> Dict[str, Any]:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -33,7 +33,7 @@ from posthog.api.utils import format_paginated_url, get_pk_or_uuid, get_target_e
 from posthog.constants import CSV_EXPORT_LIMIT, INSIGHT_FUNNELS, INSIGHT_PATHS, LIMIT, OFFSET, FunnelVizType
 from posthog.decorators import cached_function
 from posthog.logging.timing import timed
-from posthog.models import Cohort, Filter, Person, User
+from posthog.models import Cohort, Filter, Person, User, Team
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
@@ -88,7 +88,7 @@ class PersonLimitOffsetPagination(LimitOffsetPagination):
         }
 
 
-def get_person_name(person: Person) -> str:
+def get_person_name(team: Team, person: Person) -> str:
     if person.properties.get("email"):
         return person.properties["email"]
     if len(person.distinct_ids) > 0:
@@ -228,7 +228,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         )
 
         actor_ids = [row[0] for row in raw_result]
-        actors, serialized_actors = get_people(team.pk, actor_ids)
+        actors, serialized_actors = get_people(team, actor_ids)
 
         _should_paginate = len(actor_ids) >= filter.limit
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -150,7 +150,7 @@ class StructuredViewSetMixin(_GenericViewSet):
         return result
 
     def get_serializer_context(self) -> Dict[str, Any]:
-        serializer_context = super().get_serializer_context()
+        serializer_context = super().get_serializer_context() if hasattr(super(), "get_serializer_context") else {}
         serializer_context.update(self.parents_query_dict)
         # The below are lambdas for lazy evaluation (i.e. we only query Postgres for team/org if actually needed)
         serializer_context["get_team"] = lambda: self.team

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -122,7 +122,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.ViewSet):
         save_viewed = request.GET.get("save_view") is not None and not is_impersonated_session(request)
         recording.check_viewed_for_user(request.user, save_viewed=save_viewed)
 
-        serializer = SessionRecordingSerializer(recording)
+        serializer = SessionRecordingSerializer(recording, context=self.get_serializer_context())
 
         return Response(serializer.data)
 
@@ -313,7 +313,7 @@ def list_recordings(
         recording.viewed = recording.session_id in viewed_session_recordings
         recording.person = distinct_id_to_person.get(recording.distinct_id)
 
-    session_recording_serializer = SessionRecordingSerializer(recordings, many=True, context=context)
+    session_recording_serializer = SessionRecordingSerializer(recordings, context=context, many=True)
     results = session_recording_serializer.data
 
     return {"results": results, "has_next": more_recordings_available, "version": 2 if can_use_v2 else 1}

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -297,14 +297,14 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 84)
+     WHERE equals(person_distinct_id2.team_id, 2)
      GROUP BY person_distinct_id2.distinct_id
      HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''), person.version) AS properties___email,
             person.id
      FROM person
-     WHERE equals(person.team_id, 84)
+     WHERE equals(person.team_id, 2)
      GROUP BY person.id
      HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
   WHERE and(equals(events.team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
@@ -327,14 +327,14 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 85)
+     WHERE equals(person_distinct_id2.team_id, 2)
      GROUP BY person_distinct_id2.distinct_id
      HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(person.pmat_email, person.version) AS properties___email,
             person.id
      FROM person
-     WHERE equals(person.team_id, 85)
+     WHERE equals(person.team_id, 2)
      GROUP BY person.id
      HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
   WHERE and(equals(events.team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -297,14 +297,14 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 2)
+     WHERE equals(person_distinct_id2.team_id, 84)
      GROUP BY person_distinct_id2.distinct_id
      HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''), person.version) AS properties___email,
             person.id
      FROM person
-     WHERE equals(person.team_id, 2)
+     WHERE equals(person.team_id, 84)
      GROUP BY person.id
      HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
   WHERE and(equals(events.team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
@@ -327,14 +327,14 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 2)
+     WHERE equals(person_distinct_id2.team_id, 85)
      GROUP BY person_distinct_id2.distinct_id
      HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(person.pmat_email, person.version) AS properties___email,
             person.id
      FROM person
-     WHERE equals(person.team_id, 2)
+     WHERE equals(person.team_id, 85)
      GROUP BY person.id
      HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
   WHERE and(equals(events.team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -26,6 +26,18 @@ from posthog.test.base import (
 
 
 class TestPerson(ClickhouseTestMixin, APIBaseTest):
+    def test_legacy_get_person_by_id(self) -> None:
+        person = _create_person(
+            team=self.team, distinct_ids=["distinct_id"], properties={"email": "someone@gmail.com"}, immediate=True
+        )
+        flush_persons_and_events()
+
+        with self.assertNumQueries(7):
+            response = self.client.get(f"/api/person/{person.pk}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], person.pk)
+
     def test_search(self) -> None:
         _create_person(team=self.team, distinct_ids=["distinct_id"], properties={"email": "someone@gmail.com"})
         _create_person(

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -32,7 +32,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             response = self.client.get(f"/api/person/{person.pk}")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -432,6 +432,57 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             ["distinct_id1", "17787c3099427b-0e8f6c86323ea9-33647309-1aeaa0-17787c30995b7c"],
         )
 
+    def test_person_display_name(self) -> None:
+        self.team.person_display_name_properties = ["custom_name", "custom_email"]
+        self.team.save()
+        _create_person(
+            team=self.team,
+            distinct_ids=["distinct_id1"],
+            properties={"custom_name": "someone", "custom_email": "someone@custom.com", "email": "someone@gmail.com"},
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["distinct_id2"],
+            properties={"custom_email": "another_one@custom.com", "email": "another_one@gmail.com"},
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["distinct_id3"],
+            properties={"email": "yet_another_one@gmail.com"},
+        )
+        flush_persons_and_events()
+
+        response = self.client.get("/api/person/").json()
+
+        results = response["results"][::-1]  # results are in reverse order
+        self.assertEqual(results[0]["name"], "someone")
+        self.assertEqual(results[1]["name"], "another_one@custom.com")
+        self.assertEqual(results[2]["name"], "distinct_id3")
+
+    def test_person_display_name_defaults(self) -> None:
+        _create_person(
+            team=self.team,
+            distinct_ids=["distinct_id1"],
+            properties={"name": "someone", "email": "someone@gmail.com"},
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["distinct_id2"],
+            properties={"name": "another_one"},
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["distinct_id3"],
+        )
+        flush_persons_and_events()
+
+        response = self.client.get("/api/person/").json()
+
+        results = response["results"][::-1]  # results are in reverse order
+        self.assertEqual(results[0]["name"], "someone@gmail.com")
+        self.assertEqual(results[1]["name"], "another_one")
+        self.assertEqual(results[2]["name"], "distinct_id3")
+
     def test_person_cohorts(self) -> None:
         _create_person(team=self.team, distinct_ids=["1"], properties={"$some_prop": "something", "number": 1})
         person2 = _create_person(

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -188,7 +188,7 @@ class ActorBaseQuery:
                 self._team.pk, cast(int, self.aggregation_group_type_index), actor_ids, value_per_actor_id
             )
         else:
-            actors, serialized_actors = get_people(self._team.pk, actor_ids, value_per_actor_id)
+            actors, serialized_actors = get_people(self._team, actor_ids, value_per_actor_id)
 
         if self.ACTOR_VALUES_INCLUDED:
             # We fetched actors from Postgres in get_groups/get_people, so `ORDER BY actor_value DESC` no longer holds
@@ -209,7 +209,7 @@ def get_groups(
 
 
 def get_people(
-    team_id: int, people_ids: List[Any], value_per_actor_id: Optional[Dict[str, float]] = None, distinct_id_limit=1000
+    team: Team, people_ids: List[Any], value_per_actor_id: Optional[Dict[str, float]] = None, distinct_id_limit=1000
 ) -> Tuple[QuerySet[Person], List[SerializedPerson]]:
     """Get people from raw SQL results in data model and dict formats"""
     distinct_id_subquery = Subquery(
@@ -218,7 +218,7 @@ def get_people(
         ]
     )
     persons: QuerySet[Person] = (
-        Person.objects.filter(team_id=team_id, uuid__in=people_ids)
+        Person.objects.filter(team_id=team.pk, uuid__in=people_ids)
         .prefetch_related(
             Prefetch(
                 "persondistinctid_set",
@@ -229,10 +229,12 @@ def get_people(
         .order_by("-created_at", "uuid")
         .only("id", "is_identified", "created_at", "properties", "uuid")
     )
-    return persons, serialize_people(persons, value_per_actor_id)
+    return persons, serialize_people(team, persons, value_per_actor_id)
 
 
-def serialize_people(data: QuerySet[Person], value_per_actor_id: Optional[Dict[str, float]]) -> List[SerializedPerson]:
+def serialize_people(
+    team: Team, data: QuerySet[Person], value_per_actor_id: Optional[Dict[str, float]]
+) -> List[SerializedPerson]:
     from posthog.api.person import get_person_name
 
     return [
@@ -243,7 +245,7 @@ def serialize_people(data: QuerySet[Person], value_per_actor_id: Optional[Dict[s
             created_at=person.created_at,
             properties=person.properties,
             is_identified=person.is_identified,
-            name=get_person_name(person),
+            name=get_person_name(team, person),
             distinct_ids=person.distinct_ids,
             matched_recordings=[],
             value_at_data_point=value_per_actor_id[str(person.uuid)] if value_per_actor_id else None,

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -81,7 +81,8 @@ class Lifecycle:
 
         from posthog.api.person import PersonSerializer
 
-        return PersonSerializer(people, many=True).data
+        serializer_context = {"get_team": lambda: team}
+        return PersonSerializer(people, context=serializer_context, many=True).data
 
     def _get_persons_urls(self, filter: Filter, entity: Entity, times: List[str], status) -> List[Dict[str, Any]]:
         persons_url = []


### PR DESCRIPTION
## Problem

We're currently not taking into account the team's `person_display_name_properties` when accessing a person name on the backend.


## Changes

This PR adapts the `get_person_name` method to first check for any `team.person_display_name_properties`.

## Follow Up

[fix(exports): retention people name in csvs ](https://github.com/PostHog/posthog/pull/15168)

## How did you test this code?

Added tests and verified the `team.person_display_name_properties` take precedence over email and distinct ids in the UI.