### PR TITLE
fix(flags): Fix bug with cohort flag evaluation with property overrides

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -754,7 +754,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:63 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:64 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -754,7 +754,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:64 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:63 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -9,6 +9,7 @@ from prometheus_client import Counter
 from django.db import DatabaseError, IntegrityError, OperationalError
 from django.db.models.expressions import ExpressionWrapper, RawSQL
 from django.db.models.fields import BooleanField
+from django.db.models import Q
 from django.db.models.query import QuerySet
 from sentry_sdk.api import capture_exception
 
@@ -287,6 +288,7 @@ class FeatureFlagMatcher:
                     for index, condition in enumerate(feature_flag.conditions):
                         key = f"flag_{feature_flag.pk}_condition_{index}"
                         expr: Any = None
+                        annotate_query = True
                         if len(condition.get("properties", {})) > 0:
                             # Feature Flags don't support OR filtering yet
                             target_properties = self.property_value_overrides
@@ -299,39 +301,47 @@ class FeatureFlagMatcher:
                                 override_property_values=target_properties,
                             )
 
-                            # TRICKY: Due to property overrides, we sometimes shortcircuit the condition check.
-                            # In that case, the expression is empty, and we can assume the condition is a match.
-                            if not expr:
-                                all_conditions[key] = True
+                            # TRICKY: Due to property overrides for cohorts, we sometimes shortcircuit the condition check.
+                            # In that case, the expression is either an explicit True or explicit False, or multiple conditions.
+                            # We can skip going to the database in explicit True|False conditions. This is important
+                            # as it allows resolving flags correctly for non-ingested persons.
+                            # However, this doesn't work for the multiple condition case (when expr has multiple Q objects),
+                            # but it's better than nothing.
+                            # TODO: A proper fix would be to handle cohorts with property overrides before we get to this point.
+                            # Unskip test test_complex_cohort_filter_with_override_properties when we fix this.
+                            if expr == Q(pk__isnull=False) or expr == Q(pk__isnull=True):
+                                all_conditions[key] = False if expr == Q(pk__isnull=True) else True
+                                annotate_query = False
 
-                        if feature_flag.aggregation_group_type_index is None:
-                            person_query = person_query.annotate(
-                                **{
-                                    key: ExpressionWrapper(
-                                        expr if expr else RawSQL("true", []), output_field=BooleanField()
-                                    )
-                                }
-                            )
-                            person_fields.append(key)
-                        else:
-                            if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
-                                # ignore flags that didn't have the right groups passed in
-                                continue
-                            group_query, group_fields = group_query_per_group_type_mapping[
-                                feature_flag.aggregation_group_type_index
-                            ]
-                            group_query = group_query.annotate(
-                                **{
-                                    key: ExpressionWrapper(
-                                        expr if expr else RawSQL("true", []), output_field=BooleanField()
-                                    )
-                                }
-                            )
-                            group_fields.append(key)
-                            group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
-                                group_query,
-                                group_fields,
-                            )
+                        if annotate_query:
+                            if feature_flag.aggregation_group_type_index is None:
+                                person_query = person_query.annotate(
+                                    **{
+                                        key: ExpressionWrapper(
+                                            expr if expr else RawSQL("true", []), output_field=BooleanField()
+                                        )
+                                    }
+                                )
+                                person_fields.append(key)
+                            else:
+                                if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
+                                    # ignore flags that didn't have the right groups passed in
+                                    continue
+                                group_query, group_fields = group_query_per_group_type_mapping[
+                                    feature_flag.aggregation_group_type_index
+                                ]
+                                group_query = group_query.annotate(
+                                    **{
+                                        key: ExpressionWrapper(
+                                            expr if expr else RawSQL("true", []), output_field=BooleanField()
+                                        )
+                                    }
+                                )
+                                group_fields.append(key)
+                                group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
+                                    group_query,
+                                    group_fields,
+                                )
 
                 if len(person_fields) > 0:
                     person_query = person_query.values(*person_fields)

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -229,12 +229,17 @@ def property_to_Q(property: Property, override_property_values: Dict[str, Any] =
 
     # short circuit query if key exists in override_property_values
     if property.key in override_property_values and property.operator != "is_not_set":
-        # if match found, do nothing to Q
-        # if not found, return empty Q
+        # if match found, add an explicit match-all Q object
+        # if not found, return falsy Q
         if not match_property(property, override_property_values):
             return Q(pk__isnull=True)
         else:
-            return Q()
+            # TRICKY: We need to return an explicit match-all Q object, instead of an empty Q object,
+            # because the empty Q object,  when OR'ed with other Q objects, results in removing the empty Q object.
+            # This isn't what we want here, because this is an explicit true match, which when OR'ed with others,
+            # should not be removed, and return True.
+            # See https://code.djangoproject.com/ticket/32554 for gotcha explanation
+            return Q(pk__isnull=False)
 
     # if no override matches, return a true Q object
 

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.db import IntegrityError, connection
 from django.test import TransactionTestCase
 from django.utils import timezone
+import pytest
 
 from posthog.models import Cohort, FeatureFlag, GroupTypeMapping, Person
 from posthog.models.feature_flag import get_feature_flags_for_team_in_cache
@@ -1498,8 +1499,9 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
             )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             # no local computation because cohort lookup is required
+            # no postgres person query required here to get the person, because email is sufficient
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag1], "example_id", property_value_overrides={"email": "bzz"}).get_match(
                     feature_flag1
@@ -1507,7 +1509,8 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
             )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
+            # no postgres query required here to get the person
             self.assertEqual(
                 FeatureFlagMatcher(
                     [feature_flag1], "example_id", property_value_overrides={"email": "neil@posthog.com"}
@@ -1515,7 +1518,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
             )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             # Random person doesn't yet exist, but still should resolve thanks to overrides
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag2], "random_id", property_value_overrides={"email": "xxx"}).get_match(
@@ -1524,11 +1527,121 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
             )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             self.assertEqual(
                 FeatureFlagMatcher(
                     [feature_flag2], "random_id", property_value_overrides={"email": "example@posthog.com"}
                 ).get_match(feature_flag2),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+    @pytest.mark.skip("This case is not supported yet")
+    def test_complex_cohort_filter_with_override_properties(self):
+        # TODO: Currently we don't support this case for persons who haven't been ingested yet
+        # The case:
+        # - A cohort has multiple conditions
+        # - All of which are the _same_ / are true for the same property.
+        # Example: email contains .com ; email contains @ ; email contains posthog
+        # -> 3 different filters, all of which match neil@posthog.com.
+
+        cohort1 = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": r"@posthog\.com$",
+                            "negation": False,
+                            "operator": "regex",
+                        }
+                    ]
+                },
+                {
+                    "properties": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@posthog.com",
+                            "negation": False,
+                            "operator": "icontains",
+                        }
+                    ]
+                },
+            ],
+            name="cohort1",
+        )
+        feature_flag1: FeatureFlag = self.create_feature_flag(
+            key="x1", filters={"groups": [{"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}]}]}
+        )
+
+        with self.assertNumQueries(5):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1], "example_id", property_value_overrides={"email": "neil@posthog.com"}
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        with self.assertNumQueries(5):
+            # no local computation because cohort lookup is required
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag1], "example_id", property_value_overrides={"email": "bzz"}).get_match(
+                    feature_flag1
+                ),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+
+    def test_cohort_filters_with_multiple_OR_override_properties(self):
+        cohort1 = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": r"@posthog\.com$",
+                                    "negation": False,
+                                    "operator": "regex",
+                                }
+                            ],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "email", "type": "person", "value": ["fuzion@xyz.com"], "operator": "exact"}
+                            ],
+                        },
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        feature_flag1: FeatureFlag = self.create_feature_flag(
+            filters={"groups": [{"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}]}]}
+        )
+
+        Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
+
+        with self.assertNumQueries(6):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag1], "example_id", property_value_overrides={}).get_match(feature_flag1),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        with self.assertNumQueries(6):
+            # no local computation because cohort lookup is required
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1], "example_id", property_value_overrides={"email": "neil@posthog.com"}
+                ).get_match(feature_flag1),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
             )
 


### PR DESCRIPTION
## Problem

So https://github.com/PostHog/posthog/pull/15349/files didn't fix the issue. I tried prod-shell debugging to figure out exactly what was going wrong.

As it turns out, this is a gotcha with Q objects:

When you have multiple Q objects OR'ed together, and one of them is empty, it **discards** the empty Q object, rather than consider it a truthy filter.

So, we need to replace our empty Q objects with truthy Q objects.

There is still a pending issue with flags with cohorts; who have multiple conditions that refer to the same property; AND that person isn't ingested yet either - I opted not to fix this right now because it's pretty niche, doesn't seem worth the trouble right now.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
