### PR TITLE
chore: Set default recorder version to v2

### DIFF
--- a/frontend/src/scenes/ingestion/panels/SuperpowersPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/SuperpowersPanel.tsx
@@ -21,6 +21,7 @@ export function SuperpowersPanel(): JSX.Element {
                     session_recording_opt_in: sessionRecordingsChecked,
                     capture_console_log_opt_in: sessionRecordingsChecked,
                     capture_performance_opt_in: sessionRecordingsChecked,
+                    session_recording_version: sessionRecordingsChecked ? 'v2' : undefined,
                     autocapture_opt_out: !autocaptureChecked,
                 })
                 if (!showBillingStep) {

--- a/frontend/src/scenes/session-recordings/settings/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/session-recordings/settings/SessionRecordingSettings.tsx
@@ -27,6 +27,7 @@ export function SessionRecordingSettings({ inModal = false }: SessionRecordingSe
                             session_recording_opt_in: checked,
                             capture_console_log_opt_in: checked,
                             capture_performance_opt_in: checked,
+                            session_recording_version: checked ? 'v2' : undefined,
                         })
                     }}
                     label="Record user sessions"

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -134,7 +134,7 @@ class Team(UUIDClassicModel):
     session_recording_opt_in: models.BooleanField = models.BooleanField(default=False)
     capture_console_log_opt_in: models.BooleanField = models.BooleanField(null=True, blank=True)
     capture_performance_opt_in: models.BooleanField = models.BooleanField(null=True, blank=True)
-    session_recording_version: models.CharField = models.CharField(null=True, blank=True, max_length=24, default="v2")
+    session_recording_version: models.CharField = models.CharField(null=True, blank=True, max_length=24)
     signup_token: models.CharField = models.CharField(max_length=200, null=True, blank=True)
     is_demo: models.BooleanField = models.BooleanField(default=False)
     access_control: models.BooleanField = models.BooleanField(default=False)

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -134,7 +134,7 @@ class Team(UUIDClassicModel):
     session_recording_opt_in: models.BooleanField = models.BooleanField(default=False)
     capture_console_log_opt_in: models.BooleanField = models.BooleanField(null=True, blank=True)
     capture_performance_opt_in: models.BooleanField = models.BooleanField(null=True, blank=True)
-    session_recording_version: models.CharField = models.CharField(null=True, blank=True, max_length=24)
+    session_recording_version: models.CharField = models.CharField(null=True, blank=True, max_length=24, default="v2")
     signup_token: models.CharField = models.CharField(max_length=200, null=True, blank=True)
     is_demo: models.BooleanField = models.BooleanField(default=False)
     access_control: models.BooleanField = models.BooleanField(default=False)


### PR DESCRIPTION
## Problem

Part of [this](https://github.com/PostHog/posthog/issues/14053) - we have trialled this a fair bit so we should make it the default now.

## Changes

* Makes it the default option when creating a new team or turning on recordings


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 