### PR TITLE
feat: s3 loading locked to data prefix and real sessions

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -171,14 +171,14 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             raise exceptions.NotFound("Recording not found")
 
         if request.GET.get("blob_loading_enabled", "false") == "true":
-            blob_prefix = f"session_recordings/team_id/{self.team.pk}/session_id/{recording.session_id}"
+            blob_prefix = f"session_recordings/team_id/{self.team.pk}/session_id/{recording.session_id}/data/"
             blob_keys = object_storage.list_objects(blob_prefix)
 
             if blob_keys:
                 return Response(
                     {
                         "snapshot_data_by_window_id": [],
-                        "blob_keys": [x.replace(blob_prefix + "/data/", "") for x in blob_keys],
+                        "blob_keys": [x.replace(blob_prefix, "") for x in blob_keys],
                         "next": None,
                     }
                 )

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -260,8 +260,10 @@ def list_recordings(filter: SessionRecordingsFilter, request: request.Request, t
 
     if all_session_ids:
         # If we specify the session ids (like from pinned recordings) we can optimise by only going to Postgres
+        sorted_session_ids = sorted(all_session_ids)
+
         persisted_recordings_queryset = (
-            SessionRecording.objects.filter(team=team, session_id__in=sorted(all_session_ids))
+            SessionRecording.objects.filter(team=team, session_id__in=sorted_session_ids)
             .exclude(object_storage_path=None)
             .annotate(pinned_count=Count("playlist_items"))
         )
@@ -301,9 +303,9 @@ def list_recordings(filter: SessionRecordingsFilter, request: request.Request, t
     )
 
     # Get the related persons for all the recordings
-    distinct_ids = [x.distinct_id for x in recordings]
+    distinct_ids = sorted([x.distinct_id for x in recordings])
     person_distinct_ids = (
-        PersonDistinctId.objects.filter(distinct_id__in=sorted(distinct_ids), team=team)
+        PersonDistinctId.objects.filter(distinct_id__in=distinct_ids, team=team)
         .select_related("person")
         .prefetch_related(Prefetch("person__persondistinctid_set", to_attr="distinct_ids_cache"))
     )

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -261,7 +261,7 @@ def list_recordings(filter: SessionRecordingsFilter, request: request.Request, t
     if all_session_ids:
         # If we specify the session ids (like from pinned recordings) we can optimise by only going to Postgres
         persisted_recordings_queryset = (
-            SessionRecording.objects.filter(team=team, session_id__in=all_session_ids)
+            SessionRecording.objects.filter(team=team, session_id__in=sorted(all_session_ids))
             .exclude(object_storage_path=None)
             .annotate(pinned_count=Count("playlist_items"))
         )
@@ -303,7 +303,7 @@ def list_recordings(filter: SessionRecordingsFilter, request: request.Request, t
     # Get the related persons for all the recordings
     distinct_ids = [x.distinct_id for x in recordings]
     person_distinct_ids = (
-        PersonDistinctId.objects.filter(distinct_id__in=distinct_ids, team=team)
+        PersonDistinctId.objects.filter(distinct_id__in=sorted(distinct_ids), team=team)
         .select_related("person")
         .prefetch_related(Prefetch("person__persondistinctid_set", to_attr="distinct_ids_cache"))
     )

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -345,8 +345,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
-                                                     '2')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -569,9 +569,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
                                                      '3',
-                                                     '2')
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -345,8 +345,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
-                                                     '1')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -378,8 +378,8 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user')
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
+                                                      'user2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---
@@ -569,9 +569,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
                                                      '3',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -614,9 +614,9 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user3',
-                                                      'user')
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
+                                                      'user2',
+                                                      'user3')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -345,8 +345,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
-                                                     '1')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -569,9 +569,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
                                                      '3',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -399,7 +399,9 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             f"/api/projects/{self.team.id}/session_recordings/{chunked_session_id}/snapshots?blob_loading_enabled=true"
         )
         response_data = response.json()
+
         assert response_data == {"snapshot_data_by_window_id": [], "next": None, "blob_keys": blob_objects}
+        mock_list_objects.assert_called_with(f"session_recordings/team_id/{self.team.pk}/session_id/chunk_id/data/")
 
     @patch("posthog.api.session_recording.SessionRecording.get_or_build")
     @patch("posthog.api.session_recording.object_storage.get_presigned_url")


### PR DESCRIPTION
## Problem

follow-up to #15328 

## Changes

* check if a session exists for a given ID when requesting files from blob store
* enforce that the loaded blob prefix includes the data directory _in case_ we ever start storing other things in the same prefix
* sort some lists of things used in queries to stop the snapshot tests flapping because their order isn't guaranteed

## How did you test this code?

developer tests and 👀 