### PR TITLE
fix: Set the posthog uid/gid to be hard-coded

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -158,8 +158,8 @@ RUN apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Install and use a non-root user.
-RUN groupadd posthog && \
-    useradd -r -g posthog posthog && \
+RUN groupadd -g 1000 posthog && \
+    useradd -u 999 -r -g posthog posthog && \
     chown posthog:posthog /code
 USER posthog
 


### PR DESCRIPTION
## Problem

Currently the uid and gid are 999/1000 respectively, but this could potentially change when updating the base image, so hard-code these so that we can rely on these not changing and breaking volume ownership

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
