### PR TITLE
fix(data-exploration): fix breakdown filter merging

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1144,13 +1144,13 @@
         "BreakdownFilter": {
             "additionalProperties": false,
             "properties": {
-                "aggregation_group_type_index": {
-                    "type": "number"
-                },
                 "breakdown": {
                     "$ref": "#/definitions/BreakdownKeyType"
                 },
                 "breakdown_group_type_index": {
+                    "type": ["number", "null"]
+                },
+                "breakdown_histogram_bin_count": {
                     "type": ["number", "null"]
                 },
                 "breakdown_normalize_url": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -499,7 +499,7 @@ export interface BreakdownFilter {
     breakdowns?: Breakdown[]
     breakdown_value?: string | number
     breakdown_group_type_index?: number | null
-    aggregation_group_type_index?: number | undefined // Groups aggregation
+    breakdown_histogram_bin_count?: number | null
 }
 
 /** Pass custom metadata to queries. Used for e.g. custom columns in the DataTable. */

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -11,6 +11,7 @@ import {
     InsightVizNode,
     Node,
     NodeKind,
+    TrendsQuery,
 } from '~/queries/schema'
 
 import { insightLogic } from './insightLogic'
@@ -182,7 +183,10 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                 ? values.querySource
                 : queryFromKind(NodeKind.TrendsQuery, values.filterTestAccountsDefault).source
             if (isInsightQueryNode(localQuerySource)) {
-                const newQuerySource = { ...localQuerySource, breakdown }
+                const newQuerySource = {
+                    ...localQuerySource,
+                    breakdown: { ...(localQuerySource as TrendsQuery).breakdown, ...breakdown },
+                }
                 actions.updateQuerySource(newQuerySource)
             }
         },

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -478,9 +478,9 @@ class BreakdownFilter(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    aggregation_group_type_index: Optional[float] = None
     breakdown: Optional[Union[str, float, List[Union[str, float]]]] = None
     breakdown_group_type_index: Optional[float] = None
+    breakdown_histogram_bin_count: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
     breakdown_value: Optional[Union[str, float]] = None


### PR DESCRIPTION
## Problem

The breakdown filter doesn't return a full "breakdown object" in all cases and needs merging with the previous breakdown filter. This leads to issues like this https://posthog.slack.com/archives/C045L1VEG87/p1683135350902819:

> When I have an insight broken down by numeric values, and I try to check "Do not bin numeric values", the entire breakdown is removed :/

## Changes

This PR merges the new breakdown filter with the existing one.

Saw that some edge cases are still not handled properly e.g. removing the country code breakdown should move the user away from map display. At the moment we're treating the breakdown filter as a black box for data exploration and I'm going to follow up with a full conversion of the filter.

## How did you test this code?

Verified that setting options for a numeric breakdown work as expected.