### PR TITLE
fix(data-exploration): fix funnel interval

### DIFF
--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -4,11 +4,11 @@ import { IntervalType } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { LemonSelect } from '@posthog/lemon-ui'
 
-interface InvertalFilterProps {
+interface IntervalFilterProps {
     disabled?: boolean
 }
 
-export function IntervalFilter({ disabled }: InvertalFilterProps): JSX.Element {
+export function IntervalFilter({ disabled }: IntervalFilterProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { interval, enabledIntervals } = useValues(intervalFilterLogic(insightProps))
     const { setInterval } = useActions(intervalFilterLogic(insightProps))

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -72,7 +72,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
                 enabledIntervals.hour = {
                     ...enabledIntervals.hour,
                     disabledReason:
-                        'Grouping by hour is not supported on insights with weekly or monthly active users series.',
+                        'Grouping by hour is not supported on insights with weekly or monthly active users series.',
                 }
 
                 // Disallow grouping by month for WAUs as the resulting view is misleading to users
@@ -80,7 +80,7 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
                     enabledIntervals.month = {
                         ...enabledIntervals.month,
                         disabledReason:
-                            'Grouping by month is not supported on insights with weekly active users series.',
+                            'Grouping by month is not supported on insights with weekly active users series.',
                     }
                 }
             }
@@ -93,12 +93,12 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
             if (activeUsersMath && values.interval && enabledIntervals[values.interval].disabledReason) {
                 if (values.interval === 'hour') {
                     lemonToast.info(
-                        `Switched to grouping by day, because "${BASE_MATH_DEFINITIONS[activeUsersMath].name}" does not support grouping by ${values.interval}.`
+                        `Switched to grouping by day, because "${BASE_MATH_DEFINITIONS[activeUsersMath].name}" does not support grouping by ${values.interval}.`
                     )
                     actions.setInterval('day')
                 } else {
                     lemonToast.info(
-                        `Switched to grouping by week, because "${BASE_MATH_DEFINITIONS[activeUsersMath].name}" does not support grouping by ${values.interval}.`
+                        `Switched to grouping by week, because "${BASE_MATH_DEFINITIONS[activeUsersMath].name}" does not support grouping by ${values.interval}.`
                     )
                     actions.setInterval('week')
                 }

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -114,7 +114,7 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         Object.assign(filters, objectClean<Partial<Record<keyof BreakdownFilter, unknown>>>(query.breakdown))
     }
 
-    if (isTrendsQuery(query) || isStickinessQuery(query) || isLifecycleQuery(query)) {
+    if (isTrendsQuery(query) || isStickinessQuery(query) || isLifecycleQuery(query) || isFunnelsQuery(query)) {
         filters.interval = query.interval
     }
 


### PR DESCRIPTION
## Problem

The funnel interval picker does not work i.e. changing to week, month etc. still gives you daily data

## Changes

This PR:
- fixes the funnel interval filter by allowing funnels to have an interval in the query to filter conversion function
- cleans up adjacent code by removing non-standard whitespace characters and fixing a typo


## How did you test this code?

Verified that the funnel interval picker triggers a change in the query