### PR TITLE
fix(hobby-deploy): fix temporal container volume mount

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -115,6 +115,8 @@ services:
             - ENABLE_ES=false
         ports:
             - 7233:7233
+        volumes:
+            - ./posthog/docker/temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
     temporal-admin-tools:
         extends:
             file: docker-compose.base.yml


### PR DESCRIPTION
## Problem

The `temporal` container does not start healthy when installing the hobby deploy from `master`, because it cannot mount `docker/temporal/dynamicconfig`, which makes the `temporal-django-worker` unhealthy too.

## Changes

Mirroring how we do it in the `clickhouse` container, make `docker-compose.hobby.yml` file override the volume for the `temporal` container, pointing it to git checkout in the `posthog/` folder

## How did you test this code?

![image](https://github.com/PostHog/posthog/assets/6241083/cc264c67-d364-4520-a3e7-6ee4dd621890)