### PR TITLE
fix: disallow debugger statements when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     },
     plugins: ['prettier', 'react', 'cypress', '@typescript-eslint', 'no-only-tests'],
     rules: {
+        'no-debugger': 'error',
         'no-only-tests/no-only-tests': 'error',
         'react/prop-types': [0],
         'react/react-in-jsx-scope': [0],

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -155,7 +155,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
             } as SessionRecordingsResponse,
             {
                 getSessionRecordings: async (_, breakpoint) => {
-                    debugger
                     const paramsDict = {
                         ...values.filters,
                         person_uuid: props.personUUID ?? '',


### PR DESCRIPTION
## Problem

A `debugger` snuck in in #15418 🤦 

## Changes

* removes it
* adds a lint rule to error when debugger is present

## How did you test this code?

saw the lint rule take effect