### PR TITLE
feat: Add input dataclasses for database inputs

### DIFF
--- a/posthog/temporal/tests/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/test_squash_person_overrides_workflow.py
@@ -24,6 +24,8 @@ from posthog.models.person_overrides.sql import (
     PERSON_OVERRIDES_CREATE_TABLE_SQL,
 )
 from posthog.temporal.workflows.squash_person_overrides import (
+    ClickHouseConnectionInputs,
+    PostgresConnectionInputs,
     QueryInputs,
     SerializablePersonOverrideToDelete,
     SquashPersonOverridesInputs,
@@ -118,18 +120,32 @@ def person_overrides_data(person_overrides_table):
     sync_execute("TRUNCATE TABLE person_overrides")
 
 
+@pytest.fixture
+def query_inputs():
+    """A default set of QueryInputs to use in all tests.
+
+    Notice we are mocking the PG database name: Django creates a database exclusively for unit tests.
+    However, we don't use the Django ORM; we query the database directly. So, we need to update the
+    settings to point to the test database Django creates. Luckily, it's named the same but with a
+    `test_` prefix.
+    """
+    test_pg = {"default": settings.DATABASES["default"] | {"NAME": f"test_{settings.PG_DATABASE}"}}
+
+    with patch.dict(settings.DATABASES, test_pg):
+        query_inputs = QueryInputs(
+            clickhouse=ClickHouseConnectionInputs.from_posthog_settings(settings),
+            postgres=PostgresConnectionInputs.from_posthog_settings(settings),
+        )
+
+        return query_inputs
+
+
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_prepare_dictionary(activity_environment, person_overrides_data):
+async def test_prepare_dictionary(query_inputs, activity_environment, person_overrides_data):
     """Test a DICTIONARY is created by the prepare_dictionary activity."""
-    query_inputs = QueryInputs(
-        database=settings.CLICKHOUSE_DATABASE,
-        dictionary_name="fancy_dictionary",
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        dry_run=False,
-    )
+    query_inputs.dictionary_name = "fancy_dictionary"
+    query_inputs.dry_run = False
 
     latest_merge_at = await activity_environment.run(prepare_dictionary, query_inputs)
 
@@ -217,17 +233,11 @@ def newer_overrides(person_overrides_data):
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_prepare_dictionary_with_older_overrides_present(
-    activity_environment, person_overrides_data, older_overrides
+    query_inputs, activity_environment, person_overrides_data, older_overrides
 ):
     """Test a DICTIONARY contains latest available mappings."""
-    query_inputs = QueryInputs(
-        database=settings.CLICKHOUSE_DATABASE,
-        dictionary_name="fancy_dictionary",
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        dry_run=False,
-    )
+    query_inputs.dictionary_name = "fancy_dictionary"
+    query_inputs.dry_run = False
 
     latest_merge_at = await activity_environment.run(prepare_dictionary, query_inputs)
 
@@ -261,31 +271,24 @@ async def test_prepare_dictionary_with_older_overrides_present(
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_drop_dictionary(activity_environment, person_overrides_data):
+async def test_drop_dictionary(query_inputs, activity_environment, person_overrides_data):
     """Test a DICTIONARY is dropped by drop_join_table activity."""
-    dictionary_name = "extremely_fancy_join_table"
-    query_inputs = QueryInputs(
-        database=settings.CLICKHOUSE_DATABASE,
-        dictionary_name=dictionary_name,
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        dry_run=False,
-    )
+    query_inputs.dictionary_name = "distinguished_dictionary"
+    query_inputs.dry_run = False
 
     # Ensure we are starting from scratch
-    sync_execute(f"DROP DICTIONARY IF EXISTS {settings.CLICKHOUSE_DATABASE}.{dictionary_name}")
-    before = sync_execute(f"EXISTS DICTIONARY {settings.CLICKHOUSE_DATABASE}.{dictionary_name}")[0][0]
+    sync_execute(f"DROP DICTIONARY IF EXISTS {settings.CLICKHOUSE_DATABASE}.{query_inputs.dictionary_name}")
+    before = sync_execute(f"EXISTS DICTIONARY {settings.CLICKHOUSE_DATABASE}.{query_inputs.dictionary_name}")[0][0]
     assert before == 0
 
     await activity_environment.run(prepare_dictionary, query_inputs)
 
-    during = sync_execute(f"EXISTS DICTIONARY {settings.CLICKHOUSE_DATABASE}.{dictionary_name}")[0][0]
+    during = sync_execute(f"EXISTS DICTIONARY {settings.CLICKHOUSE_DATABASE}.{query_inputs.dictionary_name}")[0][0]
     assert during == 1
 
     await activity_environment.run(drop_dictionary, query_inputs)
 
-    after = sync_execute(f"EXISTS DICTIONARY {settings.CLICKHOUSE_DATABASE}.{dictionary_name}")[0][0]
+    after = sync_execute(f"EXISTS DICTIONARY {settings.CLICKHOUSE_DATABASE}.{query_inputs.dictionary_name}")[0][0]
     assert after == 0
 
 
@@ -302,19 +305,16 @@ def is_equal_sorted(list_left, list_right, key=get_team_id_old_person_id) -> boo
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_select_persons_to_delete(activity_environment, person_overrides_data):
+async def test_select_persons_to_delete(query_inputs, activity_environment, person_overrides_data):
     """Test selecting the correct dictionary of persons to delete.
 
     The select_persons_to_delete activity produces a dictionary of team_id to sets of
     old_person_id that will be overriden during the workflow and can be safely deleted
     afterwards.
     """
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        _latest_merged_at=OVERRIDES_MERGED_AT,
-        dry_run=False,
-    )
+    query_inputs.dry_run = False
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
 
@@ -337,7 +337,7 @@ async def test_select_persons_to_delete(activity_environment, person_overrides_d
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_select_persons_to_delete_selects_persons_in_older_partitions(
-    activity_environment, person_overrides_data, older_overrides
+    query_inputs, activity_environment, person_overrides_data, older_overrides
 ):
     """Test all (new and old)  persons to delete are selected when older overrides exist.
 
@@ -346,12 +346,9 @@ async def test_select_persons_to_delete_selects_persons_in_older_partitions(
     will prefer newer mappings, so the older ones do nothing and can cause troubles if left
     uncleaned.
     """
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        _latest_merged_at=OVERRIDES_MERGED_AT,
-        dry_run=False,
-    )
+    query_inputs.dry_run = False
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
 
@@ -388,19 +385,16 @@ async def test_select_persons_to_delete_selects_persons_in_older_partitions(
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_select_persons_to_squash_with_empty_table(activity_environment, person_overrides_table):
+async def test_select_persons_to_squash_with_empty_table(query_inputs, activity_environment, person_overrides_table):
     """Test nothing is selected to override when there are no person_overrides.
 
     If there are no person_overrides rows, then there is no work for us to do.
     """
     sync_execute(PERSON_OVERRIDES_CREATE_TABLE_SQL)
 
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        _latest_merged_at=OVERRIDES_MERGED_AT,
-        dry_run=False,
-    )
+    query_inputs.dry_run = False
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
 
@@ -409,19 +403,18 @@ async def test_select_persons_to_squash_with_empty_table(activity_environment, p
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_select_persons_to_squash_with_different_partition(activity_environment, person_overrides_table):
+async def test_select_persons_to_squash_with_different_partition(
+    query_inputs, activity_environment, person_overrides_table
+):
     """Test nothing is selected to override when there is no data in a partition.
 
     If there are no person_overrides rows, then there is no work for us to do.
     """
     sync_execute(PERSON_OVERRIDES_CREATE_TABLE_SQL)
 
-    query_inputs = QueryInputs(
-        partition_ids=["202002"],
-        database=settings.CLICKHOUSE_DATABASE,
-        _latest_merged_at=OVERRIDES_MERGED_AT,
-        dry_run=False,
-    )
+    query_inputs.dry_run = False
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
 
@@ -430,7 +423,7 @@ async def test_select_persons_to_squash_with_different_partition(activity_enviro
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_select_persons_to_delete_with_newer_merges(activity_environment, person_overrides_data):
+async def test_select_persons_to_delete_with_newer_merges(query_inputs, activity_environment, person_overrides_data):
     """Test selecting the correct persons to delete when we got new merges after starting.
 
     The select_persons_to_delete activity produces a dictionary of team_id to sets of
@@ -460,13 +453,10 @@ async def test_select_persons_to_delete_with_newer_merges(activity_environment, 
 
     sync_execute("INSERT INTO person_overrides (*) VALUES", newer_values_to_insert)
 
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        # Our latest_merged_at is before the newer values happened
-        _latest_merged_at=OVERRIDES_MERGED_AT,
-        dry_run=False,
-    )
+    query_inputs.dry_run = False
+    query_inputs.partition_ids = ["202001"]
+    # Our latest_merged_at is before the newer values happened
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
 
     to_delete = await activity_environment.run(select_persons_to_delete, query_inputs)
 
@@ -555,25 +545,18 @@ def assert_events_have_been_overriden(overriden_events, person_overrides):
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_squash_events_partition(activity_environment, person_overrides_data, events_to_override):
+async def test_squash_events_partition(query_inputs, activity_environment, person_overrides_data, events_to_override):
     """Test events are properly squashed by running squash_events_partition.
 
     After running squash_events_partition, we iterate over the test events created by
     events_to_override and check the person_id associated with each of them. It should
     match the override_person_id associated with the old_person_id they used to be set to.
     """
-    dictionary_name = "exciting_dictionary"
+    query_inputs.dictionary_name = "exciting_dictionary"
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
+    query_inputs.dry_run = False
 
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        dictionary_name=dictionary_name,
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
-        dry_run=False,
-    )
     await activity_environment.run(prepare_dictionary, query_inputs)
 
     await activity_environment.run(squash_events_partition, query_inputs)
@@ -585,20 +568,14 @@ async def test_squash_events_partition(activity_environment, person_overrides_da
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_squash_events_partition_dry_run(activity_environment, person_overrides_data, events_to_override):
+async def test_squash_events_partition_dry_run(
+    query_inputs, activity_environment, person_overrides_data, events_to_override
+):
     """Test events are not squashed by running squash_events_partition with dry_run=True."""
-    dictionary_name = "exciting_dictionary"
+    query_inputs.dictionary_name = "exciting_dictionary"
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
 
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        dictionary_name=dictionary_name,
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
-        dry_run=True,
-    )
     await activity_environment.run(prepare_dictionary, query_inputs)
 
     await activity_environment.run(squash_events_partition, query_inputs)
@@ -624,7 +601,7 @@ async def test_squash_events_partition_dry_run(activity_environment, person_over
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_squash_events_partition_with_older_overrides(
-    activity_environment, person_overrides_data, events_to_override, older_overrides
+    query_inputs, activity_environment, person_overrides_data, events_to_override, older_overrides
 ):
     """Test events are properly squashed even in the prescence of older overrides.
 
@@ -634,15 +611,11 @@ async def test_squash_events_partition_with_older_overrides(
     could be duplicate overrides present, either in the partition we are currently working
     with as well as older ones.
     """
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
-        dry_run=False,
-    )
+    query_inputs.dictionary_name = "exciting_dictionary"
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
+    query_inputs.dry_run = False
+
     await activity_environment.run(prepare_dictionary, query_inputs)
 
     await activity_environment.run(squash_events_partition, query_inputs)
@@ -655,7 +628,7 @@ async def test_squash_events_partition_with_older_overrides(
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_squash_events_partition_with_newer_overrides(
-    activity_environment, person_overrides_data, events_to_override, newer_overrides
+    query_inputs, activity_environment, person_overrides_data, events_to_override, newer_overrides
 ):
     """Test events are properly squashed even in the prescence of newer overrides.
 
@@ -665,15 +638,11 @@ async def test_squash_events_partition_with_newer_overrides(
     could be duplicate overrides present, either in the partition we are currently working
     with as well as newer ones.
     """
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
-        dry_run=False,
-    )
+    query_inputs.dictionary_name = "exciting_dictionary"
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
+    query_inputs.dry_run = False
+
     await activity_environment.run(prepare_dictionary, query_inputs)
 
     await activity_environment.run(squash_events_partition, query_inputs)
@@ -686,22 +655,17 @@ async def test_squash_events_partition_with_newer_overrides(
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_squash_events_partition_with_limited_team_ids(
-    activity_environment, person_overrides_data, events_to_override
+    query_inputs, activity_environment, person_overrides_data, events_to_override
 ):
     """Test events are properly squashed when we specify team_ids."""
     dictionary_name = "exciting_limited_dictionary"
     random_team = random.choice(list(person_overrides_data.keys()))
+    query_inputs.dictionary_name = dictionary_name
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
+    query_inputs.dry_run = False
+    query_inputs.team_ids = [random_team]
 
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        database=settings.CLICKHOUSE_DATABASE,
-        dictionary_name=dictionary_name,
-        user=settings.CLICKHOUSE_USER,
-        password=settings.CLICKHOUSE_PASSWORD,
-        cluster_name=settings.CLICKHOUSE_CLUSTER,
-        team_ids=[random_team],
-        dry_run=False,
-    )
     latest_merged_at = await activity_environment.run(prepare_dictionary, query_inputs)
     query_inputs._latest_merged_at = latest_merged_at
 
@@ -720,7 +684,9 @@ async def test_squash_events_partition_with_limited_team_ids(
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_delete_squashed_person_overrides_from_clickhouse(activity_environment, person_overrides_data):
+async def test_delete_squashed_person_overrides_from_clickhouse(
+    query_inputs, activity_environment, person_overrides_data
+):
     """Test we can delete person overrides that have already been squashed.
 
     For the purposes of this unit test, we take the person overrides as given. A
@@ -741,14 +707,10 @@ async def test_delete_squashed_person_overrides_from_clickhouse(activity_environ
         for team_id, person_overrides in person_overrides_data.items()
         for person_override in person_overrides
     ]
-
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        person_overrides_to_delete=persons_to_delete,
-        database=settings.CLICKHOUSE_DATABASE,
-        _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
-        dry_run=False,
-    )
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
+    query_inputs.dry_run = False
+    query_inputs.person_overrides_to_delete = persons_to_delete
 
     not_overriden_id = uuid4()
     not_overriden_person: PersonOverrideValues = {
@@ -774,7 +736,9 @@ async def test_delete_squashed_person_overrides_from_clickhouse(activity_environ
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_delete_squashed_person_overrides_from_clickhouse_dry_run(activity_environment, person_overrides_data):
+async def test_delete_squashed_person_overrides_from_clickhouse_dry_run(
+    query_inputs, activity_environment, person_overrides_data
+):
     """Test we do not delete person overrides when dry_run=True."""
     persons_to_delete = [
         SerializablePersonOverrideToDelete(
@@ -788,14 +752,10 @@ async def test_delete_squashed_person_overrides_from_clickhouse_dry_run(activity
         for team_id, person_overrides in person_overrides_data.items()
         for person_override in person_overrides
     ]
-
-    query_inputs = QueryInputs(
-        partition_ids=["202001"],
-        person_overrides_to_delete=persons_to_delete,
-        database=settings.CLICKHOUSE_DATABASE,
-        _latest_merged_at=OVERRIDES_MERGED_AT.isoformat(),
-        dry_run=True,
-    )
+    query_inputs.partition_ids = ["202001"]
+    query_inputs.latest_merged_at = OVERRIDES_MERGED_AT
+    query_inputs.dry_run = True
+    query_inputs.person_overrides_to_delete = persons_to_delete
 
     not_overriden_id = uuid4()
     not_overriden_person: PersonOverrideValues = {
@@ -825,11 +785,8 @@ def django_db_setup_fixture():
     yield django_db_setup
 
 
-DATABASE_URL = f"postgres://{settings.PG_USER}:{settings.PG_USER}@{settings.PG_HOST}:{settings.PG_PORT}/test_{settings.PG_DATABASE}"
-
-
 @pytest.fixture
-def organization_uuid(django_db_setup_fixture):
+def organization_uuid(query_inputs, django_db_setup_fixture):
     """Create an Organization and return its UUID.
 
     We cannot use the Django ORM safely in an async context, so we INSERT INTO directly
@@ -838,7 +795,7 @@ def organization_uuid(django_db_setup_fixture):
     """
     organization_uuid = uuid4()
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -876,20 +833,20 @@ def organization_uuid(django_db_setup_fixture):
 
     yield organization_uuid
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute("DELETE FROM posthog_organization WHERE id = %s", [organization_uuid])
 
 
 @pytest.fixture
-def team_id(organization_uuid):
+def team_id(query_inputs, organization_uuid):
     """Create a Team and return its ID.
 
     We cannot use the Django ORM safely in an async context, so we INSERT INTO directly
     on the database. This means we need to clean up after ourselves, which we do after
     yielding.
     """
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -951,13 +908,13 @@ def team_id(organization_uuid):
 
     yield team_id
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute("DELETE FROM posthog_team WHERE id = %s", [team_id])
 
 
 @pytest.fixture
-def person_overrides(team_id):
+def person_overrides(query_inputs, team_id):
     """Create a PersonOverrideMapping and a PersonOverride.
 
     We cannot use the Django ORM safely in an async context, so we INSERT INTO directly
@@ -968,7 +925,7 @@ def person_overrides(team_id):
     override_person_id = uuid4()
     person_override = PersonOverrideTuple(old_person_id, override_person_id)
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             person_ids = []
             for person_uuid in (override_person_id, old_person_id):
@@ -1015,7 +972,7 @@ def person_overrides(team_id):
 
     yield person_override
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(
                 "DELETE FROM posthog_personoverride WHERE team_id = %s AND old_person_id = %s",
@@ -1029,13 +986,15 @@ def person_overrides(team_id):
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_delete_squashed_person_overrides_from_postgres(activity_environment, team_id, person_overrides):
+async def test_delete_squashed_person_overrides_from_postgres(
+    query_inputs, activity_environment, team_id, person_overrides
+):
     """Test we can delete person overrides that have already been squashed.
 
     For the purposes of this unit test, we take the person overrides as given. A
     comprehensive test will cover the entire worflow end-to-end.
     """
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         # These are sanity checks to ensure the fixtures are working properly.
         # If any assertions fail here, its likely a test setup issue.
         with connection.cursor() as cursor:
@@ -1047,25 +1006,22 @@ async def test_delete_squashed_person_overrides_from_postgres(activity_environme
             overrides = cursor.fetchall()
             assert len(overrides) == 1
 
-    query_inputs = QueryInputs(
-        person_overrides_to_delete=[
-            SerializablePersonOverrideToDelete(
-                team_id,
-                person_overrides.old_person_id,
-                person_overrides.override_person_id,
-                OVERRIDES_MERGED_AT.isoformat(),
-                1,
-                OLDEST_EVENT_AT.isoformat(),
-            )
-        ],
-        dry_run=False,
-    )
+    person_overrides_to_delete = [
+        SerializablePersonOverrideToDelete(
+            team_id,
+            person_overrides.old_person_id,
+            person_overrides.override_person_id,
+            OVERRIDES_MERGED_AT.isoformat(),
+            1,
+            OLDEST_EVENT_AT.isoformat(),
+        )
+    ]
+    query_inputs.person_overrides_to_delete = person_overrides_to_delete
+    query_inputs.dry_run = False
 
-    with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
-        # Unit tests run in their own separate database, so we need to patch it.
-        await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
+    await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute("SELECT team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
@@ -1079,9 +1035,11 @@ async def test_delete_squashed_person_overrides_from_postgres(activity_environme
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_delete_squashed_person_overrides_from_postgres_dry_run(activity_environment, team_id, person_overrides):
+async def test_delete_squashed_person_overrides_from_postgres_dry_run(
+    query_inputs, activity_environment, team_id, person_overrides
+):
     """Test we do not delete person overrides when dry_run=True."""
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         # These are sanity checks to ensure the fixtures are working properly.
         # If any assertions fail here, its likely a test setup issue.
         with connection.cursor() as cursor:
@@ -1093,25 +1051,22 @@ async def test_delete_squashed_person_overrides_from_postgres_dry_run(activity_e
             overrides = cursor.fetchall()
             assert len(overrides) == 1
 
-    query_inputs = QueryInputs(
-        person_overrides_to_delete=[
-            SerializablePersonOverrideToDelete(
-                team_id,
-                person_overrides.old_person_id,
-                person_overrides.override_person_id,
-                OVERRIDES_MERGED_AT.isoformat(),
-                1,
-                OLDEST_EVENT_AT.isoformat(),
-            )
-        ],
-        dry_run=True,
-    )
+    person_overrides_to_delete = [
+        SerializablePersonOverrideToDelete(
+            team_id,
+            person_overrides.old_person_id,
+            person_overrides.override_person_id,
+            OVERRIDES_MERGED_AT.isoformat(),
+            1,
+            OLDEST_EVENT_AT.isoformat(),
+        )
+    ]
+    query_inputs.person_overrides_to_delete = person_overrides_to_delete
+    query_inputs.dry_run = True
 
-    with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
-        # Unit tests run in their own separate database, so we need to patch it.
-        await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
+    await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute("SELECT team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
@@ -1126,14 +1081,14 @@ async def test_delete_squashed_person_overrides_from_postgres_dry_run(activity_e
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_delete_squashed_person_overrides_from_postgres_with_newer_override(
-    activity_environment, team_id, person_overrides
+    query_inputs, activity_environment, team_id, person_overrides
 ):
     """Test we do not delete a newer mapping from Postgres.
 
     For the purposes of this unit test, we take the person overrides as given. A
     comprehensive test will cover the entire worflow end-to-end.
     """
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         # These are sanity checks to ensure the fixtures are working properly.
         # If any assertions fail here, its likely a test setup issue.
         with connection.cursor() as cursor:
@@ -1145,7 +1100,7 @@ async def test_delete_squashed_person_overrides_from_postgres_with_newer_overrid
             overrides = cursor.fetchall()
             assert len(overrides) == 1
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             # Let's insert a newer mapping that arrives while we are running the squash job.
             # Since only one mapping can exist per old_person_id, we'll bump the version number.
@@ -1165,25 +1120,23 @@ async def test_delete_squashed_person_overrides_from_postgres_with_newer_overrid
                 },
             )
 
-    query_inputs = QueryInputs(
-        person_overrides_to_delete=[
-            # We are schedulling for deletion an override with lower version number, so nothing should happen.
-            SerializablePersonOverrideToDelete(
-                team_id,
-                person_overrides.old_person_id,
-                person_overrides.override_person_id,
-                OVERRIDES_MERGED_AT.isoformat(),
-                1,
-                OLDEST_EVENT_AT.isoformat(),
-            )
-        ],
-        dry_run=False,
-    )
+    person_overrides_to_delete = [
+        # We are schedulling for deletion an override with lower version number, so nothing should happen.
+        SerializablePersonOverrideToDelete(
+            team_id,
+            person_overrides.old_person_id,
+            person_overrides.override_person_id,
+            OVERRIDES_MERGED_AT.isoformat(),
+            1,
+            OLDEST_EVENT_AT.isoformat(),
+        )
+    ]
+    query_inputs.person_overrides_to_delete = person_overrides_to_delete
+    query_inputs.dry_run = False
 
-    with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
-        await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
+    await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
 
-    with psycopg2.connect(DATABASE_URL) as connection:
+    with psycopg2.connect(query_inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute("SELECT id, team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
@@ -1213,7 +1166,9 @@ async def test_delete_squashed_person_overrides_from_postgres_with_newer_overrid
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_squash_person_overrides_workflow(events_to_override, person_overrides_data, person_overrides):
+async def test_squash_person_overrides_workflow(
+    query_inputs, events_to_override, person_overrides_data, person_overrides
+):
     """Test the squash_person_overrides workflow end-to-end."""
     client = await Client.connect(
         f"{settings.TEMPORAL_HOST}:{settings.TEMPORAL_PORT}",
@@ -1222,8 +1177,6 @@ async def test_squash_person_overrides_workflow(events_to_override, person_overr
 
     workflow_id = str(uuid4())
     inputs = SquashPersonOverridesInputs(
-        clickhouse_database=settings.CLICKHOUSE_DATABASE,
-        postgres_database=settings.DATABASES["default"]["NAME"],
         partition_ids=["202001"],
         dry_run=False,
     )
@@ -1244,13 +1197,12 @@ async def test_squash_person_overrides_workflow(events_to_override, person_overr
         ],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
-        with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
-            await client.execute_workflow(
-                SquashPersonOverridesWorkflow.run,
-                inputs,
-                id=workflow_id,
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
+        await client.execute_workflow(
+            SquashPersonOverridesWorkflow.run,
+            inputs,
+            id=workflow_id,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+        )
 
     assert_events_have_been_overriden(events_to_override, person_overrides_data)
 
@@ -1261,7 +1213,7 @@ async def test_squash_person_overrides_workflow(events_to_override, person_overr
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_squash_person_overrides_workflow_with_newer_overrides(
-    events_to_override, person_overrides_data, person_overrides, newer_overrides
+    query_inputs, events_to_override, person_overrides_data, person_overrides, newer_overrides
 ):
     """Test the squash_person_overrides workflow end-to-end with newer overrides."""
     client = await Client.connect(
@@ -1271,8 +1223,6 @@ async def test_squash_person_overrides_workflow_with_newer_overrides(
 
     workflow_id = str(uuid4())
     inputs = SquashPersonOverridesInputs(
-        clickhouse_database=settings.CLICKHOUSE_DATABASE,
-        postgres_database=settings.DATABASES["default"]["NAME"],
         partition_ids=["202001"],
         dry_run=False,
     )
@@ -1293,13 +1243,12 @@ async def test_squash_person_overrides_workflow_with_newer_overrides(
         ],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
-        with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
-            await client.execute_workflow(
-                SquashPersonOverridesWorkflow.run,
-                inputs,
-                id=workflow_id,
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
+        await client.execute_workflow(
+            SquashPersonOverridesWorkflow.run,
+            inputs,
+            id=workflow_id,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+        )
 
     assert_events_have_been_overriden(events_to_override, newer_overrides)
 
@@ -1307,7 +1256,7 @@ async def test_squash_person_overrides_workflow_with_newer_overrides(
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_squash_person_overrides_workflow_with_limited_team_ids(
-    events_to_override, person_overrides_data, person_overrides
+    query_inputs, events_to_override, person_overrides_data, person_overrides
 ):
     """Test the squash_person_overrides workflow end-to-end."""
     client = await Client.connect(
@@ -1318,8 +1267,6 @@ async def test_squash_person_overrides_workflow_with_limited_team_ids(
     workflow_id = str(uuid4())
     random_team = random.choice(list(person_overrides_data.keys()))
     inputs = SquashPersonOverridesInputs(
-        clickhouse_database=settings.CLICKHOUSE_DATABASE,
-        postgres_database=settings.DATABASES["default"]["NAME"],
         partition_ids=["202001"],
         team_ids=[random_team],
         dry_run=False,
@@ -1341,13 +1288,12 @@ async def test_squash_person_overrides_workflow_with_limited_team_ids(
         ],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
-        with patch.object(settings, "DATABASE_URL", new=DATABASE_URL):
-            await client.execute_workflow(
-                SquashPersonOverridesWorkflow.run,
-                inputs,
-                id=workflow_id,
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
+        await client.execute_workflow(
+            SquashPersonOverridesWorkflow.run,
+            inputs,
+            id=workflow_id,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+        )
 
     with pytest.raises(AssertionError):
         # Some checks will fail as we have limited the teams overriden.

--- a/posthog/temporal/workflows/squash_person_overrides.py
+++ b/posthog/temporal/workflows/squash_person_overrides.py
@@ -7,7 +7,6 @@ from typing import AsyncIterator, Iterable, NamedTuple
 from uuid import UUID
 
 import psycopg2
-from django.conf import settings
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
@@ -163,10 +162,61 @@ class SerializablePersonOverrideToDelete(NamedTuple):
 
 
 @dataclass
+class ClickHouseConnectionInputs:
+    """A dataclass of inputs required to connect to ClickHouse."""
+
+    host: str
+    password: str
+    database: str = "default"
+    username: str = "default"
+    port: int = 9000
+    cluster: str = ""
+
+    @classmethod
+    def from_posthog_settings(cls, settings) -> "ClickHouseConnectionInputs":
+        """Initialize from PostHog settings module."""
+        return cls(
+            host=settings.CLICKHOUSE_HOST,
+            password=settings.CLICKHOUSE_PASSWORD,
+            database=settings.CLICKHOUSE_DATABASE,
+            username=settings.CLICKHOUSE_USER,
+            cluster=settings.CLICKHOUSE_CLUSTER,
+        )
+
+
+@dataclass
+class PostgresConnectionInputs:
+    """A dataclass of inputs required to connect to Postgres."""
+
+    host: str
+    password: str
+    database: str = "posthog"
+    username: str = "posthog"
+    port: int = 5432
+
+    @classmethod
+    def from_posthog_settings(cls, settings) -> "PostgresConnectionInputs":
+        """Initialize from PostHog settings module."""
+        return cls(
+            host=settings.DATABASES["default"]["HOST"],
+            password=settings.DATABASES["default"]["PASSWORD"],
+            database=settings.DATABASES["default"]["NAME"],
+            username=settings.DATABASES["default"]["USER"],
+            port=settings.DATABASES["default"]["PORT"],
+        )
+
+    @property
+    def database_url(self) -> str:
+        return f"postgres://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}"
+
+
+@dataclass
 class QueryInputs:
     """Inputs for activities that run queries in the SquashPersonOverrides workflow.
 
     Attributes:
+        clickhouse: Inputs required to connect to ClickHouse.
+        postgres: Inputs required to connect to Postgres.
         partition_ids: When necessary, the partition ids this query should run on.
         person_overrides_to_delete: For delete queries, a list of PersonOverrideToDelete.
         database: The database where the query is supposed to run.
@@ -177,18 +227,16 @@ class QueryInputs:
             as the latest timestamp of a person merge.
     """
 
+    clickhouse: ClickHouseConnectionInputs
+    postgres: PostgresConnectionInputs
     partition_ids: list[str] = field(default_factory=list)
     team_ids: list[int] = field(default_factory=list)
     person_overrides_to_delete: list[SerializablePersonOverrideToDelete] = field(default_factory=list)
-    database: str = "default"
-    user: str = ""
-    password: str = ""
-    cluster_name: str = ""
     dictionary_name: str = "person_overrides_join_dict"
     dry_run: bool = True
     _latest_merged_at: str | datetime | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self._latest_merged_at, datetime):
             self.latest_merged_at = self._latest_merged_at
 
@@ -199,7 +247,7 @@ class QueryInputs:
         return self._latest_merged_at
 
     @latest_merged_at.setter
-    def latest_merged_at(self, v: datetime | str | None):
+    def latest_merged_at(self, v: datetime | str | None) -> None:
         if isinstance(v, datetime):
             self._latest_merged_at = v.isoformat()
         else:
@@ -227,14 +275,14 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
     The activity re_attach_person_overrides should always be executed after the squash is done to clean
     up what we do here.
     """
-    activity.logger.info("Detaching %s.person_overrides_mv", inputs.database)
+    activity.logger.info("Preparing %s.person_overrides table for squashing", inputs.clickhouse.database)
 
     detach_query = "DETACH VIEW {database}.person_overrides_mv ON CLUSTER {cluster}".format(
-        database=inputs.database, cluster=inputs.cluster_name
+        database=inputs.clickhouse.database, cluster=inputs.clickhouse.cluster
     )
     optimize_query = (
         "OPTIMIZE TABLE {database}.person_overrides ON CLUSTER {cluster} FINAL SETTINGS mutations_sync = 2".format(
-            database=inputs.database, cluster=inputs.cluster_name
+            database=inputs.clickhouse.database, cluster=inputs.clickhouse.cluster
         )
     )
 
@@ -244,9 +292,11 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
         activity.logger.info("Would have run query: %s", optimize_query)
         return
 
+    activity.logger.info("Detaching %s.person_overrides_mv", inputs.clickhouse.database)
+
     sync_execute(detach_query)
 
-    activity.logger.info("Optimizing %s.person_overrides", inputs.database)
+    activity.logger.info("Optimizing %s.person_overrides", inputs.clickhouse.database)
 
     sync_execute(optimize_query)
 
@@ -254,10 +304,10 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
 @activity.defn
 async def re_attach_person_overrides(inputs: QueryInputs) -> None:
     """Re-attach the person_overrides mat view after it was used in a squash."""
-    activity.logger.info("Re-attaching %s.person_overrides_mv", inputs.database)
+    activity.logger.info("Re-attaching %s.person_overrides_mv", inputs.clickhouse.database)
 
     attach_query = "ATTACH TABLE {database}.person_overrides_mv ON CLUSTER {cluster}".format(
-        database=inputs.database, cluster=inputs.cluster_name
+        database=inputs.clickhouse.database, cluster=inputs.clickhouse.cluster
     )
 
     if inputs.dry_run is True:
@@ -275,17 +325,17 @@ async def prepare_dictionary(inputs: QueryInputs) -> str:
     We also lock in the latest merged_at to ensure we do not process overrides that arrive after
     we have started the job.
     """
-    activity.logger.info("Preparing DICTIONARY %s.%s", inputs.database, inputs.dictionary_name)
-    latest_merged_at = sync_execute(SELECT_LATEST_MERGED_AT_QUERY.format(database=inputs.database))[0][0]
+    activity.logger.info("Preparing DICTIONARY %s.%s", inputs.clickhouse.database, inputs.dictionary_name)
+    latest_merged_at = sync_execute(SELECT_LATEST_MERGED_AT_QUERY.format(database=inputs.clickhouse.database))[0][0]
 
-    activity.logger.info("Creating DICTIONARY %s.%s", inputs.database, inputs.dictionary_name)
+    activity.logger.info("Creating DICTIONARY %s.%s", inputs.clickhouse.database, inputs.dictionary_name)
     sync_execute(
         CREATE_DICTIONARY_QUERY.format(
-            database=inputs.database,
+            database=inputs.clickhouse.database,
             dictionary_name=inputs.dictionary_name,
-            user=inputs.user,
-            password=inputs.password,
-            cluster_name=inputs.cluster_name,
+            user=inputs.clickhouse.username,
+            password=inputs.clickhouse.password,
+            cluster_name=inputs.clickhouse.cluster,
         )
     )
 
@@ -295,8 +345,10 @@ async def prepare_dictionary(inputs: QueryInputs) -> str:
 @activity.defn
 async def drop_dictionary(inputs: QueryInputs) -> None:
     """DROP the DICTIONARY used in the squash workflow."""
-    activity.logger.info("Dropping DICTIONARY %s.%s", inputs.database, inputs.dictionary_name)
-    sync_execute(DROP_DICTIONARY_QUERY.format(database=inputs.database, dictionary_name=inputs.dictionary_name))
+    activity.logger.info("Dropping DICTIONARY %s.%s", inputs.clickhouse.database, inputs.dictionary_name)
+    sync_execute(
+        DROP_DICTIONARY_QUERY.format(database=inputs.clickhouse.database, dictionary_name=inputs.dictionary_name)
+    )
 
 
 @activity.defn
@@ -317,7 +369,7 @@ async def select_persons_to_delete(inputs: QueryInputs) -> list[SerializablePers
     """
     latest_merged_at = inputs.latest_merged_at.timestamp() if inputs.latest_merged_at else inputs.latest_merged_at
     to_delete_rows = sync_execute(
-        SELECT_PERSONS_TO_DELETE_QUERY.format(database=inputs.database),
+        SELECT_PERSONS_TO_DELETE_QUERY.format(database=inputs.clickhouse.database),
         # We pass this as a timestamp ourselves as clickhouse-driver will drop any microseconds from the datetime.
         # This would cause the latest merge event to be ignored.
         # See: https://github.com/mymarilyn/clickhouse-driver/issues/306
@@ -340,7 +392,7 @@ async def select_persons_to_delete(inputs: QueryInputs) -> list[SerializablePers
 
         try:
             absolute_oldest_event_at = sync_execute(
-                SELECT_CREATED_AT_FOR_PERSON_EVENT_QUERY.format(database=inputs.database),
+                SELECT_CREATED_AT_FOR_PERSON_EVENT_QUERY.format(database=inputs.clickhouse.database),
                 {
                     "team_id": person_to_delete.team_id,
                     "old_person_id": person_to_delete.old_person_id,
@@ -398,7 +450,7 @@ async def squash_events_partition(inputs: QueryInputs) -> None:
     4. Clean up the DICTIONARY once done.
     """
     query = SQUASH_EVENTS_QUERY.format(
-        database=inputs.database,
+        database=inputs.clickhouse.database,
         dictionary_name=inputs.dictionary_name,
         team_id_filter="AND team_id in %(team_ids)s" if inputs.team_ids else "",
     )
@@ -433,7 +485,7 @@ async def delete_squashed_person_overrides_from_clickhouse(inputs: QueryInputs) 
     old_person_ids_to_delete = tuple(person.old_person_id for person in inputs.iter_person_overides_to_delete())
     activity.logger.debug("%s", old_person_ids_to_delete)
 
-    query = DELETE_SQUASHED_PERSON_OVERRIDES_QUERY.format(database=inputs.database)
+    query = DELETE_SQUASHED_PERSON_OVERRIDES_QUERY.format(database=inputs.clickhouse.database)
     latest_merged_at = inputs.latest_merged_at.timestamp() if inputs.latest_merged_at else inputs.latest_merged_at
     parameters = {
         "old_person_ids": old_person_ids_to_delete,
@@ -460,9 +512,7 @@ async def delete_squashed_person_overrides_from_postgres(inputs: QueryInputs) ->
     """
     activity.logger.info("Deleting squashed persons from Postgres")
 
-    database_url = settings.DATABASE_URL
-
-    with psycopg2.connect(database_url) as connection:
+    with psycopg2.connect(inputs.postgres.database_url) as connection:
         with connection.cursor() as cursor:
             for person_override_to_delete in inputs.iter_person_overides_to_delete():
                 activity.logger.debug("%s", person_override_to_delete)
@@ -590,8 +640,6 @@ class SquashPersonOverridesInputs:
         dry_run: If True, queries that mutate or delete data will not execute and instead will be logged.
     """
 
-    clickhouse_database: str = "default"
-    postgres_database: str = "posthog"
     team_ids: list[int] = field(default_factory=list)
     partition_ids: list[str] | None = None
     dictionary_name: str = "person_overrides_join_dict"
@@ -708,16 +756,16 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
     @workflow.run
     async def run(self, inputs: SquashPersonOverridesInputs):
         """Workflow implementation to squash person overrides into events table."""
+        from django.conf import settings
+
         workflow.logger.info("Starting squash workflow")
         workflow.logger.debug("%s", json.dumps(asdict(inputs)))
 
         retry_policy = RetryPolicy(maximum_attempts=3)
         query_inputs = QueryInputs(
-            database=inputs.clickhouse_database,
+            clickhouse=ClickHouseConnectionInputs.from_posthog_settings(settings),
+            postgres=PostgresConnectionInputs.from_posthog_settings(settings),
             dictionary_name=inputs.dictionary_name,
-            user=settings.CLICKHOUSE_USER,
-            password=settings.CLICKHOUSE_PASSWORD,
-            cluster_name=settings.CLICKHOUSE_CLUSTER,
             team_ids=inputs.team_ids,
             dry_run=inputs.dry_run,
         )
@@ -727,14 +775,12 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
             query_inputs,
             retry_policy=retry_policy,
         ) as latest_merged_at:
+            query_inputs._latest_merged_at = latest_merged_at
+            query_inputs.partition_ids = list(inputs.iter_partition_ids())
+
             persons_to_delete = await workflow.execute_activity(
                 select_persons_to_delete,
-                QueryInputs(
-                    partition_ids=list(inputs.iter_partition_ids()),
-                    database=inputs.clickhouse_database,
-                    _latest_merged_at=latest_merged_at,
-                    dry_run=inputs.dry_run,
-                ),
+                query_inputs,
                 start_to_close_timeout=timedelta(seconds=60),
                 retry_policy=retry_policy,
             )
@@ -743,16 +789,11 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
                 workflow.logger.info("No overrides to delete were found, workflow done")
                 return
 
+            query_inputs.person_overrides_to_delete = persons_to_delete
+
             await workflow.execute_activity(
                 squash_events_partition,
-                QueryInputs(
-                    partition_ids=list(inputs.iter_partition_ids()),
-                    database=inputs.clickhouse_database,
-                    team_ids=inputs.team_ids,
-                    dictionary_name=inputs.dictionary_name,
-                    _latest_merged_at=latest_merged_at,
-                    dry_run=inputs.dry_run,
-                ),
+                query_inputs,
                 start_to_close_timeout=timedelta(seconds=300),
                 retry_policy=retry_policy,
             )
@@ -761,23 +802,14 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
 
             await workflow.execute_activity(
                 delete_squashed_person_overrides_from_clickhouse,
-                QueryInputs(
-                    person_overrides_to_delete=persons_to_delete,
-                    database=inputs.clickhouse_database,
-                    _latest_merged_at=latest_merged_at,
-                    dry_run=inputs.dry_run,
-                ),
+                query_inputs,
                 start_to_close_timeout=timedelta(seconds=300),
                 retry_policy=retry_policy,
             )
 
             await workflow.execute_activity(
                 delete_squashed_person_overrides_from_postgres,
-                QueryInputs(
-                    person_overrides_to_delete=persons_to_delete,
-                    database=inputs.postgres_database,
-                    dry_run=inputs.dry_run,
-                ),
+                query_inputs,
                 start_to_close_timeout=timedelta(seconds=300),
                 retry_policy=retry_policy,
             )


### PR DESCRIPTION
## Problem

It's easy to mix-up inputs to connect to ClickHouse and inputs to connect to Postgres (as they have the same name, e.g. if you see `inputs.database_name` is that CH or PG?). So, we separate them into their own input classes, that we then add attributes of the `QueryInputs` class (following the example, now you would see `inputs.clickhouse.database` and `inputs.postgres.database`, way clearer which is which).

There is also a connection issue to Postgres: given that we are running with the default Postgres parameters, I believe we may be reading the connection details from the environment calling the `execute_temporal_workflow` command. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Added two new input classes for database connection inputs (Due to the line savings in grouping parameters in a single place, this results in net -30 lines for this pr 🎉). Eventually, these two input classes could be further abstracted to be used in other workflows, but I'm not prematurely optimizing.
* I've moved the settings import to the run function of the workflow. This way I'm attempting to ensure we read the settings when running the workflow, not when calling the execute command.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated all unit tests to use the new inputs.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
