### PR TITLE
fix(plugin-server): send headers as well with KafkaProducerWrapper

### DIFF
--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -64,15 +64,17 @@ export const produce = async ({
     topic,
     value,
     key,
+    headers,
 }: {
     producer: RdKafkaProducer
     topic: string
     value: Buffer | null
     key: Buffer | null
+    headers: { [key: string]: Buffer }[]
 }): Promise<number | null | undefined> => {
     status.debug('📤', 'Producing message', { topic: topic })
     return await new Promise((resolve, reject) =>
-        producer.produce(topic, null, value, key, Date.now(), (error: any, offset: NumberNullUndefined) => {
+        producer.produce(topic, null, value, key, Date.now(), headers, (error: any, offset: NumberNullUndefined) => {
             if (error) {
                 status.error('⚠️', 'produce_error', { error: error, topic: topic })
                 reject(error)

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -64,13 +64,13 @@ export const produce = async ({
     topic,
     value,
     key,
-    headers,
+    headers = [],
 }: {
     producer: RdKafkaProducer
     topic: string
     value: Buffer | null
     key: Buffer | null
-    headers: { [key: string]: Buffer }[]
+    headers?: { [key: string]: Buffer }[]
 }): Promise<number | null | undefined> => {
     status.debug('📤', 'Producing message', { topic: topic })
     return await new Promise((resolve, reject) =>

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -32,6 +32,16 @@ export class KafkaProducerWrapper {
                         topic: kafkaMessage.topic,
                         key: message.key ? Buffer.from(message.key) : null,
                         value: message.value ? Buffer.from(message.value) : null,
+                        // We need to convert from KafkaJS headers to rdkafka
+                        // headers format. The former has type
+                        // { [key: string]: string | Buffer | (string |
+                        // Buffer)[] | undefined }
+                        // while the latter has type
+                        // { [key: string]: Buffer }[]. The formers values that
+                        // are arrays need to be converted into an array of
+                        // objects with a single key-value pair, and the
+                        // undefined values need to be filtered out.
+                        headers: convertKafkaJSHeadersToRdKafkaHeaders(message.headers),
                     })
                 )
             )
@@ -68,3 +78,14 @@ export class KafkaProducerWrapper {
         await disconnectProducer(this.producer)
     }
 }
+
+export const convertKafkaJSHeadersToRdKafkaHeaders = (headers: Message['headers'] = {}) =>
+    Object.entries(headers)
+        .flatMap(([key, value]) =>
+            value === undefined
+                ? []
+                : Array.isArray(value)
+                ? value.map((v) => ({ key, value: Buffer.from(v) }))
+                : [{ key, value: Buffer.from(value) }]
+        )
+        .map(({ key, value }) => ({ [key]: value }))

--- a/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
@@ -115,7 +115,7 @@ describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
         })
 
         jest.spyOn(hub.kafkaProducer.producer, 'produce').mockImplementation(
-            (topic, partition, message, key, timestamp, cb) => cb(error)
+            (topic, partition, message, key, timestamp, headers, cb) => cb(error)
         )
 
         await expect(

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -29,7 +29,7 @@ describe('session-recordings-consumer', () => {
         const organizationId = await createOrganization(postgres)
         const teamId = await createTeam(postgres, organizationId)
         const error = new LibrdKafkaError({ message: 'test', code: 1, errno: 1, origin: 'test', isRetriable: true })
-        producer.produce.mockImplementation((topic, partition, message, key, timestamp, cb) => cb(error))
+        producer.produce.mockImplementation((topic, partition, message, key, timestamp, headers, cb) => cb(error))
         producer.flush.mockImplementation((timeout, cb) => cb(null))
         await expect(
             eachBachWithDependencies([
@@ -45,7 +45,7 @@ describe('session-recordings-consumer', () => {
         const organizationId = await createOrganization(postgres)
         const teamId = await createTeam(postgres, organizationId)
         const error = new LibrdKafkaError({ message: 'test', code: 1, errno: 1, origin: 'test', isRetriable: false })
-        producer.produce.mockImplementation((topic, partition, message, key, timestamp, cb) => cb(error))
+        producer.produce.mockImplementation((topic, partition, message, key, timestamp, headers, cb) => cb(error))
         producer.flush.mockImplementation((timeout, cb) => cb(null))
         await eachBachWithDependencies([
             {

--- a/plugin-server/tests/utils/kafka-producer-wrapper.test.ts
+++ b/plugin-server/tests/utils/kafka-producer-wrapper.test.ts
@@ -1,0 +1,27 @@
+import { convertKafkaJSHeadersToRdKafkaHeaders } from '../../src/utils/db/kafka-producer-wrapper'
+
+test('can convert from KafkaJS headers to rdkafka headers', () => {
+    expect(convertKafkaJSHeadersToRdKafkaHeaders()).toEqual([])
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({})).toEqual([])
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: 'bar' })).toEqual([{ foo: Buffer.from('bar') }])
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: ['bar', 'baz'] })).toEqual([
+        { foo: Buffer.from('bar') },
+        { foo: Buffer.from('baz') },
+    ])
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: ['bar', 'baz'], qux: 'quux' })).toEqual([
+        { foo: Buffer.from('bar') },
+        { foo: Buffer.from('baz') },
+        { qux: Buffer.from('quux') },
+    ])
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: undefined })).toEqual([])
+
+    // We should be able to use strings and Buffers interchangeably
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: Buffer.from('bar') })).toEqual([{ foo: Buffer.from('bar') }])
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: 'bar' })).toEqual([{ foo: Buffer.from('bar') }])
+
+    // We should be able to use strings and Buffers interchangeably in arrays
+    expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: [Buffer.from('bar'), 'baz'] })).toEqual([
+        { foo: Buffer.from('bar') },
+        { foo: Buffer.from('baz') },
+    ])
+})


### PR DESCRIPTION
I forgot to pass this through. I think we nuked the buffer tests so was
only apparent in production :grimace:

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
