### PR TITLE
revert: "chore: Revert Cohort matching with property overrides"

### DIFF
--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -262,6 +262,7 @@ class FeatureFlagMatcher:
     def query_conditions(self) -> Dict[str, bool]:
         try:
             with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS):
+                all_conditions = {}
                 team_id = self.feature_flags[0].team_id
                 person_query: QuerySet = Person.objects.filter(
                     team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id
@@ -298,6 +299,11 @@ class FeatureFlagMatcher:
                                 override_property_values=target_properties,
                             )
 
+                            # TRICKY: Due to property overrides, we sometimes shortcircuit the condition check.
+                            # In that case, the expression is empty, and we can assume the condition is a match.
+                            if not expr:
+                                all_conditions[key] = True
+
                         if feature_flag.aggregation_group_type_index is None:
                             person_query = person_query.annotate(
                                 **{
@@ -327,7 +333,6 @@ class FeatureFlagMatcher:
                                 group_fields,
                             )
 
-                all_conditions = {}
                 if len(person_fields) > 0:
                     person_query = person_query.values(*person_fields)
                     if len(person_query) > 0:


### PR DESCRIPTION
Reverts PostHog/posthog#15357

False alarm, this wasn't the problem.