### PR TITLE
fix(plugin-server): use site_url as host for apps api

### DIFF
--- a/plugin-server/src/worker/vm/extensions/api.ts
+++ b/plugin-server/src/worker/vm/extensions/api.ts
@@ -38,7 +38,7 @@ export function createApi(server: Hub, pluginConfig: PluginConfig): ApiExtension
             throw new Error('You must specify a personalApiKey if you specify a projectApiKey and vice-versa!')
         }
 
-        let host = options.host ?? DEFAULT_API_HOST
+        let host = options.host ?? (await server.siteUrlManager.getSiteUrl()) ?? DEFAULT_API_HOST
 
         if (path.startsWith('/')) {
             path = path.slice(1)


### PR DESCRIPTION
Looks like we'd default to https://app.posthog.com e.g. for EU and
self-hosted, hence people end up seeing errors such as
https://posthogusers.slack.com/archives/C01GLBKHKQT/p1677672755593229?thread_ts=1677670308.024399&cid=C01GLBKHKQT

This change uses the SITE_URL as a preference, falling back to
https://app.posthog.com if all else fails.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
