### PR TITLE
fix: Clean up sessions after destroying them

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -267,7 +267,7 @@ export class SessionRecordingBlobIngester {
 
                 this.offsetManager?.revokePartitions(KAFKA_SESSION_RECORDING_EVENTS, revokedPartitions)
 
-                await Promise.all(sessionsToDrop.map((session) => session.destroy()))
+                await this.destroySessions(sessionsToDrop)
 
                 status.info('⚖️', 'blob_ingester_consumer - partitions revoked', {
                     currentPartitions: currentPartitions,
@@ -346,13 +346,19 @@ export class SessionRecordingBlobIngester {
         await this.batchConsumer?.stop()
 
         // This is inefficient but currently necessary due to new instances restarting from the committed offset point
+        await this.destroySessions([...this.sessions.values()])
+
+        this.sessions = new Map()
+    }
+
+    private async destroySessions(sessionsToDestroy: SessionManager[]): Promise<void> {
         const destroyPromises: Promise<void>[] = []
-        this.sessions.forEach((sessionManager) => {
+
+        sessionsToDestroy.forEach((sessionManager) => {
+            this.sessions.delete(sessionManager.sessionId)
             destroyPromises.push(sessionManager.destroy())
         })
 
         await Promise.allSettled(destroyPromises)
-
-        this.sessions = new Map()
     }
 }


### PR DESCRIPTION
## Problem

We didn't delete the session manager after it was destroyed so it could still be referenced causing uncaught exceptions

## Changes

* Fixes this to ensure it is always cleaned up

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
...