### PR TITLE
feat: duplicate actions

### DIFF
--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -332,12 +332,7 @@ export function ActionsTable(): JSX.Element {
                     </>
                 }
             >
-                <LemonInput
-                    type="text"
-                    placeholder="Enter name for duplicated action"
-                    onChange={setDupName}
-                    value={dupName}
-                />
+                <LemonInput type="text" placeholder="Enter name" onChange={setDupName} value={dupName} />
             </LemonModal>
         </div>
     )

--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -5,7 +5,7 @@ import { deleteWithUndo, stripHTTP } from 'lib/utils'
 import { useActions, useValues } from 'kea'
 import { actionsModel } from '~/models/actionsModel'
 import { NewActionButton } from './NewActionButton'
-import { ActionType, AvailableFeature, ChartDisplayType, InsightType } from '~/types'
+import { ActionStepType, ActionType, AvailableFeature, ChartDisplayType, InsightType } from '~/types'
 import Fuse from 'fuse.js'
 import { userLogic } from 'scenes/userLogic'
 import { teamLogic } from '../teamLogic'
@@ -22,7 +22,7 @@ import { combineUrl } from 'kea-router'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
 import { PageHeader } from 'lib/components/PageHeader'
-import { LemonInput } from '@posthog/lemon-ui'
+import { LemonInput, LemonModal, lemonToast } from '@posthog/lemon-ui'
 import { actionsLogic } from 'scenes/actions/actionsLogic'
 import { IconCheckmark, IconPlayCircle } from 'lib/lemon-ui/icons'
 
@@ -46,8 +46,39 @@ export function ActionsTable(): JSX.Element {
     const { loadActions } = useActions(actionsModel)
     const [searchTerm, setSearchTerm] = useState('')
     const [filterByMe, setFilterByMe] = useState(false)
+    const [dupVisible, setDupVisible] = useState(false)
+    const [dupName, setDupName] = useState('')
+    const [dupAction, setDupAction] = useState<ActionType>()
     const { user, hasAvailableFeature } = useValues(userLogic)
 
+    const duplicateAction = async (action: ActionType | undefined): Promise<void> => {
+        if (action) {
+            try {
+                const { id, action_id, ...partialAction } = action
+                const newActionSteps: ActionStepType[] | undefined = action.steps?.map(({ id, ...partialStep }) => ({
+                    ...partialStep,
+                }))
+                await api.actions.create({
+                    ...partialAction,
+                    name: dupName,
+                    steps: newActionSteps,
+                })
+                loadActions()
+                lemonToast.success('Action duplicated')
+            } catch (response: any) {
+                if (response.type === 'validation_error' && response.code === 'unique') {
+                } else {
+                    lemonToast.error(
+                        <>
+                            Couldn't create this action. You can try{' '}
+                            <Link to={urls.createAction()}>manually creating an action instead.</Link>
+                        </>
+                    )
+                    return
+                }
+            }
+        }
+    }
     const columns: LemonTableColumns<ActionType> = [
         {
             title: 'Name',
@@ -197,6 +228,17 @@ export function ActionsTable(): JSX.Element {
                                 >
                                     Try out in Insights
                                 </LemonButton>
+                                <LemonButton
+                                    status="stealth"
+                                    onClick={() => {
+                                        setDupName(action.name?.toString() ?? '')
+                                        setDupVisible(true)
+                                        setDupAction(action)
+                                    }}
+                                    fullWidth
+                                >
+                                    Duplicate
+                                </LemonButton>
                                 <LemonDivider />
                                 <LemonButton
                                     status="danger"
@@ -260,6 +302,43 @@ export function ActionsTable(): JSX.Element {
                 }}
                 emptyState="The first step to standardized analytics is creating your first action."
             />
+            <LemonModal
+                isOpen={dupVisible}
+                onClose={() => {
+                    setDupVisible(false)
+                }}
+                title={`Duplicate action`}
+                footer={
+                    <>
+                        <LemonButton
+                            key="duplicate-button"
+                            type="primary"
+                            onClick={() => {
+                                setDupVisible(false)
+                                duplicateAction(dupAction)
+                            }}
+                        >
+                            Duplicate
+                        </LemonButton>
+                        <LemonButton
+                            key="cancel-button"
+                            type="secondary"
+                            onClick={() => {
+                                setDupVisible(false)
+                            }}
+                        >
+                            Cancel
+                        </LemonButton>
+                    </>
+                }
+            >
+                <LemonInput
+                    type="text"
+                    placeholder="Enter name for duplicated action"
+                    onChange={setDupName}
+                    value={dupName}
+                />
+            </LemonModal>
         </div>
     )
 }

--- a/frontend/src/scenes/actions/actionsTableLogic.tsx
+++ b/frontend/src/scenes/actions/actionsTableLogic.tsx
@@ -1,0 +1,79 @@
+import { kea } from 'kea'
+import { actionsModel } from '~/models/actionsModel'
+import type { actionsTableLogicType } from './actionsTableLogicType'
+import { ActionStepType, ActionType } from '~/types'
+import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
+import api from 'lib/api'
+import { urls } from '../urls'
+import { lemonToast } from '@posthog/lemon-ui'
+import { Link } from 'lib/lemon-ui/Link'
+
+export const actionsTableLogic = kea<actionsTableLogicType>({
+    path: ['scenes', 'actions', 'actionsTableLogic'],
+
+    actions: () => ({
+        setActionDupName: (actionDupName) => ({ actionDupName }),
+        setIsActionDupModalVisible: (isActionDupModalVisible) => ({ isActionDupModalVisible }),
+        setDuplicateAction: (dupAction) => ({ dupAction }),
+    }),
+    connect: () => ({
+        actions: [actionsModel, ['loadActions'], eventDefinitionsTableLogic, ['loadEventDefinitions']],
+    }),
+    loaders: ({ values, actions }) => ({
+        actions: {
+            duplicateAction: async (): Promise<void> => {
+                const action = values.dupAction
+                if (action) {
+                    try {
+                        const { id, action_id, ...partialAction } = action
+                        const newActionSteps: ActionStepType[] | undefined = action.steps?.map(
+                            ({ id, ...partialStep }) => ({
+                                ...partialStep,
+                            })
+                        )
+                        await api.actions.create({
+                            ...partialAction,
+                            name: values.actionDupName,
+                            steps: newActionSteps,
+                        })
+                        actions.loadActions()
+                        actions.setDuplicateAction(null)
+                        actions.setIsActionDupModalVisible(false)
+                        lemonToast.success('Action duplicated')
+                    } catch (response: any) {
+                        if (response.type === 'validation_error' && response.code === 'unique') {
+                            return
+                        } else {
+                            lemonToast.error(
+                                <>
+                                    Couldn't create this action. You can try{' '}
+                                    <Link to={urls.createAction()}>manually creating an action instead.</Link>
+                                </>
+                            )
+                        }
+                    }
+                }
+            },
+        },
+    }),
+    reducers: () => ({
+        actionDupName: [
+            '' as string,
+            {
+                setActionDupName: (_, { actionDupName }) => actionDupName,
+            },
+        ],
+        isActionDupModalVisible: [
+            false as boolean,
+            {
+                setIsActionDupModalVisible: (_, { isActionDupModalVisible }) => isActionDupModalVisible,
+            },
+        ],
+        dupAction: [
+            null as ActionType | null,
+            {
+                setDuplicateAction: (_, { dupAction }) => dupAction,
+            },
+        ],
+    }),
+})


### PR DESCRIPTION
## Problem
Sometimes you want to extend the definition of an action to encompass more events (e.g. considering dashboards & Discoveries) without changing the original action.

fixes https://github.com/PostHog/posthog/issues/8431
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
As a starting point, I have added an option to duplicate an action.
<!-- If there are frontend changes, please include screenshots. -->
![Screenshot 2023-05-11 at 11 51 44 AM](https://github.com/PostHog/posthog/assets/20830832/e10ded10-ac91-42ae-85a6-1c6d0219fbf6)
![Screenshot 2023-05-11 at 11 53 50 AM](https://github.com/PostHog/posthog/assets/20830832/c8725c20-d1a9-410e-b0eb-5abdb72a904a)
![Screenshot 2023-05-11 at 11 54 27 AM](https://github.com/PostHog/posthog/assets/20830832/09f97e1c-2351-473f-ba9c-e04dfcda1a7a)

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Done basic UI testing. Pushed the changes for some criticism before adding tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
