### PR TITLE
fix(lemon-ui): Fix `onBlur` in `LemonTextArea`

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
@@ -37,7 +37,7 @@ export interface LemonTextAreaProps
 
 /** A `textarea` component for multi-line text. */
 export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextAreaProps>(function _LemonTextArea(
-    { className, onChange, onBlur, onPressCmdEnter: onPressEnter, minRows = 3, onKeyDown, ...textProps },
+    { className, onChange, onPressCmdEnter: onPressEnter, minRows = 3, onKeyDown, ...textProps },
     ref
 ): JSX.Element {
     const _ref = useRef<HTMLTextAreaElement | null>(null)

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -211,6 +211,7 @@ function CustomHogQLOption({
                 onFocus={(e) => {
                     e.target.selectionStart = localValue.length // Focus at the end of the input
                 }}
+                onPressCmdEnter={() => onSelect(localValue)}
                 className={`font-mono ${CLICK_OUTSIDE_BLOCK_CLASS}`}
                 minRows={6}
                 maxRows={6}
@@ -220,10 +221,7 @@ function CustomHogQLOption({
             <LemonButton
                 fullWidth
                 type="primary"
-                onClick={() => {
-                    console.log(actualValue, localValue)
-                    onSelect(localValue)
-                }}
+                onClick={() => onSelect(localValue)}
                 disabledReason={!localValue ? 'Please enter a HogQL expression' : undefined}
                 center
             >


### PR DESCRIPTION
## Changes

I fixed a bug in #15429 where `LemonTextArea`'s `onFocus` prop was discarded, but forgot to also fix `onBlur` in the same way. So this does that.
Also, removed a stray `console.log()`.