### PR TITLE
fix(event-explorer): create action from event

### DIFF
--- a/frontend/src/scenes/events/createActionFromEvent.tsx
+++ b/frontend/src/scenes/events/createActionFromEvent.tsx
@@ -61,7 +61,7 @@ export async function createActionFromEvent(
                           url_matching: ActionStepUrlMatching.Exact,
                       }
                     : {}),
-                ...(event.elements.length > 0 ? elementsToAction(event.elements) : {}),
+                ...(event.elements?.length > 0 ? elementsToAction(event.elements) : {}),
             },
         ],
     }


### PR DESCRIPTION
"Create action from event" on the menu in the event explorer wasn't working. Reported by a customer.