### PR TITLE
fix: flush sessions when idle not when buffer has reached an age

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -105,21 +105,18 @@ export class SessionManager {
         const gzipSizeKb = bufferSizeKb * ESTIMATED_GZIP_COMPRESSION_RATIO
         const gzippedCapacity = gzipSizeKb / this.serverConfig.SESSION_RECORDING_MAX_BUFFER_SIZE_KB
 
-        const overCapacity = gzippedCapacity > 1
-
-        if (overCapacity) {
+        if (gzippedCapacity > 1) {
             // return the promise and let the caller decide whether to await
             return this.flush()
         }
     }
 
     public async flushIfSessionIsIdle(): Promise<void> {
-        const timeSinceLastEventTooLong =
+        if (
             this.buffer.lastMessageReceivedAt !== null &&
             Date.now() - this.buffer.lastMessageReceivedAt >=
                 this.serverConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS * 1000
-
-        if (timeSinceLastEventTooLong) {
+        ) {
             // return the promise and let the caller decide whether to await
             return this.flush()
         }

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -82,7 +82,7 @@ export class SessionManager {
         }
     }
 
-    public async add(message: IncomingRecordingMessage, kafkaMessageTimestamp: number | undefined): Promise<void> {
+    public async add(message: IncomingRecordingMessage): Promise<void> {
         // TODO: Check that the offset is higher than the lastProcessed
         // If not - ignore it
         // If it is - update lastProcessed and process it
@@ -92,7 +92,7 @@ export class SessionManager {
             await this.addToChunks(message)
         }
 
-        this.buffer.lastMessageReceivedAt = kafkaMessageTimestamp || Date.now()
+        this.buffer.lastMessageReceivedAt = message.metadata.timestamp || Date.now()
         await this.flushIfBufferExceedsCapacity()
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/types.ts
@@ -4,6 +4,7 @@ export type IncomingRecordingMessage = {
         topic: string
         partition: number
         offset: number
+        timestamp: number | undefined
     }
 
     team_id: number

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon'
 import fs from 'node:fs'
 
 import { defaultConfig } from '../../../../../src/config/config'
@@ -22,11 +23,13 @@ describe('session-manager', () => {
         const event = createIncomingRecordingMessage({
             data: compressToString(payload),
         })
-        await sessionManager.add(event)
+        const kafkaMessageTimestamp = DateTime.local().toMillis()
+        await sessionManager.add(event, kafkaMessageTimestamp)
 
         expect(sessionManager.buffer).toEqual({
             count: 1,
             createdAt: expect.any(Date),
+            lastMessageReceivedAt: kafkaMessageTimestamp,
             file: expect.any(String),
             id: expect.any(String),
             size: 61, // The size of the event payload - this may change when test data changes
@@ -36,9 +39,33 @@ describe('session-manager', () => {
         expect(fileContents.data).toEqual(payload)
     })
 
+    it('does not flush if it has received a message recently', async () => {
+        const payload = JSON.stringify([{ simple: 'data' }])
+        const event = createIncomingRecordingMessage({
+            data: compressToString(payload),
+        })
+        await sessionManager.add(event, DateTime.local().minus({ minutes: 9 }).toMillis())
+
+        await sessionManager.flushIfSessionIsIdle()
+
+        expect(sessionManager.buffer.count).toEqual(1)
+    })
+
+    it('does not flush if it has not received a message recently', async () => {
+        const payload = JSON.stringify([{ simple: 'data' }])
+        const event = createIncomingRecordingMessage({
+            data: compressToString(payload),
+        })
+        await sessionManager.add(event, DateTime.local().minus({ minutes: 11 }).toMillis())
+
+        await sessionManager.flushIfSessionIsIdle()
+
+        expect(sessionManager.buffer.count).toEqual(0)
+    })
+
     it('flushes messages', async () => {
         const event = createIncomingRecordingMessage()
-        await sessionManager.add(event)
+        await sessionManager.add(event, DateTime.local().toMillis())
         expect(sessionManager.buffer.count).toEqual(1)
         const file = sessionManager.buffer.file
         expect(fs.existsSync(file)).toEqual(true)
@@ -58,11 +85,11 @@ describe('session-manager', () => {
     it('flushes messages and whilst collecting new ones', async () => {
         const event = createIncomingRecordingMessage()
         const event2 = createIncomingRecordingMessage()
-        await sessionManager.add(event)
+        await sessionManager.add(event, DateTime.local().toMillis())
         expect(sessionManager.buffer.count).toEqual(1)
 
         const flushPromise = sessionManager.flush()
-        await sessionManager.add(event2)
+        await sessionManager.add(event2, DateTime.local().toMillis())
 
         expect(sessionManager.buffer.count).toEqual(1)
         expect(sessionManager.flushBuffer?.count).toEqual(1)
@@ -84,15 +111,15 @@ describe('session-manager', () => {
         expect(events[1].data.length).toBeGreaterThan(1)
         expect(events[2].data.length).toBeGreaterThan(1)
 
-        await sessionManager.add(events[0])
+        await sessionManager.add(events[0], DateTime.local().toMillis())
         expect(sessionManager.buffer.count).toEqual(0)
         expect(sessionManager.chunks.size).toEqual(1)
 
-        await sessionManager.add(events[2])
+        await sessionManager.add(events[2], DateTime.local().toMillis())
         expect(sessionManager.buffer.count).toEqual(0)
         expect(sessionManager.chunks.size).toEqual(1)
 
-        await sessionManager.add(events[1])
+        await sessionManager.add(events[1], DateTime.local().toMillis())
         expect(sessionManager.buffer.count).toEqual(1)
         expect(sessionManager.chunks.size).toEqual(0)
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
@@ -10,6 +10,7 @@ export function createIncomingRecordingMessage(data: Partial<IncomingRecordingMe
             topic: 'session_recording_events',
             partition: 1,
             offset: 1,
+            timestamp: undefined,
         },
 
         team_id: 1,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer-rebalancing.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer-rebalancing.test.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon'
+
 import { waitForExpect } from '../../../../functional_tests/expectations'
 import { defaultConfig } from '../../../../src/config/config'
 import { SessionRecordingBlobIngester } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-blob-consumer'
@@ -37,10 +39,12 @@ describe('ingester rebalancing tests', () => {
         await ingesterOne.start()
 
         await ingesterOne.consume(
-            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 })
+            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 }),
+            DateTime.local().toMillis()
         )
         await ingesterOne.consume(
-            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 })
+            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 }),
+            DateTime.local().toMillis()
         )
 
         await waitForExpect(() => {
@@ -51,6 +55,7 @@ describe('ingester rebalancing tests', () => {
         await ingesterTwo.start()
 
         await waitForExpect(() => {
+            // because the rebalancing strategy is cooperative sticky the partition stays on the same ingester
             assertIngesterHasExpectedPartitions(ingesterOne, [1])
 
             // only one partition so nothing for the new consumer to do

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer-rebalancing.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer-rebalancing.test.ts
@@ -1,5 +1,3 @@
-import { DateTime } from 'luxon'
-
 import { waitForExpect } from '../../../../functional_tests/expectations'
 import { defaultConfig } from '../../../../src/config/config'
 import { SessionRecordingBlobIngester } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-blob-consumer'
@@ -39,12 +37,10 @@ describe('ingester rebalancing tests', () => {
         await ingesterOne.start()
 
         await ingesterOne.consume(
-            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 }),
-            DateTime.local().toMillis()
+            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 })
         )
         await ingesterOne.consume(
-            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 }),
-            DateTime.local().toMillis()
+            createIncomingRecordingMessage({ session_id: new UUIDT().toString(), chunk_count: 2 })
         )
 
         await waitForExpect(() => {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -29,8 +29,11 @@ describe('session-recordings-consumer', () => {
         const organizationId = await createOrganization(postgres)
         const teamId = await createTeam(postgres, organizationId)
         const error = new LibrdKafkaError({ message: 'test', code: 1, errno: 1, origin: 'test', isRetriable: true })
-        producer.produce.mockImplementation((topic, partition, message, key, timestamp, headers, cb) => cb(error))
-        producer.flush.mockImplementation((timeout, cb) => cb(null))
+        producer.produce.mockImplementation(
+            (_topic: any, _partition: any, _message: any, _key: any, _timestamp: any, _headers: any, cb: any) =>
+                cb(error)
+        )
+        producer.flush.mockImplementation((_timeout: any, cb: any) => cb(null))
         await expect(
             eachBachWithDependencies([
                 {
@@ -45,8 +48,11 @@ describe('session-recordings-consumer', () => {
         const organizationId = await createOrganization(postgres)
         const teamId = await createTeam(postgres, organizationId)
         const error = new LibrdKafkaError({ message: 'test', code: 1, errno: 1, origin: 'test', isRetriable: false })
-        producer.produce.mockImplementation((topic, partition, message, key, timestamp, headers, cb) => cb(error))
-        producer.flush.mockImplementation((timeout, cb) => cb(null))
+        producer.produce.mockImplementation(
+            (_topic: any, _partition: any, _message: any, _key: any, _timestamp: any, _headers: any, cb: any) =>
+                cb(error)
+        )
+        producer.flush.mockImplementation((_timeout: any, cb: any) => cb(null))
         await eachBachWithDependencies([
             {
                 key: 'test',


### PR DESCRIPTION
## Problem

During recording blob ingestion we flush the buffers to S3 based on time since we created the buffer files or the size of the buffer file. 

But this is likely to lead to flushing all sessions on a consumer very close together in time. Which will push up RAM usage during flushing.

It's also anyway not quite what we want.

## Changes

* when adding messages to the buffer we pass in the kafka message timestamp
* we track the last kafka message timestamp against the buffer
* periodically we flush the buffer to S3 if the time since the last message is too large
* when adding a message to the buffer we check if the buffer is past the size threshold and flush to s3 if it is
    * previously we would flush based on size _or_ time when adding messages

## How did you test this code?

developer tests and 👀 locally
