### PR TITLE
chore: Use `SENTRY_ENVIRONMENT` on the frontend

### DIFF
--- a/frontend/src/lib/utils/getAppContext.ts
+++ b/frontend/src/lib/utils/getAppContext.ts
@@ -3,6 +3,8 @@ import { AppContext, PathType } from '~/types'
 declare global {
     export interface Window {
         POSTHOG_APP_CONTEXT?: AppContext
+        SENTRY_DSN?: string
+        SENTRY_ENVIRONMENT?: string
     }
 }
 

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -56,11 +56,12 @@ export function loadPostHogJS(): void {
         })
     }
 
-    if ((window as any).SENTRY_DSN) {
+    if (window.SENTRY_DSN) {
         Sentry.init({
-            dsn: (window as any).SENTRY_DSN,
-            ...(window.location.host.indexOf('app.posthog.com') > -1 && {
-                integrations: [new posthog.SentryIntegration(posthog, 'posthog2', 1899813)],
+            dsn: window.SENTRY_DSN,
+            environment: window.SENTRY_ENVIRONMENT,
+            ...(location.host.includes('posthog.com') && {
+                integrations: [new posthog.SentryIntegration(posthog, 'posthog', 1899813)],
             }),
         })
     }

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -77,7 +77,6 @@ def sentry_init() -> None:
 
         sentry_sdk.init(
             dsn=os.environ["SENTRY_DSN"],
-            environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
             integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration(), sentry_logging],
             request_bodies="always",
             sample_rate=1.0,

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -18,15 +18,22 @@
 
 {% if not opt_out_capture and js_posthog_api_key %}
     <script>
-    window.JS_POSTHOG_API_KEY = {{js_posthog_api_key | safe}};
-    window.JS_POSTHOG_HOST = {{js_posthog_host | safe}};
-    window.JS_POSTHOG_SELF_CAPTURE = {{self_capture | yesno:"true,false" }};
-    window.POSTHOG_USER_IDENTITY_WITH_FLAGS = JSON.parse("{{ posthog_bootstrap | escapejs }}")
-    window.IMPERSONATED_SESSION = {{impersonated_session | yesno:"true,false"}};
+        window.JS_POSTHOG_API_KEY = {{js_posthog_api_key | safe}};
+        window.JS_POSTHOG_HOST = {{js_posthog_host | safe}};
+        window.JS_POSTHOG_SELF_CAPTURE = {{self_capture | yesno:"true,false" }};
+        window.POSTHOG_USER_IDENTITY_WITH_FLAGS = JSON.parse("{{ posthog_bootstrap | escapejs }}")
+        window.IMPERSONATED_SESSION = {{impersonated_session | yesno:"true,false"}};
     </script>
 {% endif %}
 {% if sentry_dsn %}
-    <script>window.SENTRY_DSN = '{{sentry_dsn}}';</script>
+    <script>
+        window.SENTRY_DSN = '{{ sentry_dsn | escapejs }}';
+    </script>
+{% endif %}
+{% if sentry_environment %}
+    <script>
+        window.SENTRY_ENVIRONMENT = '{{ sentry_environment | escapejs }}';
+    </script>
 {% endif %}
 <script id='posthog-app-user-preload'>
     window.POSTHOG_APP_CONTEXT = JSON.parse("{{ posthog_app_context | escapejs }}");

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -319,8 +319,10 @@ def render_template(
     context["impersonated_session"] = is_impersonated_session(request)
     context["self_capture"] = settings.SELF_CAPTURE
 
-    if os.environ.get("SENTRY_DSN"):
-        context["sentry_dsn"] = os.environ["SENTRY_DSN"]
+    if sentry_dsn := os.environ.get("SENTRY_DSN"):
+        context["sentry_dsn"] = sentry_dsn
+    if sentry_environment := os.environ.get("SENTRY_ENVIRONMENT"):
+        context["sentry_environment"] = sentry_environment
 
     if settings.DEBUG and not settings.TEST:
         context["debug"] = True


### PR DESCRIPTION
## Changes

Companion to https://github.com/PostHog/posthog-cloud-infra/pull/1574, consolidating Sentry environment tracking between the backend and frontend.