### PR TITLE
fix: Correct decision for oldest timestamp in blob consumer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/types.ts
@@ -4,7 +4,7 @@ export type IncomingRecordingMessage = {
         topic: string
         partition: number
         offset: number
-        timestamp: number | undefined
+        timestamp: number
     }
 
     team_id: number

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -29,8 +29,7 @@ describe('session-manager', () => {
 
         expect(sessionManager.buffer).toEqual({
             count: 1,
-            createdAt: expect.any(Date),
-            lastMessageReceivedAt: messageTimestamp,
+            oldestKafkaTimestamp: messageTimestamp,
             file: expect.any(String),
             id: expect.any(String),
             size: 61, // The size of the event payload - this may change when test data changes

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -23,7 +23,7 @@ describe('session-manager', () => {
         const event = createIncomingRecordingMessage({
             data: compressToString(payload),
         })
-        const messageTimestamp = DateTime.local().toMillis()
+        const messageTimestamp = Date.now() - 10000
         event.metadata.timestamp = messageTimestamp
         await sessionManager.add(event)
 


### PR DESCRIPTION
## Problem

We were always updating the timestamp which meant the flushing never happened.

## Changes

* Fixed to only use the oldest value

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
