### PR TITLE
fix: wait for s3 to flush before destroying

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -272,7 +272,27 @@ export class SessionManager {
         }
     }
 
+    private waitForFlushToComplete(checkInterval = 100): Promise<void> {
+        return new Promise((resolve) => {
+            // Check if the variable is already undefined
+            if (typeof this.flushBuffer === 'undefined') {
+                resolve()
+                return
+            }
+
+            // If the variable is not undefined, set an interval to check its value
+            const intervalId = setInterval(() => {
+                if (typeof this.flushBuffer === 'undefined') {
+                    clearInterval(intervalId)
+                    resolve()
+                }
+            }, checkInterval)
+        })
+    }
+
     public async destroy(): Promise<void> {
+        await this.waitForFlushToComplete()
+
         status.debug('␡', `blob_ingester_session_manager Destroying session manager ${this.sessionId}`)
         const filePromises: Promise<void>[] = [this.flushBuffer?.file, this.buffer.file]
             .filter((x): x is string => x !== undefined)


### PR DESCRIPTION
## Problem

The logs suggest that we sometimes fail to delete files on s3 flush and sometimes on destroy

## Changes

newest theory they're overlapping!

wait for s3 to flush before deleting files

-> possible problem -> we can flush to s3 and _not_ commit the offset because we're destroying on rebalance 🤷 

## How did you test this code?

🙈 