### PR TITLE
fix: Notification popup appearing on escape

### DIFF
--- a/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
+++ b/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
@@ -23,7 +23,7 @@ export function NotificationBell(): JSX.Element {
     return (
         <Popover
             visible={isNotificationPopoverOpen}
-            onClickOutside={toggleNotificationsPopover}
+            onClickOutside={() => (isNotificationPopoverOpen ? toggleNotificationsPopover() : null)}
             overlay={
                 <div className="activity-log notifications-menu">
                     <h5>


### PR DESCRIPTION
## Problem

Noticed if you just press escape then the notifications popover appears. This might be the wrong fix @Twixes as it might be that the popover should be only calling the "onclickoutside" if it is actually showing.

## Changes

* Stops this happening with a quick fix

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 