### PR TITLE
fix: Use merged_at for squash-person-overrides

### DIFF
--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--workflow-id",
-            default=None,
+            default=str(uuid4()),
             help=(
                 "Optionally, set an id for this workflow. If the ID is already in use, "
                 "the workflow will not execute unless it failed. If not used, a random UUID "
@@ -52,7 +52,7 @@ class Command(BaseCommand):
         server_root_ca_cert = options.get("server_root_ca_cert", None)
         client_cert = options.get("client_cert", None)
         client_key = options.get("client_key", None)
-        workflow_id = options.get("workflow_id", str(uuid4()))
+        workflow_id = options["workflow_id"]
         workflow_name = options["workflow"]
 
         if options["client_key"]:

--- a/posthog/temporal/tests/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/test_squash_person_overrides_workflow.py
@@ -128,6 +128,7 @@ async def test_prepare_dictionary(activity_environment, person_overrides_data):
         user=settings.CLICKHOUSE_USER,
         password=settings.CLICKHOUSE_PASSWORD,
         cluster_name=settings.CLICKHOUSE_CLUSTER,
+        dry_run=False,
     )
 
     latest_merge_at = await activity_environment.run(prepare_dictionary, query_inputs)
@@ -225,6 +226,7 @@ async def test_prepare_dictionary_with_older_overrides_present(
         user=settings.CLICKHOUSE_USER,
         password=settings.CLICKHOUSE_PASSWORD,
         cluster_name=settings.CLICKHOUSE_CLUSTER,
+        dry_run=False,
     )
 
     latest_merge_at = await activity_environment.run(prepare_dictionary, query_inputs)
@@ -268,6 +270,7 @@ async def test_drop_dictionary(activity_environment, person_overrides_data):
         user=settings.CLICKHOUSE_USER,
         password=settings.CLICKHOUSE_PASSWORD,
         cluster_name=settings.CLICKHOUSE_CLUSTER,
+        dry_run=False,
     )
 
     # Ensure we are starting from scratch
@@ -310,6 +313,7 @@ async def test_select_persons_to_delete(activity_environment, person_overrides_d
         partition_ids=["202001"],
         database=settings.CLICKHOUSE_DATABASE,
         _latest_merged_at=OVERRIDES_MERGED_AT,
+        dry_run=False,
     )
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
@@ -346,6 +350,7 @@ async def test_select_persons_to_delete_selects_persons_in_older_partitions(
         partition_ids=["202001"],
         database=settings.CLICKHOUSE_DATABASE,
         _latest_merged_at=OVERRIDES_MERGED_AT,
+        dry_run=False,
     )
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
@@ -394,6 +399,7 @@ async def test_select_persons_to_squash_with_empty_table(activity_environment, p
         partition_ids=["202001"],
         database=settings.CLICKHOUSE_DATABASE,
         _latest_merged_at=OVERRIDES_MERGED_AT,
+        dry_run=False,
     )
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
@@ -414,6 +420,7 @@ async def test_select_persons_to_squash_with_different_partition(activity_enviro
         partition_ids=["202002"],
         database=settings.CLICKHOUSE_DATABASE,
         _latest_merged_at=OVERRIDES_MERGED_AT,
+        dry_run=False,
     )
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
@@ -458,6 +465,7 @@ async def test_select_persons_to_delete_with_newer_merges(activity_environment, 
         database=settings.CLICKHOUSE_DATABASE,
         # Our latest_merged_at is before the newer values happened
         _latest_merged_at=OVERRIDES_MERGED_AT,
+        dry_run=False,
     )
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
@@ -564,6 +572,7 @@ async def test_squash_events_partition(activity_environment, person_overrides_da
         password=settings.CLICKHOUSE_PASSWORD,
         cluster_name=settings.CLICKHOUSE_CLUSTER,
         _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
+        dry_run=False,
     )
     await activity_environment.run(prepare_dictionary, query_inputs)
 
@@ -632,6 +641,7 @@ async def test_squash_events_partition_with_older_overrides(
         password=settings.CLICKHOUSE_PASSWORD,
         cluster_name=settings.CLICKHOUSE_CLUSTER,
         _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
+        dry_run=False,
     )
     await activity_environment.run(prepare_dictionary, query_inputs)
 
@@ -662,6 +672,7 @@ async def test_squash_events_partition_with_newer_overrides(
         password=settings.CLICKHOUSE_PASSWORD,
         cluster_name=settings.CLICKHOUSE_CLUSTER,
         _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
+        dry_run=False,
     )
     await activity_environment.run(prepare_dictionary, query_inputs)
 
@@ -689,6 +700,7 @@ async def test_squash_events_partition_with_limited_team_ids(
         password=settings.CLICKHOUSE_PASSWORD,
         cluster_name=settings.CLICKHOUSE_CLUSTER,
         team_ids=[random_team],
+        dry_run=False,
     )
     latest_merged_at = await activity_environment.run(prepare_dictionary, query_inputs)
     query_inputs._latest_merged_at = latest_merged_at
@@ -735,6 +747,7 @@ async def test_delete_squashed_person_overrides_from_clickhouse(activity_environ
         person_overrides_to_delete=persons_to_delete,
         database=settings.CLICKHOUSE_DATABASE,
         _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
+        dry_run=False,
     )
 
     not_overriden_id = uuid4()
@@ -1045,6 +1058,7 @@ async def test_delete_squashed_person_overrides_from_postgres(activity_environme
                 OLDEST_EVENT_AT.isoformat(),
             )
         ],
+        dry_run=False,
     )
 
     with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
@@ -1163,6 +1177,7 @@ async def test_delete_squashed_person_overrides_from_postgres_with_newer_overrid
                 OLDEST_EVENT_AT.isoformat(),
             )
         ],
+        dry_run=False,
     )
 
     with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
@@ -1210,6 +1225,7 @@ async def test_squash_person_overrides_workflow(events_to_override, person_overr
         clickhouse_database=settings.CLICKHOUSE_DATABASE,
         postgres_database=settings.DATABASES["default"]["NAME"],
         partition_ids=["202001"],
+        dry_run=False,
     )
 
     async with Worker(
@@ -1258,6 +1274,7 @@ async def test_squash_person_overrides_workflow_with_newer_overrides(
         clickhouse_database=settings.CLICKHOUSE_DATABASE,
         postgres_database=settings.DATABASES["default"]["NAME"],
         partition_ids=["202001"],
+        dry_run=False,
     )
 
     async with Worker(
@@ -1305,6 +1322,7 @@ async def test_squash_person_overrides_workflow_with_limited_team_ids(
         postgres_database=settings.DATABASES["default"]["NAME"],
         partition_ids=["202001"],
         team_ids=[random_team],
+        dry_run=False,
     )
 
     async with Worker(

--- a/posthog/temporal/tests/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/test_squash_person_overrides_workflow.py
@@ -596,8 +596,20 @@ async def test_squash_events_partition_dry_run(activity_environment, person_over
 
     await activity_environment.run(drop_dictionary, query_inputs)
 
-    with pytest.raises(AssertionError):
-        assert_events_have_been_overriden(events_to_override, person_overrides_data)
+    for event in events_to_override:
+        rows = sync_execute(
+            "SELECT uuid, event, team_id, person_id FROM events WHERE uuid = %(uuid)s", {"uuid": event["uuid"]}
+        )
+        new_event = {
+            "uuid": rows[0][0],
+            "event": rows[0][1],
+            "team_id": rows[0][2],
+            "person_id": rows[0][3],
+        }
+
+        assert event["uuid"] == new_event["uuid"]  # Sanity check
+        assert event["team_id"] == new_event["team_id"]  # Sanity check
+        assert event["person_id"] == new_event["person_id"]
 
 
 @pytest.mark.django_db

--- a/posthog/temporal/workflows/squash_person_overrides.py
+++ b/posthog/temporal/workflows/squash_person_overrides.py
@@ -185,7 +185,7 @@ class QueryInputs:
     password: str = ""
     cluster_name: str = ""
     dictionary_name: str = "person_overrides_join_dict"
-    dry_run: bool = False
+    dry_run: bool = True
     _latest_merged_at: str | datetime | None = None
 
     def __post_init__(self):
@@ -567,7 +567,7 @@ class SquashPersonOverridesInputs:
     partition_ids: list[str] | None = None
     dictionary_name: str = "person_overrides_join_dict"
     last_n_months: int = 1
-    dry_run: bool = False
+    dry_run: bool = True
 
     def iter_partition_ids(self) -> Iterator[str]:
         """Iterate over configured partition ids.


### PR DESCRIPTION
## Problem

Running the Squash Workflow fails during the last two delete activities. Also, we cannot run dry runs for testing.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

1. Use `merged_at` in the Squash Workflow instead of `created_at`.
2. Use correct PG connection parameters by not patching them manually but instead reading from Django settings and only patching for unit tests.
3. Add a `dry_run` parameter. This parameter only affects the squash events, delete from ClickHouse, and delete from Postgres activities. Instead of executing any `ALTER TABLE` or `DELETE` queries, we log them. By default, this is disabled as it's intended to be used during testing.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

