### PR TITLE
fix(data-exploration): fix group aggregation

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -134,8 +134,12 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             breakdowns: filters.breakdowns,
             breakdown_value: filters.breakdown_value,
             breakdown_group_type_index: filters.breakdown_group_type_index,
-            aggregation_group_type_index: filters.aggregation_group_type_index,
         })
+    }
+
+    // group aggregation
+    if (filters.aggregation_group_type_index !== undefined) {
+        query.aggregation_group_type_index = filters.aggregation_group_type_index
     }
 
     // trends filter

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -93,6 +93,7 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         date_from: query.dateRange?.date_from,
         entity_type: 'events',
         sampling_factor: query.samplingFactor,
+        aggregation_group_type_index: query.aggregation_group_type_index,
     })
 
     if (!isRetentionQuery(query) && !isPathsQuery(query)) {


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C0368RPHLQH/p1683018104740229

## Changes

This PR converts the group aggregation filter independently of breakdowns. 

## How did you test this code?

Tested that changing the group aggregation works for a new insight and that loading an insight with a set group aggregation works as well.