### PR TITLE
fix: Loading toolbar assets in production

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -50,6 +50,9 @@ await buildInParallel(
             // make sure we don't link to a global window.define
             banner: { js: 'var posthogToolbar = (function () { var define = undefined;' },
             footer: { js: 'return posthogToolbar })();' },
+            // This isn't great but we load some static assets at runtime for the toolbar and we can't sub in
+            // a variable at runtime it seems...
+            publicPath: isDev ? '/static/' : 'https://app.posthog.com/static/',
             ...common,
         },
     ],


### PR DESCRIPTION
## Problem

Currently the hedgehog assets aren't loaded at runtime due to them trying to load from `/` (which will be the customer's website). 

## Changes

* Best quick fix I could find is to forcefully set app.posthog.com when built for production. It's not perfect but I couldn't see anyway of "subbing" this in without much more effort than this feature warrants...


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested it locally with both options and it worked.