### PR TITLE
fix(data-exploration): refactor taxonomic breakdown filter (1/3)

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -153,7 +153,6 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             breakdown: filters.breakdown,
             breakdown_normalize_url: filters.breakdown_normalize_url,
             breakdowns: filters.breakdowns,
-            breakdown_value: filters.breakdown_value,
             breakdown_group_type_index: filters.breakdown_group_type_index,
         })
     }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -134,9 +134,6 @@
                                 }
                             ]
                         },
-                        "breakdown_value": {
-                            "type": ["string", "number"]
-                        },
                         "breakdowns": {
                             "items": {
                                 "$ref": "#/definitions/Breakdown"
@@ -267,9 +264,6 @@
                                     "type": "null"
                                 }
                             ]
-                        },
-                        "breakdown_value": {
-                            "type": ["string", "number"]
                         },
                         "breakdowns": {
                             "items": {
@@ -409,9 +403,6 @@
                                     "type": "null"
                                 }
                             ]
-                        },
-                        "breakdown_value": {
-                            "type": ["string", "number"]
                         },
                         "breakdowns": {
                             "items": {
@@ -602,9 +593,6 @@
                                 }
                             ]
                         },
-                        "breakdown_value": {
-                            "type": ["string", "number"]
-                        },
                         "breakdowns": {
                             "items": {
                                 "$ref": "#/definitions/Breakdown"
@@ -767,9 +755,6 @@
                                 }
                             ]
                         },
-                        "breakdown_value": {
-                            "type": ["string", "number"]
-                        },
                         "breakdowns": {
                             "items": {
                                 "$ref": "#/definitions/Breakdown"
@@ -888,9 +873,6 @@
                                 }
                             ]
                         },
-                        "breakdown_value": {
-                            "type": ["string", "number"]
-                        },
                         "breakdowns": {
                             "items": {
                                 "$ref": "#/definitions/Breakdown"
@@ -1001,9 +983,6 @@
                                     "type": "null"
                                 }
                             ]
-                        },
-                        "breakdown_value": {
-                            "type": ["string", "number"]
                         },
                         "breakdowns": {
                             "items": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1147,9 +1147,6 @@
         "BreakdownFilter": {
             "additionalProperties": false,
             "properties": {
-                "aggregation_group_type_index": {
-                    "type": "number"
-                },
                 "breakdown": {
                     "$ref": "#/definitions/BreakdownKeyType"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1166,9 +1166,6 @@
                         }
                     ]
                 },
-                "breakdown_value": {
-                    "type": ["string", "number"]
-                },
                 "breakdowns": {
                     "items": {
                         "$ref": "#/definitions/Breakdown"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -494,7 +494,6 @@ export interface BreakdownFilter {
     breakdowns?: Breakdown[]
     breakdown_value?: string | number
     breakdown_group_type_index?: number | null
-    aggregation_group_type_index?: number | undefined // Groups aggregation
 }
 
 /** Pass custom metadata to queries. Used for e.g. custom columns in the DataTable. */

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -492,7 +492,6 @@ export interface BreakdownFilter {
     breakdown?: BreakdownKeyType
     breakdown_normalize_url?: boolean
     breakdowns?: Breakdown[]
-    breakdown_value?: string | number
     breakdown_group_type_index?: number | null
 }
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -4,7 +4,7 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { cohortsModel } from '~/models/cohortsModel'
 import { FilterType } from '~/types'
 import { breakdownTagLogic } from './breakdownTagLogic'
-import { isAllCohort, isCohort, isPersonEventOrGroup } from './TaxonomicBreakdownFilter'
+import { isAllCohort, isCohort, isPersonEventOrGroup } from './taxonomicBreakdownFilterUtils'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -8,19 +8,12 @@ import { BreakdownTag } from './BreakdownTag'
 import './TaxonomicBreakdownFilter.scss'
 import { onFilterChange, isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { isCohortBreakdown } from './taxonomicBreakdownFilterUtils'
 
 export interface TaxonomicBreakdownFilterProps {
     filters: Partial<FilterType>
     setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
 }
-
-export const isAllCohort = (t: number | string): t is string => typeof t === 'string' && t == 'all'
-
-export const isCohort = (t: number | string): t is number => typeof t === 'number'
-
-export const isCohortBreakdown = (t: number | string): t is number | string => isAllCohort(t) || isCohort(t)
-
-export const isPersonEventOrGroup = (t: number | string): t is string => typeof t === 'string' && t !== 'all'
 
 export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
     const { breakdown, breakdown_type } = filters

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -6,6 +6,14 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 import { taxonomicFilterTypeToPropertyFilterType } from 'lib/components/PropertyFilters/utils'
 
+export const isAllCohort = (t: number | string): t is string => typeof t === 'string' && t == 'all'
+
+export const isCohort = (t: number | string): t is number => typeof t === 'number'
+
+export const isCohortBreakdown = (t: number | string): t is number | string => isAllCohort(t) || isCohort(t)
+
+export const isPersonEventOrGroup = (t: number | string): t is string => typeof t === 'string' && t !== 'all'
+
 export const isURLNormalizeable = (propertyName: string): boolean => {
     return ['$current_url', '$pathname'].includes(propertyName)
 }

--- a/frontend/src/scenes/insights/insightDataTimingLogic.ts
+++ b/frontend/src/scenes/insights/insightDataTimingLogic.ts
@@ -44,7 +44,6 @@ export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
     }),
     listeners(({ actions, values }) => ({
         loadData: ({ queryId }) => {
-            console.debug('loadData', queryId)
             actions.startQuery(queryId)
         },
         loadDataSuccess: ({ payload }) => {

--- a/frontend/src/scenes/retention/abstractRetentionLogic.ts
+++ b/frontend/src/scenes/retention/abstractRetentionLogic.ts
@@ -86,7 +86,6 @@ export const abstractRetentionLogic = kea<abstractRetentionLogicType>({
                     breakdown: filters.breakdown,
                     breakdown_normalize_url: filters.breakdown_normalize_url,
                     breakdowns: filters.breakdowns,
-                    breakdown_value: filters.breakdown_value,
                     breakdown_group_type_index: filters.breakdown_group_type_index,
                 }
             },

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -12,6 +12,7 @@ import {
     GraphDataset,
     LifecycleToggle,
     StepOrderValue,
+    TrendsFilterType,
 } from '~/types'
 import { filterTrendsClientSideParams } from 'scenes/insights/sharedUtils'
 import { InsightLabel } from 'lib/components/InsightLabel'
@@ -137,7 +138,7 @@ export function parsePeopleParams(peopleParams: PeopleParamType, filters: Partia
         entity_type: action?.type || filters?.events?.[0]?.type || filters?.actions?.[0]?.type,
         entity_math: action?.math || undefined,
         breakdown_value,
-    })
+    } as TrendsFilterType)
 
     // casting here is not the best
     if (isStickinessFilter(filters)) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1554,7 +1554,6 @@ export interface FilterType {
     breakdown?: BreakdownKeyType
     breakdown_normalize_url?: boolean
     breakdowns?: Breakdown[]
-    breakdown_value?: string | number
     breakdown_group_type_index?: number | null
     aggregation_group_type_index?: number // Groups aggregation
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1018,7 +1018,6 @@ class AnyPartialFilterTypeItem(BaseModel):
     breakdown_histogram_bin_count: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
     compare: Optional[bool] = None
     date_from: Optional[str] = None
@@ -1075,7 +1074,6 @@ class AnyPartialFilterTypeItem1(BaseModel):
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
     compare: Optional[bool] = None
     date_from: Optional[str] = None
@@ -1134,7 +1132,6 @@ class AnyPartialFilterTypeItem2(BaseModel):
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
     date_from: Optional[str] = None
     date_to: Optional[str] = None
@@ -1202,7 +1199,6 @@ class AnyPartialFilterTypeItem3(BaseModel):
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
     date_from: Optional[str] = None
     date_to: Optional[str] = None
@@ -1268,7 +1264,6 @@ class AnyPartialFilterTypeItem4(BaseModel):
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
     date_from: Optional[str] = None
     date_to: Optional[str] = None
@@ -1323,7 +1318,6 @@ class AnyPartialFilterTypeItem5(BaseModel):
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
     date_from: Optional[str] = None
     date_to: Optional[str] = None
@@ -1375,7 +1369,6 @@ class AnyPartialFilterTypeItem6(BaseModel):
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
     date_from: Optional[str] = None
     date_to: Optional[str] = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -474,7 +474,6 @@ class BreakdownFilter(BaseModel):
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
-    breakdown_value: Optional[Union[str, float]] = None
     breakdowns: Optional[List[Breakdown]] = None
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -470,7 +470,6 @@ class BreakdownFilter(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    aggregation_group_type_index: Optional[float] = None
     breakdown: Optional[Union[str, float, List[Union[str, float]]]] = None
     breakdown_group_type_index: Optional[float] = None
     breakdown_normalize_url: Optional[bool] = None


### PR DESCRIPTION
## Problem

The breakdown filter has a couple of issues:
- we're displaying the histogram options for funnel breakdowns, where they aren't supported
- it's possible to add a cohort multiple times
- changing the histogram options breaks in data exploration
- the differing options for trends and funnels is not properly handled for data exploration
- the breakdown filter is only updated after results are in

This stacked PR does the following:
1. improvements to the breakdown types and moving utils around in preparation of step 2: this PR
2. refactoring the breakdown filter by breaking it down into multiple components and moving the business logic into a logic: https://github.com/PostHog/posthog/pull/15425
3. fixing the actual issues: https://github.com/PostHog/posthog/pull/15427

## Changes

This PR:
- moves the utils in `TaxonomicBreakdownFilter` to the `taxonomicBreakdownFilterUtils` file
- removes the `breakdown_value` property from the breakdown filter, as it is actually a result property
- removes the aggregation_group_type_index` from the breakdown filter, as it is a separate root level property

## How did you test this code?

\- 