### PR TITLE
feat(exports): support SQL insight exports

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
@@ -4,12 +4,13 @@ import { triggerExport } from 'lib/components/ExportButton/exporter'
 import { ExporterFormat } from '~/types'
 import { DataNode, DataTableNode } from '~/queries/schema'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
-import { isEventsQuery, isPersonsNode } from '~/queries/utils'
+import { isEventsQuery, isHogQLQuery, isPersonsNode } from '~/queries/utils'
 import { getEventsEndpoint, getPersonsEndpoint } from '~/queries/query'
 import { ExportWithConfirmation } from '~/queries/nodes/DataTable/ExportWithConfirmation'
 
 const EXPORT_LIMIT_EVENTS = 3500
 const EXPORT_LIMIT_PERSONS = 10000
+const EXPORT_LIMIT_HOGQL = 65536
 
 function startDownload(query: DataTableNode, onlySelectedColumns: boolean): void {
     const exportContext = isEventsQuery(query.source)
@@ -19,6 +20,8 @@ function startDownload(query: DataTableNode, onlySelectedColumns: boolean): void
           }
         : isPersonsNode(query.source)
         ? { path: getPersonsEndpoint(query.source), max_limit: EXPORT_LIMIT_PERSONS }
+        : isHogQLQuery(query.source)
+        ? { source: query.source, max_limit: EXPORT_LIMIT_HOGQL }
         : undefined
     if (!exportContext) {
         throw new Error('Unsupported node type')

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2693,7 +2693,13 @@ export type OnlineExportContext = {
     max_limit?: number
 }
 
-export type ExportContext = OnlineExportContext | LocalExportContext
+export type QueryExportContext = {
+    source: Record<string, any>
+    filename?: string
+    max_limit?: number
+}
+
+export type ExportContext = OnlineExportContext | LocalExportContext | QueryExportContext
 
 export interface ExportedAssetType {
     id: number

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -3177,7 +3177,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND 1 = 1
+          AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
@@ -3203,7 +3203,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND event = 'sign up'
+          AND 1 = 1
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -3177,7 +3177,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND event = 'sign up'
+          AND 1 = 1
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
@@ -3203,7 +3203,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND 1 = 1
+          AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -200,6 +200,17 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
             # Figure out how to handle funnel polling....
             data = response.json()
 
+            if data is None:
+                unexpected_empty_json_response = UnexpectedEmptyJsonResponse("JSON is None when calling API for data")
+                logger.error(
+                    "csv_exporter.json_was_none",
+                    exc=unexpected_empty_json_response,
+                    exc_info=True,
+                    response_text=response.text,
+                )
+
+                raise unexpected_empty_json_response
+
             csv_rows = _convert_response_to_csv_data(data)
 
             all_csv_rows = all_csv_rows + csv_rows

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -174,8 +174,8 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
 
     if resource.get("source"):
         query = resource.get("source")
-        data = process_query(team=exported_asset.team, query_json=query, is_hogql_enabled=True)
-        all_csv_rows = _convert_response_to_csv_data(data)
+        response = process_query(team=exported_asset.team, query_json=query, is_hogql_enabled=True)
+        all_csv_rows = _convert_response_to_csv_data(response)
 
     else:
         path: str = resource["path"]
@@ -200,7 +200,7 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
             # Figure out how to handle funnel polling....
             data = response.json()
 
-            if data is None:  # type: ignore
+            if data is None:
                 unexpected_empty_json_response = UnexpectedEmptyJsonResponse("JSON is None when calling API for data")
                 logger.error(
                     "csv_exporter.json_was_none",

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -174,8 +174,8 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
 
     if resource.get("source"):
         query = resource.get("source")
-        response = process_query(team=exported_asset.team, query_json=query, is_hogql_enabled=True)
-        all_csv_rows = _convert_response_to_csv_data(response)
+        query_response = process_query(team=exported_asset.team, query_json=query, is_hogql_enabled=True)
+        all_csv_rows = _convert_response_to_csv_data(query_response)
 
     else:
         path: str = resource["path"]

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -200,17 +200,6 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
             # Figure out how to handle funnel polling....
             data = response.json()
 
-            if data is None:
-                unexpected_empty_json_response = UnexpectedEmptyJsonResponse("JSON is None when calling API for data")
-                logger.error(
-                    "csv_exporter.json_was_none",
-                    exc=unexpected_empty_json_response,
-                    exc_info=True,
-                    response_text=response.text,
-                )
-
-                raise unexpected_empty_json_response
-
             csv_rows = _convert_response_to_csv_data(data)
 
             all_csv_rows = all_csv_rows + csv_rows

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -200,7 +200,7 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
             # Figure out how to handle funnel polling....
             data = response.json()
 
-            if data is None:
+            if data is None:  # type: ignore
                 unexpected_empty_json_response = UnexpectedEmptyJsonResponse("JSON is None when calling API for data")
                 logger.error(
                     "csv_exporter.json_was_none",


### PR DESCRIPTION
## Problem

Exports don't support SQL insights

## Changes

Now they do

## How did you test this code?

Added a test.

Note: I hardcoded a `is_hogql_enabled=True` into the export code. We're ready to release HogQL soon, and pulling in a backend feature flag here to double check that this is enabled, would have been too much work. If anyone's strongly against this behaviour, let me know and we'll see what we can do.