### PR TITLE
feat(hogql): null display

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -29,7 +29,7 @@ export function renderColumn(
     } else if (value === errorColumn) {
         return <LemonTag color="red">Error</LemonTag>
     } else if (value === null) {
-        return <LemonTag>NULL</LemonTag>
+        return <span className="italic text-muted">NULL</span>
     } else if (isHogQLQuery(query.source)) {
         if (typeof value === 'string') {
             try {


### PR DESCRIPTION
## Problem

These nulls grab too much attention

<img width="1124" alt="image" src="https://github.com/PostHog/posthog/assets/53387/40327df5-1275-459c-8264-46a1c4e088da">


## Changes

`italic text-muted`

<img width="1137" alt="image" src="https://github.com/PostHog/posthog/assets/53387/f45518e4-beb0-4f61-a71e-53f7e93f60df">

Pure `italic` without `text-muted` seemed to make the value feel more important than the filled in non-NULL text values. Thus I muted it a bit. 🤷 

## How did you test this code?

Visually.