### PR TITLE
feat(data-management): display type for properties

### DIFF
--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -62,19 +62,6 @@ export function ActionsTable(): JSX.Element {
                 )
             },
         },
-        ...(hasAvailableFeature(AvailableFeature.TAGGING)
-            ? [
-                  {
-                      title: 'Tags',
-                      dataIndex: 'tags',
-                      width: 250,
-                      key: 'tags',
-                      render: function renderTags(tags: string[]) {
-                          return <ObjectTags tags={tags} staticOnly />
-                      },
-                  } as LemonTableColumn<ActionType, keyof ActionType | undefined>,
-              ]
-            : []),
         {
             title: 'Type',
             key: 'type',
@@ -128,6 +115,19 @@ export function ActionsTable(): JSX.Element {
                 )
             },
         },
+        ...(hasAvailableFeature(AvailableFeature.TAGGING)
+            ? [
+                  {
+                      title: 'Tags',
+                      dataIndex: 'tags',
+                      width: 250,
+                      key: 'tags',
+                      render: function renderTags(tags: string[]) {
+                          return <ObjectTags tags={tags} staticOnly />
+                      },
+                  } as LemonTableColumn<ActionType, keyof ActionType | undefined>,
+              ]
+            : []),
         createdByColumn() as LemonTableColumn<ActionType, keyof ActionType | undefined>,
         createdAtColumn() as LemonTableColumn<ActionType, keyof ActionType | undefined>,
         ...(currentTeam?.slack_incoming_webhook

--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
@@ -15,7 +15,7 @@ import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-managemen
 import { UsageDisabledWarning } from 'scenes/events/UsageDisabledWarning'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { PageHeader } from 'lib/components/PageHeader'
-import { LemonInput, LemonSelect } from '@posthog/lemon-ui'
+import { LemonInput, LemonSelect, LemonTag } from '@posthog/lemon-ui'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { ThirtyDayQueryCountTitle } from 'lib/components/DefinitionPopover/DefinitionPopoverContents'
 
@@ -48,6 +48,19 @@ export function PropertyDefinitionsTable(): JSX.Element {
                 return <PropertyDefinitionHeader definition={definition} hideIcon asLink />
             },
             sorter: (a, b) => a.name.localeCompare(b.name),
+        },
+        {
+            title: 'Type',
+            key: 'type',
+            render: function RenderType(_, definition: PropertyDefinition) {
+                return definition.property_type ? (
+                    <LemonTag type="success" className="uppercase">
+                        {definition.property_type}
+                    </LemonTag>
+                ) : (
+                    <span className="text-muted">—</span>
+                )
+            },
         },
         ...(hasDashboardCollaboration
             ? [


### PR DESCRIPTION
## Problem

I've been trying to find out which properties are histogram-able i.e. numeric.

## Changes

This PR add a type column to the data management page for properties and re-orders the columns for the actions page so that tags come after the type.

<img width="2279" alt="type_column" src="https://user-images.githubusercontent.com/1851359/236502004-1b92e82a-3e2b-45a1-88d2-9afc95ad5e02.png">

## How did you test this code?

Verfied the column works locally