### PR TITLE
fix(breakdown): gracefully handle histogram without values

### DIFF
--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -205,7 +205,9 @@ export function formatBreakdownLabel(
     isHistogram?: boolean
 ): string {
     if (isHistogram && typeof breakdown_value === 'string') {
-        const [bucketStart, bucketEnd] = JSON.parse(breakdown_value)
+        // replace nan with null
+        const bucketValues = breakdown_value.replace(/\bnan\b/g, 'null')
+        const [bucketStart, bucketEnd] = JSON.parse(bucketValues)
         const formattedBucketStart = formatBreakdownLabel(
             cohorts,
             formatPropertyValueForDisplay,

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -1,4 +1,5 @@
 import json
+import re
 import urllib.parse
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -495,7 +496,9 @@ class TrendsBreakdown:
 
     def breakdown_sort_function(self, value):
         if self.filter.using_histogram:
-            return json.loads(value.get("breakdown_value"))[0]
+            breakdown_value = value.get("breakdown_value")
+            breakdown_value = re.sub(r"\bnan\b", "NaN", breakdown_value)  # fix NaN values for JSON loading
+            return json.loads(breakdown_value)[0]
         if value.get("breakdown_value") == "all":
             return (-1, "")
         if self.filter.breakdown_type == "session":

--- a/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
@@ -601,3 +601,65 @@
   ORDER BY breakdown_value
   '
 ---
+# name: TestBreakdowns.test_breakdown_histogram_by_missing_property_regression
+  '
+  
+  SELECT arrayCompact(arrayMap(x -> floor(x, 2), quantiles(0.00, 0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 1.00)(value)))
+  FROM
+    (SELECT toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'this_property_does_not_exist'), '^"|"$', ''))) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event = 'watched movie'
+       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
+     GROUP BY value)
+  '
+---
+# name: TestBreakdowns.test_breakdown_histogram_by_missing_property_regression.1
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-12 23:59:59', 'UTC') - number * 86400) as day_start
+              FROM numbers(11)
+              UNION ALL SELECT toStartOfDay(toDateTime('2020-01-02 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['[nan,nan]'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(*) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            multiIf(toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'this_property_does_not_exist'), '^"|"$', ''))) >= nan
+                                    AND toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'this_property_does_not_exist'), '^"|"$', ''))) < nan, '[nan,nan]', '["",""]') as breakdown_value
+           FROM events e
+           WHERE e.team_id = 2
+             AND event = 'watched movie'
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
+             AND toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'this_property_does_not_exist'), '^"|"$', ''))) is not null
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
+  '
+---

--- a/posthog/queries/trends/test/test_breakdowns.py
+++ b/posthog/queries/trends/test/test_breakdowns.py
@@ -312,3 +312,20 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
                 ("https://example.com", 2.0, [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
             ],
         )
+
+    @snapshot_clickhouse_queries
+    def test_breakdown_histogram_by_missing_property_regression(self):
+        response = self._run(
+            {
+                "breakdown": "this_property_does_not_exist",
+                "breakdown_type": "event",
+                "breakdown_histogram_bin_count": 10,
+            },
+        )
+
+        self.assertEqual(
+            [(item["breakdown_value"], item["count"], item["data"]) for item in response],
+            [
+                ("[nan,nan]", 0.0, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ],
+        )


### PR DESCRIPTION
## Problem

The breakdown for a numeric property breaks when there are no values for the given event. Example: `file_size_b` for `$pageview` event in the demo data.

## Changes

This PR gracefully handles this case on the frontend and backend.

## How did you test this code?

Verified that the above mentioned case works