### PR TITLE
fix(filter): remove automatic tab-right

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -120,7 +120,7 @@ describe('taxonomicFilterLogic', () => {
             .clearHistory()
             .toMatchValues({
                 searchQuery: 'selector',
-                activeTab: TaxonomicFilterGroupType.Elements, // tab changed!
+                activeTab: TaxonomicFilterGroupType.Events, // no tab change
                 infiniteListCounts: {
                     [TaxonomicFilterGroupType.Events]: 0,
                     [TaxonomicFilterGroupType.Actions]: 0,
@@ -137,7 +137,7 @@ describe('taxonomicFilterLogic', () => {
             .clearHistory()
             .toMatchValues({
                 searchQuery: 'this is not found',
-                activeTab: TaxonomicFilterGroupType.Elements, // no change
+                activeTab: TaxonomicFilterGroupType.Events, // no change
                 infiniteListCounts: {
                     [TaxonomicFilterGroupType.Events]: 0,
                     [TaxonomicFilterGroupType.Actions]: 0,
@@ -154,7 +154,7 @@ describe('taxonomicFilterLogic', () => {
             .clearHistory()
             .toMatchValues({
                 searchQuery: '',
-                activeTab: TaxonomicFilterGroupType.Elements, // no change
+                activeTab: TaxonomicFilterGroupType.Events,
                 infiniteListCounts: {
                     [TaxonomicFilterGroupType.Events]: 56,
                     [TaxonomicFilterGroupType.Actions]: 0,
@@ -165,24 +165,24 @@ describe('taxonomicFilterLogic', () => {
 
         // move right, skipping Actions
         await expectLogic(logic, () => logic.actions.tabRight()).toMatchValues({
+            activeTab: TaxonomicFilterGroupType.Elements,
+        })
+        await expectLogic(logic, () => logic.actions.tabRight()).toMatchValues({
             activeTab: TaxonomicFilterGroupType.Sessions,
         })
         await expectLogic(logic, () => logic.actions.tabRight()).toMatchValues({
             activeTab: TaxonomicFilterGroupType.Events,
-        })
-        await expectLogic(logic, () => logic.actions.tabRight()).toMatchValues({
-            activeTab: TaxonomicFilterGroupType.Elements,
         })
 
         // move left, skipping Actions
         await expectLogic(logic, () => logic.actions.tabLeft()).toMatchValues({
-            activeTab: TaxonomicFilterGroupType.Events,
-        })
-        await expectLogic(logic, () => logic.actions.tabLeft()).toMatchValues({
             activeTab: TaxonomicFilterGroupType.Sessions,
         })
         await expectLogic(logic, () => logic.actions.tabLeft()).toMatchValues({
             activeTab: TaxonomicFilterGroupType.Elements,
+        })
+        await expectLogic(logic, () => logic.actions.tabLeft()).toMatchValues({
+            activeTab: TaxonomicFilterGroupType.Events,
         })
 
         // open remote items tab after loading
@@ -194,7 +194,7 @@ describe('taxonomicFilterLogic', () => {
             .clearHistory()
             .toMatchValues({
                 searchQuery: 'event',
-                activeTab: TaxonomicFilterGroupType.Events, // changed!
+                activeTab: TaxonomicFilterGroupType.Events,
                 infiniteListCounts: {
                     [TaxonomicFilterGroupType.Events]: 3,
                     [TaxonomicFilterGroupType.Actions]: 0,

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -588,26 +588,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             }
         },
 
-        setSearchQuery: () => {
-            const { activeTaxonomicGroup, infiniteListCounts } = values
-
-            // Taxonomic group with a local data source, zero results after searching.
-            // Open the next tab.
-            if (
-                activeTaxonomicGroup &&
-                !activeTaxonomicGroup.endpoint &&
-                infiniteListCounts[activeTaxonomicGroup.type] === 0
-            ) {
-                actions.tabRight()
-            }
-        },
-
         infiniteListResultsReceived: ({ groupType, results }) => {
-            // Open the next tab if no results on an active tab.
-            if (groupType === values.activeTab && !results.count && !results.expandedCount) {
-                actions.tabRight()
-            }
-
             // Update app-wide cached property metadata
             if (
                 results.count > 0 &&


### PR DESCRIPTION
## Problem

We automatically select the next tab if there are no results in the filter. This works fine, but always moves you to HogQL if you're making mistakes, and never moves back:

![2023-05-05 10 17 49](https://user-images.githubusercontent.com/53387/236409261-057b1c2d-fb05-460c-9363-bc111282fb25.gif)

Plus on cloud the events properties load so slow that it'll "jump" when you're not expecting it.

## Changes

Removed automatic tab-right.

![2023-05-05 10 15 46](https://user-images.githubusercontent.com/53387/236408996-edbbca5b-8fd9-4cbd-bceb-951baba3d44c.gif)

## How did you test this code?

Clicked around in the filter.