### PR TITLE
fix: Pass datetime strings ourselves to avoid dropping microseconds

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -754,7 +754,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:63 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:64 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -754,7 +754,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:64 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:63 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/temporal/tests/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/test_squash_person_overrides_workflow.py
@@ -78,7 +78,7 @@ def person_overrides_table():
 PersonOverrideTuple = namedtuple("PersonOverrideTuple", ("old_person_id", "override_person_id"))
 
 
-OVERRIDES_MERGED_AT = datetime.fromisoformat("2020-01-02T00:00:00+00:00")
+OVERRIDES_MERGED_AT = datetime.fromisoformat("2020-01-02T00:00:00.123123+00:00")
 OLDEST_EVENT_AT = OVERRIDES_MERGED_AT - timedelta(days=1)
 
 


### PR DESCRIPTION
## Problem

When the Squash Workflow is identifying which persons to delete and eventually deleting them is doing so by adding an upper bound in `merged_at`. However, the `clickhouse-driver` library drops microseconds from any `datetime` passed as parameters (see: https://github.com/mymarilyn/clickhouse-driver/issues/306). This is causing us to miss the latest person that was merged, as it's usually a few milliseconds in the future.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Convert dates to strings by ourselves before passing them to query.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added microseconds to the reference date used in testing.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
