### PR TITLE
feat(materialization): remove backfill

### DIFF
--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -1,7 +1,6 @@
 # isort: skip_file
 # Needs to be first to set up django environment
 from .helpers import *
-from datetime import timedelta
 from typing import List, Tuple
 from ee.clickhouse.materialized_columns.analyze import (
     backfill_materialized_columns,
@@ -636,7 +635,7 @@ class QuerySuite:
         for table, property in MATERIALIZED_PROPERTIES:
             if (property, "properties") not in get_materialized_columns(table):
                 materialize(table, property)
-                backfill_materialized_columns(table, [(property, "properties")], backfill_period=timedelta(days=1_000))
+                backfill_materialized_columns(table, [(property, "properties")])
 
         # :TRICKY: Data in benchmark servers has ID=2
         team = Team.objects.filter(id=2).first()

--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -1,6 +1,5 @@
 import re
 from collections import defaultdict
-from datetime import timedelta
 from typing import Dict, Generator, List, Optional, Set, Tuple
 
 import structlog
@@ -13,7 +12,6 @@ from ee.clickhouse.materialized_columns.columns import (
 )
 from ee.settings import (
     MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS,
-    MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS,
     MATERIALIZE_COLUMNS_MAX_AT_ONCE,
     MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME,
 )
@@ -167,7 +165,6 @@ def materialize_properties_task(
     time_to_analyze_hours: int = MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS,
     maximum: int = MATERIALIZE_COLUMNS_MAX_AT_ONCE,
     min_query_time: int = MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME,
-    backfill_period_days: int = MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS,
     dry_run: bool = False,
 ) -> None:
     """
@@ -195,7 +192,7 @@ def materialize_properties_task(
             materialize(table, property_name, table_column=table_column)
         properties[table].append((property_name, table_column))
 
-    if backfill_period_days > 0 and not dry_run:
-        logger.info(f"Starting backfill for new materialized columns. period_days={backfill_period_days}")
-        backfill_materialized_columns("events", properties["events"], timedelta(days=backfill_period_days))
-        backfill_materialized_columns("person", properties["person"], timedelta(days=backfill_period_days))
+    if not dry_run:
+        logger.info(f"Starting backfill for new materialized columns.")
+        backfill_materialized_columns("events", properties["events"])
+        backfill_materialized_columns("person", properties["person"])

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -146,7 +146,7 @@ def backfill_materialized_columns(
     """
     Backfills the materialized column after its creation.
 
-    This will require reading and writing a lot of data on clickhouse disk.
+    This starts an async process that will backfill the materialized column.
     """
 
     if len(properties) == 0:

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -1,5 +1,4 @@
 import random
-from datetime import timedelta
 from time import sleep
 
 from freezegun import freeze_time
@@ -142,9 +141,8 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         with freeze_time("2021-05-10T14:00:01Z"):
             backfill_materialized_columns(
                 "events",
-                [("prop", "properties"), ("another", "properties")],
-                timedelta(days=50),
-                test_settings={"mutations_sync": "0"},
+                [("prop", "properties")],  # , ("another", "properties")],
+                test_settings={"mutations_sync": "2"},
             )
 
         _create_event(
@@ -174,8 +172,8 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         expr = "replaceRegexpAll(JSONExtractRaw(properties, 'myprop'), '^\"|\"$', '')"
         self.assertEqual(("MATERIALIZED", expr), self._get_column_types("mat_myprop"))
 
-        backfill_materialized_columns("events", [("myprop", "properties")], timedelta(days=50))
-        self.assertEqual(("DEFAULT", expr), self._get_column_types("mat_myprop"))
+        backfill_materialized_columns("events", [("myprop", "properties")])
+        self.assertEqual(("MATERIALIZED", expr), self._get_column_types("mat_myprop"))
 
         try:
             from ee.tasks.materialized_columns import mark_all_materialized

--- a/ee/management/commands/materialize_columns.py
+++ b/ee/management/commands/materialize_columns.py
@@ -6,7 +6,6 @@ from ee.clickhouse.materialized_columns.analyze import logger, materialize_prope
 from ee.clickhouse.materialized_columns.columns import DEFAULT_TABLE_COLUMN
 from posthog.settings import (
     MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS,
-    MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS,
     MATERIALIZE_COLUMNS_MAX_AT_ONCE,
     MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME,
 )
@@ -27,13 +26,6 @@ class Command(BaseCommand):
             help="The column to which --property should be materialised from.",
             default=DEFAULT_TABLE_COLUMN,
         )
-        parser.add_argument(
-            "--backfill-period",
-            type=int,
-            default=MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS,
-            help="How many days worth of data to backfill. 0 to disable. Same as MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS env variable.",
-        )
-
         parser.add_argument(
             "--min-query-time",
             type=int,
@@ -64,7 +56,6 @@ class Command(BaseCommand):
 
             materialize_properties_task(
                 columns_to_materialize=[(options["property_table"], options["table_column"], options["property"], 0)],
-                backfill_period_days=options["backfill_period"],
                 dry_run=options["dry_run"],
             )
         else:
@@ -72,6 +63,5 @@ class Command(BaseCommand):
                 time_to_analyze_hours=options["analyze_period"],
                 maximum=options["max_columns"],
                 min_query_time=options["min_query_time"],
-                backfill_period_days=options["backfill_period"],
                 dry_run=options["dry_run"],
             )

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -53,8 +53,6 @@ MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME = get_from_env("MATERIALIZE_COLUMNS_MINIM
 MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS = get_from_env(
     "MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS", 7 * 24, type_cast=int
 )
-# How big of a timeframe to backfill when materializing event properties. 0 for no backfilling
-MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS = get_from_env("MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS", 90, type_cast=int)
 # Maximum number of columns to materialize at once. Avoids running into resource bottlenecks (storage + ingest + backfilling).
 MATERIALIZE_COLUMNS_MAX_AT_ONCE = get_from_env("MATERIALIZE_COLUMNS_MAX_AT_ONCE", 10, type_cast=int)
 

--- a/posthog/clickhouse/materialized_columns/column.py
+++ b/posthog/clickhouse/materialized_columns/column.py
@@ -29,7 +29,6 @@ def materialize(
 def backfill_materialized_columns(
     table: TableWithProperties,
     properties: List[Tuple[PropertyName, TableColumn]],
-    backfill_period: timedelta,
     test_settings=None,
 ) -> None:
     pass

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -363,8 +363,8 @@
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'event_name'
-       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-05-03 00:00:00', 'UTC')
-       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2023-05-04 00:00:00', 'UTC')
+       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-11 23:59:59', 'UTC')
        AND (pdi.person_id IN
               (SELECT DISTINCT person_id
                FROM cohortpeople
@@ -394,9 +394,9 @@
                   ticks.day_start as day_start,
                   breakdown_value
            FROM
-             (SELECT toStartOfDay(toDateTime('2023-05-10 23:59:59', 'UTC') - number * 86400) as day_start
+             (SELECT toStartOfDay(toDateTime('2023-05-11 23:59:59', 'UTC') - number * 86400) as day_start
               FROM numbers(8)
-              UNION ALL SELECT toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')) as day_start) as ticks
+              UNION ALL SELECT toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')) as day_start) as ticks
            CROSS JOIN
              (SELECT breakdown_value
               FROM
@@ -430,8 +430,8 @@
                      WHERE team_id = 2
                        AND cohort_id = 2
                        AND version = 0 ))
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), 'UTC')
-             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-11 23:59:59', 'UTC')
              AND replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') in (['Jane'])
            GROUP BY day_start,
                     breakdown_value))
@@ -1178,10 +1178,10 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2023-05-10 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), toDateTime('2023-05-10 23:59:59', 'UTC')))
+               toStartOfDay(toDateTime('2023-05-11 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), toDateTime('2023-05-11 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC'))
+                         toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
@@ -1200,8 +1200,8 @@
            HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'event_name'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-11 23:59:59', 'UTC')
           AND (pdi.person_id IN
                  (SELECT DISTINCT person_id
                   FROM cohortpeople
@@ -1243,10 +1243,10 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2023-05-10 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), toDateTime('2023-05-10 23:59:59', 'UTC')))
+               toStartOfDay(toDateTime('2023-05-11 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), toDateTime('2023-05-11 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC'))
+                         toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
@@ -1258,8 +1258,8 @@
            GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         WHERE team_id = 2
           AND event = 'event_name'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-03 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-10 23:59:59', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-11 23:59:59', 'UTC')
           AND (if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) IN
                  (SELECT DISTINCT person_id
                   FROM cohortpeople


### PR DESCRIPTION
## Problem

We used to rely on some ClickHouse hacks to materialize columns. Materialization would affect only a `backfill` amount of days, because we'd have to [rewrite/optimize all columns](https://github.com/ClickHouse/ClickHouse/issues/27730).

## Changes

ClickHouse has since then added a new `ALTER TABLE .. MATERIALIZE COLUMN` syntax, which should do the backfill automatically for any parts that are missing a column.

## How did you test this code?

Didn't test it yet. Putting it out there for criticisim.