### PR TITLE
fix(breakdowns): display tags for breakdowns without type

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -37,6 +37,7 @@ export function TaxonomicBreakdownFilter({
     }
 
     const hasSelectedBreakdown = breakdown && typeof breakdown === 'string'
+    const hasSingleOrMultiBreakdown = hasSelectedBreakdown || (breakdowns || []).length > 0
 
     const breakdownArray = useMultiBreakdown
         ? (breakdowns || []).map((b) => b.property)
@@ -89,7 +90,7 @@ export function TaxonomicBreakdownFilter({
           }
         : undefined
 
-    const tags = !breakdown_type
+    const tags = !hasSingleOrMultiBreakdown
         ? []
         : breakdownArray.map((t, index) => {
               const key = `${t}-${index}`


### PR DESCRIPTION
## Problem

The breakdown tag is not displayed for the autogenerated insights for feature flag volume, see e.g. [here](http://localhost:8000/insights/xuTEao2y/edit).

## Changes

It seems we're defaulting to "event" for the breakdown type on the backend. Thus this PR bases the condition wether we should display breakdown tags on the `breakdown` and `breakdowns` property.

It is not apparent to me, why we would not simply loop over the `breakdownArray` and need the additional check, so this might very well be wrong.

## How did you test this code?

Tried different combinations of breakdowns, including the faulty one for feature flag volume.