### PR TITLE
refactor(data-exploration): remove feature flag from insightNavLogic and summarizeInsight function

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -237,7 +237,6 @@ function InsightMeta({
         aggregationLabel,
         cohortsById,
         mathDefinitions,
-        isUsingDataExploration: !!featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_INSIGHTS],
         isUsingDashboardQueries: !!featureFlags[FEATURE_FLAGS.HOGQL],
     })
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -130,7 +130,6 @@ export const FEATURE_FLAGS = {
     ROLE_BASED_ACCESS: 'role-based-access', // owner: #team-experiments, @liyiy
     YULE_HOG: 'yule-hog', // owner: @benjackwhite
     QUERY_RUNNING_TIME: 'query_running_time', // owner: @mariusandra
-    DATA_EXPLORATION_INSIGHTS: 'data-exploration-insights', // owner @thmsobrmlr
     RECORDING_DEBUGGING: 'recording-debugging', // owner #team-session-recordings
     REQUIRE_EMAIL_VERIFICATION: 'require-email-verification', // owner: @raquelmsmith
     SAMPLING: 'sampling', // owner: @yakkomajuri

--- a/frontend/src/scenes/funnels/funnelCorrelationDetailsLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelCorrelationDetailsLogic.test.ts
@@ -1,7 +1,10 @@
 import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
+import { DataNode } from '~/queries/schema'
 import { FunnelCorrelationResultsType, FunnelCorrelationType, InsightLogicProps, InsightType } from '~/types'
 
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { funnelCorrelationDetailsLogic } from './funnelCorrelationDetailsLogic'
 
 const funnelResults = [
@@ -42,8 +45,8 @@ describe('funnelCorrelationDetailsLogic', () => {
             filters: {
                 insight: InsightType.FUNNELS,
                 actions: [
-                    { id: '$pageview', order: 0 },
-                    { id: '$pageview', order: 1 },
+                    { type: 'actions', id: '$pageview', order: 0 },
+                    { type: 'actions', id: '$pageview', order: 1 },
                 ],
             },
             result: funnelResults,
@@ -51,6 +54,13 @@ describe('funnelCorrelationDetailsLogic', () => {
     }
 
     beforeEach(async () => {
+        const builtDataNodeLogic = dataNodeLogic({
+            key: insightVizDataNodeKey(defaultProps),
+            query: {} as DataNode,
+            cachedResults: { result: funnelResults },
+        })
+        builtDataNodeLogic.mount()
+
         logic = funnelCorrelationDetailsLogic(defaultProps)
         logic.mount()
     })

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -1,7 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 
-import { InsightLogicProps, InsightShortId, InsightType } from '~/types'
+import { InsightLogicProps, InsightType } from '~/types'
 import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
 import { useMocks } from '~/mocks/jest'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -87,21 +87,6 @@ describe('insightNavLogic', () => {
         })
 
         describe('filters changing changes active view', () => {
-            it('takes view from cached insight filters', async () => {
-                const propsWithCachedInsight = {
-                    dashboardItemId: 'insight' as InsightShortId,
-                    cachedInsight: { filters: { insight: InsightType.FUNNELS } },
-                }
-                const theInsightLogicWithCachedInsight = insightLogic(propsWithCachedInsight)
-                theInsightLogicWithCachedInsight.mount()
-                const theInsightNavLogicForTheCachedInsight = insightNavLogic({
-                    dashboardItemId: 'insight' as InsightShortId,
-                    cachedInsight: { filters: { insight: InsightType.FUNNELS } },
-                })
-                theInsightNavLogicForTheCachedInsight.mount()
-                expect(theInsightNavLogicForTheCachedInsight.values.activeView).toEqual(InsightType.FUNNELS)
-            })
-
             it('does set view from setInsight if filters are overriding', async () => {
                 await expectLogic(builtInsightNavLogic, () => {
                     builtInsightLogic.actions.setInsight(

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -35,7 +35,7 @@ export const insightNavLogic = kea<insightNavLogicType>([
             filterTestAccountsDefaultsLogic,
             ['filterTestAccountsDefault'],
         ],
-        actions: [insightLogic(props), ['setFilters'], insightDataLogic(props), ['setQuery']],
+        actions: [insightDataLogic(props), ['setQuery']],
     })),
     actions({
         setActiveView: (view: InsightType) => ({ view }),

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -3,7 +3,6 @@ import { InsightLogicProps, InsightType } from '~/types'
 
 import type { insightNavLogicType } from './insightNavLogicType'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
-import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { NodeKind } from '~/queries/schema'
 import { insightDataLogic, queryFromKind } from 'scenes/insights/insightDataLogic'
@@ -47,10 +46,6 @@ export const insightNavLogic = kea<insightNavLogicType>([
         },
     }),
     selectors({
-        isUsingDataExploration: [
-            (s) => [s.featureFlags],
-            (featureFlags) => !!featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_INSIGHTS],
-        ],
         allowQueryTab: [(s) => [s.featureFlags], (featureFlags) => !!featureFlags[FEATURE_FLAGS.HOGQL]],
         activeView: [
             (s) => [s.filters, s.query, s.userSelectedView],
@@ -162,30 +157,18 @@ export const insightNavLogic = kea<insightNavLogicType>([
                     actions.setQuery(examples.HogQLTable)
                 }
             } else {
-                if (values.isUsingDataExploration) {
-                    if (view === InsightType.TRENDS) {
-                        actions.setQuery(queryFromKind(NodeKind.TrendsQuery, values.filterTestAccountsDefault))
-                    } else if (view === InsightType.FUNNELS) {
-                        actions.setQuery(queryFromKind(NodeKind.FunnelsQuery, values.filterTestAccountsDefault))
-                    } else if (view === InsightType.RETENTION) {
-                        actions.setQuery(queryFromKind(NodeKind.RetentionQuery, values.filterTestAccountsDefault))
-                    } else if (view === InsightType.PATHS) {
-                        actions.setQuery(queryFromKind(NodeKind.PathsQuery, values.filterTestAccountsDefault))
-                    } else if (view === InsightType.STICKINESS) {
-                        actions.setQuery(queryFromKind(NodeKind.StickinessQuery, values.filterTestAccountsDefault))
-                    } else if (view === InsightType.LIFECYCLE) {
-                        actions.setQuery(queryFromKind(NodeKind.LifecycleQuery, values.filterTestAccountsDefault))
-                    }
-                } else {
-                    actions.setFilters(
-                        cleanFilters(
-                            // double-check that the view is valid
-                            { ...values.filters, insight: view || InsightType.TRENDS },
-                            values.filters
-                        ),
-                        undefined,
-                        true
-                    )
+                if (view === InsightType.TRENDS) {
+                    actions.setQuery(queryFromKind(NodeKind.TrendsQuery, values.filterTestAccountsDefault))
+                } else if (view === InsightType.FUNNELS) {
+                    actions.setQuery(queryFromKind(NodeKind.FunnelsQuery, values.filterTestAccountsDefault))
+                } else if (view === InsightType.RETENTION) {
+                    actions.setQuery(queryFromKind(NodeKind.RetentionQuery, values.filterTestAccountsDefault))
+                } else if (view === InsightType.PATHS) {
+                    actions.setQuery(queryFromKind(NodeKind.PathsQuery, values.filterTestAccountsDefault))
+                } else if (view === InsightType.STICKINESS) {
+                    actions.setQuery(queryFromKind(NodeKind.StickinessQuery, values.filterTestAccountsDefault))
+                } else if (view === InsightType.LIFECYCLE) {
+                    actions.setQuery(queryFromKind(NodeKind.LifecycleQuery, values.filterTestAccountsDefault))
                 }
             }
         },

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -120,7 +120,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         name="name"
                         value={insight.name || ''}
                         placeholder={summarizeInsight(query, filters, {
-                            isUsingDataExploration,
                             aggregationLabel,
                             cohortsById,
                             mathDefinitions,

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -45,7 +45,6 @@ const Insight12 = '12' as InsightShortId
 const Insight42 = '42' as InsightShortId
 const Insight43 = '43' as InsightShortId
 const Insight44 = '44' as InsightShortId
-const Insight500 = '500' as InsightShortId
 
 const partialInsight43 = {
     id: 43,
@@ -318,304 +317,236 @@ describe('insightLogic', () => {
             ])
         })
     })
-
-    describe('as dashboard item', () => {
-        describe('props with filters and cached results', () => {
-            beforeEach(() => {
-                logic = insightLogic({
-                    dashboardItemId: Insight42,
-                    cachedInsight: {
-                        short_id: Insight42,
-                        results: ['cached result'],
-                        filters: {
-                            insight: InsightType.TRENDS,
-                            events: [{ id: 2 }],
-                            properties: [
-                                {
-                                    value: 'lol',
-                                    operator: PropertyOperator.Exact,
-                                    key: 'lol',
-                                    type: PropertyFilterType.Person,
-                                },
-                            ],
-                        },
-                    },
-                })
-                logic.mount()
-            })
-
-            it('has the key set to the id', () => {
-                expect(logic.key).toEqual('42')
-            })
-            it('no query to load results', async () => {
-                await expectLogic(logic)
-                    .toMatchValues({
-                        insight: partial({ short_id: Insight42, results: ['cached result'] }),
-                        filters: partial({
-                            events: [{ id: 2 }],
-                            properties: [partial({ type: PropertyFilterType.Person })],
-                        }),
-                    })
-                    .toNotHaveDispatchedActions(['loadResultsSuccess']) // this took the cached results
-            })
-        })
-
-        describe('props with query and cached results', () => {
-            beforeEach(() => {
-                logic = insightLogic({
-                    dashboardItemId: Insight42,
-                    cachedInsight: {
-                        short_id: Insight42,
-                        results: ['cached result'],
-                        filters: {},
-                        query: { kind: NodeKind.TimeToSeeDataSessionsQuery },
-                    },
-                })
-                logic.mount()
-            })
-
-            it('has the key set to the id', () => {
-                expect(logic.key).toEqual('42')
-            })
-
-            it('no query to load results', async () => {
-                await expectLogic(logic)
-                    .toMatchValues({
-                        insight: partial({
-                            short_id: Insight42,
-                            results: ['cached result'],
-                            query: { kind: NodeKind.TimeToSeeDataSessionsQuery },
-                        }),
-                        filters: {},
-                    })
-                    .toNotHaveDispatchedActions(['loadResultsSuccess']) // this took the cached results
-            })
-        })
-
-        describe('props with filters, no cached results', () => {
-            it('makes a query to load the results', async () => {
-                logic = insightLogic({
-                    dashboardItemId: Insight42,
-                    cachedInsight: {
-                        short_id: Insight42,
-                        results: undefined,
-                        filters: {
-                            insight: InsightType.TRENDS,
-                            events: [{ id: 3 }],
-                            properties: [
-                                {
-                                    value: 'a',
-                                    operator: PropertyOperator.Exact,
-                                    key: 'a',
-                                    type: PropertyFilterType.Person,
-                                },
-                            ],
-                        },
-                    },
-                })
-                logic.mount()
-
-                await expectLogic(logic)
-                    .toDispatchActions(['loadResults', 'loadResultsSuccess'])
-                    .toMatchValues({
-                        insight: partial({ short_id: Insight42, result: ['result from api'] }),
-                        filters: partial({
-                            events: [{ id: 3 }],
-                            properties: [partial({ value: 'a' })],
-                        }),
-                    })
-                    .delay(1)
-                    // do not override the insight if querying with different filters
-                    .toNotHaveDispatchedActions(['updateInsight', 'updateInsightSuccess'])
-            })
-        })
-
-        describe('props with query, no cached results', () => {
-            it('still does not make a query to load the results', async () => {
-                logic = insightLogic({
-                    dashboardItemId: Insight42,
-                    cachedInsight: {
-                        short_id: Insight42,
-                        results: undefined,
-                        filters: {},
-                        query: { kind: NodeKind.TimeToSeeDataSessionsQuery },
-                    },
-                })
-                logic.mount()
-
-                await expectLogic(logic)
-                    .toDispatchActions([])
-                    .toMatchValues({
-                        insight: partial({ short_id: Insight42, query: { kind: NodeKind.TimeToSeeDataSessionsQuery } }),
-                        filters: {},
-                    })
-                    .delay(1)
-                    // do not override the insight if querying with different filters
-                    .toNotHaveDispatchedActions([
-                        'loadResults',
-                        'loadResultsSuccess',
-                        'updateInsight',
-                        'updateInsightSuccess',
-                    ])
-            })
-        })
-
-        describe('props with filters, no cached results, error from API', () => {
-            beforeEach(silenceKeaLoadersErrors)
-            afterEach(resumeKeaLoadersErrors)
-
-            it('makes a query to load the results', async () => {
-                const insight: Partial<InsightModel> = {
+    describe('props with filters and cached results', () => {
+        beforeEach(() => {
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                cachedInsight: {
                     short_id: Insight42,
+                    results: ['cached result'],
                     filters: {
                         insight: InsightType.TRENDS,
-                        events: [{ id: 3, throw: true }],
+                        events: [{ id: 2 }],
                         properties: [
-                            { value: 'a', operator: PropertyOperator.Exact, key: 'a', type: PropertyFilterType.Person },
+                            {
+                                value: 'lol',
+                                operator: PropertyOperator.Exact,
+                                key: 'lol',
+                                type: PropertyFilterType.Person,
+                            },
                         ],
                     },
-                }
-                logic = insightLogic({
-                    dashboardItemId: Insight42,
-                    cachedInsight: insight,
-                })
-                logic.mount()
-
-                await expectLogic(logic)
-                    .toDispatchActions(['loadResults', 'loadResultsFailure'])
-                    .toMatchValues({
-                        insight: insight,
-                        filters: partial({
-                            events: [partial({ id: 3 })],
-                            properties: [partial({ value: 'a' })],
-                        }),
-                        maybeShowErrorMessage: true,
-                    })
-                    .delay(1)
-                    .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
+                },
             })
+            logic.mount()
         })
 
-        describe('props with filters, no cached results, respects doNotLoad', () => {
-            it('does not make a query', async () => {
-                const insight: Partial<InsightModel> = {
+        it('has the key set to the id', () => {
+            expect(logic.key).toEqual('42')
+        })
+        it('no query to load results', async () => {
+            await expectLogic(logic)
+                .toMatchValues({
+                    insight: partial({ short_id: Insight42, results: ['cached result'] }),
+                    filters: partial({
+                        events: [{ id: 2 }],
+                        properties: [partial({ type: PropertyFilterType.Person })],
+                    }),
+                })
+                .toNotHaveDispatchedActions(['loadResultsSuccess']) // this took the cached results
+        })
+    })
+
+    describe('props with query and cached results', () => {
+        beforeEach(() => {
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                cachedInsight: {
                     short_id: Insight42,
+                    results: ['cached result'],
+                    filters: {},
+                    query: { kind: NodeKind.TimeToSeeDataSessionsQuery },
+                },
+            })
+            logic.mount()
+        })
+
+        it('has the key set to the id', () => {
+            expect(logic.key).toEqual('42')
+        })
+
+        it('no query to load results', async () => {
+            await expectLogic(logic)
+                .toMatchValues({
+                    insight: partial({
+                        short_id: Insight42,
+                        results: ['cached result'],
+                        query: { kind: NodeKind.TimeToSeeDataSessionsQuery },
+                    }),
+                    filters: {},
+                })
+                .toNotHaveDispatchedActions(['loadResultsSuccess']) // this took the cached results
+        })
+    })
+
+    describe('props with filters, no cached results', () => {
+        it('makes a query to load the results', async () => {
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                cachedInsight: {
+                    short_id: Insight42,
+                    results: undefined,
                     filters: {
                         insight: InsightType.TRENDS,
-                        events: [{ id: 3, throw: true }],
+                        events: [{ id: 3 }],
                         properties: [
-                            { value: 'a', operator: PropertyOperator.Exact, key: 'a', type: PropertyFilterType.Person },
+                            {
+                                value: 'a',
+                                operator: PropertyOperator.Exact,
+                                key: 'a',
+                                type: PropertyFilterType.Person,
+                            },
                         ],
                     },
-                }
-                logic = insightLogic({
-                    dashboardItemId: Insight42,
-                    cachedInsight: insight,
-                    doNotLoad: true,
-                })
-                logic.mount()
-
-                await expectLogic(logic)
-                    .toMatchValues({
-                        insight: insight,
-                        filters: partial({
-                            events: [partial({ id: 3 })],
-                            properties: [partial({ value: 'a' })],
-                        }),
-                    })
-                    .delay(1)
-                    .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
+                },
             })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadResults', 'loadResultsSuccess'])
+                .toMatchValues({
+                    insight: partial({ short_id: Insight42, result: ['result from api'] }),
+                    filters: partial({
+                        events: [{ id: 3 }],
+                        properties: [partial({ value: 'a' })],
+                    }),
+                })
+                .delay(1)
+                // do not override the insight if querying with different filters
+                .toNotHaveDispatchedActions(['updateInsight', 'updateInsightSuccess'])
         })
+    })
 
-        describe('props with no filters, no cached results, results from API', () => {
-            it('makes a query to load the results', async () => {
-                logic = insightLogic({
-                    dashboardItemId: Insight42,
-                    cachedInsight: {
-                        short_id: Insight42,
-                        results: undefined,
-                        filters: undefined,
-                    },
-                })
-                logic.mount()
-
-                await expectLogic(logic)
-                    .toDispatchActions(['loadInsight', 'loadInsightSuccess'])
-                    .toMatchValues({
-                        insight: partial({ short_id: Insight42, result: ['result from api'] }),
-                        filters: partial({
-                            events: [{ id: 3 }],
-                            properties: [partial({ value: 'a' })],
-                        }),
-                    })
-                    .toNotHaveDispatchedActions(['loadResults']) // does not fetch results as there was no filter
+    describe('props with query, no cached results', () => {
+        it('still does not make a query to load the results', async () => {
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                cachedInsight: {
+                    short_id: Insight42,
+                    results: undefined,
+                    filters: {},
+                    query: { kind: NodeKind.TimeToSeeDataSessionsQuery },
+                },
             })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions([])
+                .toMatchValues({
+                    insight: partial({ short_id: Insight42, query: { kind: NodeKind.TimeToSeeDataSessionsQuery } }),
+                    filters: {},
+                })
+                .delay(1)
+                // do not override the insight if querying with different filters
+                .toNotHaveDispatchedActions([
+                    'loadResults',
+                    'loadResultsSuccess',
+                    'updateInsight',
+                    'updateInsightSuccess',
+                ])
         })
+    })
 
-        describe('props with no filters, no cached results, no results from API', () => {
-            it('makes a query to load the results', async () => {
-                logic = insightLogic({
-                    dashboardItemId: Insight43, // 43 --> result: null
-                    cachedInsight: undefined,
-                })
-                logic.mount()
+    describe('props with filters, no cached results, error from API', () => {
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
 
-                await expectLogic(logic)
-                    .toDispatchActions(['loadInsight', 'loadInsightSuccess'])
-                    .toMatchValues({
-                        insight: partial({ id: 43, result: null }),
-                        filters: partial({
-                            events: [{ id: 3 }],
-                            properties: [partial({ value: 'a' })],
-                        }),
-                    })
-                    // first result comes from the /insights/43/ api
-                    .toDispatchActions(['loadResults', 'loadResultsSuccess'])
-                    .toMatchValues({
-                        insight: partial({ id: 43, result: ['result 43'] }),
-                        filters: partial({
-                            events: [{ id: 3 }],
-                            properties: [partial({ value: 'a' })],
-                        }),
-                    })
-
-                await expectLogic(logic, () => {
-                    logic.actions.setFilters({ ...API_FILTERS, events: [{ id: 4 }] })
-                })
-                    // result with changed filters comes from the /insights/trends/ api
-                    .toDispatchActions(['loadResults', 'loadResultsSuccess'])
-                    .toMatchValues({
-                        insight: partial({ id: 43, result: ['result from api'] }),
-                        filters: partial({
-                            events: [{ id: 4 }],
-                            properties: [partial({ value: 'a' })],
-                        }),
-                    })
+        it('makes a query to load the results', async () => {
+            const insight: Partial<InsightModel> = {
+                short_id: Insight42,
+                filters: {
+                    insight: InsightType.TRENDS,
+                    events: [{ id: 3, throw: true }],
+                    properties: [
+                        { value: 'a', operator: PropertyOperator.Exact, key: 'a', type: PropertyFilterType.Person },
+                    ],
+                },
+            }
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                cachedInsight: insight,
             })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadResults', 'loadResultsFailure'])
+                .toMatchValues({
+                    insight: insight,
+                    filters: partial({
+                        events: [partial({ id: 3 })],
+                        properties: [partial({ value: 'a' })],
+                    }),
+                    maybeShowErrorMessage: true,
+                })
+                .delay(1)
+                .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
         })
+    })
 
-        describe('props with no filters, no cached results, API throws', () => {
-            beforeEach(silenceKeaLoadersErrors)
-            afterEach(resumeKeaLoadersErrors)
-
-            it('makes a query to load the results', async () => {
-                logic = insightLogic({
-                    dashboardItemId: Insight500, // 500 --> result: throws
-                    cachedInsight: undefined,
-                })
-                logic.mount()
-
-                await expectLogic(logic)
-                    .toDispatchActions(['loadInsight', 'loadInsightFailure'])
-                    .toMatchValues({
-                        insight: partial({ short_id: '500', result: null, filters: { filter_test_accounts: true } }),
-                        filters: {},
-                        maybeShowErrorMessage: true,
-                    })
-                    .delay(1)
-                    .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
+    describe('props with filters, no cached results, respects doNotLoad', () => {
+        it('does not make a query', async () => {
+            const insight: Partial<InsightModel> = {
+                short_id: Insight42,
+                filters: {
+                    insight: InsightType.TRENDS,
+                    events: [{ id: 3, throw: true }],
+                    properties: [
+                        { value: 'a', operator: PropertyOperator.Exact, key: 'a', type: PropertyFilterType.Person },
+                    ],
+                },
+            }
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                cachedInsight: insight,
+                doNotLoad: true,
             })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toMatchValues({
+                    insight: insight,
+                    filters: partial({
+                        events: [partial({ id: 3 })],
+                        properties: [partial({ value: 'a' })],
+                    }),
+                })
+                .delay(1)
+                .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
+        })
+    })
+
+    describe('props with no filters, no cached results, results from API', () => {
+        it('makes a query to load the results', async () => {
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                cachedInsight: {
+                    short_id: Insight42,
+                    results: undefined,
+                    filters: undefined,
+                },
+            })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadInsight', 'loadInsightSuccess'])
+                .toMatchValues({
+                    insight: partial({ short_id: Insight42, result: ['result from api'] }),
+                    filters: partial({
+                        events: [{ id: 3 }],
+                        properties: [partial({ value: 'a' })],
+                    }),
+                })
+                .toNotHaveDispatchedActions(['loadResults']) // does not fetch results as there was no filter
         })
     })
 
@@ -1301,54 +1232,6 @@ describe('insightLogic', () => {
                 .toMatchValues({
                     insight: expect.objectContaining({ dashboards: [1, 2, 3] }),
                 })
-        })
-    })
-
-    describe('cancelling queries', () => {
-        beforeEach(async () => {
-            logic = insightLogic({
-                dashboardItemId: 'new',
-            })
-            logic.mount()
-        })
-
-        it('cancels a running query', async () => {
-            jest.spyOn(api, 'create')
-
-            setTimeout(() => {
-                // this change of filters will dispatch cancellation on the first query
-                // will run while the -180d query is still running
-                logic.actions.setFilters({ insight: InsightType.TRENDS, date_from: '-90d' })
-            }, 200)
-            // dispatches an artificially slow data request
-            // takes 3000 milliseconds to return
-            logic.actions.setFilters({ insight: InsightType.TRENDS, date_from: '-180d' })
-
-            await expectLogic(logic)
-                .toDispatchActions([
-                    'loadResults',
-                    'abortAnyRunningQuery',
-                    'loadResults',
-                    'abortAnyRunningQuery',
-                    'abortQuery',
-                    'loadResultsSuccess',
-                ])
-                .toMatchValues({
-                    filters: partial({ date_from: '-90d' }),
-                })
-
-            const mockCreateCalls = (api.create as jest.Mock).mock.calls
-            // there will be at least two used client query ids
-            // the most recent has not been cancelled
-            // the one before that has been
-            expect(mockCreateCalls).toEqual([
-                [
-                    `api/projects/${MOCK_TEAM_ID}/insights/cancel`,
-                    {
-                        client_query_id: seenQueryIDs[seenQueryIDs.length - 2],
-                    },
-                ],
-            ])
         })
     })
 

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -605,24 +605,9 @@ export const insightLogic = kea<insightLogicType>([
                 !!props.dashboardItemId && props.dashboardItemId !== 'new' && !props.dashboardItemId.startsWith('new-'),
         ],
         derivedName: [
-            (s) => [
-                s.insight,
-                s.aggregationLabel,
-                s.cohortsById,
-                s.mathDefinitions,
-                s.isUsingDataExploration,
-                s.isUsingDashboardQueries,
-            ],
-            (
-                insight,
-                aggregationLabel,
-                cohortsById,
-                mathDefinitions,
-                isUsingDataExploration,
-                isUsingDashboardQueries
-            ) =>
+            (s) => [s.insight, s.aggregationLabel, s.cohortsById, s.mathDefinitions, s.isUsingDashboardQueries],
+            (insight, aggregationLabel, cohortsById, mathDefinitions, isUsingDashboardQueries) =>
                 summarizeInsight(insight.query, insight.filters || {}, {
-                    isUsingDataExploration,
                     aggregationLabel,
                     cohortsById,
                     mathDefinitions,

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -777,9 +777,9 @@ export const insightLogic = kea<insightLogicType>([
             },
         ],
         isUsingDataExploration: [
-            (s) => [s.featureFlags],
-            (featureFlags: FeatureFlagsSet): boolean => {
-                return !!featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_INSIGHTS]
+            () => [],
+            (): boolean => {
+                return true
             },
         ],
         isUsingDashboardQueries: [

--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -6,15 +6,12 @@ import { ChartDisplayType, InsightShortId } from '~/types'
 import { insightDataLogic } from './insightDataLogic'
 import { useMocks } from '~/mocks/jest'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 const Insight123 = '123' as InsightShortId
 
 describe('insightVizDataLogic', () => {
     let theInsightVizDataLogic: ReturnType<typeof insightVizDataLogic.build>
     let theInsightDataLogic: ReturnType<typeof insightDataLogic.build>
-    let theFeatureFlagLogic: ReturnType<typeof featureFlagLogic.build>
 
     beforeEach(() => {
         useMocks({
@@ -23,12 +20,6 @@ describe('insightVizDataLogic', () => {
             },
         })
         initKeaTests()
-
-        theFeatureFlagLogic = featureFlagLogic()
-        theFeatureFlagLogic.mount()
-        theFeatureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DATA_EXPLORATION_INSIGHTS], {
-            [FEATURE_FLAGS.DATA_EXPLORATION_INSIGHTS]: false,
-        })
 
         const props = { dashboardItemId: Insight123 }
 

--- a/frontend/src/scenes/insights/summarizeInsight.test.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.test.ts
@@ -67,13 +67,11 @@ const summaryContext: SummaryContext = {
     aggregationLabel,
     cohortsById: cohortIdsMapped,
     mathDefinitions,
-    isUsingDataExploration: false,
     isUsingDashboardQueries: false,
 }
 
 const flagsOnSummaryContext: SummaryContext = {
     ...summaryContext,
-    isUsingDataExploration: true,
     isUsingDashboardQueries: true,
 }
 

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -327,7 +327,6 @@ function summariseQuery(query: Node): string {
 }
 
 export interface SummaryContext {
-    isUsingDataExploration: boolean
     isUsingDashboardQueries: boolean
     aggregationLabel: groupsModelType['values']['aggregationLabel']
     cohortsById: cohortsModelType['values']['cohortsById']
@@ -341,7 +340,7 @@ export function summarizeInsight(
 ): string {
     const hasFilters = Object.keys(filters || {}).length > 0
 
-    return context.isUsingDataExploration && isInsightVizNode(query)
+    return isInsightVizNode(query)
         ? summarizeInsightQuery(query.source, context)
         : context.isUsingDashboardQueries && !!query && !isInsightVizNode(query)
         ? summariseQuery(query)

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -341,7 +341,6 @@ function SavedInsightsGrid(): JSX.Element {
 
 export function SavedInsights(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    const isUsingDataExploration = !!featureFlags[FEATURE_FLAGS.DATA_EXPLORATION_INSIGHTS]
     const isUsingDashboardQueries = !!featureFlags[FEATURE_FLAGS.HOGQL]
 
     const { loadInsights, updateFavoritedInsight, renameInsight, duplicateInsight, setSavedInsightsFilters } =
@@ -379,7 +378,6 @@ export function SavedInsights(): JSX.Element {
                                 {name || (
                                     <i>
                                         {summarizeInsight(insight.query, insight.filters, {
-                                            isUsingDataExploration,
                                             aggregationLabel,
                                             cohortsById,
                                             mathDefinitions,

--- a/frontend/src/scenes/trends/trendsLogic.test.ts
+++ b/frontend/src/scenes/trends/trendsLogic.test.ts
@@ -1,6 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { InsightShortId, InsightType } from '~/types'
+import { InsightShortId } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
@@ -19,21 +19,6 @@ describe('trendsLogic', () => {
             },
         })
         initKeaTests()
-    })
-
-    describe('core assumptions', () => {
-        beforeEach(() => {
-            logic = trendsLogic({
-                dashboardItemId: undefined,
-                cachedInsight: { filters: { insight: InsightType.TRENDS } },
-            })
-            logic.mount()
-        })
-        it('loads results on mount if with filters', async () => {
-            await expectLogic(logic).toDispatchActions([
-                insightLogic({ dashboardItemId: undefined }).actionTypes.loadResults,
-            ])
-        })
     })
 
     describe('syncs with insightLogic', () => {


### PR DESCRIPTION
## Problem

Lot's of dead code after the data exploration feature flag is rolled out (part 1/X)

## Changes

Yeet:
- Removes the feature flag `DATA_EXPLORATION_INSIGHTS` and sets `isUsingDataExploration
` to true in `insightLogic`
- removes unflagged code from insightNavLogic
- removes unflagged code from the summarizeInsight function

## How did you test this code?

Verified navigation still works and the summary still displays