### PR TITLE
feat: Add team_id tag to plugin-server sentry errors

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -17,6 +17,7 @@ export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: Ing
         func: () => queue.workerMethods.runAsyncHandlersEventPipeline(event),
         statsKey: `kafka_queue.process_async_handlers`,
         timeoutMessage: 'After 30 seconds still running runAsyncHandlersEventPipeline',
+        teamId: event.teamId,
     })
 }
 

--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -11,6 +11,7 @@ interface FunctionInstrumentation<T, E> {
     timeoutMessage: string
     statsKey: string
     func: (event: E) => Promise<T>
+    teamId: number
 }
 
 export async function runInstrumentedFunction<T, E>({
@@ -19,6 +20,7 @@ export async function runInstrumentedFunction<T, E>({
     event,
     func,
     statsKey,
+    teamId,
 }: FunctionInstrumentation<T, E>): Promise<T> {
     const timeout = timeoutGuard(timeoutMessage, {
         event: JSON.stringify(event),
@@ -34,7 +36,7 @@ export async function runInstrumentedFunction<T, E>({
     } catch (error) {
         end({ success: 'false' })
         status.info('🔔', error)
-        Sentry.captureException(error)
+        Sentry.captureException(error, { tags: { team_id: teamId } })
         throw error
     } finally {
         server.statsd?.increment(`${statsKey}_total`)

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -679,7 +679,7 @@ export class DB {
                     continue
                 }
             } catch (error) {
-                captureException(error)
+                captureException(error, { tags: { team_id: teamId } })
             }
 
             this.statsd?.increment('group_info_cache.miss')
@@ -705,7 +705,7 @@ export class DB {
                         created_at: createdAt,
                     })
                 } catch (error) {
-                    captureException(error)
+                    captureException(error, { tags: { team_id: teamId } })
                 }
             } else {
                 // We couldn't find the data from the cache nor Postgres, so record this in a metric and in Sentry
@@ -1277,7 +1277,7 @@ export class DB {
         try {
             await this.kafkaProducer.queueSingleJsonMessage(KAFKA_PLUGIN_LOG_ENTRIES, parsedEntry.id, parsedEntry)
         } catch (e) {
-            captureException(e)
+            captureException(e, { tags: { team_id: entry.pluginConfig.team_id } })
             console.error('Failed to produce message', e, parsedEntry)
         }
     }

--- a/plugin-server/src/utils/db/elements-chain.ts
+++ b/plugin-server/src/utils/db/elements-chain.ts
@@ -37,7 +37,7 @@ export function elementsToString(elements: Element[]): string {
     return ret.join(';')
 }
 
-export function chainToElements(chain: string, options: { throwOnError?: boolean } = {}): Element[] {
+export function chainToElements(chain: string, teamId: number, options: { throwOnError?: boolean } = {}): Element[] {
     const elements: Element[] = []
 
     // Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes
@@ -94,7 +94,7 @@ export function chainToElements(chain: string, options: { throwOnError?: boolean
                 elements.push(element)
             })
     } catch (error) {
-        Sentry.captureException(error, { extra: { chain } })
+        Sentry.captureException(error, { tags: { team_id: teamId }, extra: { chain } })
         if (options.throwOnError) {
             throw error
         }

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -22,7 +22,9 @@ export async function processError(
     event?: PluginEvent | ProcessedPluginEvent | null
 ): Promise<void> {
     if (!pluginConfig) {
-        captureException(new Error('Tried to process error for nonexistent plugin config!'))
+        captureException(new Error('Tried to process error for nonexistent plugin config!'), {
+            tags: { team_id: event?.team_id },
+        })
         return
     }
 

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -33,7 +33,7 @@ export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHous
         timestamp: clickHouseTimestampToDateTime(rawEvent.timestamp),
         created_at: clickHouseTimestampToDateTime(rawEvent.created_at),
         properties: rawEvent.properties ? JSON.parse(rawEvent.properties) : {},
-        elements_chain: rawEvent.elements_chain ? chainToElements(rawEvent.elements_chain) : null,
+        elements_chain: rawEvent.elements_chain ? chainToElements(rawEvent.elements_chain, rawEvent.team_id) : null,
         person_created_at: rawEvent.person_created_at
             ? clickHouseTimestampToDateTime(rawEvent.person_created_at)
             : null,
@@ -71,7 +71,7 @@ export function convertToIngestionEvent(event: RawClickHouseEvent): PostIngestio
         distinctId: event.distinct_id,
         properties,
         timestamp: clickHouseTimestampToISO(event.timestamp),
-        elementsList: event.elements_chain ? chainToElements(event.elements_chain) : [],
+        elementsList: event.elements_chain ? chainToElements(event.elements_chain, event.team_id) : [],
         person_id: event.person_id,
         person_created_at: event.person_created_at
             ? clickHouseTimestampSecondPrecisionToISO(event.person_created_at)

--- a/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
@@ -14,6 +14,7 @@ export async function pluginsProcessEventStep(
         func: (event) => runProcessEvent(runner.hub, event),
         statsKey: 'kafka_queue.single_event',
         timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
+        teamId: event.team_id,
     })
 
     if (processedEvent) {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
@@ -19,6 +19,7 @@ async function processOnEvent(runner: EventPipelineRunner, event: PostIngestionE
         func: (event) => runOnEvent(runner.hub, event),
         statsKey: `kafka_queue.single_on_event`,
         timeoutMessage: `After 30 seconds still running onEvent`,
+        teamId: event.teamId,
     })
 }
 

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -195,7 +195,9 @@ export class HookCommander {
             const webhookRequests = actionMatches
                 .filter((action) => action.post_to_slack)
                 .map((action) => this.postWebhook(webhookUrl, action, event))
-            await Promise.all(webhookRequests).catch((error) => captureException(error))
+            await Promise.all(webhookRequests).catch((error) =>
+                captureException(error, { tags: { team_id: event.teamId } })
+            )
         }
 
         if (await this.organizationManager.hasAvailableFeature(team.id, 'zapier')) {
@@ -203,7 +205,9 @@ export class HookCommander {
 
             if (restHooks.length > 0) {
                 const restHookRequests = restHooks.map((hook) => this.postRestHook(hook, event))
-                await Promise.all(restHookRequests).catch((error) => captureException(error))
+                await Promise.all(restHookRequests).catch((error) =>
+                    captureException(error, { tags: { team_id: event.teamId } })
+                )
 
                 this.statsd?.increment('zapier_hooks_fired', {
                     team_id: String(team.id),

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -147,6 +147,7 @@ export class PersonState {
                 status.error('🚨', 'create_person_failed', { error, teamId: this.teamId, distinctId: this.distinctId })
                 if (!error.message || !error.message.includes('duplicate key value violates unique constraint')) {
                     Sentry.captureException(error, {
+                        tags: { team_id: this.teamId },
                         extra: {
                             teamId: this.teamId,
                             distinctId: this.distinctId,

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -128,7 +128,7 @@ export class EventsProcessor {
         try {
             await this.propertyDefinitionsManager.updateEventNamesAndProperties(team.id, event, properties)
         } catch (err) {
-            Sentry.captureException(err)
+            Sentry.captureException(err, { tags: { team_id: team.id } })
             status.warn('⚠️', 'Failed to update property definitions for an event', {
                 event,
                 properties,

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -24,7 +24,7 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
         }
     }
 
-    const parsedTs = handleTimestamp(data, now, sentAt, callback)
+    const parsedTs = handleTimestamp(data, now, sentAt, data.team_id, callback)
     if (!parsedTs.isValid) {
         callback?.('ignored_invalid_timestamp', {
             field: 'timestamp',
@@ -41,6 +41,7 @@ function handleTimestamp(
     data: PluginEvent,
     now: DateTime,
     sentAt: DateTime | null,
+    teamId: number,
     callback?: IngestionWarningCallback
 ): DateTime {
     let parsedTs: DateTime = now
@@ -72,7 +73,11 @@ function handleTimestamp(
             parsedTs = now.plus(timestamp.diff(sentAt))
         } catch (error) {
             status.error('⚠️', 'Error when handling timestamp:', { error: error.message })
-            Sentry.captureException(error, { extra: { data, now, sentAt } })
+            Sentry.captureException(error, {
+                tags: { team_id: teamId },
+                extra: { data, now, sentAt },
+            })
+
             return timestamp
         }
     }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -449,7 +449,7 @@ export function addHistoricalEventsExportCapabilityV2(
                 eventsPerRun
             )
         } catch (error) {
-            Sentry.captureException(error)
+            Sentry.captureException(error, { tags: { team_id: pluginConfig.team_id } })
 
             await handleFetchError(error, activeExportParameters, payload)
             return

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -211,7 +211,7 @@ export function addHistoricalEventsExportCapability(
             )
         } catch (error) {
             fetchEventsError = error
-            Sentry.captureException(error)
+            Sentry.captureException(error, { tags: { team_id: pluginConfig.team_id } })
         }
 
         let exportEventsError: Error | unknown | null = null

--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -73,7 +73,7 @@ export const fetchTimestampBoundariesForTeam = async (
 
         return isValidMin && isValidMax ? { min: minDate, max: maxDate } : null
     } catch (e) {
-        Sentry.captureException(e)
+        Sentry.captureException(e, { tags: { team_id: teamId } })
         return null
     }
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
If we had team id info in sentry we could look this up for bug reports by tag

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

ran locally (https://posthog.sentry.io/settings/projects/karl-playground/keys/): 
```
SENTRY_DSN='<DNS-for-Karl-playground>' REGION='testing' DEBUG=1 ./bin/start
```

Example sentry error with team_id tag: https://posthog.sentry.io/issues/4166587036/?project=6605447&query=&referrer=issue-stream&statsPeriod=14d&stream_index=0

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
