### PR TITLE
fix(hobby-deploy): fix celery first startup

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -60,7 +60,7 @@ services:
         restart: on-failure
 
     worker: &worker
-        command: ./bin/start-worker
+        command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
         environment:
             DISABLE_SECURE_SSL_REDIRECT: 'true'


### PR DESCRIPTION
## Problem

Celery is not healthy on first starts of the hobby deploy using `latest`, since https://github.com/PostHog/posthog/pull/14658 was merged:

```
Traceback (most recent call last):
  File "/python-runtime/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UndefinedTable: relation "posthog_asyncmigration" does not exist
LINE 1: ...sion", "posthog_asyncmigration"."parameters" FROM "posthog_a...
```

It can currently we worked around with a `docker restart root-worker-1`, but users should not need to do that.

We were also running two instances of plugin-server (in the `plugins` container, and also in the `worker` container).

## Changes

Restore the previous cmd for the `worker` container: 

- it runs `migrate-check` first, to make sure migrations have been executed by the `web` container before starting celery
- it run celery alone, as plugin-server already runs in its own `plugins` container. Celery failing will trigger a container restart, instead of a stuck celery


## How did you test this code?

Deployed this branch on a DO droplet. The container does restart a lot while the rest of the stack boots, but it settles in a healthy state, and the preflight check passes:

![image](https://github.com/PostHog/posthog/assets/6241083/eff53ed9-1baa-4666-bcac-2bccb4c578cf)
