### PR TITLE
fix: support included addons that have no price info

### DIFF
--- a/frontend/src/scenes/billing/test/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/test/BillingProduct.tsx
@@ -216,16 +216,16 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
         ?.map((tier, i) => {
             const addonPricesForTier = product.addons?.map((addon) => ({
                 [`${addon.type}-price`]: `${
-                    addon.tiers?.[i].unit_amount_usd !== '0' ? '$' + addon.tiers?.[i].unit_amount_usd : 'Free'
+                    addon.tiers?.[i]?.unit_amount_usd !== '0' ? '$' + addon.tiers?.[i]?.unit_amount_usd : 'Free'
                 }`,
             }))
             // take the tier.current_amount_usd and add it to the same tier level for all the addons
             const totalForTier =
                 parseFloat(tier.current_amount_usd || '') +
-                product.addons?.reduce((acc, addon) => acc + parseFloat(addon.tiers?.[i].current_amount_usd || ''), 0)
+                product.addons?.reduce((acc, addon) => acc + parseFloat(addon.tiers?.[i]?.current_amount_usd || ''), 0)
             const projectedTotalForTier =
                 (tier.projected_amount_usd || 0) +
-                product.addons?.reduce((acc, addon) => acc + (addon.tiers?.[i].projected_amount_usd || 0), 0)
+                product.addons?.reduce((acc, addon) => acc + (addon.tiers?.[i]?.projected_amount_usd || 0), 0)
 
             const tierData = {
                 volume: getTierDescription(tier, i, product, billing?.billing_period?.interval || ''),


### PR DESCRIPTION
## Problem

Will be changing the billing service so that if an addon is included with the main product (eg pricing is not separate) then it will be correctly reported in the API. But making this work properly broke some things on the frontend, so this is the fix.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

UI now tolerates addons with no pricing/tier info.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
