### PR TITLE
feat: add rate leaky bucket rate limiter to CH client

### DIFF
--- a/posthog/clickhouse/client/rate_limiter.py
+++ b/posthog/clickhouse/client/rate_limiter.py
@@ -1,0 +1,52 @@
+from datetime import timedelta
+
+import redis
+
+from posthog import redis as pr
+
+
+class RateLimiter:
+    def __init__(self, redis: redis.Redis, default_ttl: int = 60 * 60 * 24, lock_timeout: int = 5):
+        if redis is None:
+            self.redis = pr.get_client()
+        else:
+            self.redis = redis
+        self.DEFAULT_TTL = default_ttl
+        self.REDIS_RATE_LIMITER_LOCK_TIMEOUT = lock_timeout
+
+    def _get_redis_time_now(self) -> float:
+        return float(self.redis.time()[0])
+
+    def request_is_limited(self, key: str, limit: int, period: timedelta) -> bool:
+        """
+        Returns whether a request should be allowed
+
+        This implementation is modified from https://dev.to/astagi/rate-limiting-using-python-and-redis-58gk
+
+        1. uses higher precision floats instead of ints
+        2. returns true for allowing instead of returning true for rejecting
+
+        This rate limiter follows the GCRA algorithm. Resources:
+        - https://smarketshq.com/implementing-gcra-in-python-5df1f11aaa96
+        - https://brandur.org/rate-limiting
+        - https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm
+        """
+
+        period_in_seconds = int(period.total_seconds())
+        now = self._get_redis_time_now()
+
+        separation = period_in_seconds / limit
+        self.redis.setnx(key, 0)
+        try:
+            with self.redis.lock(
+                "rate_limiter_lock:" + key,
+                blocking_timeout=self.REDIS_RATE_LIMITER_LOCK_TIMEOUT,
+            ):
+                tat = max(float(self.redis.get(key) or now), now)
+                if tat - now <= period_in_seconds - separation:
+                    new_tat = max(tat, now) + separation
+                    self.redis.set(name=key, value=new_tat, ex=self.DEFAULT_TTL)
+                    return True
+                return False
+        except redis.LockError:
+            return False

--- a/posthog/clickhouse/client/test/test_rate_limiter.py
+++ b/posthog/clickhouse/client/test/test_rate_limiter.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+from typing import Tuple
+from uuid import uuid4
+
+from freezegun import freeze_time
+
+from posthog.clickhouse.client.rate_limiter import RateLimiter
+
+
+def simulate_requests(rl: RateLimiter, requests: int, key: str) -> Tuple[int, int]:
+    limit = 10
+    period = timedelta(minutes=1)
+
+    good_calls = 0
+    bad_calls = 0
+
+    for _ in range(requests):
+        if rl.request_is_limited(key, limit, period):
+            bad_calls += 1
+        else:
+            good_calls += 1
+    return (good_calls, bad_calls)
+
+
+def test_basic_rate_limiting():
+    rl = RateLimiter()
+    key = str(uuid4())
+    good_calls, bad_calls = simulate_requests(rl, 20, key)
+    assert bad_calls == 10
+    assert good_calls == 10
+
+
+def test_rate_limiting_recovers():
+    rl = RateLimiter()
+    key = str(uuid4())
+
+    with freeze_time("2012-01-14 12:00:01"):
+        good_calls, bad_calls = simulate_requests(rl, 20, key)
+        assert bad_calls == 10
+        assert good_calls == 10
+
+    with freeze_time("2012-01-14 12:00:01"):
+        good_calls, bad_calls = simulate_requests(rl, 20, key)
+        assert bad_calls == 20
+        assert good_calls == 0
+
+    with freeze_time("2012-01-14 12:00:31"):
+        good_calls, bad_calls = simulate_requests(rl, 20, key)
+        assert bad_calls == 15
+        assert good_calls == 5
+
+    with freeze_time("2012-01-14 12:01:31"):
+        good_calls, bad_calls = simulate_requests(rl, 20, key)
+        assert bad_calls == 10
+        assert good_calls == 10


### PR DESCRIPTION
## Problem

Adding a rate limiter that will be used to limit the number of queries that a team can send to clickhouse.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
