### PR TITLE
fix(flags): add breakdown_type to the dashboard template for feature flags

### DIFF
--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -519,6 +519,7 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
                 ],
             },
             BREAKDOWN: "$feature_flag_response",
+            BREAKDOWN_TYPE: "event",
             FILTER_TEST_ACCOUNTS: False,
         },
         layouts={
@@ -566,6 +567,7 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
                 ],
             },
             BREAKDOWN: "$feature_flag_response",
+            BREAKDOWN_TYPE: "event",
             FILTER_TEST_ACCOUNTS: False,
         },
         layouts={


### PR DESCRIPTION
## Problem

The feature flag volume insights show a blank line under the breakdown filter.

<img width="239" alt="Screenshot_2023-05-03_at_20_35_35" src="https://user-images.githubusercontent.com/1851359/236011906-50e39cb1-9bc5-4284-ac70-5453ea519221.png">

## Changes

Seems we require the `breakdown_type` property on the frontend for breakdowns (whereas we default to events on the backend). I had a quick look and it seems this template and some breakdowns by `$browser` are mainly affected. Only this template is affecting new insights.

<img width="489" alt="Screenshot 2023-05-03 at 17 18 15" src="https://user-images.githubusercontent.com/1851359/236011287-1b6e8789-6f96-4e90-9651-aeb8e6f30f39.png">

http://metabase-prod-us/question/77-insights-with-broken-breakdown-type-by-breakdown (let me know if the link isn't working)

**This PR fixes the template by adding the `breakdown_type` property.**

## How did you test this code?

Created a new dashboard and saw that the breakdown tag now appears