### PR TITLE
fix: Typo in Cohort operators

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
@@ -206,7 +206,7 @@ export const FIELD_VALUES: Record<FieldOptionsType, FieldValues> = {
                 label: 'does not equal',
             },
             [PropertyOperator.IContains]: {
-                label: 'contain',
+                label: 'contains',
             },
             [PropertyOperator.NotIContains]: {
                 label: 'does not contain',


### PR DESCRIPTION
Issue [#15096](https://github.com/PostHog/posthog/issues/15096)
Fix: Typo in Cohort operators

## Changes
- Changed "contain" to "contains" in the cohort operators
<img width="764" alt="Screenshot 2023-05-05 at 11 27 48 PM" src="https://user-images.githubusercontent.com/111201256/236533030-3b14ca56-acd4-46a2-82c6-cce13beb4476.png">

## How did you test this code?
- Tested it locally and it is running smoothly
