### PR TITLE
fix(image-upload): Show correct file name for compressed images

### DIFF
--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -49,7 +49,7 @@ export function SupportModal(): JSX.Element {
 
     const { setFilesToUpload, filesToUpload, uploading } = useUploadFiles({
         onUpload: (url, fileName) => {
-            setSendSupportRequestValue('message', sendSupportRequest.message + `\n\n![${fileName}](${url})`)
+            setSendSupportRequestValue('message', sendSupportRequest.message + `\n\nAttachment "${fileName}": ${url}`)
         },
         onError: (detail) => {
             lemonToast.error(`Error uploading image: ${detail}`)

--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -43,11 +43,12 @@ export function useUploadFiles({
             try {
                 setUploading(true)
                 const formData = new FormData()
-                let blob: Blob = filesToUpload[0]
-                if (blob.type.startsWith('image/')) {
-                    blob = await lazyImageBlobReducer(blob)
+                let file: File = filesToUpload[0]
+                if (file.type.startsWith('image/')) {
+                    const compressedBlob = await lazyImageBlobReducer(file)
+                    file = new File([compressedBlob], file.name, { type: compressedBlob.type })
                 }
-                formData.append('image', blob)
+                formData.append('image', file)
                 const media = await api.media.upload(formData)
                 onUpload?.(media.image_location, media.name)
             } catch (error) {
@@ -170,7 +171,7 @@ export const LemonFileInput = ({
                 ref={dropRef}
                 className={clsx('flex flex-col gap-1', !alternativeDropTargetRef?.current && drag && 'FileDropTarget')}
             >
-                <label className="text-muted    inline-flex flex flow-row items-center gap-1 cursor-pointer">
+                <label className="text-muted inline-flex flex flow-row items-center gap-1 cursor-pointer">
                     <input
                         className={'hidden'}
                         type="file"


### PR DESCRIPTION
## Changes

### Before
<img width="416" alt="before" src="https://github.com/PostHog/posthog/assets/4550621/ed1640d4-fcc9-4c7d-84a1-472b2084380f">

### After
<img width="418" alt="after" src="https://github.com/PostHog/posthog/assets/4550621/5ffb7982-1785-4d12-9177-0325390e485b">

In dashboard text cards we still use Markdown syntax, except also maintaining the original file name.