### PR TITLE
feat(ingestion): add KAFKA_PRODUCER_WAIT_FOR_ACK to measure possible perf impact

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -45,6 +45,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_CONSUMPTION_OVERFLOW_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv() ? 0 : 1000,
+        KAFKA_PRODUCER_WAIT_FOR_ACK: true, // Turning it off can lead to dropped data
         KAFKA_MAX_MESSAGE_BATCH_SIZE: isDevEnv() ? 0 : 900_000,
         KAFKA_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 500,
         APP_METRICS_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 20_000,

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -65,25 +65,44 @@ export const produce = async ({
     value,
     key,
     headers = [],
+    waitForAck = true,
 }: {
     producer: RdKafkaProducer
     topic: string
     value: Buffer | null
     key: Buffer | null
     headers?: { [key: string]: Buffer }[]
+    waitForAck?: boolean
 }): Promise<number | null | undefined> => {
     status.debug('📤', 'Producing message', { topic: topic })
-    return await new Promise((resolve, reject) =>
-        producer.produce(topic, null, value, key, Date.now(), headers, (error: any, offset: NumberNullUndefined) => {
-            if (error) {
-                status.error('⚠️', 'produce_error', { error: error, topic: topic })
-                reject(error)
-            } else {
-                status.debug('📤', 'Produced message', { topic: topic, offset: offset })
-                resolve(offset)
-            }
-        })
-    )
+    return await new Promise((resolve, reject) => {
+        if (waitForAck) {
+            producer.produce(
+                topic,
+                null,
+                value,
+                key,
+                Date.now(),
+                headers,
+                (error: any, offset: NumberNullUndefined) => {
+                    if (error) {
+                        status.error('⚠️', 'produce_error', { error: error, topic: topic })
+                        reject(error)
+                    } else {
+                        status.debug('📤', 'Produced message', { topic: topic, offset: offset })
+                        resolve(offset)
+                    }
+                }
+            )
+        } else {
+            producer.produce(topic, null, value, key, Date.now(), headers, (error: any, _: NumberNullUndefined) => {
+                if (error) {
+                    status.error('⚠️', 'produce_error', { error: error, topic: topic })
+                }
+            })
+            resolve(undefined)
+        }
+    })
 }
 export const disconnectProducer = async (producer: RdKafkaProducer) => {
     status.info('🔌', 'Disconnecting producer')

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -107,6 +107,7 @@ export interface PluginsServerConfig {
     KAFKA_CONSUMPTION_TOPIC: string | null
     KAFKA_CONSUMPTION_OVERFLOW_TOPIC: string | null
     KAFKA_PRODUCER_MAX_QUEUE_SIZE: number
+    KAFKA_PRODUCER_WAIT_FOR_ACK: boolean
     KAFKA_MAX_MESSAGE_BATCH_SIZE: number
     KAFKA_FLUSH_FREQUENCY_MS: number
     APP_METRICS_FLUSH_FREQUENCY_MS: number

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -134,7 +134,7 @@ export async function createHub(
     const kafkaConnectionConfig = createRdConnectionConfigFromEnvVars(serverConfig as KafkaConfig)
     const producer = await createKafkaProducer({ ...kafkaConnectionConfig, 'linger.ms': 0 })
 
-    const kafkaProducer = new KafkaProducerWrapper(producer)
+    const kafkaProducer = new KafkaProducerWrapper(producer, serverConfig.KAFKA_PRODUCER_WAIT_FOR_ACK)
     status.info('👍', `Kafka ready`)
 
     status.info('🤔', `Connecting to Postgresql...`)

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -18,9 +18,11 @@ import { DependencyUnavailableError } from './error'
 export class KafkaProducerWrapper {
     /** Kafka producer used for syncing Postgres and ClickHouse person data. */
     public producer: HighLevelProducer
+    private readonly waitForAck: boolean
 
-    constructor(producer: HighLevelProducer) {
+    constructor(producer: HighLevelProducer, waitForAck: boolean) {
         this.producer = producer
+        this.waitForAck = waitForAck
     }
 
     async queueMessage(kafkaMessage: ProducerRecord) {
@@ -42,6 +44,7 @@ export class KafkaProducerWrapper {
                         // objects with a single key-value pair, and the
                         // undefined values need to be filtered out.
                         headers: convertKafkaJSHeadersToRdKafkaHeaders(message.headers),
+                        waitForAck: this.waitForAck,
                     })
                 )
             )


### PR DESCRIPTION
## Problem

Introducing the rdkafka producer to the plugins-ingestion workload didn't give us the expected performance increase, and I think the issue comes from us waiting for the write ACK on every message queue, instead of taking advantage of write batching.

Before we do the heavy lifting of correcting that, I want to measure the possible gain, by temporarily disabling the ACK waits, and moving forward as soon as the message are queued.

As commented in the code, turning `KAFKA_PRODUCER_WAIT_FOR_ACK` off can lead to data loss as retriable rdkafka errors will not be retried. We can monitor for that by checking for `produce_error` logs. Right now, the only such lines are `Message size too large` errors, which are not retried (we drop the event and move forward).

**This PR will be reverted after the experiment**

## Changes

- Add a `KAFKA_PRODUCER_WAIT_FOR_ACK` setting, on by default
- If it's off, the analytics ingestion queue will run the new code path, and not wait for write ACKs anymore.

## How did you test this code?

devenv auto-instrumentation comes through, with both `KAFKA_PRODUCER_WAIT_FOR_ACK=0 DEBUG=1 ./bin/start` and `KAFKA_PRODUCER_WAIT_FOR_ACK=1 DEBUG=1 ./bin/start`
