### PR TITLE
chore(insights): remove multi property breakdown code

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -1,6 +1,4 @@
 import { useValues } from 'kea'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { allOperatorsMapping, alphabet, capitalizeFirstLetter, formatPropertyLabel } from 'lib/utils'
 import { LocalFilter, toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
@@ -26,7 +24,7 @@ import { TZLabel } from '../../TZLabel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import React from 'react'
-import { isFunnelsFilter, isPathsFilter, isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { isPathsFilter, isTrendsFilter } from 'scenes/insights/sharedUtils'
 import {
     isAnyPropertyfilter,
     isCohortPropertyFilter,
@@ -285,16 +283,10 @@ export function FiltersSummary({ filters }: { filters: Partial<FilterType> }): J
 }
 
 export function BreakdownSummary({ filters }: { filters: Partial<FilterType> }): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
     return (
         <div>
             <h5>Breakdown by</h5>
-            <TaxonomicBreakdownFilter
-                filters={filters}
-                useMultiBreakdown={
-                    isFunnelsFilter(filters) && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]
-                }
-            />
+            <TaxonomicBreakdownFilter filters={filters} />
         </div>
     )
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -111,7 +111,6 @@ export const FEATURE_FLAGS = {
     // Cloud-only
     CLOUD_ANNOUNCEMENT: 'cloud-announcement',
     // Experiments / beta features
-    BREAKDOWN_BY_MULTIPLE_PROPERTIES: '938-breakdown-by-multiple-properties', // owner: @pauldambra
     FUNNELS_CUE_OPT_OUT: 'funnels-cue-opt-out-7301', // owner: @neilkakkar
     RETENTION_BREAKDOWN: 'retention-breakdown', // owner: @hazzadous
     WEB_PERFORMANCE: 'hackathon-apm', //owner: @pauldambra

--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -1,23 +1,17 @@
-import { useValues, useActions } from 'kea'
+import { useActions } from 'kea'
 import { QueryEditorFilterProps } from '~/types'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { isTrendsQuery } from '~/queries/utils'
 import { queryNodeToFilter } from '../InsightQuery/utils/queryNodeToFilter'
 import { BreakdownFilter as BreakdownFilterType } from '~/queries/schema'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 export function Breakdown({ insightProps, query }: QueryEditorFilterProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
     const { updateBreakdown } = useActions(insightVizDataLogic(insightProps))
-
-    const useMultiBreakdown = !isTrendsQuery(query) && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]
 
     // treat breakdown filter as black box for data exploration for now
     const filters = queryNodeToFilter(query)
     const setFilters = (breakdown: BreakdownFilterType): void => {
         updateBreakdown(breakdown)
     }
-    return <TaxonomicBreakdownFilter filters={filters} setFilters={setFilters} useMultiBreakdown={useMultiBreakdown} />
+    return <TaxonomicBreakdownFilter filters={filters} setFilters={setFilters} />
 }

--- a/frontend/src/scenes/insights/EditorFilters/Breakdown.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/Breakdown.tsx
@@ -1,22 +1,10 @@
-import { useActions, useValues } from 'kea'
-import { EditorFilterProps, InsightType } from '~/types'
+import { useActions } from 'kea'
+import { EditorFilterProps } from '~/types'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function Breakdown({ filters }: EditorFilterProps): JSX.Element {
     const { setFiltersMerge } = useActions(insightLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
-    const useMultiBreakdown =
-        filters.insight !== InsightType.TRENDS && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]
-
-    return (
-        <TaxonomicBreakdownFilter
-            filters={filters}
-            setFilters={setFiltersMerge}
-            useMultiBreakdown={useMultiBreakdown}
-        />
-    )
+    return <TaxonomicBreakdownFilter filters={filters} setFilters={setFiltersMerge} />
 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
@@ -19,192 +19,90 @@ const setFilters = jest.fn()
 const getPropertyDefinition = jest.fn()
 
 describe('taxonomic breakdown filter utils', () => {
-    describe('with multi property breakdown flag on', () => {
-        it('sets breakdowns for events', () => {
-            const onChange = onFilterChange({
-                useMultiBreakdown: true,
-                breakdownParts: ['a', 'b'],
-                setFilters,
-                getPropertyDefinition,
-            })
-            const changedBreakdown = 'c'
-            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties)
-
-            onChange(changedBreakdown, group)
-
-            expect(setFilters).toHaveBeenCalledWith(
-                {
-                    breakdown_type: 'event',
-                    breakdowns: [
-                        { property: 'a', type: 'event', normalize_url: false },
-                        { property: 'b', type: 'event', normalize_url: false },
-                        { property: 'c', type: 'event', normalize_url: false },
-                    ],
-                    breakdown: undefined,
-                    breakdown_group_type_index: undefined,
-                    breakdown_histogram_bin_count: undefined,
-                    breakdown_normalize_url: false,
-                },
-                true
-            )
+    it('sets breakdown for events', () => {
+        const onChange = onFilterChange({
+            breakdownParts: ['a', 'b'],
+            setFilters,
+            getPropertyDefinition,
         })
-
-        it('sets breakdowns for cohorts', () => {
-            const onChange = onFilterChange({
-                useMultiBreakdown: true,
-                breakdownParts: ['all', 1],
-                setFilters,
-                getPropertyDefinition,
-            })
-            const changedBreakdown = 2
-            const group: TaxonomicFilterGroup = taxonomicGroupFor(
-                TaxonomicFilterGroupType.CohortsWithAllUsers,
-                undefined
-            )
-
-            onChange(changedBreakdown, group)
-
-            expect(setFilters).toHaveBeenCalledWith(
-                {
-                    breakdown_type: 'cohort',
-                    breakdowns: [
-                        { property: 'all', type: 'cohort', normalize_url: false },
-                        { property: 1, type: 'cohort', normalize_url: false },
-                        { property: 2, type: 'cohort', normalize_url: false },
-                    ],
-                    breakdown_histogram_bin_count: undefined,
-                    breakdown_normalize_url: false,
-                    breakdown: undefined,
-                    breakdown_group_type_index: undefined,
-                },
-                true
-            )
-        })
-
-        it('sets breakdowns for person properties', () => {
-            const onChange = onFilterChange({
-                useMultiBreakdown: true,
-                breakdownParts: ['country'],
-                setFilters,
-                getPropertyDefinition,
-            })
-            const changedBreakdown = 'height'
-            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
-
-            onChange(changedBreakdown, group)
-
-            expect(setFilters).toHaveBeenCalledWith(
-                {
-                    breakdown: undefined,
-                    breakdown_type: 'person',
-                    breakdowns: [
-                        { property: 'country', type: 'person', normalize_url: false },
-                        { property: 'height', type: 'person', normalize_url: false },
-                    ],
-                    breakdown_group_type_index: undefined,
-                    breakdown_histogram_bin_count: undefined,
-                    breakdown_normalize_url: false,
-                },
-                true
-            )
-        })
-
-        // multi property breakdown not implemented for groups
+        const changedBreakdown = 'c'
+        const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
+        onChange(changedBreakdown, group)
+        expect(setFilters).toHaveBeenCalledWith(
+            {
+                breakdown_type: 'event',
+                breakdown: 'c',
+                breakdowns: undefined,
+                breakdown_group_type_index: undefined,
+                breakdown_histogram_bin_count: undefined,
+                breakdown_normalize_url: false,
+            },
+            true
+        )
     })
 
-    describe('with single property breakdown', () => {
-        it('sets breakdown for events', () => {
-            const onChange = onFilterChange({
-                useMultiBreakdown: false,
-                breakdownParts: ['a', 'b'],
-                setFilters,
-                getPropertyDefinition,
-            })
-            const changedBreakdown = 'c'
-            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
-            onChange(changedBreakdown, group)
-            expect(setFilters).toHaveBeenCalledWith(
-                {
-                    breakdown_type: 'event',
-                    breakdown: 'c',
-                    breakdowns: undefined,
-                    breakdown_group_type_index: undefined,
-                    breakdown_histogram_bin_count: undefined,
-                    breakdown_normalize_url: false,
-                },
-                true
-            )
+    it('sets breakdown for cohorts', () => {
+        const onChange = onFilterChange({
+            breakdownParts: ['all', 1],
+            setFilters,
+            getPropertyDefinition,
         })
+        const changedBreakdown = 2
+        const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.CohortsWithAllUsers, undefined)
+        onChange(changedBreakdown, group)
+        expect(setFilters).toHaveBeenCalledWith(
+            {
+                breakdown_type: 'cohort',
+                breakdown: ['all', 1, 2],
+                breakdowns: undefined,
+                breakdown_group_type_index: undefined,
+                breakdown_normalize_url: false,
+            },
+            true
+        )
+    })
 
-        it('sets breakdown for cohorts', () => {
-            const onChange = onFilterChange({
-                useMultiBreakdown: false,
-                breakdownParts: ['all', 1],
-                setFilters,
-                getPropertyDefinition,
-            })
-            const changedBreakdown = 2
-            const group: TaxonomicFilterGroup = taxonomicGroupFor(
-                TaxonomicFilterGroupType.CohortsWithAllUsers,
-                undefined
-            )
-            onChange(changedBreakdown, group)
-            expect(setFilters).toHaveBeenCalledWith(
-                {
-                    breakdown_type: 'cohort',
-                    breakdown: ['all', 1, 2],
-                    breakdowns: undefined,
-                    breakdown_group_type_index: undefined,
-                    breakdown_normalize_url: false,
-                },
-                true
-            )
+    it('sets breakdown for person properties', () => {
+        const onChange = onFilterChange({
+            breakdownParts: ['country'],
+            setFilters,
+            getPropertyDefinition,
         })
+        const changedBreakdown = 'height'
+        const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
+        onChange(changedBreakdown, group)
+        expect(setFilters).toHaveBeenCalledWith(
+            {
+                breakdown_type: 'person',
+                breakdown: 'height',
+                breakdowns: undefined,
+                breakdown_group_type_index: undefined,
+                breakdown_normalize_url: false,
+            },
+            true
+        )
+    })
 
-        it('sets breakdown for person properties', () => {
-            const onChange = onFilterChange({
-                useMultiBreakdown: false,
-                breakdownParts: ['country'],
-                setFilters,
-                getPropertyDefinition,
-            })
-            const changedBreakdown = 'height'
-            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
-            onChange(changedBreakdown, group)
-            expect(setFilters).toHaveBeenCalledWith(
-                {
-                    breakdown_type: 'person',
-                    breakdown: 'height',
-                    breakdowns: undefined,
-                    breakdown_group_type_index: undefined,
-                    breakdown_normalize_url: false,
-                },
-                true
-            )
+    it('sets breakdowns for group properties', () => {
+        const onChange = onFilterChange({
+            breakdownParts: ['$lib'],
+            setFilters,
+            getPropertyDefinition,
         })
+        const changedBreakdown = '$lib_version'
+        const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.GroupsPrefix, 0)
 
-        it('sets breakdowns for group properties', () => {
-            const onChange = onFilterChange({
-                useMultiBreakdown: false,
-                breakdownParts: ['$lib'],
-                setFilters,
-                getPropertyDefinition,
-            })
-            const changedBreakdown = '$lib_version'
-            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.GroupsPrefix, 0)
+        onChange(changedBreakdown, group)
 
-            onChange(changedBreakdown, group)
-
-            expect(setFilters).toHaveBeenCalledWith(
-                {
-                    breakdown_type: 'group',
-                    breakdowns: undefined,
-                    breakdown: '$lib_version',
-                    breakdown_group_type_index: 0,
-                    breakdown_normalize_url: false,
-                },
-                true
-            )
-        })
+        expect(setFilters).toHaveBeenCalledWith(
+            {
+                breakdown_type: 'group',
+                breakdowns: undefined,
+                breakdown: '$lib_version',
+                breakdown_group_type_index: 0,
+                breakdown_normalize_url: false,
+            },
+            true
+        )
     })
 })

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -10,18 +10,17 @@ export const isURLNormalizeable = (propertyName: string): boolean => {
     return ['$current_url', '$pathname'].includes(propertyName)
 }
 interface FilterChange {
-    useMultiBreakdown: string | boolean | undefined
     breakdownParts: (string | number)[]
     setFilters: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
     getPropertyDefinition: (propertyName: string | number) => PropertyDefinition | null
 }
 
-export function onFilterChange({ useMultiBreakdown, breakdownParts, setFilters, getPropertyDefinition }: FilterChange) {
+export function onFilterChange({ breakdownParts, setFilters, getPropertyDefinition }: FilterChange) {
     return (changedBreakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup): void => {
         const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type) as BreakdownType
 
         if (changedBreakdownType) {
-            const isHistogramable = !useMultiBreakdown && !!getPropertyDefinition(changedBreakdown)?.is_numerical
+            const isHistogramable = !!getPropertyDefinition(changedBreakdown)?.is_numerical
 
             const newFilters: Partial<TrendsFilterType> = {
                 breakdown_type: changedBreakdownType,
@@ -34,20 +33,10 @@ export function onFilterChange({ useMultiBreakdown, breakdownParts, setFilters, 
                 ),
             }
 
-            if (useMultiBreakdown) {
-                newFilters.breakdowns = [...breakdownParts, changedBreakdown]
-                    .filter((b): b is string | number => !!b)
-                    .map((b) => ({
-                        property: b,
-                        type: changedBreakdownType,
-                        normalize_url: isURLNormalizeable(b.toString()),
-                    }))
-            } else {
-                newFilters.breakdown =
-                    taxonomicGroup.type === TaxonomicFilterGroupType.CohortsWithAllUsers
-                        ? [...breakdownParts, changedBreakdown].filter((b): b is string | number => !!b)
-                        : changedBreakdown
-            }
+            newFilters.breakdown =
+                taxonomicGroup.type === TaxonomicFilterGroupType.CohortsWithAllUsers
+                    ? [...breakdownParts, changedBreakdown].filter((b): b is string | number => !!b)
+                    : changedBreakdown
 
             setFilters(newFilters, true)
         }

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -194,7 +194,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                         {
                             ...createEmptyInsight('new', teamFilterTestAccounts),
                             ...(filters
-                                ? { filters: cleanFilters(filters || {}, undefined, undefined, teamFilterTestAccounts) }
+                                ? { filters: cleanFilters(filters || {}, undefined, teamFilterTestAccounts) }
                                 : {}),
                             ...(dashboard ? { dashboards: [dashboard] } : {}),
                             ...(q ? { query: JSON.parse(q) } : {}),

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -8,7 +8,7 @@ import {
     InsightType,
     TrendsFilterType,
 } from '~/types'
-import { NON_VALUES_ON_SERIES_DISPLAY_TYPES, FEATURE_FLAGS, ShownAsValue } from 'lib/constants'
+import { NON_VALUES_ON_SERIES_DISPLAY_TYPES, ShownAsValue } from 'lib/constants'
 
 describe('cleanFilters', () => {
     it('removes shownas if moving from stickiness to trends', () => {
@@ -285,31 +285,6 @@ describe('cleanFilters', () => {
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', 'one thing')
-        expect(cleanedFilters).toHaveProperty('breakdown_type', 'event')
-        expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
-    })
-
-    it('adds the first multi property filter when switching from trends', () => {
-        const featureFlags = {}
-        featureFlags[`${FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES}`] = true
-
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [{ property: 'one thing', type: 'event' }],
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            },
-            {
-                breakdown: 'one thing',
-                breakdown_type: 'event',
-                insight: InsightType.TRENDS,
-            },
-            featureFlags
-        )
-
-        expect(cleanedFilters).toHaveProperty('breakdowns', [{ property: 'one thing', type: 'event' }])
-        expect(cleanedFilters).toHaveProperty('breakdown', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown_type', 'event')
         expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
     })


### PR DESCRIPTION
## Problem

The flag `BREAKDOWN_BY_MULTIPLE_PROPERTIES` is not going to be released and is a bit in the way now.

## Changes

Removes it and the corresponding frontend code. I didn't dare to touch the backend parts, as we'll be rewriting these anyway.

## How did you test this code?

Hoping CI is green.