### PR TITLE
fix: functional tests flakiness

### DIFF
--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -619,6 +619,14 @@ testIfPoEEmbraceJoinEnabled(`chained merge results in all events resolving to th
             $anon_distinct_id: secondDistinctId,
         },
     })
+
+    // This guarantees that we process them in order, which verifies the right overrides and
+    // makes sure we don't run into Merge refused errors if secondDistinctId is already identified if later completed first
+    await waitForExpect(async () => {
+        const persons = await fetchEvents(teamId)
+        expect(persons.length).toBe(4)
+    }, 10000)
+
     // Then we merge the third person
     await capture({
         teamId,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

For some reason I was able to repro it only when running all the tests in parallel, but what happened then was the second identify completed first (well managed to commit the merge transaction and the other failed) the other (first) identify then went into a retry and failed because now second person is_identified.


## Changes

Updated the test to guarantee required ordering.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

local repro (note it doesn't repro if only individual test is ran
```
while POE_EMBRACE_JOIN_FOR_TEAMS='*' pnpm functional_tests plugin-server/functional_tests/ingestion.test.ts; do echo "x"; done &>test-out
```

printed out the merge and refuse merge with team info like so
```
--------------------->>>>>  MERGE for teamID=161 old = 276 ; new = undefined   <---------------------------------
--------------------->>>>>  MERGE for teamID=164 old = 280 ; new = undefined   <---------------------------------
--------------------->>>>>  MERGE for teamID=165 old = 283 ; new = 284   <---------------------------------
--------------------->>>>>  MERGE for teamID=164 old = 281 ; new = 280   <---------------------------------
--------------------->>>>>  MERGE for teamID=165 old = 284 ; new = 282   <---------------------------------
--------------------->>>>>  MERGE for teamID=166 old = 285 ; new = 287   <---------------------------------
--------------------->>>>>  MERGE for teamID=166 old = 288 ; new = 286   <---------------------------------
--------------------->>>>>  MERGE for teamID=165 old = 284 ; new = 282   <---------------------------------
<------------------------------ REFUSED MERGE 165  282  284  ----------------------------------------->
[17:11:25.304] WARN (28939): [MAIN] 🤔 refused to merge an already identified user via an $identify or $create_alias call
--------------------->>>>>  MERGE for teamID=166 old = 286 ; new = 287   <---------------------------------
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
