### PR TITLE
fix(ci): run e2e hobby on more PRs

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -9,8 +9,10 @@ on:
             - 'release-*.*'
     pull_request:
         paths:
+            - docker-compose.base.yml
             - docker-compose.hobby.yml
-            - bin/deploy-hobby
+            - bin/*
+            - docker/*
             - .github/workflows/ci-hobby.yml
 
 concurrency:


### PR DESCRIPTION
## Problem

We committed a PR that broke hobby deploys, because the `docker-compose.base.yml` change didn't trigger this workflow

## Changes

- Trigger the e2e workflow on changes to `docker-compose.base.yml`
- Add `bin/*` (scripts run in containers) and `docker/*` (config files mounted in containers) to the scope too

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
