### PR TITLE
chore: move EventsQuery to be Online

### DIFF
--- a/posthog/models/event/events_query.py
+++ b/posthog/models/event/events_query.py
@@ -139,7 +139,7 @@ def run_events_query(
         offset=ast.Constant(value=offset),
     )
 
-    query_result = execute_hogql_query(query=stmt, team=team, workload=Workload.OFFLINE, query_type="EventsQuery")
+    query_result = execute_hogql_query(query=stmt, team=team, workload=Workload.ONLINE, query_type="EventsQuery")
 
     # Convert star field from tuple to dict in each result
     if "*" in select_input_raw:


### PR DESCRIPTION
## Problem

live events are timing out currently which is degrading the experience for users and the experience for onboarding to the product.

Have live events processed by the 'online' cluster.

## Changes

workload from OFFLINE -> ONLINE

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
