### PR TITLE
fix(insights): Immediately refresh shared insights correctly

### DIFF
--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -1,6 +1,6 @@
 import { ChartDisplayType, InsightLogicProps, InsightModel } from '~/types'
 import { BindLogic } from 'kea'
-import { insightLogic } from 'scenes/insights/insightLogic'
+import { SharingAccessTokenContext, insightLogic } from 'scenes/insights/insightLogic'
 import { InsightViz } from 'lib/components/Cards/InsightCard/InsightCard'
 import './ExportedInsight.scss'
 import { FriendlyLogo } from '~/toolbar/assets/FriendlyLogo'
@@ -13,6 +13,7 @@ import { isDataTableNode } from '~/queries/utils'
 import { QueriesUnsupportedHere } from 'lib/components/Cards/InsightCard/QueriesUnsupportedHere'
 import { Query } from '~/queries/Query/Query'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
+import { useContext } from 'react'
 
 export function ExportedInsight({
     insight,
@@ -35,10 +36,13 @@ export function ExportedInsight({
         insight.query.showActions = false
     }
 
+    const sharingAccessToken = useContext(SharingAccessTokenContext)
+
     const insightLogicProps: InsightLogicProps = {
         dashboardItemId: insight.short_id,
         cachedInsight: insight,
         doNotLoad: true,
+        sharingAccessToken,
     }
 
     const { filters, query, name, derived_name, description } = insight

--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -11,6 +11,7 @@ import { Link } from 'lib/lemon-ui/Link'
 import clsx from 'clsx'
 import { useValues } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
+import { SharingAccessTokenContext } from 'scenes/insights/insightLogic'
 
 export function Exporter(props: ExportedData): JSX.Element {
     const { type, dashboard, insight, accessToken, ...exportOptions } = props
@@ -61,18 +62,19 @@ export function Exporter(props: ExportedData): JSX.Element {
                     </>
                 ) : null
             ) : null}
-            {insight ? (
-                <ExportedInsight type={type} insight={insight} exportOptions={exportOptions} />
-            ) : dashboard ? (
-                <Dashboard
-                    id={String(dashboard.id)}
-                    dashboard={dashboard}
-                    placement={type === ExportType.Image ? DashboardPlacement.Export : DashboardPlacement.Public}
-                    sharingAccessToken={accessToken}
-                />
-            ) : (
-                <h1 className="text-center p-4">Something went wrong...</h1>
-            )}
+            <SharingAccessTokenContext.Provider value={accessToken}>
+                {insight ? (
+                    <ExportedInsight type={type} insight={insight} exportOptions={exportOptions} />
+                ) : dashboard ? (
+                    <Dashboard
+                        id={String(dashboard.id)}
+                        dashboard={dashboard}
+                        placement={type === ExportType.Image ? DashboardPlacement.Export : DashboardPlacement.Public}
+                    />
+                ) : (
+                    <h1 className="text-center p-4">Something went wrong...</h1>
+                )}
+            </SharingAccessTokenContext.Provider>
             {!whitelabel && dashboard && (
                 <div className="text-center pb-4">
                     {type === ExportType.Image ? <FriendlyLogo className="text-lg" /> : null}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { capitalizeFirstLetter } from 'lib/utils'
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { Layout } from 'react-grid-layout'
 import {
     FunnelInvalidExclusionState,
@@ -10,7 +10,7 @@ import {
     InsightErrorState,
     InsightTimeoutState,
 } from 'scenes/insights/EmptyStates'
-import { insightLogic } from 'scenes/insights/insightLogic'
+import { SharingAccessTokenContext, insightLogic } from 'scenes/insights/insightLogic'
 import { urls } from 'scenes/urls'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import {
@@ -520,11 +520,14 @@ function InsightCardInternal(
     }: InsightCardProps,
     ref: React.Ref<HTMLDivElement>
 ): JSX.Element {
+    const sharingAccessToken = useContext(SharingAccessTokenContext)
+
     const insightLogicProps: InsightLogicProps = {
         dashboardItemId: insight.short_id,
         dashboardId: dashboardId,
         cachedInsight: insight,
         doNotLoad: true,
+        sharingAccessToken,
     }
 
     const { timedOutQueryId, erroredQueryId, insightLoading, isUsingDashboardQueries } = useValues(

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 import { BindLogic, useActions, useValues } from 'kea'
 import { dashboardLogic, DashboardLogicProps } from 'scenes/dashboard/dashboardLogic'
 import { DashboardItems } from 'scenes/dashboard/DashboardItems'
@@ -20,12 +20,12 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupsModel } from '../../models/groupsModel'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { SharingAccessTokenContext } from 'scenes/insights/insightLogic'
 
 interface DashboardProps {
     id?: string
     dashboard?: DashboardType
     placement?: DashboardPlacement
-    sharingAccessToken?: string
 }
 
 export const scene: SceneExport = {
@@ -37,7 +37,9 @@ export const scene: SceneExport = {
     }),
 }
 
-export function Dashboard({ id, dashboard, placement, sharingAccessToken }: DashboardProps = {}): JSX.Element {
+export function Dashboard({ id, dashboard, placement }: DashboardProps = {}): JSX.Element {
+    const sharingAccessToken = useContext(SharingAccessTokenContext)
+
     return (
         <BindLogic
             logic={dashboardLogic}

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -17,7 +17,7 @@ import {
     TrendsFilterType,
 } from '~/types'
 import { captureTimeToSeeData, currentSessionId } from 'lib/internalMetrics'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import api, { ApiMethodOptions, getJSONOrThrow } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import {
@@ -59,6 +59,7 @@ import { userLogic } from 'scenes/userLogic'
 import { globalInsightLogic } from './globalInsightLogic'
 import { transformLegacyHiddenLegendKeys } from 'scenes/funnels/funnelUtils'
 import { summarizeInsight } from 'scenes/insights/summarizeInsight'
+import React from 'react'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 const SHOW_TIMEOUT_MESSAGE_AFTER = 5000
@@ -82,6 +83,9 @@ export const createEmptyInsight = (
     filters: filterTestAccounts ? { filter_test_accounts: true } : {},
     result: null,
 })
+
+/** Context for passing down the insight/dashboard sharing access token. */
+export const SharingAccessTokenContext = React.createContext<string | undefined>(undefined)
 
 export const insightLogic = kea<insightLogicType>([
     props({} as InsightLogicProps),
@@ -331,7 +335,15 @@ export const insightLogic = kea<insightLogicType>([
                         ) {
                             // Instead of making a search for filters, reload the insight via its id if possible.
                             // This makes sure we update the insight's cache key if we get new default filters.
-                            apiUrl = `api/projects/${currentTeamId}/insights/${values.savedInsight.id}/?refresh=true`
+                            apiUrl = combineUrl(
+                                `api/projects/${currentTeamId}/insights/${values.savedInsight.id}/?refresh=true`,
+                                {
+                                    refresh: true,
+                                    ...(props.sharingAccessToken
+                                        ? { sharing_access_token: props.sharingAccessToken }
+                                        : {}),
+                                }
+                            ).url
                             fetchResponse = await api.getResponse(apiUrl, methodOptions)
                         } else {
                             const params = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1968,6 +1968,8 @@ export interface InsightLogicProps {
     cachedInsight?: Partial<InsightModel> | null
     /** enable this to avoid API requests */
     doNotLoad?: boolean
+    /** If showing a shared insight/dashboard, we need the access token for refreshing. */
+    sharingAccessToken?: string
 }
 
 export interface SetInsightOptions {


### PR DESCRIPTION
## Problem

#15153 added refreshing of insights on shared dashboards, but there was one small issue: if there were no cached results, they would only appear on _second_ dashboard load, because "the initial load because of no data" refresh is in that case handled by `insightLogic`, which didn't have the sharing access token – unlike the "there's data but it's stale" refresh, handled by `dashboardLogic`, which did have the token. (Okay – loading insights is a bit of a quagmire.)

## Changes

Now we pass the sharing access token down to `insightLogic`, so everything loads always.

## How did you test this code?

This is annoying to test E2E, so just cleared all cache locally and opened a shared dashboard in incognito to see it load correctly.