### PR TITLE
fix: do not allow flush after destroy has begun

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -86,6 +86,7 @@ export class SessionManager {
     public async add(message: IncomingRecordingMessage): Promise<void> {
         if (this.destroying) {
             status.warn('⚠️', `blob_ingester_session_manager add called after destroy ${this.sessionId}`, { message })
+            return
         }
         this.buffer.oldestKafkaTimestamp = Math.min(this.buffer.oldestKafkaTimestamp, message.metadata.timestamp)
         // TODO: Check that the offset is higher than the lastProcessed
@@ -123,6 +124,7 @@ export class SessionManager {
     public async flushIfSessionBufferIsOld(): Promise<void> {
         if (this.destroying) {
             status.warn('⚠️', `blob_ingester_session_manager flush on age called after destroy ${this.sessionId}`)
+            return
         }
 
         const bufferAge = Date.now() - this.buffer.oldestKafkaTimestamp
@@ -145,6 +147,11 @@ export class SessionManager {
     public async flush(): Promise<void> {
         if (this.flushBuffer) {
             status.warn('⚠️', "blob_ingester_session_manager Flush called but we're already flushing")
+            return
+        }
+
+        if (this.destroying) {
+            status.warn('⚠️', 'blob_ingester_session_manager somehow flush called after destroy')
             return
         }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -86,7 +86,7 @@ export class SessionManager {
     public async add(message: IncomingRecordingMessage): Promise<void> {
         if (this.destroying) {
             status.warn('⚠️', `blob_ingester_session_manager add called after destroy ${this.sessionId}`, { message })
-            return
+            // return
         }
         this.buffer.oldestKafkaTimestamp = Math.min(this.buffer.oldestKafkaTimestamp, message.metadata.timestamp)
         // TODO: Check that the offset is higher than the lastProcessed
@@ -124,7 +124,7 @@ export class SessionManager {
     public async flushIfSessionBufferIsOld(): Promise<void> {
         if (this.destroying) {
             status.warn('⚠️', `blob_ingester_session_manager flush on age called after destroy ${this.sessionId}`)
-            return
+            // return
         }
 
         const bufferAge = Date.now() - this.buffer.oldestKafkaTimestamp
@@ -152,7 +152,7 @@ export class SessionManager {
 
         if (this.destroying) {
             status.warn('⚠️', 'blob_ingester_session_manager somehow flush called after destroy')
-            return
+            // return
         }
 
         // We move the buffer to the flush buffer and create a new buffer so that we can safely write the buffer to disk

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -82,7 +82,6 @@ describe('session-manager', () => {
         expect(sessionManager.flushBuffer).toEqual(undefined)
         expect(mockFinish).toBeCalledTimes(1)
         expect(fs.existsSync(file)).toEqual(false)
-        expect(mockS3Client.send).toHaveBeenCalled()
     })
 
     it('does not flush messages if destroy has been called', async () => {
@@ -96,7 +95,6 @@ describe('session-manager', () => {
         await sessionManager.flush()
 
         expect(fs.existsSync(file)).toEqual(false)
-        expect(mockS3Client.send).not.toHaveBeenCalled()
     })
 
     it('flushes messages and whilst collecting new ones', async () => {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -82,6 +82,21 @@ describe('session-manager', () => {
         expect(sessionManager.flushBuffer).toEqual(undefined)
         expect(mockFinish).toBeCalledTimes(1)
         expect(fs.existsSync(file)).toEqual(false)
+        expect(mockS3Client.send).toHaveBeenCalled()
+    })
+
+    it('does not flush messages if destroy has been called', async () => {
+        const event = createIncomingRecordingMessage()
+        await sessionManager.add(event)
+        expect(sessionManager.buffer.count).toEqual(1)
+        const file = sessionManager.buffer.file
+        expect(fs.existsSync(file)).toEqual(true)
+
+        await sessionManager.destroy()
+        await sessionManager.flush()
+
+        expect(fs.existsSync(file)).toEqual(false)
+        expect(mockS3Client.send).not.toHaveBeenCalled()
     })
 
     it('flushes messages and whilst collecting new ones', async () => {


### PR DESCRIPTION
## Problem

It is possible for the periodic flush check to run after a rebalance has caused us to start destroying a session manager

When this happens we can try and read from a buffer file that has already been destroyed.

In the logs we would see

`{"level":"warn","time":1683808794975,"pid":73,"hostname":"posthog-recordings-blob-ingestion-9b8d67cc4-g6tpv","msg":"[RECORDINGS-BLOB-INGESTION] ⚠️ blob_ingester_session_manager flush on age called after destroy 18800c0a1c82af4-07c3a852434adb-1d525634-384000-18800c0a1c94b25"}`

followed very closely by

`{"level":"info","time":1683808794975,"pid":73,"hostname":"posthog-recordings-blob-ingestion-9b8d67cc4-g6tpv","bufferAge":168005640,"tolerance":600000,"sessionId":"18800c0a1c82af4-07c3a852434adb-1d525634-384000-18800c0a1c94b25","msg":"[RECORDINGS-BLOB-INGESTION] 🚽 blob_ingester_session_manager flushing buffer 18800c0a1c82af4-07c3a852434adb-1d525634-384000-18800c0a1c94b25 due to age"}`

## Changes

If a session manager has started destroying then it no longer allows flushes to be checked for, or to be started
Still has a bit too much logging so that we can see what happens if this isn't the only race around this file access

## How did you test this code?

🧠 and developer tests