### PR TITLE
chore: fix flaky dlq functional tests

### DIFF
--- a/plugin-server/functional_tests/jobs-consumer.test.ts
+++ b/plugin-server/functional_tests/jobs-consumer.test.ts
@@ -22,7 +22,7 @@ describe('dlq handling', () => {
     beforeAll(async () => {
         dlq = []
         dlqConsumer = kafka.consumer({ groupId: 'jobs-consumer-test' })
-        await dlqConsumer.subscribe({ topic: 'jobs_dlq' })
+        await dlqConsumer.subscribe({ topic: 'jobs_dlq', fromBeginning: true })
         await dlqConsumer.run({
             eachMessage: ({ message }) => {
                 dlq.push(message)

--- a/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
+++ b/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
@@ -22,7 +22,7 @@ describe('dlq handling', () => {
     beforeAll(async () => {
         dlq = []
         dlqConsumer = kafka.consumer({ groupId: 'scheduled-tasks-consumer-test' })
-        await dlqConsumer.subscribe({ topic: 'scheduled_tasks_dlq' })
+        await dlqConsumer.subscribe({ topic: 'scheduled_tasks_dlq', fromBeginning: true })
         await dlqConsumer.run({
             eachMessage: ({ message }) => {
                 dlq.push(message)

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -25,7 +25,7 @@ beforeAll(async () => {
 
     dlq = []
     dlqConsumer = kafka.consumer({ groupId: 'session_recording_events_test' })
-    await dlqConsumer.subscribe({ topic: 'session_recording_events_dlq' })
+    await dlqConsumer.subscribe({ topic: 'session_recording_events_dlq', fromBeginning: true })
     await dlqConsumer.run({
         eachMessage: ({ message }) => {
             dlq.push(message)


### PR DESCRIPTION
There is a race condition in these tests where the consumer isn't
consuming in time to pick up bad messages, so we ensure that we set the
offsets to the earliest messages.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
