### PR TITLE
fix: Consistent dict name and early return

### DIFF
--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -327,10 +327,10 @@
   '
   SELECT pg_sleep(1);
   
-  SELECT (true) AS "flag_X_condition_0",
-         (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
+  SELECT (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
           AND "posthog_person"."properties" ? 'email'
-          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0"
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -327,10 +327,10 @@
   '
   SELECT pg_sleep(1);
   
-  SELECT (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
+  SELECT (true) AS "flag_X_condition_0",
+         (("posthog_person"."properties" -> 'email') = '"tim@posthog.com"'
           AND "posthog_person"."properties" ? 'email'
-          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
-         (true) AS "flag_X_condition_0"
+          AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'example_id'

--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -79,8 +79,7 @@ class Command(BaseCommand):
                 f"Workflow '{workflow_name}' is not a CommandableWorkflow that can invoked by execute_temporal_workflow."
             )
 
-        logging.info(f"Executing Temporal Workflow %s with ID %s", workflow_name, workflow_id)
-
+        logging.info("Executing Temporal Workflow %s with ID %s", workflow_name, workflow_id)
         result = asyncio.run(
             client.execute_workflow(
                 workflow_name,
@@ -91,4 +90,4 @@ class Command(BaseCommand):
                 retry_policy=retry_policy,
             )
         )
-        logging.warning(f"Workflow output: {result}")
+        logging.info("Workflow output: %s", result)

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -4010,7 +4010,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND 1 = 1
+          AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
@@ -4036,7 +4036,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND event = 'sign up'
+          AND 1 = 1
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -4010,7 +4010,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND event = 'sign up'
+          AND 1 = 1
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
@@ -4036,7 +4036,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 2
-          AND 1 = 1
+          AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -363,8 +363,8 @@
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'event_name'
-       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-05-02 00:00:00', 'UTC')
-       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-09 23:59:59', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-05-03 00:00:00', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
        AND (pdi.person_id IN
               (SELECT DISTINCT person_id
                FROM cohortpeople
@@ -394,9 +394,9 @@
                   ticks.day_start as day_start,
                   breakdown_value
            FROM
-             (SELECT toStartOfDay(toDateTime('2023-05-09 23:59:59', 'UTC') - number * 86400) as day_start
+             (SELECT toStartOfDay(toDateTime('2023-05-10 23:59:59', 'UTC') - number * 86400) as day_start
               FROM numbers(8)
-              UNION ALL SELECT toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC')) as day_start) as ticks
+              UNION ALL SELECT toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')) as day_start) as ticks
            CROSS JOIN
              (SELECT breakdown_value
               FROM
@@ -430,8 +430,8 @@
                      WHERE team_id = 2
                        AND cohort_id = 2
                        AND version = 0 ))
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC')), 'UTC')
-             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-09 23:59:59', 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
              AND replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') in (['Jane'])
            GROUP BY day_start,
                     breakdown_value))
@@ -1178,10 +1178,10 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2023-05-09 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC')), toDateTime('2023-05-09 23:59:59', 'UTC')))
+               toStartOfDay(toDateTime('2023-05-10 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), toDateTime('2023-05-10 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC'))
+                         toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
@@ -1200,8 +1200,8 @@
            HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'event_name'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-09 23:59:59', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
           AND (pdi.person_id IN
                  (SELECT DISTINCT person_id
                   FROM cohortpeople
@@ -1243,10 +1243,10 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2023-05-09 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC')), toDateTime('2023-05-09 23:59:59', 'UTC')))
+               toStartOfDay(toDateTime('2023-05-10 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), toDateTime('2023-05-10 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC'))
+                         toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
@@ -1258,8 +1258,8 @@
            GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         WHERE team_id = 2
           AND event = 'event_name'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-02 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-09 23:59:59', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
           AND (if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) IN
                  (SELECT DISTINCT person_id
                   FROM cohortpeople


### PR DESCRIPTION
## Changes

Couple of small fixes for the squash-person-overrides workflow:
* Use a consistent default dictionary name.
* Move the early return before the squash activity runs.
* Take a workflow-id when running as Django command. This allows us to limit concurrency when running locally, as we can keep on passing the same workflow-id.
