### PR TITLE
feat: with activity milliseconds

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -61,6 +61,7 @@ jobs:
                   export RELEASE_NAME=posthog
                   export NAMESPACE=pr-$PR_NUM-${BRANCH_NAME//\//-}
                   export NAMESPACE=${NAMESPACE:0:38}
+                  export NAMESPACE=${NAMESPACE%%-}
                   export HOSTNAME=$NAMESPACE
                   export TAILNET_NAME=hedgehog-kitefin
                   export TS_AUTHKEY=${{ secrets.TAILSCALE_SERVICE_AUTHKEY }}

--- a/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
@@ -2,6 +2,14 @@ import { EventType, IncrementalSource, eventWithTime } from '@rrweb/types'
 import { Dayjs } from 'lib/dayjs'
 import { RecordingSegment, RecordingSnapshot } from '~/types'
 
+/**
+ * This file is copied into the plugin server to calculate activeMilliseconds on ingestion
+ * plugin-server/src/main/ingestion-queues/session-recording/snapshot-segmenter.ts
+ *
+ * Changes here should be reflected there
+ * TODO add code sharing between plugin-server and front-end so that this duplication is unnecessary
+ */
+
 const activeSources = [
     IncrementalSource.MouseMove,
     IncrementalSource.MouseInteraction,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -121,7 +121,8 @@ export function getDefaultConfig(): PluginsServerConfig {
             : 1024 * 50, // ~50MB after compression in prod
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
 
-        // NB set to all so that this feature is enabled in the PR deploy
+        // NB set to all so that this feature is enabled
+        // in the PR deploy
         SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS: 'all', // TODO: Change this to 'all' when we release it fully
     }
 }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -121,7 +121,8 @@ export function getDefaultConfig(): PluginsServerConfig {
             : 1024 * 50, // ~50MB after compression in prod
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
 
-        // NB set to all so that this feature is enabled
+        // NB set to all so that
+        // this feature is enabled
         // in the PR deploy
         SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS: 'all', // TODO: Change this to 'all' when we release it fully
     }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -121,7 +121,8 @@ export function getDefaultConfig(): PluginsServerConfig {
             : 1024 * 50, // ~50MB after compression in prod
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
 
-        SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS: '', // TODO: Change this to 'all' when we release it fully
+        // NB set to all so that this feature is enabled in the PR deploy
+        SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS: 'all', // TODO: Change this to 'all' when we release it fully
     }
 }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/snapshot-segmenter.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/snapshot-segmenter.ts
@@ -1,0 +1,133 @@
+/**
+ * This file is a cut-down version of the segmenter.ts
+ * https://github.com/PostHog/posthog/blob/db2deaf650d2eca9addba5e3f304a17a21041f25/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
+ *
+ * It has been modified to not need the same dependencies
+ * Any changes may need to be sync'd between the two
+ */
+
+const activeSources = [1, 2, 3, 4, 5, 6, 7, 12]
+
+const ACTIVITY_THRESHOLD_MS = 5000
+
+export interface RRWebEventSummaryData {
+    href?: string
+    source?: number
+    payload?: Record<string, any>
+}
+
+export interface RRWebEventSummary {
+    timestamp: number
+    type: number
+    data: RRWebEventSummaryData
+    windowId: string
+}
+
+interface RecordingSegment {
+    kind: 'window' | 'buffer' | 'gap'
+    startTimestamp: number // Epoch time that the segment starts
+    endTimestamp: number // Epoch time that the segment ends
+    durationMs: number
+    windowId?: string
+    isActive: boolean
+}
+
+const isActiveEvent = (event: RRWebEventSummary): boolean => {
+    return event.type === 3 && activeSources.includes(event.data?.source || -1)
+}
+
+const createSegments = (snapshots: RRWebEventSummary[]): RecordingSegment[] => {
+    let segments: RecordingSegment[] = []
+    let activeSegment!: Partial<RecordingSegment>
+    let lastActiveEventTimestamp = 0
+
+    snapshots.forEach((snapshot) => {
+        const eventIsActive = isActiveEvent(snapshot)
+        lastActiveEventTimestamp = eventIsActive ? snapshot.timestamp : lastActiveEventTimestamp
+
+        // When do we create a new segment?
+        // 1. If we don't have one yet
+        let isNewSegment = !activeSegment
+
+        // 2. If it is currently inactive but a new "active" event comes in
+        if (eventIsActive && !activeSegment?.isActive) {
+            isNewSegment = true
+        }
+
+        // 3. If it is currently active but no new active event has been seen for the activity threshold
+        if (activeSegment?.isActive && lastActiveEventTimestamp + ACTIVITY_THRESHOLD_MS < snapshot.timestamp) {
+            isNewSegment = true
+        }
+
+        // 4. If windowId changes we create a new segment
+        if (activeSegment?.windowId !== snapshot.windowId) {
+            isNewSegment = true
+        }
+
+        if (isNewSegment) {
+            if (activeSegment) {
+                segments.push(activeSegment as RecordingSegment)
+            }
+
+            activeSegment = {
+                kind: 'window',
+                startTimestamp: snapshot.timestamp,
+                windowId: snapshot.windowId,
+                isActive: eventIsActive,
+            }
+        }
+
+        activeSegment.endTimestamp = snapshot.timestamp
+    })
+
+    if (activeSegment) {
+        segments.push(activeSegment as RecordingSegment)
+    }
+
+    segments = segments.reduce((acc, segment, index) => {
+        const previousSegment = segments[index - 1]
+        const list = [...acc]
+
+        if (previousSegment && segment.startTimestamp - previousSegment.endTimestamp > 1) {
+            const startTimestamp = previousSegment.endTimestamp + 1
+            const endTimestamp = segment.startTimestamp - 1
+            const gapSegment: Partial<RecordingSegment> = {
+                kind: 'gap',
+                startTimestamp,
+                endTimestamp,
+                isActive: false,
+            }
+
+            list.push(gapSegment as RecordingSegment)
+        }
+
+        list.push(segment)
+
+        return list
+    }, [] as RecordingSegment[])
+
+    segments = segments.map((segment) => {
+        // These can all be done in a loop at the end...
+        segment.durationMs = segment.endTimestamp - segment.startTimestamp
+        return segment
+    })
+
+    return segments
+}
+
+/**
+ * TODO add code sharing between plugin-server and front-end so that this method can
+ * call the same createSegments function as the front-end
+ */
+export const activeMilliseconds = (snapshots: RRWebEventSummary[]): number => {
+    const segments = createSegments(snapshots)
+    return segments.reduce((acc, segment) => {
+        if (segment.isActive) {
+            // if the segment is active but has no duration we count it as 1ms
+            // to distinguish it from segments with no activity at all
+            return acc + Math.max(1, segment.durationMs)
+        }
+
+        return acc
+    }, 0)
+}

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -3,6 +3,7 @@ import { PluginEvent, Properties } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import { DateTime } from 'luxon'
 
+import { activeMilliseconds, RRWebEventSummary } from '../../main/ingestion-queues/session-recording/snapshot-segmenter'
 import {
     Element,
     GroupTypeIndex,
@@ -290,18 +291,7 @@ export interface SummarizedSessionRecordingEvent {
     click_count: number
     keypress_count: number
     mouse_activity_count: number
-}
-
-interface RRWebEventSummaryData {
-    href?: string
-    source?: number
-    payload?: Record<string, any>
-}
-
-export interface RRWebEventSummary {
-    timestamp: number
-    type: number
-    data: RRWebEventSummaryData
+    active_milliseconds: number
 }
 
 export const createSessionReplayEvent = (
@@ -345,6 +335,8 @@ export const createSessionReplayEvent = (
         }
     })
 
+    const activeTime = activeMilliseconds(eventsSummaries)
+
     const data: SummarizedSessionRecordingEvent = {
         uuid,
         team_id: team_id,
@@ -356,6 +348,7 @@ export const createSessionReplayEvent = (
         keypress_count: keypressCount,
         mouse_activity_count: mouseActivity,
         first_url: url,
+        active_milliseconds: activeTime,
     }
 
     return data

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -331,7 +331,8 @@
       first_url Nullable(VARCHAR),
       click_count Int64,
       keypress_count Int64,
-      mouse_activity_count Int64
+      mouse_activity_count Int64,
+      active_milliseconds Int64
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '
@@ -911,7 +912,8 @@
       first_url Nullable(VARCHAR),
       click_count Int64,
       keypress_count Int64,
-      mouse_activity_count Int64
+      mouse_activity_count Int64,
+      active_milliseconds Int64
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '
@@ -1322,7 +1324,8 @@
       first_url Nullable(VARCHAR),
       click_count SimpleAggregateFunction(sum, Int64),
       keypress_count SimpleAggregateFunction(sum, Int64),
-      mouse_activity_count SimpleAggregateFunction(sum, Int64)
+      mouse_activity_count SimpleAggregateFunction(sum, Int64),
+      active_milliseconds SimpleAggregateFunction(sum, Int64)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '
@@ -1341,7 +1344,8 @@
   any(first_url) AS first_url,
   sum(click_count) as click_count,
   sum(keypress_count) as keypress_count,
-  sum(mouse_activity_count) as mouse_activity_count
+  sum(mouse_activity_count) as mouse_activity_count,
+  sum(active_milliseconds) as active_milliseconds
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
   
@@ -1562,7 +1566,8 @@
       first_url Nullable(VARCHAR),
       click_count SimpleAggregateFunction(sum, Int64),
       keypress_count SimpleAggregateFunction(sum, Int64),
-      mouse_activity_count SimpleAggregateFunction(sum, Int64)
+      mouse_activity_count SimpleAggregateFunction(sum, Int64),
+      active_milliseconds SimpleAggregateFunction(sum, Int64)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(first_timestamp)
@@ -2160,7 +2165,8 @@
       first_url Nullable(VARCHAR),
       click_count SimpleAggregateFunction(sum, Int64),
       keypress_count SimpleAggregateFunction(sum, Int64),
-      mouse_activity_count SimpleAggregateFunction(sum, Int64)
+      mouse_activity_count SimpleAggregateFunction(sum, Int64),
+      active_milliseconds SimpleAggregateFunction(sum, Int64)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(first_timestamp)

--- a/posthog/models/session_replay_event/sql.py
+++ b/posthog/models/session_replay_event/sql.py
@@ -107,7 +107,7 @@ DROP_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: (
     f"DROP TABLE IF EXISTS {SESSION_REPLAY_EVENTS_DATA_TABLE()} ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'"
 )
 
-SELECT_ALL_SUMMARIZED_SESSIONS = """
+SELECT_SUMMARIZED_SESSIONS = """
 select
    session_id,
    any(team_id),
@@ -118,7 +118,11 @@ select
    sum(click_count),
    sum(keypress_count),
    sum(mouse_activity_count),
-   sum(active_milliseconds)
+   round((sum(active_milliseconds)/1000)/duration, 2) as active_time
 from session_replay_events
+prewhere team_id = %(team_id)s
+and first_timestamp >= %(start_time)s
+and last_timestamp <= %(end_time)s
+and session_id in (%(session_ids)s)
 group by session_id
 """

--- a/posthog/models/session_replay_event/sql.py
+++ b/posthog/models/session_replay_event/sql.py
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     first_url Nullable(VARCHAR),
     click_count Int64,
     keypress_count Int64,
-    mouse_activity_count Int64
+    mouse_activity_count Int64,
+    active_milliseconds Int64
 ) ENGINE = {engine}
 """
 
@@ -33,7 +34,8 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     first_url Nullable(VARCHAR),
     click_count SimpleAggregateFunction(sum, Int64),
     keypress_count SimpleAggregateFunction(sum, Int64),
-    mouse_activity_count SimpleAggregateFunction(sum, Int64)
+    mouse_activity_count SimpleAggregateFunction(sum, Int64),
+    active_milliseconds SimpleAggregateFunction(sum, Int64)
 ) ENGINE = {engine}
 """
 
@@ -73,7 +75,8 @@ max(last_timestamp) AS last_timestamp,
 any(first_url) AS first_url,
 sum(click_count) as click_count,
 sum(keypress_count) as keypress_count,
-sum(mouse_activity_count) as mouse_activity_count
+sum(mouse_activity_count) as mouse_activity_count,
+sum(active_milliseconds) as active_milliseconds
 FROM {database}.kafka_session_replay_events
 group by session_id, team_id
 """.format(
@@ -114,7 +117,8 @@ select
    dateDiff('SECOND', min(first_timestamp), max(last_timestamp)) as duration,
    sum(click_count),
    sum(keypress_count),
-   sum(mouse_activity_count)
+   sum(mouse_activity_count),
+   sum(active_milliseconds)
 from session_replay_events
 group by session_id
 """


### PR DESCRIPTION
## Problem

stacked on top of #15245 

mostly so I can get a fresh deployment to test changed migration

## Changes

* adds active milliseconds to the summary table
* and slightly kludgy code sharing to achieve that

## How did you test this code?

developer tests and 👀 
