### PR TITLE
revert(plugin-server): use librdkafka producer everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,8 +275,8 @@
             "prettier --write"
         ],
         "(plugin-server/**).{js,jsx,mjs,ts,tsx}": [
-            "pnpm --dir plugin-server exec eslint --fix",
-            "pnpm --dir plugin-server exec prettier --write"
+            "eslint -c plugin-server/.eslintrc.js --fix",
+            "prettier --write"
         ],
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
             "black",

--- a/plugin-server/functional_tests/kafka.ts
+++ b/plugin-server/functional_tests/kafka.ts
@@ -3,7 +3,6 @@ import SnappyCodec from 'kafkajs-snappy'
 import { HighLevelProducer } from 'node-rdkafka-acosom'
 
 import { defaultConfig } from '../src/config/config'
-import { produce as defaultProduce } from '../src/kafka/producer'
 
 CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
 
@@ -24,7 +23,6 @@ afterAll(async () => {
 export async function createKafkaProducer() {
     producer = new HighLevelProducer({
         'metadata.broker.list': defaultConfig.KAFKA_HOSTS,
-        'linger.ms': 0,
     })
 
     await new Promise((resolve, reject) =>
@@ -38,5 +36,22 @@ export async function createKafkaProducer() {
 
 export async function produce({ topic, message, key }: { topic: string; message: Buffer | null; key: string }) {
     producer = producer ?? (await createKafkaProducer())
-    await defaultProduce({ producer, topic, value: message, key: Buffer.from(key) })
+    await new Promise((resolve, reject) =>
+        producer.produce(topic, undefined, message, Buffer.from(key), Date.now(), (err, offset) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve(offset)
+            }
+        })
+    )
+    await new Promise((resolve, reject) =>
+        producer.flush(10000, (err) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve(null)
+            }
+        })
+    )
 }

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -176,7 +176,7 @@ test.concurrent(`recording events not ingested to ClickHouse if team is opted ou
     })
 
     // NOTE: we're assuming that we have a single partition for the Kafka topic,
-    // and that the consumer produceAndFlushs messages in the order they are consumed.
+    // and that the consumer produces messages in the order they are consumed.
     // TODO: add some side-effect we can assert on rather than relying on the
     // partitioning / ordering setup e.g. an ingestion warning.
     const events = await fetchSessionRecordingsEvents(teamOptedOutId, uuidOptedOut)

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -59,17 +59,12 @@ export const createKafkaProducer = async (config: ProducerGlobalConfig) => {
 
     return producer
 }
-export const produce = async ({
-    producer,
-    topic,
-    value,
-    key,
-}: {
-    producer: RdKafkaProducer
-    topic: string
-    value: Buffer | null
+export const produce = async (
+    producer: RdKafkaProducer,
+    topic: string,
+    value: Buffer | null,
     key: Buffer | null
-}): Promise<number | null | undefined> => {
+): Promise<number | null | undefined> => {
     status.debug('📤', 'Producing message', { topic: topic })
     return await new Promise((resolve, reject) =>
         producer.produce(topic, null, value, key, Date.now(), (error: any, offset: NumberNullUndefined) => {

--- a/plugin-server/src/main/graphile-worker/schedule.ts
+++ b/plugin-server/src/main/graphile-worker/schedule.ts
@@ -52,7 +52,7 @@ export async function runScheduledTasks(
     if (server.USE_KAFKA_FOR_SCHEDULED_TASKS) {
         for (const pluginConfigId of server.pluginSchedule?.[taskType] || []) {
             status.info('⏲️', 'queueing_schedule_task', { taskType, pluginConfigId })
-            await server.kafkaProducer.queueMessage({
+            await server.kafkaProducer.producer.send({
                 topic: KAFKA_SCHEDULED_TASKS,
                 messages: [{ key: pluginConfigId.toString(), value: JSON.stringify({ taskType, pluginConfigId }) }],
             })

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -164,12 +164,12 @@ const eachMessage =
                 partition: message.partition,
             })
             return [
-                produce({
+                produce(
                     producer,
-                    topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ,
-                    value: message.value,
-                    key: message.key ? Buffer.from(message.key) : null,
-                }),
+                    KAFKA_SESSION_RECORDING_EVENTS_DLQ,
+                    message.value,
+                    message.key ? Buffer.from(message.key) : null
+                ),
             ]
         }
 
@@ -191,12 +191,12 @@ const eachMessage =
                 partition: message.partition,
             })
             return [
-                produce({
+                produce(
                     producer,
-                    topic: KAFKA_SESSION_RECORDING_EVENTS_DLQ,
-                    value: message.value,
-                    key: message.key ? Buffer.from(message.key) : null,
-                }),
+                    KAFKA_SESSION_RECORDING_EVENTS_DLQ,
+                    message.value,
+                    message.key ? Buffer.from(message.key) : null
+                ),
             ]
         }
 
@@ -253,12 +253,12 @@ const eachMessage =
                     )
 
                     return [
-                        produce({
+                        produce(
                             producer,
-                            topic: KAFKA_CLICKHOUSE_SESSION_RECORDING_EVENTS,
-                            value: Buffer.from(JSON.stringify(clickHouseRecord)),
-                            key: message.key ? Buffer.from(message.key) : null,
-                        }),
+                            KAFKA_CLICKHOUSE_SESSION_RECORDING_EVENTS,
+                            Buffer.from(JSON.stringify(clickHouseRecord)),
+                            message.key ? Buffer.from(message.key) : null
+                        ),
                     ]
                 } else if (event.event === '$performance_event') {
                     const clickHouseRecord = createPerformanceEvent(
@@ -269,12 +269,12 @@ const eachMessage =
                     )
 
                     return [
-                        produce({
+                        produce(
                             producer,
-                            topic: KAFKA_PERFORMANCE_EVENTS,
-                            value: Buffer.from(JSON.stringify(clickHouseRecord)),
-                            key: message.key ? Buffer.from(message.key) : null,
-                        }),
+                            KAFKA_PERFORMANCE_EVENTS,
+                            Buffer.from(JSON.stringify(clickHouseRecord)),
+                            message.key ? Buffer.from(message.key) : null
+                        ),
                     ]
                 } else {
                     status.warn('⚠️', 'invalid_message', {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs'
 import { createPool } from 'generic-pool'
 import { StatsD } from 'hot-shots'
 import Redis from 'ioredis'
-import { Kafka, SASLOptions } from 'kafkajs'
+import { Kafka, KafkaJSError, Partitioners, SASLOptions } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { hostname } from 'os'
 import * as path from 'path'
@@ -15,8 +15,6 @@ import { getPluginServerCapabilities } from '../../capabilities'
 import { defaultConfig } from '../../config/config'
 import { KAFKAJS_LOG_LEVEL_MAPPING } from '../../config/constants'
 import { KAFKA_JOBS } from '../../config/kafka-topics'
-import { createRdConnectionConfigFromEnvVars } from '../../kafka/config'
-import { createKafkaProducer } from '../../kafka/producer'
 import { getObjectStorage } from '../../main/services/object_storage'
 import {
     EnqueuedPluginJob,
@@ -41,6 +39,7 @@ import { PluginsApiKeyManager } from './../../worker/vm/extensions/helpers/api-k
 import { RootAccessManager } from './../../worker/vm/extensions/helpers/root-acess-manager'
 import { PromiseManager } from './../../worker/vm/promise-manager'
 import { DB } from './db'
+import { DependencyUnavailableError } from './error'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
 
 // `node-postgres` would return dates as plain JS Date objects, which would use the local timezone.
@@ -131,10 +130,13 @@ export async function createHub(
 
     const kafka = createKafkaClient(serverConfig as KafkaConfig)
 
-    const kafkaConnectionConfig = createRdConnectionConfigFromEnvVars(serverConfig as KafkaConfig)
-    const producer = await createKafkaProducer({ ...kafkaConnectionConfig, 'linger.ms': 0 })
+    const producer = kafka.producer({
+        retry: { retries: 10, initialRetryTime: 1000, maxRetryTime: 30 },
+        createPartitioner: Partitioners.LegacyPartitioner,
+    })
+    await producer.connect()
 
-    const kafkaProducer = new KafkaProducerWrapper(producer)
+    const kafkaProducer = new KafkaProducerWrapper(producer, statsd, serverConfig)
     status.info('👍', `Kafka ready`)
 
     status.info('🤔', `Connecting to Postgresql...`)
@@ -192,15 +194,31 @@ export async function createHub(
         // an acknowledgement as for instance there are some jobs that are
         // chained, and if we do not manage to produce then the chain will be
         // broken.
-        await kafkaProducer.queueMessage({
-            topic: KAFKA_JOBS,
-            messages: [
-                {
-                    value: Buffer.from(JSON.stringify(job)),
-                    key: Buffer.from(job.pluginConfigTeam.toString()),
-                },
-            ],
-        })
+        try {
+            await kafkaProducer.producer.send({
+                topic: KAFKA_JOBS,
+                messages: [
+                    {
+                        key: job.pluginConfigTeam.toString(),
+                        value: JSON.stringify(job),
+                    },
+                ],
+            })
+        } catch (error) {
+            if (error instanceof KafkaJSError) {
+                // If we get a retriable Kafka error (maybe it's down for
+                // example), rethrow the error as a generic `DependencyUnavailableError`
+                // passing through retriable such that we can decide if this is
+                // something we should retry at the consumer level.
+                if (error.retriable) {
+                    throw new DependencyUnavailableError(error.message, 'Kafka', error)
+                }
+            }
+
+            // Otherwise, just rethrow the error as is. E.g. if we fail to
+            // serialize then we don't want to retry.
+            throw error
+        }
     }
 
     const hub: Partial<Hub> = {

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -1,55 +1,111 @@
-import { Message, ProducerRecord } from 'kafkajs'
-import { HighLevelProducer, LibrdKafkaError } from 'node-rdkafka-acosom'
+import * as Sentry from '@sentry/node'
+import { StatsD } from 'hot-shots'
+import {
+    CompressionCodecs,
+    CompressionTypes,
+    KafkaJSError,
+    KafkaJSNumberOfRetriesExceeded,
+    Message,
+    Producer,
+    ProducerRecord,
+} from 'kafkajs'
+// @ts-expect-error no type definitions
+import SnappyCodec from 'kafkajs-snappy'
 
-import { disconnectProducer, flushProducer, produce } from '../../kafka/producer'
-import { status } from '../../utils/status'
+import { runInSpan } from '../../sentry'
+import { PluginsServerConfig } from '../../types'
+import { instrument } from '../metrics'
+import { status } from '../status'
 import { DependencyUnavailableError } from './error'
+import { timeoutGuard } from './utils'
 
-/** This class is a wrapper around the rdkafka producer, and does very little.
- * It used to be a wrapper around KafkaJS, but we switched to rdkafka because of
- * increased performance.
+CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
+
+/** This class wraps kafkajs producer, adding batching to optimize performance.
  *
- * The big difference between this and the original is that we return a promise from
- * queueMessage, which will only resolve once we get an ack that the message has
- * been persisted to Kafka. So we should get stronger guarantees on processing.
+ * As messages get queued, we flush the queue in the following cases.
  *
- * TODO: refactor Kafka producer usage to use rdkafka directly.
+ * 1. Message size + current batch exceeds max batch message size
+ * 2. Too much time passed
+ * 3. Too many messages queued.
+ *
+ * We also flush the queue regularly to avoid dropping any messages as the program quits.
  */
 export class KafkaProducerWrapper {
+    /** StatsD instance used to do instrumentation */
+    private statsd: StatsD | undefined
+
     /** Kafka producer used for syncing Postgres and ClickHouse person data. */
-    public producer: HighLevelProducer
+    producer: Producer
 
-    constructor(producer: HighLevelProducer) {
+    lastFlushTime: number
+    currentBatch: Array<ProducerRecord>
+    currentBatchSize: number
+
+    flushFrequencyMs: number
+    maxQueueSize: number
+    maxBatchSize: number
+
+    flushInterval: NodeJS.Timeout | undefined
+
+    constructor(producer: Producer, statsd: StatsD | undefined, serverConfig: PluginsServerConfig) {
         this.producer = producer
-    }
+        this.statsd = statsd
 
-    async queueMessage(kafkaMessage: ProducerRecord) {
-        try {
-            return await Promise.all(
-                kafkaMessage.messages.map((message) =>
-                    produce({
-                        producer: this.producer,
-                        topic: kafkaMessage.topic,
-                        key: message.key ? Buffer.from(message.key) : null,
-                        value: message.value ? Buffer.from(message.value) : null,
-                    })
-                )
-            )
-        } catch (error) {
-            status.error('⚠️', 'kafka_produce_error', { error: error, topic: kafkaMessage.topic })
+        this.lastFlushTime = Date.now()
+        this.currentBatch = []
+        this.currentBatchSize = 0
 
-            if ((error as LibrdKafkaError).isRetriable) {
-                // If we get a retriable error, bubble that up so that the
-                // caller can retry.
-                throw new DependencyUnavailableError(error.message, 'Kafka', error)
-            }
+        this.flushFrequencyMs = serverConfig.KAFKA_FLUSH_FREQUENCY_MS
+        this.maxQueueSize = serverConfig.KAFKA_PRODUCER_MAX_QUEUE_SIZE
+        this.maxBatchSize = serverConfig.KAFKA_MAX_MESSAGE_BATCH_SIZE
 
-            throw error
+        if (this.flushFrequencyMs > 0) {
+            // If flush frequency is set, we flush the queue at intervals. We
+            // allow disabling this to avoid out of band flushing occuring for
+            // which we would not be able to explicitly handle.
+            this.flushInterval = setInterval(async () => {
+                // :TRICKY: Swallow uncaught errors from flush as flush is already doing custom error reporting which would get lost.
+                try {
+                    await this.flush()
+                } catch (err) {}
+            }, this.flushFrequencyMs)
         }
     }
 
+    queueMessage(kafkaMessage: ProducerRecord): Promise<void> {
+        return runInSpan(
+            {
+                op: 'kafka.queueMessage',
+                description: kafkaMessage.topic,
+            },
+            async () => {
+                const messageSize = this.estimateMessageSize(kafkaMessage)
+
+                if (this.currentBatch.length > 0 && this.currentBatchSize + messageSize > this.maxBatchSize) {
+                    // :TRICKY: We want to first flush then immediately add the message to the queue. Awaiting and then pushing would result in a race condition.
+                    await this.flush(kafkaMessage)
+                } else {
+                    this.currentBatch.push(kafkaMessage)
+                    this.currentBatchSize += messageSize
+
+                    const timeSinceLastFlush = Date.now() - this.lastFlushTime
+                    if (
+                        this.currentBatchSize > this.maxBatchSize ||
+                        timeSinceLastFlush > this.flushFrequencyMs ||
+                        this.currentBatch.length >= this.maxQueueSize
+                    ) {
+                        await this.flush()
+                    }
+                }
+            }
+        )
+    }
+
     async queueMessages(kafkaMessages: ProducerRecord[]): Promise<void> {
-        await Promise.all(kafkaMessages.map((message) => this.queueMessage(message)))
+        for (const message of kafkaMessages) {
+            await this.queueMessage(message)
+        }
     }
 
     async queueSingleJsonMessage(topic: string, key: Message['key'], object: Record<string, any>): Promise<void> {
@@ -59,12 +115,68 @@ export class KafkaProducerWrapper {
         })
     }
 
-    public async flush() {
-        return await flushProducer(this.producer)
+    public flush(append?: ProducerRecord): Promise<void> {
+        if (this.currentBatch.length === 0) {
+            return Promise.resolve()
+        }
+
+        return instrument(this.statsd, { metricName: 'query.kafka_send' }, async () => {
+            const messages = this.currentBatch
+            const batchSize = this.currentBatchSize
+            this.lastFlushTime = Date.now()
+            this.currentBatch = append ? [append] : []
+            this.currentBatchSize = append ? this.estimateMessageSize(append) : 0
+
+            this.statsd?.histogram('query.kafka_send.size', batchSize)
+            const timeout = timeoutGuard('Kafka message sending delayed. Waiting over 30 sec to send messages.')
+
+            try {
+                await this.producer.sendBatch({
+                    topicMessages: messages,
+                    compression: CompressionTypes.Snappy,
+                })
+            } catch (err) {
+                Sentry.captureException(err, {
+                    extra: {
+                        batchCount: messages.length,
+                        topics: messages.map((record) => record.topic),
+                        messageCounts: messages.map((record) => record.messages.length),
+                        estimatedSize: batchSize,
+                    },
+                })
+                // :TODO: Implement some retrying, https://github.com/PostHog/plugin-server/issues/511
+                this.statsd?.increment('query.kafka_send.failure', {
+                    firstTopic: messages[0].topic,
+                })
+                status.error('⚠️', 'Failed to flush kafka messages that were produced', {
+                    error: err,
+                    batchCount: messages.length,
+                    topics: messages.map((record) => record.topic),
+                    messageCounts: messages.map((record) => record.messages.length),
+                    estimatedSize: batchSize,
+                })
+
+                if (err instanceof KafkaJSNumberOfRetriesExceeded && err.cause instanceof KafkaJSError) {
+                    if (err.cause.retriable === true) {
+                        throw new DependencyUnavailableError(err.cause.name, 'Kafka', err.cause)
+                    }
+                }
+
+                throw err
+            } finally {
+                clearTimeout(timeout)
+            }
+        })
     }
 
     public async disconnect(): Promise<void> {
+        clearInterval(this.flushInterval)
         await this.flush()
-        await disconnectProducer(this.producer)
+        await this.producer.disconnect()
+    }
+
+    private estimateMessageSize(kafkaMessage: ProducerRecord): number {
+        // :TRICKY: This length respects unicode
+        return Buffer.from(JSON.stringify(kafkaMessage)).length
     }
 }

--- a/plugin-server/src/worker/worker.ts
+++ b/plugin-server/src/worker/worker.ts
@@ -120,7 +120,8 @@ export function processUnhandledException(error: Error, server: Hub, kind: strin
         },
     })
 
-    status.error('🤮', `${kind}!`, { error, stack: error.stack })
+    status.error('🤮', `${kind}!`)
+    status.error('🤮', error)
 }
 
 const jobDuration = new Histogram({

--- a/plugin-server/tests/e2e.buffer.test.ts
+++ b/plugin-server/tests/e2e.buffer.test.ts
@@ -1,0 +1,153 @@
+import IORedis from 'ioredis'
+
+import { ONE_HOUR } from '../src/config/constants'
+import { startPluginsServer } from '../src/main/pluginsServer'
+import { LogLevel, PluginsServerConfig } from '../src/types'
+import { Hub } from '../src/types'
+import { UUIDT } from '../src/utils/utils'
+import { makePiscina } from '../src/worker/piscina'
+import { createPosthog, DummyPostHog } from '../src/worker/vm/extensions/posthog'
+import { writeToFile } from '../src/worker/vm/extensions/test-utils'
+import { delayUntilEventIngested, resetTestDatabaseClickhouse } from './helpers/clickhouse'
+import { resetKafka } from './helpers/kafka'
+import { pluginConfig39 } from './helpers/plugins'
+import { resetTestDatabase } from './helpers/sql'
+const { console: testConsole } = writeToFile
+
+jest.setTimeout(60000) // 60 sec timeout
+
+const indexJs = `
+import { console as testConsole } from 'test-utils/write-to-file'
+
+export async function processEvent (event) {
+    testConsole.log('processEvent')
+    console.info('amogus')
+    event.properties.processed = 'hell yes'
+    event.properties.upperUuid = event.properties.uuid?.toUpperCase()
+    event.properties['$snapshot_data'] = 'no way'
+    return event
+}
+
+export function onEvent (event, { global }) {
+    // we use this to mock setupPlugin being
+    // run after some events were already ingested
+    global.timestampBoundariesForTeam = {
+        max: new Date(),
+        min: new Date(Date.now()-${ONE_HOUR})
+    }
+    testConsole.log('onEvent', event.event)
+}`
+
+describe('E2E with buffer topic enabled', () => {
+    let hub: Hub
+    let stopServer: () => Promise<void>
+    let posthog: DummyPostHog
+    let redis: IORedis.Redis
+
+    const extraServerConfig: Partial<PluginsServerConfig> = {
+        WORKER_CONCURRENCY: 1,
+        LOG_LEVEL: LogLevel.Log,
+        KAFKA_PRODUCER_MAX_QUEUE_SIZE: 100, // The default in tests is 0 but here we specifically want to test batching
+        KAFKA_FLUSH_FREQUENCY_MS: 0, // Same as above, but with time
+        BUFFER_CONVERSION_SECONDS: 3, // We want to test the delay mechanism, but with a much lower delay than in prod
+        CONVERSION_BUFFER_ENABLED: true,
+        CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS: '2', // For these tests we want to validate that we function correctly with the buffer topic enabled
+    }
+
+    beforeEach(async () => {
+        testConsole.reset()
+        await resetTestDatabase(indexJs)
+        await resetTestDatabaseClickhouse(extraServerConfig)
+        await resetKafka(extraServerConfig)
+        const startResponse = await startPluginsServer(extraServerConfig, makePiscina)
+        hub = startResponse.hub
+        stopServer = startResponse.stop
+        redis = await hub.redisPool.acquire()
+        posthog = createPosthog(hub, pluginConfig39)
+    })
+
+    afterEach(async () => {
+        await hub.redisPool.release(redis)
+        await stopServer()
+    })
+
+    describe('ClickHouse ingestion', () => {
+        test('event captured, processed, ingested', async () => {
+            expect((await hub.db.fetchEvents()).length).toBe(0)
+
+            const uuid = new UUIDT().toString()
+
+            await posthog.capture('custom event via buffer', { name: 'hehe', uuid })
+            await hub.kafkaProducer.flush()
+
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, undefined, 500)
+            const events = await hub.db.fetchEvents()
+
+            expect(events.length).toBe(1)
+
+            // processEvent ran and modified
+            expect(events[0].properties.processed).toEqual('hell yes')
+            expect(events[0].properties.upperUuid).toEqual(uuid.toUpperCase())
+
+            // onEvent ran
+            expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event via buffer']])
+        })
+    })
+})
+
+describe('E2E with direct to graphile worker', () => {
+    let hub: Hub
+    let stopServer: () => Promise<void>
+    let posthog: DummyPostHog
+    let redis: IORedis.Redis
+
+    const extraServerConfig: Partial<PluginsServerConfig> = {
+        WORKER_CONCURRENCY: 1,
+        LOG_LEVEL: LogLevel.Log,
+        KAFKA_PRODUCER_MAX_QUEUE_SIZE: 100, // The default in tests is 0 but here we specifically want to test batching
+        KAFKA_FLUSH_FREQUENCY_MS: 0, // Same as above, but with time
+        BUFFER_CONVERSION_SECONDS: 3, // We want to test the delay mechanism, but with a much lower delay than in prod
+        CONVERSION_BUFFER_ENABLED: true,
+        CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS: '',
+    }
+
+    beforeEach(async () => {
+        testConsole.reset()
+        await resetTestDatabase(indexJs)
+        await resetTestDatabaseClickhouse(extraServerConfig)
+        await resetKafka(extraServerConfig)
+        const startResponse = await startPluginsServer(extraServerConfig, makePiscina)
+        hub = startResponse.hub
+        stopServer = startResponse.stop
+        redis = await hub.redisPool.acquire()
+        posthog = createPosthog(hub, pluginConfig39)
+    })
+
+    afterEach(async () => {
+        await hub.redisPool.release(redis)
+        await stopServer()
+    })
+
+    describe('ClickHouse ingestion', () => {
+        test('event captured, processed, ingested', async () => {
+            expect((await hub.db.fetchEvents()).length).toBe(0)
+
+            const uuid = new UUIDT().toString()
+
+            await posthog.capture('custom event via buffer', { name: 'hehe', uuid })
+            await hub.kafkaProducer.flush()
+
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, undefined, 500)
+            const events = await hub.db.fetchEvents()
+
+            expect(events.length).toBe(1)
+
+            // processEvent ran and modified
+            expect(events[0].properties.processed).toEqual('hell yes')
+            expect(events[0].properties.upperUuid).toEqual(uuid.toUpperCase())
+
+            // onEvent ran
+            expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event via buffer']])
+        })
+    })
+})

--- a/plugin-server/tests/main/jobs/schedule.test.ts
+++ b/plugin-server/tests/main/jobs/schedule.test.ts
@@ -1,3 +1,5 @@
+import { Producer } from 'kafkajs'
+
 import { KAFKA_SCHEDULED_TASKS } from '../../../src/config/kafka-topics'
 import { runScheduledTasks } from '../../../src/main/graphile-worker/schedule'
 import { Hub } from '../../../src/types'
@@ -29,8 +31,10 @@ describe('Graphile Worker schedule', () => {
                 runEveryDay: [7, 8, 9],
             },
             kafkaProducer: {
-                queueMessage: jest.fn(),
-            } as unknown as KafkaProducerWrapper,
+                producer: {
+                    send: jest.fn(),
+                } as unknown as Producer,
+            } as KafkaProducerWrapper,
             USE_KAFKA_FOR_SCHEDULED_TASKS: true,
         }
 
@@ -38,7 +42,7 @@ describe('Graphile Worker schedule', () => {
             job: { run_at: new Date() },
         } as any)
 
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(1, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(1, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -50,7 +54,7 @@ describe('Graphile Worker schedule', () => {
                 },
             ],
         })
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(2, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(2, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -62,7 +66,7 @@ describe('Graphile Worker schedule', () => {
                 },
             ],
         })
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(3, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(3, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -78,7 +82,7 @@ describe('Graphile Worker schedule', () => {
         await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryHour', {
             job: { run_at: new Date() },
         } as any)
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(4, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(4, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -90,7 +94,7 @@ describe('Graphile Worker schedule', () => {
                 },
             ],
         })
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(5, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(5, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -102,7 +106,7 @@ describe('Graphile Worker schedule', () => {
                 },
             ],
         })
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(6, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(6, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -118,7 +122,7 @@ describe('Graphile Worker schedule', () => {
         await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryDay', {
             job: { run_at: new Date() },
         } as any)
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(7, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(7, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -130,7 +134,7 @@ describe('Graphile Worker schedule', () => {
                 },
             ],
         })
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(8, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(8, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {
@@ -142,7 +146,7 @@ describe('Graphile Worker schedule', () => {
                 },
             ],
         })
-        expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(9, {
+        expect(mockHubWithPluginSchedule.kafkaProducer.producer.send).toHaveBeenNthCalledWith(9, {
             topic: KAFKA_SCHEDULED_TASKS,
             messages: [
                 {

--- a/plugin-server/tests/main/kafka-producer-wrapper.test.ts
+++ b/plugin-server/tests/main/kafka-producer-wrapper.test.ts
@@ -1,0 +1,164 @@
+import { CompressionTypes, Producer } from 'kafkajs'
+
+import { PluginsServerConfig } from '../../src/types'
+import { KafkaProducerWrapper } from '../../src/utils/db/kafka-producer-wrapper'
+
+describe('KafkaProducerWrapper', () => {
+    let producer: KafkaProducerWrapper
+    let mockKafkaProducer: Producer
+    let flushSpy: any
+
+    beforeEach(() => {
+        jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
+
+        mockKafkaProducer = { sendBatch: jest.fn() } as any
+        producer = new KafkaProducerWrapper(mockKafkaProducer, undefined, {
+            KAFKA_FLUSH_FREQUENCY_MS: 20000,
+            KAFKA_PRODUCER_MAX_QUEUE_SIZE: 4,
+            KAFKA_MAX_MESSAGE_BATCH_SIZE: 500,
+        } as PluginsServerConfig)
+        clearInterval(producer.flushInterval)
+
+        flushSpy = jest.spyOn(producer, 'flush')
+    })
+
+    describe('queueMessage()', () => {
+        it('respects MAX_QUEUE_SIZE', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(10) }],
+            })
+            await producer.queueMessage({
+                topic: 'b',
+                messages: [{ value: '1'.repeat(30) }],
+            })
+            await producer.queueMessage({
+                topic: 'b',
+                messages: [{ value: '1'.repeat(30) }],
+            })
+
+            expect(flushSpy).not.toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(3)
+
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(30) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.currentBatchSize).toEqual(0)
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
+                topicMessages: [expect.anything(), expect.anything(), expect.anything(), expect.anything()],
+            })
+        })
+
+        it('respects KAFKA_MAX_MESSAGE_BATCH_SIZE', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(400) }],
+            })
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(20) }],
+            })
+            expect(flushSpy).not.toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(2)
+
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(40) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+
+            expect(producer.currentBatch.length).toEqual(1)
+            expect(producer.currentBatchSize).toBeGreaterThan(40)
+            expect(producer.currentBatchSize).toBeLessThan(100)
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
+                topicMessages: [expect.anything(), expect.anything()],
+            })
+        })
+
+        it('flushes immediately when message exceeds KAFKA_MAX_MESSAGE_BATCH_SIZE', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(10000) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.currentBatchSize).toEqual(0)
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
+                topicMessages: [expect.anything()],
+            })
+        })
+
+        it('respects KAFKA_FLUSH_FREQUENCY_MS', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(10) }],
+            })
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:20').getTime())
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(10) }],
+            })
+
+            expect(flushSpy).not.toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(2)
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:26').getTime())
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(10) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.lastFlushTime).toEqual(Date.now())
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
+                topicMessages: [expect.anything(), expect.anything(), expect.anything()],
+            })
+        })
+    })
+
+    describe('flush()', () => {
+        it('flushes messages in memory', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(10) }],
+            })
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:15').getTime())
+
+            await producer.flush()
+
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
+                topicMessages: [
+                    {
+                        topic: 'a',
+                        messages: [{ value: '1'.repeat(10) }],
+                    },
+                ],
+            })
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.currentBatchSize).toEqual(0)
+            expect(producer.lastFlushTime).toEqual(Date.now())
+        })
+
+        it('does nothing if nothing queued', async () => {
+            await producer.flush()
+
+            expect(mockKafkaProducer.sendBatch).not.toHaveBeenCalled()
+        })
+    })
+})


### PR DESCRIPTION
Warming up CI just in case the deploy doesn't work out so well... 🤞 

Reverts PostHog/posthog#15314