### PR TITLE
refactor(cleanup): remove unused clickhouse person serializer

### DIFF
--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -10,7 +10,6 @@ from django.db.models.query import QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils.timezone import now
-from rest_framework import serializers
 
 from posthog.client import sync_execute
 from posthog.kafka_client.client import ClickhouseProducer
@@ -213,37 +212,3 @@ def _delete_ch_distinct_id(team_id: int, uuid: UUID, distinct_id: str, version: 
         is_deleted=True,
         sync=sync,
     )
-
-
-class ClickhousePersonSerializer(serializers.Serializer):
-    id = serializers.SerializerMethodField()
-    created_at = serializers.SerializerMethodField()
-    team_id = serializers.SerializerMethodField()
-    properties = serializers.SerializerMethodField()
-    is_identified = serializers.SerializerMethodField()
-    name = serializers.SerializerMethodField()
-    distinct_ids = serializers.SerializerMethodField()
-
-    def get_name(self, person):
-        props = json.loads(person[3])
-        email = props.get("email", None)
-        return email or person[0]
-
-    def get_id(self, person):
-        return person[0]
-
-    def get_created_at(self, person):
-        return person[1]
-
-    def get_team_id(self, person):
-        return person[2]
-
-    def get_properties(self, person):
-        return json.loads(person[3])
-
-    def get_is_identified(self, person):
-        return person[4]
-
-    # all queries might not retrieve distinct_ids
-    def get_distinct_ids(self, person):
-        return person[5] if len(person) > 5 else []


### PR DESCRIPTION
## Problem

While working on this https://github.com/PostHog/posthog/pull/15315 I ran into the seemingly unused `ClickhousePersonSerializer` serializer.

## Changes

This PR removes said serializer.

## How did you test this code?

Verified tests still run. Could we be importing this serializer from another codebase?