### PR TITLE
fix(data-exploration): refactor taxonomic breakdown filter (2/3)

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -145,7 +145,17 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
         /* handle missing breakdown_type */
         // check for undefined and null values
         if (filters.breakdown != null && filters.breakdown_type == null) {
+<<<<<<< HEAD
             filters.breakdown_type = 'event'
+=======
+            if (Array.isArray(filters.breakdown)) {
+                filters.breakdown_type = 'cohort'
+            } else if ((filters.breakdown as string).startsWith('$initial_')) {
+                filters.breakdown_type = 'person'
+            } else {
+                filters.breakdown_type = 'event'
+            }
+>>>>>>> 45ac2f8ae (fix typing)
         }
 
         query.breakdown = objectCleanWithEmpty({

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -145,17 +145,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
         /* handle missing breakdown_type */
         // check for undefined and null values
         if (filters.breakdown != null && filters.breakdown_type == null) {
-<<<<<<< HEAD
             filters.breakdown_type = 'event'
-=======
-            if (Array.isArray(filters.breakdown)) {
-                filters.breakdown_type = 'cohort'
-            } else if ((filters.breakdown as string).startsWith('$initial_')) {
-                filters.breakdown_type = 'person'
-            } else {
-                filters.breakdown_type = 'event'
-            }
->>>>>>> 45ac2f8ae (fix typing)
         }
 
         query.breakdown = objectCleanWithEmpty({

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -9,7 +9,6 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
-import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 type BreakdownTagProps = {
     breakdown: string | number
@@ -24,9 +23,9 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
 
     const logicProps = { breakdown, filters, setFilters }
     const { binCount, useHistogram } = useValues(breakdownTagLogic(logicProps))
-    const { setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(breakdownTagLogic(logicProps))
-
-    const { removeBreakdown } = useActions(taxonomicBreakdownFilterLogic)
+    const { removeBreakdown, setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(
+        breakdownTagLogic(logicProps)
+    )
 
     const propertyDefinition = getPropertyDefinition(breakdown)
     const isHistogramable = !!propertyDefinition?.is_numerical
@@ -36,7 +35,7 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
         <LemonTag
             className="taxonomic-breakdown-filter tag-pill"
             closable={!!setFilters && !isHistogramable && !isNormalizeable}
-            onClose={() => removeBreakdown(breakdown)}
+            onClose={removeBreakdown}
             popover={{
                 overlay: isNormalizeable ? (
                     <>
@@ -72,7 +71,7 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
                             }
                         />
                         <LemonDivider />
-                        <LemonButton status="danger" onClick={() => removeBreakdown(breakdown)} fullWidth>
+                        <LemonButton status="danger" onClick={removeBreakdown} fullWidth>
                             Remove breakdown
                         </LemonButton>
                     </>
@@ -111,7 +110,7 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
                             Do not bin numeric values
                         </LemonButton>
                         <LemonDivider />
-                        <LemonButton status="danger" onClick={() => removeBreakdown(breakdown)} fullWidth>
+                        <LemonButton status="danger" onClick={removeBreakdown} fullWidth>
                             Remove breakdown
                         </LemonButton>
                     </div>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -9,28 +9,24 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
+import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 type BreakdownTagProps = {
     setFilters?: (filter: Partial<FilterType>, mergeFilters?: boolean) => void
     filters: FilterType
-    removeBreakdown?: () => void
     breakdown: string | number
     logicKey: string
 }
 
-export function BreakdownTag({
-    setFilters,
-    filters,
-    removeBreakdown,
-    breakdown,
-    logicKey,
-}: BreakdownTagProps): JSX.Element {
+export function BreakdownTag({ setFilters, filters, breakdown, logicKey }: BreakdownTagProps): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
     const breakdownTagLogicInstance = breakdownTagLogic({ logicKey, setFilters, filters })
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
     const { binCount, useHistogram } = useValues(breakdownTagLogicInstance)
     const { setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(breakdownTagLogicInstance)
+
+    const { removeBreakdown } = useActions(taxonomicBreakdownFilterLogic)
 
     const propertyDefinition = getPropertyDefinition(breakdown)
     const isHistogramable = !!propertyDefinition?.is_numerical
@@ -40,7 +36,7 @@ export function BreakdownTag({
         <LemonTag
             className="taxonomic-breakdown-filter tag-pill"
             closable={!!setFilters && !isHistogramable && !isNormalizeable}
-            onClose={removeBreakdown}
+            onClose={() => removeBreakdown(breakdown)}
             popover={{
                 overlay: isNormalizeable ? (
                     <>
@@ -76,7 +72,7 @@ export function BreakdownTag({
                             }
                         />
                         <LemonDivider />
-                        <LemonButton status="danger" onClick={onClose} fullWidth>
+                        <LemonButton status="danger" onClick={() => removeBreakdown(breakdown)} fullWidth>
                             Remove breakdown
                         </LemonButton>
                     </>
@@ -115,7 +111,7 @@ export function BreakdownTag({
                             Do not bin numeric values
                         </LemonButton>
                         <LemonDivider />
-                        <LemonButton status="danger" onClick={removeBreakdown} fullWidth>
+                        <LemonButton status="danger" onClick={() => removeBreakdown(breakdown)} fullWidth>
                             Remove breakdown
                         </LemonButton>
                     </div>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -8,7 +8,6 @@ import { isAllCohort, isCohort, isPersonEventOrGroup } from './taxonomicBreakdow
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 
 type BreakdownTagProps = {
     breakdown: string | number
@@ -21,15 +20,11 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
 
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const logicProps = { breakdown, filters, setFilters }
-    const { binCount, useHistogram } = useValues(breakdownTagLogic(logicProps))
+    const logicProps = { breakdown, filters, setFilters, getPropertyDefinition }
+    const { binCount, useHistogram, isHistogramable, isNormalizeable } = useValues(breakdownTagLogic(logicProps))
     const { removeBreakdown, setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(
         breakdownTagLogic(logicProps)
     )
-
-    const propertyDefinition = getPropertyDefinition(breakdown)
-    const isHistogramable = !!propertyDefinition?.is_numerical
-    const isNormalizeable = isURLNormalizeable(propertyDefinition?.name || '')
 
     return (
         <LemonTag

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -12,15 +12,14 @@ import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 type BreakdownTagProps = {
-    setFilters?: (filter: Partial<FilterType>, mergeFilters?: boolean) => void
-    filters: FilterType
     breakdown: string | number
-    logicKey: string
+    filters: FilterType
+    setFilters?: (filter: Partial<FilterType>, mergeFilters?: boolean) => void
 }
 
-export function BreakdownTag({ setFilters, filters, breakdown, logicKey }: BreakdownTagProps): JSX.Element {
+export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagProps): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
-    const breakdownTagLogicInstance = breakdownTagLogic({ logicKey, setFilters, filters })
+    const breakdownTagLogicInstance = breakdownTagLogic({ breakdown, filters, setFilters })
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
     const { binCount, useHistogram } = useValues(breakdownTagLogicInstance)

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -1,12 +1,11 @@
-import { LemonButton, LemonDivider, LemonInput, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
-import { useActions, useValues } from 'kea'
+import { LemonTag } from '@posthog/lemon-ui'
+import { BindLogic, useActions, useValues } from 'kea'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { cohortsModel } from '~/models/cohortsModel'
 import { FilterType } from '~/types'
 import { breakdownTagLogic } from './breakdownTagLogic'
 import { isAllCohort, isCohort, isPersonEventOrGroup } from './taxonomicBreakdownFilterUtils'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { IconInfo } from 'lib/lemon-ui/icons'
+import { BreakdownTagMenu } from './BreakdownTagMenu'
 
 type BreakdownTagProps = {
     breakdown: string | number
@@ -18,107 +17,29 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
     const { cohortsById } = useValues(cohortsModel)
 
     const logicProps = { breakdown, filters, setFilters }
-    const { binCount, useHistogram, isViewOnly, isHistogramable, isNormalizeable } = useValues(
-        breakdownTagLogic(logicProps)
-    )
-    const { removeBreakdown, setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(
-        breakdownTagLogic(logicProps)
-    )
+    const { isViewOnly, shouldShowMenu } = useValues(breakdownTagLogic(logicProps))
+    const { removeBreakdown } = useActions(breakdownTagLogic(logicProps))
 
     return (
-        <LemonTag
-            className="taxonomic-breakdown-filter tag-pill"
-            closable={!isViewOnly && !isHistogramable && !isNormalizeable}
-            onClose={removeBreakdown}
-            popover={{
-                overlay: isNormalizeable ? (
-                    <>
-                        <LemonSwitch
-                            checked={!!filters.breakdown_normalize_url}
-                            fullWidth={true}
-                            onChange={(checked) => setNormalizeBreakdownURL(checked)}
-                            className="min-h-10 px-2"
-                            id="normalize-breakdown-url-switch"
-                            label={
-                                <div className="flex flex-row items-center">
-                                    Normalize paths
-                                    <Tooltip
-                                        title={
-                                            <>
-                                                <p>
-                                                    Strip noise (trailing slashes, question marks, and hashes) from
-                                                    paths by enabling this option.
-                                                </p>
-                                                <p>
-                                                    Without path normalization, "https://example.com",
-                                                    "https://example.com/", "https://example.com/?" and
-                                                    "https://example.com/#" are treated as four distinct breakdown
-                                                    values. With normalization, they all count towards
-                                                    "https://example.com".
-                                                </p>
-                                            </>
-                                        }
-                                    >
-                                        <IconInfo className="text-xl text-muted-alt ml-1 shrink-0" />
-                                    </Tooltip>
-                                </div>
-                            }
-                        />
-                        <LemonDivider />
-                        <LemonButton status="danger" onClick={removeBreakdown} fullWidth>
-                            Remove breakdown
-                        </LemonButton>
-                    </>
-                ) : isHistogramable ? (
-                    <div>
-                        <LemonButton
-                            onClick={() => {
-                                setUseHistogram(true)
-                            }}
-                            status="stealth"
-                            active={useHistogram}
-                            fullWidth
-                        >
-                            Use{' '}
-                            <LemonInput
-                                min={1}
-                                value={binCount}
-                                onChange={(newValue) => {
-                                    setBinCount(newValue)
-                                }}
-                                fullWidth={false}
-                                type="number"
-                                className="histogram-bin-input"
-                            />
-                            bins
-                        </LemonButton>
-                        <LemonButton
-                            onClick={() => {
-                                setUseHistogram(false)
-                            }}
-                            status="stealth"
-                            active={!useHistogram}
-                            className="mt-2"
-                            fullWidth
-                        >
-                            Do not bin numeric values
-                        </LemonButton>
-                        <LemonDivider />
-                        <LemonButton status="danger" onClick={removeBreakdown} fullWidth>
-                            Remove breakdown
-                        </LemonButton>
-                    </div>
-                ) : undefined,
-                closeOnClickInside: false,
-            }}
-        >
-            <>
-                {isPersonEventOrGroup(breakdown) && <PropertyKeyInfo value={breakdown} />}
-                {isAllCohort(breakdown) && <PropertyKeyInfo value={'All Users'} />}
-                {isCohort(breakdown) && (
-                    <PropertyKeyInfo value={cohortsById[breakdown]?.name || `Cohort ${breakdown}`} />
-                )}
-            </>
-        </LemonTag>
+        <BindLogic logic={breakdownTagLogic} props={logicProps}>
+            <LemonTag
+                className="taxonomic-breakdown-filter tag-pill"
+                // display remove button only if we can edit and don't have a separate menu
+                closable={!isViewOnly && !shouldShowMenu}
+                onClose={removeBreakdown}
+                popover={{
+                    overlay: shouldShowMenu ? <BreakdownTagMenu filters={filters} /> : undefined,
+                    closeOnClickInside: false,
+                }}
+            >
+                <>
+                    {isPersonEventOrGroup(breakdown) && <PropertyKeyInfo value={breakdown} />}
+                    {isAllCohort(breakdown) && <PropertyKeyInfo value={'All Users'} />}
+                    {isCohort(breakdown) && (
+                        <PropertyKeyInfo value={cohortsById[breakdown]?.name || `Cohort ${breakdown}`} />
+                    )}
+                </>
+            </LemonTag>
+        </BindLogic>
     )
 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -13,12 +13,18 @@ import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 type BreakdownTagProps = {
     setFilters?: (filter: Partial<FilterType>, mergeFilters?: boolean) => void
     filters: FilterType
-    onClose?: () => void
+    removeBreakdown?: () => void
     breakdown: string | number
     logicKey: string
 }
 
-export function BreakdownTag({ setFilters, filters, onClose, breakdown, logicKey }: BreakdownTagProps): JSX.Element {
+export function BreakdownTag({
+    setFilters,
+    filters,
+    removeBreakdown,
+    breakdown,
+    logicKey,
+}: BreakdownTagProps): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
     const breakdownTagLogicInstance = breakdownTagLogic({ logicKey, setFilters, filters })
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
@@ -34,7 +40,7 @@ export function BreakdownTag({ setFilters, filters, onClose, breakdown, logicKey
         <LemonTag
             className="taxonomic-breakdown-filter tag-pill"
             closable={!!setFilters && !isHistogramable && !isNormalizeable}
-            onClose={onClose}
+            onClose={removeBreakdown}
             popover={{
                 overlay: isNormalizeable ? (
                     <>
@@ -109,7 +115,7 @@ export function BreakdownTag({ setFilters, filters, onClose, breakdown, logicKey
                             Do not bin numeric values
                         </LemonButton>
                         <LemonDivider />
-                        <LemonButton status="danger" onClick={onClose} fullWidth>
+                        <LemonButton status="danger" onClick={removeBreakdown} fullWidth>
                             Remove breakdown
                         </LemonButton>
                     </div>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -8,11 +8,10 @@ import { BreakdownTagMenu } from './BreakdownTagMenu'
 type BreakdownTagProps = {
     breakdown: string | number
     filters: FilterType
-    setFilters?: (filter: Partial<FilterType>, mergeFilters?: boolean) => void
 }
 
-export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagProps): JSX.Element {
-    const logicProps = { breakdown, filters, setFilters }
+export function BreakdownTag({ breakdown, filters }: BreakdownTagProps): JSX.Element {
+    const logicProps = { breakdown }
     const { isViewOnly, shouldShowMenu, propertyName } = useValues(breakdownTagLogic(logicProps))
     const { removeBreakdown } = useActions(breakdownTagLogic(logicProps))
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -7,11 +7,10 @@ import { breakdownTagLogic } from './breakdownTagLogic'
 import { isAllCohort, isCohort, isPersonEventOrGroup } from './taxonomicBreakdownFilterUtils'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 
 type BreakdownTagProps = {
-    isHistogramable: boolean
-    // e.g. example.com and example.com/ should be treated as the same value
-    isURLNormalizeable: boolean
     setFilters?: (filter: Partial<FilterType>, mergeFilters?: boolean) => void
     filters: FilterType
     onClose?: () => void
@@ -19,28 +18,25 @@ type BreakdownTagProps = {
     logicKey: string
 }
 
-export function BreakdownTag({
-    isHistogramable,
-    isURLNormalizeable,
-    setFilters,
-    filters,
-    onClose,
-    breakdown,
-    logicKey,
-}: BreakdownTagProps): JSX.Element {
+export function BreakdownTag({ setFilters, filters, onClose, breakdown, logicKey }: BreakdownTagProps): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
     const breakdownTagLogicInstance = breakdownTagLogic({ logicKey, setFilters, filters })
+    const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
     const { binCount, useHistogram } = useValues(breakdownTagLogicInstance)
     const { setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(breakdownTagLogicInstance)
 
+    const propertyDefinition = getPropertyDefinition(breakdown)
+    const isHistogramable = !!propertyDefinition?.is_numerical
+    const isNormalizeable = isURLNormalizeable(propertyDefinition?.name || '')
+
     return (
         <LemonTag
             className="taxonomic-breakdown-filter tag-pill"
-            closable={!!setFilters && !isHistogramable && !isURLNormalizeable}
+            closable={!!setFilters && !isHistogramable && !isNormalizeable}
             onClose={onClose}
             popover={{
-                overlay: isURLNormalizeable ? (
+                overlay: isNormalizeable ? (
                     <>
                         <LemonSwitch
                             checked={!!filters.breakdown_normalize_url}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -7,7 +7,6 @@ import { breakdownTagLogic } from './breakdownTagLogic'
 import { isAllCohort, isCohort, isPersonEventOrGroup } from './taxonomicBreakdownFilterUtils'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
-import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
 type BreakdownTagProps = {
     breakdown: string | number
@@ -18,9 +17,7 @@ type BreakdownTagProps = {
 export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagProps): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
 
-    const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
-
-    const logicProps = { breakdown, filters, setFilters, getPropertyDefinition }
+    const logicProps = { breakdown, filters, setFilters }
     const { binCount, useHistogram, isViewOnly, isHistogramable, isNormalizeable } = useValues(
         breakdownTagLogic(logicProps)
     )

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -19,11 +19,12 @@ type BreakdownTagProps = {
 
 export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagProps): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
-    const breakdownTagLogicInstance = breakdownTagLogic({ breakdown, filters, setFilters })
+
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const { binCount, useHistogram } = useValues(breakdownTagLogicInstance)
-    const { setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(breakdownTagLogicInstance)
+    const logicProps = { breakdown, filters, setFilters }
+    const { binCount, useHistogram } = useValues(breakdownTagLogic(logicProps))
+    const { setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(breakdownTagLogic(logicProps))
 
     const { removeBreakdown } = useActions(taxonomicBreakdownFilterLogic)
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -1,10 +1,8 @@
 import { LemonTag } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useValues } from 'kea'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { cohortsModel } from '~/models/cohortsModel'
 import { FilterType } from '~/types'
 import { breakdownTagLogic } from './breakdownTagLogic'
-import { isAllCohort, isCohort, isPersonEventOrGroup } from './taxonomicBreakdownFilterUtils'
 import { BreakdownTagMenu } from './BreakdownTagMenu'
 
 type BreakdownTagProps = {
@@ -14,10 +12,8 @@ type BreakdownTagProps = {
 }
 
 export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagProps): JSX.Element {
-    const { cohortsById } = useValues(cohortsModel)
-
     const logicProps = { breakdown, filters, setFilters }
-    const { isViewOnly, shouldShowMenu } = useValues(breakdownTagLogic(logicProps))
+    const { isViewOnly, shouldShowMenu, propertyName } = useValues(breakdownTagLogic(logicProps))
     const { removeBreakdown } = useActions(breakdownTagLogic(logicProps))
 
     return (
@@ -32,13 +28,7 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
                     closeOnClickInside: false,
                 }}
             >
-                <>
-                    {isPersonEventOrGroup(breakdown) && <PropertyKeyInfo value={breakdown} />}
-                    {isAllCohort(breakdown) && <PropertyKeyInfo value={'All Users'} />}
-                    {isCohort(breakdown) && (
-                        <PropertyKeyInfo value={cohortsById[breakdown]?.name || `Cohort ${breakdown}`} />
-                    )}
-                </>
+                <PropertyKeyInfo value={propertyName} />
             </LemonTag>
         </BindLogic>
     )

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -21,7 +21,9 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
     const logicProps = { breakdown, filters, setFilters, getPropertyDefinition }
-    const { binCount, useHistogram, isHistogramable, isNormalizeable } = useValues(breakdownTagLogic(logicProps))
+    const { binCount, useHistogram, isViewOnly, isHistogramable, isNormalizeable } = useValues(
+        breakdownTagLogic(logicProps)
+    )
     const { removeBreakdown, setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(
         breakdownTagLogic(logicProps)
     )
@@ -29,7 +31,7 @@ export function BreakdownTag({ breakdown, filters, setFilters }: BreakdownTagPro
     return (
         <LemonTag
             className="taxonomic-breakdown-filter tag-pill"
-            closable={!!setFilters && !isHistogramable && !isNormalizeable}
+            closable={!isViewOnly && !isHistogramable && !isNormalizeable}
             onClose={removeBreakdown}
             popover={{
                 overlay: isNormalizeable ? (

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTagMenu.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTagMenu.tsx
@@ -6,14 +6,19 @@ import { IconInfo } from 'lib/lemon-ui/icons'
 
 import { breakdownTagLogic } from './breakdownTagLogic'
 import { BreakdownFilter } from '~/queries/schema'
+import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 type BreakdownTagMenuProps = {
     filters: BreakdownFilter
 }
 
 export const BreakdownTagMenu = ({ filters }: BreakdownTagMenuProps): JSX.Element => {
-    const { binCount, useHistogram, isHistogramable, isNormalizeable } = useValues(breakdownTagLogic)
-    const { removeBreakdown, setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(breakdownTagLogic)
+    const { isHistogramable, isNormalizeable } = useValues(breakdownTagLogic)
+    const { removeBreakdown } = useActions(breakdownTagLogic)
+
+    const { histogramBinCount, histogramBinsUsed } = useValues(taxonomicBreakdownFilterLogic)
+    const { setHistogramBinCount, setHistogramBinsUsed, setNormalizeBreakdownURL } =
+        useActions(taxonomicBreakdownFilterLogic)
 
     return (
         <>
@@ -53,18 +58,18 @@ export const BreakdownTagMenu = ({ filters }: BreakdownTagMenuProps): JSX.Elemen
                 <>
                     <LemonButton
                         onClick={() => {
-                            setUseHistogram(true)
+                            setHistogramBinsUsed(true)
                         }}
                         status="stealth"
-                        active={useHistogram}
+                        active={histogramBinsUsed}
                         fullWidth
                     >
                         Use{' '}
                         <LemonInput
                             min={1}
-                            value={binCount}
+                            value={histogramBinCount}
                             onChange={(newValue) => {
-                                setBinCount(newValue)
+                                setHistogramBinCount(newValue)
                             }}
                             fullWidth={false}
                             type="number"
@@ -74,10 +79,10 @@ export const BreakdownTagMenu = ({ filters }: BreakdownTagMenuProps): JSX.Elemen
                     </LemonButton>
                     <LemonButton
                         onClick={() => {
-                            setUseHistogram(false)
+                            setHistogramBinsUsed(false)
                         }}
                         status="stealth"
-                        active={!useHistogram}
+                        active={!histogramBinsUsed}
                         className="mt-2"
                         fullWidth
                     >

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTagMenu.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTagMenu.tsx
@@ -1,0 +1,94 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonDivider, LemonInput, LemonSwitch } from '@posthog/lemon-ui'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { IconInfo } from 'lib/lemon-ui/icons'
+
+import { breakdownTagLogic } from './breakdownTagLogic'
+import { BreakdownFilter } from '~/queries/schema'
+
+type BreakdownTagMenuProps = {
+    filters: BreakdownFilter
+}
+
+export const BreakdownTagMenu = ({ filters }: BreakdownTagMenuProps): JSX.Element => {
+    const { binCount, useHistogram, isHistogramable, isNormalizeable } = useValues(breakdownTagLogic)
+    const { removeBreakdown, setBinCount, setUseHistogram, setNormalizeBreakdownURL } = useActions(breakdownTagLogic)
+
+    return (
+        <>
+            {isNormalizeable && (
+                <LemonSwitch
+                    checked={!!filters.breakdown_normalize_url} // TODO move global values/actions to taxonomicBreakdownFilterLogic
+                    fullWidth={true}
+                    onChange={(checked) => setNormalizeBreakdownURL(checked)}
+                    className="min-h-10 px-2"
+                    id="normalize-breakdown-url-switch"
+                    label={
+                        <div className="flex flex-row items-center">
+                            Normalize paths
+                            <Tooltip
+                                title={
+                                    <>
+                                        <p>
+                                            Strip noise (trailing slashes, question marks, and hashes) from paths by
+                                            enabling this option.
+                                        </p>
+                                        <p>
+                                            Without path normalization, "https://example.com", "https://example.com/",
+                                            "https://example.com/?" and "https://example.com/#" are treated as four
+                                            distinct breakdown values. With normalization, they all count towards
+                                            "https://example.com".
+                                        </p>
+                                    </>
+                                }
+                            >
+                                <IconInfo className="text-xl text-muted-alt ml-1 shrink-0" />
+                            </Tooltip>
+                        </div>
+                    }
+                />
+            )}
+            {isHistogramable && (
+                <>
+                    <LemonButton
+                        onClick={() => {
+                            setUseHistogram(true)
+                        }}
+                        status="stealth"
+                        active={useHistogram}
+                        fullWidth
+                    >
+                        Use{' '}
+                        <LemonInput
+                            min={1}
+                            value={binCount}
+                            onChange={(newValue) => {
+                                setBinCount(newValue)
+                            }}
+                            fullWidth={false}
+                            type="number"
+                            className="histogram-bin-input"
+                        />
+                        bins
+                    </LemonButton>
+                    <LemonButton
+                        onClick={() => {
+                            setUseHistogram(false)
+                        }}
+                        status="stealth"
+                        active={!useHistogram}
+                        className="mt-2"
+                        fullWidth
+                    >
+                        Do not bin numeric values
+                    </LemonButton>
+                </>
+            )}
+            <LemonDivider />
+            <LemonButton status="danger" onClick={removeBreakdown} fullWidth>
+                Remove breakdown
+            </LemonButton>
+        </>
+    )
+}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -15,14 +15,14 @@ import { IconPlusMini } from 'lib/lemon-ui/icons'
 
 export interface TaxonomicBreakdownButtonProps {
     breakdownType?: TaxonomicFilterGroupType
-    onChange: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => void
+    addBreakdown: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => void
     onlyCohorts?: boolean
     includeSessions?: boolean
 }
 
 export function TaxonomicBreakdownButton({
     breakdownType,
-    onChange,
+    addBreakdown,
     onlyCohorts,
     includeSessions,
 }: TaxonomicBreakdownButtonProps): JSX.Element {
@@ -49,7 +49,7 @@ export function TaxonomicBreakdownButton({
                     groupType={breakdownType}
                     onChange={(taxonomicGroup, value) => {
                         if (value) {
-                            onChange(value, taxonomicGroup)
+                            addBreakdown(value, taxonomicGroup)
                             setOpen(false)
                         }
                     }}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -1,34 +1,27 @@
-import {
-    TaxonomicFilterGroup,
-    TaxonomicFilterGroupType,
-    TaxonomicFilterValue,
-} from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useState } from 'react'
 import { Popover } from 'lib/lemon-ui/Popover/Popover'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { LemonButton } from '@posthog/lemon-ui'
 import { IconPlusMini } from 'lib/lemon-ui/icons'
+import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 export interface TaxonomicBreakdownButtonProps {
-    breakdownType?: TaxonomicFilterGroupType
-    addBreakdown: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => void
     onlyCohorts?: boolean
     includeSessions?: boolean
 }
 
-export function TaxonomicBreakdownButton({
-    breakdownType,
-    addBreakdown,
-    onlyCohorts,
-    includeSessions,
-}: TaxonomicBreakdownButtonProps): JSX.Element {
+export function TaxonomicBreakdownButton({ onlyCohorts, includeSessions }: TaxonomicBreakdownButtonProps): JSX.Element {
     const [open, setOpen] = useState(false)
     const { allEventNames } = useValues(insightLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
+
+    const { taxonomicBreakdownType } = useValues(taxonomicBreakdownFilterLogic)
+    const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic)
 
     const taxonomicGroupTypes = onlyCohorts
         ? [TaxonomicFilterGroupType.CohortsWithAllUsers]
@@ -46,7 +39,7 @@ export function TaxonomicBreakdownButton({
         <Popover
             overlay={
                 <TaxonomicFilter
-                    groupType={breakdownType}
+                    groupType={taxonomicBreakdownType}
                     onChange={(taxonomicGroup, value) => {
                         if (value) {
                             addBreakdown(value, taxonomicGroup)
@@ -70,7 +63,9 @@ export function TaxonomicBreakdownButton({
             >
                 <PropertyKeyInfo
                     value={
-                        breakdownType === TaxonomicFilterGroupType.CohortsWithAllUsers ? 'Add cohort' : 'Add breakdown'
+                        taxonomicBreakdownType === TaxonomicFilterGroupType.CohortsWithAllUsers
+                            ? 'Add cohort'
+                            : 'Add breakdown'
                     }
                 />
             </LemonButton>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -15,12 +15,10 @@ export interface TaxonomicBreakdownFilterProps {
 }
 
 export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
-    const { breakdown_type } = filters
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const { hasNonCohortBreakdown, taxonomicBreakdownType, breakdownArray, breakdownCohortArray } = useValues(
-        taxonomicBreakdownFilterLogic({ filters })
-    )
+    const { hasBreakdown, hasNonCohortBreakdown, taxonomicBreakdownType, breakdownArray, breakdownCohortArray } =
+        useValues(taxonomicBreakdownFilterLogic({ filters }))
 
     const onCloseFor = setFilters
         ? (t: string | number, index: number): (() => void) => {
@@ -49,7 +47,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
           }
         : undefined
 
-    const tags = !breakdown_type
+    const tags = !hasBreakdown
         ? []
         : breakdownArray.map((t, index) => {
               const key = `${t}-${index}`

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -18,17 +18,15 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { breakdown_type } = filters
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const { hasSelectedBreakdown, taxonomicBreakdownType, breakdownArray } = useValues(
+    const { hasSelectedBreakdown, taxonomicBreakdownType, breakdownArray, breakdownCohortArray } = useValues(
         taxonomicBreakdownFilterLogic({ filters })
     )
-
-    const breakdownParts = breakdownArray.map((b) => (isNaN(Number(b)) ? b : Number(b)))
 
     const onCloseFor = setFilters
         ? (t: string | number, index: number): (() => void) => {
               return () => {
                   if (isCohortBreakdown(t)) {
-                      const newParts = breakdownParts.filter((_, i): _ is string | number => i !== index)
+                      const newParts = breakdownCohortArray.filter((_, i): _ is string | number => i !== index)
                       if (newParts.length === 0) {
                           setFilters({ breakdown: null, breakdown_type: null })
                       } else {
@@ -74,7 +72,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
 
     const onChange = setFilters
         ? onFilterChange({
-              breakdownParts,
+              breakdownCohortArray,
               setFilters,
               getPropertyDefinition: getPropertyDefinition,
           })

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -21,9 +21,9 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic({ filters, setFilters, getPropertyDefinition }))
 
     const onCloseFor = setFilters
-        ? (t: string | number, index: number): (() => void) => {
+        ? (breakdown: string | number, index: number): (() => void) => {
               return () => {
-                  if (isCohortBreakdown(t)) {
+                  if (isCohortBreakdown(breakdown)) {
                       const newParts = breakdownCohortArray.filter((_, i): _ is string | number => i !== index)
                       if (newParts.length === 0) {
                           setFilters({ breakdown: null, breakdown_type: null })
@@ -49,12 +49,12 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
 
     const tags = !hasBreakdown
         ? []
-        : breakdownArray.map((t, index) => (
+        : breakdownArray.map((breakdown, index) => (
               <BreakdownTag
-                  key={`${t}-${index}`}
-                  logicKey={`${t}-${index}`}
-                  breakdown={t}
-                  onClose={onCloseFor ? onCloseFor(t, index) : undefined}
+                  key={`${breakdown}-${index}`}
+                  logicKey={`${breakdown}-${index}`}
+                  breakdown={breakdown}
+                  removeBreakdown={onCloseFor ? onCloseFor(breakdown, index) : undefined}
                   filters={filters}
                   setFilters={setFilters}
               />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -4,7 +4,6 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { ChartDisplayType, FilterType, InsightType, TrendsFilterType } from '~/types'
 import { BreakdownTag } from './BreakdownTag'
 import './TaxonomicBreakdownFilter.scss'
-import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { isCohortBreakdown } from './taxonomicBreakdownFilterUtils'
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
@@ -50,24 +49,16 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
 
     const tags = !hasBreakdown
         ? []
-        : breakdownArray.map((t, index) => {
-              const key = `${t}-${index}`
-              const propertyDefinition = getPropertyDefinition(t)
-              const isPropertyHistogramable = !!propertyDefinition?.is_numerical
-
-              return (
-                  <BreakdownTag
-                      key={key}
-                      logicKey={key}
-                      isHistogramable={isPropertyHistogramable}
-                      isURLNormalizeable={isURLNormalizeable(propertyDefinition?.name || '')}
-                      breakdown={t}
-                      onClose={onCloseFor ? onCloseFor(t, index) : undefined}
-                      filters={filters}
-                      setFilters={setFilters}
-                  />
-              )
-          })
+        : breakdownArray.map((t, index) => (
+              <BreakdownTag
+                  key={`${t}-${index}`}
+                  logicKey={`${t}-${index}`}
+                  breakdown={t}
+                  onClose={onCloseFor ? onCloseFor(t, index) : undefined}
+                  filters={filters}
+                  setFilters={setFilters}
+              />
+          ))
 
     return (
         <div className="flex flex-wrap gap-2 items-center">

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -15,12 +15,12 @@ export interface TaxonomicBreakdownFilterProps {
 }
 
 export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
-    const { breakdown, breakdown_type } = filters
+    const { breakdown_type } = filters
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const { hasSelectedBreakdown, taxonomicBreakdownType } = useValues(taxonomicBreakdownFilterLogic({ filters }))
-
-    const breakdownArray = (Array.isArray(breakdown) ? breakdown : [breakdown]).filter((b): b is string | number => !!b)
+    const { hasSelectedBreakdown, taxonomicBreakdownType, breakdownArray } = useValues(
+        taxonomicBreakdownFilterLogic({ filters })
+    )
 
     const breakdownParts = breakdownArray.map((b) => (isNaN(Number(b)) ? b : Number(b)))
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -1,6 +1,5 @@
 import { BindLogic, useValues } from 'kea'
 import { TaxonomicBreakdownButton } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton'
-import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { FilterType, InsightType } from '~/types'
 import { BreakdownTag } from './BreakdownTag'
 import './TaxonomicBreakdownFilter.scss'
@@ -12,9 +11,7 @@ export interface TaxonomicBreakdownFilterProps {
 }
 
 export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
-    const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
-
-    const logicProps = { filters, setFilters, getPropertyDefinition }
+    const logicProps = { filters, setFilters }
     const { hasBreakdown, hasNonCohortBreakdown, breakdownArray, isViewOnly } = useValues(
         taxonomicBreakdownFilterLogic(logicProps)
     )

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -18,7 +18,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { breakdown_type } = filters
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const { hasSelectedBreakdown, taxonomicBreakdownType, breakdownArray, breakdownCohortArray } = useValues(
+    const { hasNonCohortBreakdown, taxonomicBreakdownType, breakdownArray, breakdownCohortArray } = useValues(
         taxonomicBreakdownFilterLogic({ filters })
     )
 
@@ -81,7 +81,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     return (
         <div className="flex flex-wrap gap-2 items-center">
             {tags}
-            {onChange && !hasSelectedBreakdown ? (
+            {onChange && !hasNonCohortBreakdown ? (
                 <TaxonomicBreakdownButton
                     breakdownType={taxonomicBreakdownType}
                     onChange={onChange}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -18,9 +18,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
 
     const tags = !hasBreakdown
         ? []
-        : breakdownArray.map((breakdown) => (
-              <BreakdownTag key={breakdown} breakdown={breakdown} filters={filters} setFilters={setFilters} />
-          ))
+        : breakdownArray.map((breakdown) => <BreakdownTag key={breakdown} breakdown={breakdown} filters={filters} />)
 
     return (
         <BindLogic logic={taxonomicBreakdownFilterLogic} props={logicProps}>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -19,14 +19,8 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
 
     const tags = !hasBreakdown
         ? []
-        : breakdownArray.map((breakdown, index) => (
-              <BreakdownTag
-                  key={`${breakdown}-${index}`}
-                  logicKey={`${breakdown}-${index}`}
-                  breakdown={breakdown}
-                  filters={filters}
-                  setFilters={setFilters}
-              />
+        : breakdownArray.map((breakdown) => (
+              <BreakdownTag key={breakdown} breakdown={breakdown} filters={filters} setFilters={setFilters} />
           ))
 
     return (

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -15,7 +15,9 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
     const logicProps = { filters, setFilters, getPropertyDefinition }
-    const { hasBreakdown, hasNonCohortBreakdown, breakdownArray } = useValues(taxonomicBreakdownFilterLogic(logicProps))
+    const { hasBreakdown, hasNonCohortBreakdown, breakdownArray, isViewOnly } = useValues(
+        taxonomicBreakdownFilterLogic(logicProps)
+    )
 
     const tags = !hasBreakdown
         ? []
@@ -27,7 +29,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
         <BindLogic logic={taxonomicBreakdownFilterLogic} props={logicProps}>
             <div className="flex flex-wrap gap-2 items-center">
                 {tags}
-                {setFilters && !hasNonCohortBreakdown ? (
+                {!isViewOnly && !hasNonCohortBreakdown ? (
                     <TaxonomicBreakdownButton
                         includeSessions={filters.insight === InsightType.TRENDS} // TODO: convert to data exploration
                     />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -21,10 +21,10 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic({ filters, setFilters, getPropertyDefinition }))
 
     const onCloseFor = setFilters
-        ? (breakdown: string | number, index: number): (() => void) => {
+        ? (breakdown: string | number): (() => void) => {
               return () => {
                   if (isCohortBreakdown(breakdown)) {
-                      const newParts = breakdownCohortArray.filter((_, i): _ is string | number => i !== index)
+                      const newParts = breakdownCohortArray.filter((cohort) => cohort !== breakdown)
                       if (newParts.length === 0) {
                           setFilters({ breakdown: null, breakdown_type: null })
                       } else {
@@ -54,7 +54,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
                   key={`${breakdown}-${index}`}
                   logicKey={`${breakdown}-${index}`}
                   breakdown={breakdown}
-                  removeBreakdown={onCloseFor ? onCloseFor(breakdown, index) : undefined}
+                  removeBreakdown={onCloseFor ? onCloseFor(breakdown) : undefined}
                   filters={filters}
                   setFilters={setFilters}
               />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -1,4 +1,4 @@
-import { BindLogic, useActions, useValues } from 'kea'
+import { BindLogic, useValues } from 'kea'
 import { TaxonomicBreakdownButton } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { FilterType, InsightType } from '~/types'
@@ -15,10 +15,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
     const logicProps = { filters, setFilters, getPropertyDefinition }
-    const { hasBreakdown, hasNonCohortBreakdown, taxonomicBreakdownType, breakdownArray } = useValues(
-        taxonomicBreakdownFilterLogic(logicProps)
-    )
-    const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic(logicProps))
+    const { hasBreakdown, hasNonCohortBreakdown, breakdownArray } = useValues(taxonomicBreakdownFilterLogic(logicProps))
 
     const tags = !hasBreakdown
         ? []
@@ -38,8 +35,6 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
                 {tags}
                 {setFilters && !hasNonCohortBreakdown ? (
                     <TaxonomicBreakdownButton
-                        breakdownType={taxonomicBreakdownType}
-                        addBreakdown={addBreakdown}
                         includeSessions={filters.insight === InsightType.TRENDS} // TODO: convert to data exploration
                     />
                 ) : null}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -11,7 +11,7 @@ export interface TaxonomicBreakdownFilterProps {
 }
 
 export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
-    const logicProps = { filters, setFilters }
+    const logicProps = { filters, setFilters: setFilters || null }
     const { hasBreakdown, hasNonCohortBreakdown, breakdownArray, isViewOnly } = useValues(
         taxonomicBreakdownFilterLogic(logicProps)
     )

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -1,11 +1,9 @@
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { TaxonomicBreakdownButton } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { ChartDisplayType, FilterType, InsightType, TrendsFilterType } from '~/types'
+import { FilterType, InsightType } from '~/types'
 import { BreakdownTag } from './BreakdownTag'
 import './TaxonomicBreakdownFilter.scss'
-import { isTrendsFilter } from 'scenes/insights/sharedUtils'
-import { isCohortBreakdown } from './taxonomicBreakdownFilterUtils'
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 export interface TaxonomicBreakdownFilterProps {
@@ -16,36 +14,11 @@ export interface TaxonomicBreakdownFilterProps {
 export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreakdownFilterProps): JSX.Element {
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const { hasBreakdown, hasNonCohortBreakdown, taxonomicBreakdownType, breakdownArray, breakdownCohortArray } =
-        useValues(taxonomicBreakdownFilterLogic({ filters, setFilters, getPropertyDefinition }))
-    const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic({ filters, setFilters, getPropertyDefinition }))
-
-    const onCloseFor = setFilters
-        ? (breakdown: string | number): (() => void) => {
-              return () => {
-                  if (isCohortBreakdown(breakdown)) {
-                      const newParts = breakdownCohortArray.filter((cohort) => cohort !== breakdown)
-                      if (newParts.length === 0) {
-                          setFilters({ breakdown: null, breakdown_type: null })
-                      } else {
-                          setFilters({ breakdown: newParts, breakdown_type: 'cohort' })
-                      }
-                  } else {
-                      const newFilters: Partial<TrendsFilterType> = {
-                          breakdown: undefined,
-                          breakdown_type: undefined,
-                          breakdown_histogram_bin_count: undefined,
-                          // Make sure we are no longer in map view after removing the Country Code breakdown
-                          display:
-                              isTrendsFilter(filters) && filters.display !== ChartDisplayType.WorldMap
-                                  ? filters.display
-                                  : undefined,
-                      }
-                      setFilters(newFilters)
-                  }
-              }
-          }
-        : undefined
+    const logicProps = { filters, setFilters, getPropertyDefinition }
+    const { hasBreakdown, hasNonCohortBreakdown, taxonomicBreakdownType, breakdownArray } = useValues(
+        taxonomicBreakdownFilterLogic(logicProps)
+    )
+    const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic(logicProps))
 
     const tags = !hasBreakdown
         ? []
@@ -54,22 +27,23 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
                   key={`${breakdown}-${index}`}
                   logicKey={`${breakdown}-${index}`}
                   breakdown={breakdown}
-                  removeBreakdown={onCloseFor ? onCloseFor(breakdown) : undefined}
                   filters={filters}
                   setFilters={setFilters}
               />
           ))
 
     return (
-        <div className="flex flex-wrap gap-2 items-center">
-            {tags}
-            {setFilters && !hasNonCohortBreakdown ? (
-                <TaxonomicBreakdownButton
-                    breakdownType={taxonomicBreakdownType}
-                    addBreakdown={addBreakdown}
-                    includeSessions={filters.insight === InsightType.TRENDS} // TODO: convert to data exploration
-                />
-            ) : null}
-        </div>
+        <BindLogic logic={taxonomicBreakdownFilterLogic} props={logicProps}>
+            <div className="flex flex-wrap gap-2 items-center">
+                {tags}
+                {setFilters && !hasNonCohortBreakdown ? (
+                    <TaxonomicBreakdownButton
+                        breakdownType={taxonomicBreakdownType}
+                        addBreakdown={addBreakdown}
+                        includeSessions={filters.insight === InsightType.TRENDS} // TODO: convert to data exploration
+                    />
+                ) : null}
+            </div>
+        </BindLogic>
     )
 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -1,6 +1,4 @@
 import { useValues } from 'kea'
-import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicBreakdownButton } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { ChartDisplayType, FilterType, InsightType, TrendsFilterType } from '~/types'
@@ -20,12 +18,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { breakdown, breakdown_type } = filters
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
-    const { hasSelectedBreakdown } = useValues(taxonomicBreakdownFilterLogic({ filters }))
-
-    let breakdownType = propertyFilterTypeToTaxonomicFilterType(breakdown_type)
-    if (breakdownType === TaxonomicFilterGroupType.Cohorts) {
-        breakdownType = TaxonomicFilterGroupType.CohortsWithAllUsers
-    }
+    const { hasSelectedBreakdown, taxonomicBreakdownType } = useValues(taxonomicBreakdownFilterLogic({ filters }))
 
     const breakdownArray = (Array.isArray(breakdown) ? breakdown : [breakdown]).filter((b): b is string | number => !!b)
 
@@ -92,7 +85,7 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
             {tags}
             {onChange && !hasSelectedBreakdown ? (
                 <TaxonomicBreakdownButton
-                    breakdownType={breakdownType}
+                    breakdownType={taxonomicBreakdownType}
                     onChange={onChange}
                     includeSessions={filters.insight === InsightType.TRENDS}
                 />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -1,10 +1,10 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { TaxonomicBreakdownButton } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { ChartDisplayType, FilterType, InsightType, TrendsFilterType } from '~/types'
 import { BreakdownTag } from './BreakdownTag'
 import './TaxonomicBreakdownFilter.scss'
-import { onFilterChange, isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
+import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { isCohortBreakdown } from './taxonomicBreakdownFilterUtils'
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
@@ -18,7 +18,8 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
     const { hasBreakdown, hasNonCohortBreakdown, taxonomicBreakdownType, breakdownArray, breakdownCohortArray } =
-        useValues(taxonomicBreakdownFilterLogic({ filters }))
+        useValues(taxonomicBreakdownFilterLogic({ filters, setFilters, getPropertyDefinition }))
+    const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic({ filters, setFilters, getPropertyDefinition }))
 
     const onCloseFor = setFilters
         ? (t: string | number, index: number): (() => void) => {
@@ -68,22 +69,14 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
               )
           })
 
-    const onChange = setFilters
-        ? onFilterChange({
-              breakdownCohortArray,
-              setFilters,
-              getPropertyDefinition: getPropertyDefinition,
-          })
-        : undefined
-
     return (
         <div className="flex flex-wrap gap-2 items-center">
             {tags}
-            {onChange && !hasNonCohortBreakdown ? (
+            {setFilters && !hasNonCohortBreakdown ? (
                 <TaxonomicBreakdownButton
                     breakdownType={taxonomicBreakdownType}
-                    onChange={onChange}
-                    includeSessions={filters.insight === InsightType.TRENDS}
+                    addBreakdown={addBreakdown}
+                    includeSessions={filters.insight === InsightType.TRENDS} // TODO: convert to data exploration
                 />
             ) : null}
         </div>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -9,6 +9,7 @@ import './TaxonomicBreakdownFilter.scss'
 import { onFilterChange, isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { isCohortBreakdown } from './taxonomicBreakdownFilterUtils'
+import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 export interface TaxonomicBreakdownFilterProps {
     filters: Partial<FilterType>
@@ -19,12 +20,12 @@ export function TaxonomicBreakdownFilter({ filters, setFilters }: TaxonomicBreak
     const { breakdown, breakdown_type } = filters
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
 
+    const { hasSelectedBreakdown } = useValues(taxonomicBreakdownFilterLogic({ filters }))
+
     let breakdownType = propertyFilterTypeToTaxonomicFilterType(breakdown_type)
     if (breakdownType === TaxonomicFilterGroupType.Cohorts) {
         breakdownType = TaxonomicFilterGroupType.CohortsWithAllUsers
     }
-
-    const hasSelectedBreakdown = breakdown && typeof breakdown === 'string'
 
     const breakdownArray = (Array.isArray(breakdown) ? breakdown : [breakdown]).filter((b): b is string | number => !!b)
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -6,13 +6,13 @@ import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 
 export interface BreakdownTagLogicProps {
     setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
-    logicKey?: string
+    breakdown: string | number
     filters?: Partial<FilterType>
 }
 
 export const breakdownTagLogic = kea<breakdownTagLogicType>([
     props({} as BreakdownTagLogicProps),
-    key(({ logicKey }) => logicKey || 'global'),
+    key(({ breakdown }) => breakdown),
     path((key) => ['scenes', 'insights', 'BreakdownFilter', 'breakdownTagLogic', key]),
     actions(() => ({
         setUseHistogram: (useHistogram: boolean) => ({ useHistogram }),

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -55,6 +55,10 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
             (s) => [s.propertyDefinition],
             (propertyDefinition) => isURLNormalizeable(propertyDefinition?.name || ''),
         ],
+        shouldShowMenu: [
+            (s) => [s.isHistogramable, s.isNormalizeable],
+            (isHistogramable, isNormalizeable) => isHistogramable || isNormalizeable,
+        ],
     }),
     listeners(({ props, values, actions }) => ({
         removeBreakdown: () => {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -5,6 +5,7 @@ import type { breakdownTagLogicType } from './breakdownTagLogicType'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
 export interface BreakdownTagLogicProps {
     setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
@@ -16,10 +17,10 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
     props({} as BreakdownTagLogicProps),
     key(({ breakdown }) => breakdown),
     path((key) => ['scenes', 'insights', 'BreakdownFilter', 'breakdownTagLogic', key]),
-    connect({
-        values: [taxonomicBreakdownFilterLogic, ['isViewOnly']],
+    connect(() => ({
+        values: [taxonomicBreakdownFilterLogic, ['isViewOnly'], propertyDefinitionsModel, ['getPropertyDefinition']],
         actions: [taxonomicBreakdownFilterLogic, ['removeBreakdown as removeBreakdownFromList']],
-    }),
+    })),
     actions(() => ({
         removeBreakdown: true,
         setUseHistogram: (useHistogram: boolean) => ({ useHistogram }),
@@ -46,7 +47,7 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
     })),
     selectors({
         propertyDefinition: [
-            (_, p) => [p.getPropertyDefinition, p.breakdown],
+            (s, p) => [s.getPropertyDefinition, p.breakdown],
             (getPropertyDefinition, breakdown) => getPropertyDefinition(breakdown),
         ],
         isHistogramable: [(s) => [s.propertyDefinition], (propertyDefinition) => !!propertyDefinition?.is_numerical],

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -1,8 +1,9 @@
-import { actions, kea, key, listeners, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { FilterType, TrendsFilterType } from '~/types'
 
 import type { breakdownTagLogicType } from './breakdownTagLogicType'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
 export interface BreakdownTagLogicProps {
     setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
@@ -14,7 +15,11 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
     props({} as BreakdownTagLogicProps),
     key(({ breakdown }) => breakdown),
     path((key) => ['scenes', 'insights', 'BreakdownFilter', 'breakdownTagLogic', key]),
+    connect({
+        actions: [taxonomicBreakdownFilterLogic, ['removeBreakdown as removeBreakdownFromList']],
+    }),
     actions(() => ({
+        removeBreakdown: true,
         setUseHistogram: (useHistogram: boolean) => ({ useHistogram }),
         setBinCount: (binCount: number | undefined) => ({ binCount }),
         setNormalizeBreakdownURL: (normalizeBreakdownURL: boolean) => ({
@@ -37,7 +42,10 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
             },
         ],
     })),
-    listeners(({ props, values }) => ({
+    listeners(({ props, values, actions }) => ({
+        removeBreakdown: () => {
+            actions.removeBreakdownFromList(props.breakdown)
+        },
         setNormalizeBreakdownURL: ({ normalizeBreakdownURL }) => {
             const newFilter: TrendsFilterType = {
                 breakdown_normalize_url: normalizeBreakdownURL,

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -1,9 +1,10 @@
-import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { FilterType, TrendsFilterType } from '~/types'
 
 import type { breakdownTagLogicType } from './breakdownTagLogicType'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
+import { isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 
 export interface BreakdownTagLogicProps {
     setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
@@ -42,6 +43,17 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
             },
         ],
     })),
+    selectors({
+        propertyDefinition: [
+            (_, p) => [p.getPropertyDefinition, p.breakdown],
+            (getPropertyDefinition, breakdown) => getPropertyDefinition(breakdown),
+        ],
+        isHistogramable: [(s) => [s.propertyDefinition], (propertyDefinition) => !!propertyDefinition?.is_numerical],
+        isNormalizeable: [
+            (s) => [s.propertyDefinition],
+            (propertyDefinition) => isURLNormalizeable(propertyDefinition?.name || ''),
+        ],
+    }),
     listeners(({ props, values, actions }) => ({
         removeBreakdown: () => {
             actions.removeBreakdownFromList(props.breakdown)

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -1,17 +1,13 @@
-import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import { FilterType, TrendsFilterType } from '~/types'
+import { actions, connect, kea, key, listeners, path, props, selectors } from 'kea'
 
 import type { breakdownTagLogicType } from './breakdownTagLogicType'
-import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 import { isAllCohort, isCohort, isURLNormalizeable } from './taxonomicBreakdownFilterUtils'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 
 export interface BreakdownTagLogicProps {
-    setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
     breakdown: string | number
-    filters?: Partial<FilterType>
 }
 
 export const breakdownTagLogic = kea<breakdownTagLogicType>([
@@ -31,27 +27,6 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
     })),
     actions(() => ({
         removeBreakdown: true,
-        setUseHistogram: (useHistogram: boolean) => ({ useHistogram }),
-        setBinCount: (binCount: number | undefined) => ({ binCount }),
-        setNormalizeBreakdownURL: (normalizeBreakdownURL: boolean) => ({
-            normalizeBreakdownURL,
-        }),
-    })),
-    reducers(({ props }) => ({
-        useHistogram: [
-            props.filters && isTrendsFilter(props.filters) && props.filters.breakdown_histogram_bin_count !== undefined,
-            {
-                setUseHistogram: (_, { useHistogram }) => useHistogram,
-            },
-        ],
-        binCount: [
-            ((props.filters && isTrendsFilter(props.filters) && props.filters.breakdown_histogram_bin_count) ?? 10) as
-                | number
-                | undefined,
-            {
-                setBinCount: (_, { binCount }) => binCount,
-            },
-        ],
     })),
     selectors({
         propertyDefinition: [
@@ -81,28 +56,9 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
             (isHistogramable, isNormalizeable) => isHistogramable || isNormalizeable,
         ],
     }),
-    listeners(({ props, values, actions }) => ({
+    listeners(({ props, actions }) => ({
         removeBreakdown: () => {
             actions.removeBreakdownFromList(props.breakdown)
-        },
-        setNormalizeBreakdownURL: ({ normalizeBreakdownURL }) => {
-            const newFilter: TrendsFilterType = {
-                breakdown_normalize_url: normalizeBreakdownURL,
-            }
-            props.setFilters?.(newFilter, true)
-        },
-        setUseHistogram: ({ useHistogram }) => {
-            const newFilter: TrendsFilterType = {
-                breakdown_histogram_bin_count: useHistogram ? values.binCount : undefined,
-            }
-            props.setFilters?.(newFilter, true)
-        },
-        setBinCount: async ({ binCount }, breakpoint) => {
-            await breakpoint(1000)
-            const newFilter: TrendsFilterType = {
-                breakdown_histogram_bin_count: values.useHistogram ? binCount : undefined,
-            }
-            props.setFilters?.(newFilter, true)
         },
     })),
 ])

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -17,6 +17,7 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
     key(({ breakdown }) => breakdown),
     path((key) => ['scenes', 'insights', 'BreakdownFilter', 'breakdownTagLogic', key]),
     connect({
+        values: [taxonomicBreakdownFilterLogic, ['isViewOnly']],
         actions: [taxonomicBreakdownFilterLogic, ['removeBreakdown as removeBreakdownFromList']],
     }),
     actions(() => ({

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -15,7 +15,7 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
 export type TaxonomicBreakdownFilterLogicProps = {
     filters: BreakdownFilter
-    setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
+    setFilters: ((filters: Partial<FilterType>, mergeFilters?: boolean) => void) | null
 }
 
 export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicType>([

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -24,5 +24,10 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                 return breakdownType
             },
         ],
+        breakdownArray: [
+            (_, p) => [p.filters],
+            ({ breakdown }) =>
+                (Array.isArray(breakdown) ? breakdown : [breakdown]).filter((b): b is string | number => !!b),
+        ],
     }),
 ])

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -13,6 +13,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
     path(['scenes', 'insights', 'filters', 'BreakdownFilter', 'taxonomicBreakdownFilterLogic']),
     props({} as TaxonomicBreakdownFilterLogicProps),
     selectors({
+        hasBreakdown: [(_, p) => [p.filters], ({ breakdown_type }) => !!breakdown_type,
         hasNonCohortBreakdown: [(_, p) => [p.filters], ({ breakdown }) => breakdown && typeof breakdown === 'string'],
         taxonomicBreakdownType: [
             (_, p) => [p.filters],

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -50,6 +50,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             (s) => [s.breakdownArray],
             (breakdownArray) => breakdownArray.map((b) => (isNaN(Number(b)) ? b : Number(b))),
         ],
+        isViewOnly: [(_, p) => [p.setFilters], (setFilters) => !setFilters],
     }),
     listeners(({ props, values }) => ({
         addBreakdown: ({ breakdown, taxonomicGroup }) => {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, props, actions, selectors, listeners } from 'kea'
+import { kea, path, props, actions, selectors, listeners, connect } from 'kea'
 import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
 import {
     TaxonomicFilterGroup,
@@ -7,20 +7,21 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 import { BreakdownFilter } from '~/queries/schema'
 import { isCohortBreakdown, onFilterChange } from './taxonomicBreakdownFilterUtils'
-import { ChartDisplayType, FilterType, PropertyDefinition, TrendsFilterType } from '~/types'
+import { ChartDisplayType, FilterType, TrendsFilterType } from '~/types'
 
 import type { taxonomicBreakdownFilterLogicType } from './taxonomicBreakdownFilterLogicType'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
 type TaxonomicBreakdownFilterLogicProps = {
     filters: BreakdownFilter
     setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
-    getPropertyDefinition: (s: TaxonomicFilterValue) => PropertyDefinition | null
 }
 
 export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicType>([
     path(['scenes', 'insights', 'filters', 'BreakdownFilter', 'taxonomicBreakdownFilterLogic']),
     props({} as TaxonomicBreakdownFilterLogicProps),
+    connect(() => ({ values: [propertyDefinitionsModel, ['getPropertyDefinition']] })),
     actions({
         addBreakdown: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => ({
             breakdown,
@@ -61,7 +62,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             onFilterChange({
                 breakdownCohortArray: values.breakdownCohortArray,
                 setFilters: props.setFilters,
-                getPropertyDefinition: props.getPropertyDefinition,
+                getPropertyDefinition: values.getPropertyDefinition,
             })(breakdown, taxonomicGroup)
         },
         removeBreakdown: ({ breakdown }) => {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -13,7 +13,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
     path(['scenes', 'insights', 'filters', 'BreakdownFilter', 'taxonomicBreakdownFilterLogic']),
     props({} as TaxonomicBreakdownFilterLogicProps),
     selectors({
-        hasSelectedBreakdown: [(_, p) => [p.filters], ({ breakdown }) => breakdown && typeof breakdown === 'string'],
+        hasNonCohortBreakdown: [(_, p) => [p.filters], ({ breakdown }) => breakdown && typeof breakdown === 'string'],
         taxonomicBreakdownType: [
             (_, p) => [p.filters],
             ({ breakdown_type }) => {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -1,19 +1,33 @@
-import { kea, path, props, selectors } from 'kea'
+import { kea, path, props, actions, selectors, listeners } from 'kea'
 import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import {
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from 'lib/components/TaxonomicFilter/types'
 import { BreakdownFilter } from '~/queries/schema'
+import { onFilterChange } from './taxonomicBreakdownFilterUtils'
+import { FilterType, PropertyDefinition } from '~/types'
 
 import type { taxonomicBreakdownFilterLogicType } from './taxonomicBreakdownFilterLogicType'
 
 type TaxonomicBreakdownFilterLogicProps = {
     filters: BreakdownFilter
+    setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
+    getPropertyDefinition: (s: TaxonomicFilterValue) => PropertyDefinition | null
 }
 
 export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicType>([
     path(['scenes', 'insights', 'filters', 'BreakdownFilter', 'taxonomicBreakdownFilterLogic']),
     props({} as TaxonomicBreakdownFilterLogicProps),
+    actions({
+        addBreakdown: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => ({
+            breakdown,
+            taxonomicGroup,
+        }),
+    }),
     selectors({
-        hasBreakdown: [(_, p) => [p.filters], ({ breakdown_type }) => !!breakdown_type,
+        hasBreakdown: [(_, p) => [p.filters], ({ breakdown_type }) => !!breakdown_type],
         hasNonCohortBreakdown: [(_, p) => [p.filters], ({ breakdown }) => breakdown && typeof breakdown === 'string'],
         taxonomicBreakdownType: [
             (_, p) => [p.filters],
@@ -35,4 +49,17 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             (breakdownArray) => breakdownArray.map((b) => (isNaN(Number(b)) ? b : Number(b))),
         ],
     }),
+    listeners(({ props, values }) => ({
+        addBreakdown: ({ breakdown, taxonomicGroup }) => {
+            if (!props.setFilters) {
+                return
+            }
+
+            onFilterChange({
+                breakdownCohortArray: values.breakdownCohortArray,
+                setFilters: props.setFilters,
+                getPropertyDefinition: props.getPropertyDefinition,
+            })(breakdown, taxonomicGroup)
+        },
+    })),
 ])

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, props, actions, reducers, selectors, listeners, connect } from 'kea'
+import { kea, path, props, defaults, actions, reducers, selectors, listeners, connect } from 'kea'
 import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
 import {
     TaxonomicFilterGroup,
@@ -21,6 +21,10 @@ export type TaxonomicBreakdownFilterLogicProps = {
 export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicType>([
     path(['scenes', 'insights', 'filters', 'BreakdownFilter', 'taxonomicBreakdownFilterLogic']),
     props({} as TaxonomicBreakdownFilterLogicProps),
+    defaults({
+        // This is a hack to get `TaxonomicFilterGroupType` imported in `taxonomicBreakdownFilterLogicType.ts`
+        __ignore: null as TaxonomicFilterGroupType | null,
+    }),
     connect(() => ({ values: [propertyDefinitionsModel, ['getPropertyDefinition']] })),
     actions({
         addBreakdown: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => ({

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -1,0 +1,16 @@
+import { kea, path, props, selectors } from 'kea'
+import { BreakdownFilter } from '~/queries/schema'
+
+import type { taxonomicBreakdownFilterLogicType } from './taxonomicBreakdownFilterLogicType'
+
+type TaxonomicBreakdownFilterLogicProps = {
+    filters: BreakdownFilter
+}
+
+export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicType>([
+    path(['scenes', 'insights', 'filters', 'BreakdownFilter', 'taxonomicBreakdownFilterLogic']),
+    props({} as TaxonomicBreakdownFilterLogicProps),
+    selectors({
+        hasSelectedBreakdown: [(_, p) => [p.filters], ({ breakdown }) => breakdown && typeof breakdown === 'string'],
+    }),
+])

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -13,7 +13,7 @@ import type { taxonomicBreakdownFilterLogicType } from './taxonomicBreakdownFilt
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
-type TaxonomicBreakdownFilterLogicProps = {
+export type TaxonomicBreakdownFilterLogicProps = {
     filters: BreakdownFilter
     setFilters?: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -29,5 +29,9 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             ({ breakdown }) =>
                 (Array.isArray(breakdown) ? breakdown : [breakdown]).filter((b): b is string | number => !!b),
         ],
+        breakdownCohortArray: [
+            (s) => [s.breakdownArray],
+            (breakdownArray) => breakdownArray.map((b) => (isNaN(Number(b)) ? b : Number(b))),
+        ],
     }),
 ])

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -1,4 +1,6 @@
 import { kea, path, props, selectors } from 'kea'
+import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { BreakdownFilter } from '~/queries/schema'
 
 import type { taxonomicBreakdownFilterLogicType } from './taxonomicBreakdownFilterLogicType'
@@ -12,5 +14,15 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
     props({} as TaxonomicBreakdownFilterLogicProps),
     selectors({
         hasSelectedBreakdown: [(_, p) => [p.filters], ({ breakdown }) => breakdown && typeof breakdown === 'string'],
+        taxonomicBreakdownType: [
+            (_, p) => [p.filters],
+            ({ breakdown_type }) => {
+                let breakdownType = propertyFilterTypeToTaxonomicFilterType(breakdown_type)
+                if (breakdownType === TaxonomicFilterGroupType.Cohorts) {
+                    breakdownType = TaxonomicFilterGroupType.CohortsWithAllUsers
+                }
+                return breakdownType
+            },
+        ],
     }),
 ])

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
@@ -21,7 +21,7 @@ const getPropertyDefinition = jest.fn()
 describe('taxonomic breakdown filter utils', () => {
     it('sets breakdown for events', () => {
         const onChange = onFilterChange({
-            breakdownParts: ['a', 'b'],
+            breakdownCohortArray: ['a', 'b'],
             setFilters,
             getPropertyDefinition,
         })
@@ -43,7 +43,7 @@ describe('taxonomic breakdown filter utils', () => {
 
     it('sets breakdown for cohorts', () => {
         const onChange = onFilterChange({
-            breakdownParts: ['all', 1],
+            breakdownCohortArray: ['all', 1],
             setFilters,
             getPropertyDefinition,
         })
@@ -64,7 +64,7 @@ describe('taxonomic breakdown filter utils', () => {
 
     it('sets breakdown for person properties', () => {
         const onChange = onFilterChange({
-            breakdownParts: ['country'],
+            breakdownCohortArray: ['country'],
             setFilters,
             getPropertyDefinition,
         })
@@ -85,7 +85,7 @@ describe('taxonomic breakdown filter utils', () => {
 
     it('sets breakdowns for group properties', () => {
         const onChange = onFilterChange({
-            breakdownParts: ['$lib'],
+            breakdownCohortArray: ['$lib'],
             setFilters,
             getPropertyDefinition,
         })

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -17,6 +17,7 @@ export const isPersonEventOrGroup = (t: number | string): t is string => typeof 
 export const isURLNormalizeable = (propertyName: string): boolean => {
     return ['$current_url', '$pathname'].includes(propertyName)
 }
+
 interface FilterChange {
     breakdownCohortArray: (string | number)[]
     setFilters: (filters: Partial<FilterType>, mergeFilters?: boolean) => void

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -12,8 +12,6 @@ export const isCohort = (t: number | string): t is number => typeof t === 'numbe
 
 export const isCohortBreakdown = (t: number | string): t is number | string => isAllCohort(t) || isCohort(t)
 
-export const isPersonEventOrGroup = (t: number | string): t is string => typeof t === 'string' && t !== 'all'
-
 export const isURLNormalizeable = (propertyName: string): boolean => {
     return ['$current_url', '$pathname'].includes(propertyName)
 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -18,12 +18,12 @@ export const isURLNormalizeable = (propertyName: string): boolean => {
     return ['$current_url', '$pathname'].includes(propertyName)
 }
 interface FilterChange {
-    breakdownParts: (string | number)[]
+    breakdownCohortArray: (string | number)[]
     setFilters: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
     getPropertyDefinition: (propertyName: string | number) => PropertyDefinition | null
 }
 
-export function onFilterChange({ breakdownParts, setFilters, getPropertyDefinition }: FilterChange) {
+export function onFilterChange({ breakdownCohortArray, setFilters, getPropertyDefinition }: FilterChange) {
     return (changedBreakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup): void => {
         const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type) as BreakdownType
 
@@ -43,7 +43,7 @@ export function onFilterChange({ breakdownParts, setFilters, getPropertyDefiniti
 
             newFilters.breakdown =
                 taxonomicGroup.type === TaxonomicFilterGroupType.CohortsWithAllUsers
-                    ? [...breakdownParts, changedBreakdown].filter((b): b is string | number => !!b)
+                    ? [...breakdownCohortArray, changedBreakdown].filter((b): b is string | number => !!b)
                     : changedBreakdown
 
             setFilters(newFilters, true)


### PR DESCRIPTION
## Problem

Stacked PR, see https://github.com/PostHog/posthog/pull/15397.

## Changes

This PR refactors the `<TaxonomicBreakdownFilter />` . This makes it easier to implement the fixes coming in PR 3.

## How did you test this code?

Verified the breakdown filter is still working for regular properties, normalizable properties, histogramable properties and cohorts.