### PR TITLE
feat(hogql): cmd+enter in hogql query editor

### DIFF
--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -60,9 +60,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                                             id: 'saveAndRunPostHog',
                                             label: 'Save and run query',
                                             keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
-                                            run: () => {
-                                                saveQuery()
-                                            },
+                                            run: () => saveQuery(),
                                         })
                                     )
                                 }}

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { HogQLQuery } from '~/queries/schema'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { hogQLQueryEditorLogic } from './hogQLQueryEditorLogic'
 import MonacoEditor from '@monaco-editor/react'
 import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
@@ -8,6 +8,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
+import { IDisposable } from 'monaco-editor'
 
 export interface HogQLQueryEditorProps {
     query: HogQLQuery
@@ -20,6 +21,14 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
     const hogQLQueryEditorLogicProps = { query: props.query, setQuery: props.setQuery, key }
     const { queryInput } = useValues(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
     const { setQueryInput, saveQuery } = useActions(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
+
+    // Using useRef, not useState, as we don't want to reload the component when this changes.
+    const monacoDisposables = useRef([] as IDisposable[])
+    useEffect(() => {
+        return () => {
+            monacoDisposables.current.forEach((d) => d?.dispose())
+        }
+    }, [])
 
     return (
         <div className="space-y-2">
@@ -45,6 +54,18 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                                 value={queryInput}
                                 onChange={(v) => setQueryInput(v ?? '')}
                                 height={height}
+                                onMount={(editor, monaco) => {
+                                    monacoDisposables.current.push(
+                                        editor.addAction({
+                                            id: 'saveAndRunPostHog',
+                                            label: 'Save and run query',
+                                            keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+                                            run: () => {
+                                                saveQuery()
+                                            },
+                                        })
+                                    )
+                                }}
                                 options={{
                                     minimap: {
                                         enabled: false,


### PR DESCRIPTION
## Problem

You can't save and run a query with CMD+Enter like in any other SQL software.

## Changes

Now you can.

![2023-05-10 21 14 31](https://github.com/PostHog/posthog/assets/53387/52732458-e938-4dde-80ce-72ca6e3de87e)

## How did you test this code?

I tried adding the command in a simpler way, but it would stick around when I opened another editor on a different page. This system that disposes actions when the component unmounts seemed to be the only real way to get it to work. 

## Additional context

This feels almost as good as dark mode.
