### PR TITLE
fix(insights): Add JWT auth back to InsightViewSet

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -13,6 +13,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse
 from rest_framework import request, serializers, status, viewsets
+from rest_framework.authentication import BaseAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.parsers import JSONParser
@@ -558,6 +559,11 @@ class InsightViewSet(
         ):
             return InsightBasicSerializer
         return super().get_serializer_class()
+
+    def get_authenticators(self) -> List[BaseAuthentication]:
+        authenticators = super().get_authenticators()
+        authenticators.append(SharingAccessTokenAuthentication())
+        return authenticators
 
     def get_serializer_context(self) -> Dict[str, Any]:
         context = super().get_serializer_context()

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -12,7 +12,7 @@ from django.utils.timezone import now
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse
-from rest_framework import request, serializers, status, viewsets, authentication
+from rest_framework import request, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.parsers import JSONParser
@@ -36,7 +36,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.api.utils import format_paginated_url
-from posthog.auth import PersonalAPIKeyAuthentication, SharingAccessTokenAuthentication
+from posthog.auth import SharingAccessTokenAuthentication
 from posthog.caching.fetch_from_cache import InsightResult, fetch_cached_insight_result, synchronously_update_cache
 from posthog.caching.insights_api import should_refresh_insight
 from posthog.client import sync_execute
@@ -536,12 +536,6 @@ class InsightViewSet(
         IsAuthenticated,
         ProjectMembershipNecessaryPermissions,
         TeamMemberAccessPermission,
-    ]
-    authentication_classes = [
-        PersonalAPIKeyAuthentication,
-        authentication.BasicAuthentication,
-        authentication.SessionAuthentication,
-        SharingAccessTokenAuthentication,
     ]
     throttle_classes = [
         ClickHouseBurstRateThrottle,

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -8,7 +8,7 @@ from rest_framework_extensions.routers import ExtendedDefaultRouter
 from rest_framework_extensions.settings import extensions_api_settings
 
 from posthog.api.utils import get_token
-from posthog.auth import JwtAuthentication, PersonalAPIKeyAuthentication
+from posthog.auth import JwtAuthentication, PersonalAPIKeyAuthentication, SharingAccessTokenAuthentication
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -44,6 +44,7 @@ class StructuredViewSetMixin(_GenericViewSet):
         PersonalAPIKeyAuthentication,
         authentication.SessionAuthentication,
         authentication.BasicAuthentication,
+        SharingAccessTokenAuthentication,
     ]
 
     def get_queryset(self):

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -8,7 +8,7 @@ from rest_framework_extensions.routers import ExtendedDefaultRouter
 from rest_framework_extensions.settings import extensions_api_settings
 
 from posthog.api.utils import get_token
-from posthog.auth import JwtAuthentication, PersonalAPIKeyAuthentication, SharingAccessTokenAuthentication
+from posthog.auth import JwtAuthentication, PersonalAPIKeyAuthentication
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -44,7 +44,6 @@ class StructuredViewSetMixin(_GenericViewSet):
         PersonalAPIKeyAuthentication,
         authentication.SessionAuthentication,
         authentication.BasicAuthentication,
-        SharingAccessTokenAuthentication,
     ]
 
     def get_queryset(self):


### PR DESCRIPTION
## Problem

Exports are currently broken because of JWT auth missing from Insights view.
This regression was introduced in https://github.com/PostHog/posthog/pull/15153.

## Changes

Just use StructuredViewSetMixin auth classes _extended_ with `SharingAccessTokenAuthentication`.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
