### PR TITLE
fix(dashboards): only refresh two dashboard items at a time

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1028,14 +1028,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 }
             })
 
-            // run 4 item reloaders in parallel
             function loadNextPromise(): void {
                 if (!cancelled && fetchItemFunctions.length > 0) {
                     fetchItemFunctions.shift()?.().then(loadNextPromise)
                 }
             }
 
-            for (let i = 0; i < 4; i++) {
+            // run 2 item reloaders in parallel
+            for (let i = 0; i < 2; i++) {
                 void loadNextPromise()
             }
 


### PR DESCRIPTION
we're getting hammered sometimes when people refresh dashboards with heavy insights, let's load fewer items in parallel