### PR TITLE
fix(decide): Switch to a more performant throttle

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -103,13 +103,24 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -120,18 +131,29 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -159,7 +181,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -179,22 +201,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -103,24 +103,13 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -131,29 +120,18 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
-  SELECT "posthog_asyncmigration"."id",
-         "posthog_asyncmigration"."name",
-         "posthog_asyncmigration"."description",
-         "posthog_asyncmigration"."progress",
-         "posthog_asyncmigration"."status",
-         "posthog_asyncmigration"."current_operation_index",
-         "posthog_asyncmigration"."current_query_id",
-         "posthog_asyncmigration"."celery_task_id",
-         "posthog_asyncmigration"."started_at",
-         "posthog_asyncmigration"."finished_at",
-         "posthog_asyncmigration"."posthog_min_version",
-         "posthog_asyncmigration"."posthog_max_version",
-         "posthog_asyncmigration"."parameters"
-  FROM "posthog_asyncmigration"
-  WHERE ("posthog_asyncmigration"."name" = '0007_persons_and_groups_on_events_backfill'
-         AND "posthog_asyncmigration"."status" = 2)
-  ORDER BY "posthog_asyncmigration"."id" ASC
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -181,7 +159,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -201,6 +179,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -1,6 +1,8 @@
 import base64
 import json
 from unittest.mock import patch
+import time
+
 
 from django.core.cache import cache
 from django.db import connection
@@ -1641,7 +1643,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             # need to pass in exact string to get the property flag
 
     def test_rate_limits(self):
-        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_RATE_LIMIT="3/m"):
+        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_BUCKET_REPLENISH_RATE=0.1, DECIDE_BUCKET_CAPACITY=3):
             self.client.logout()
             Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
             FeatureFlag.objects.create(
@@ -1671,10 +1673,39 @@ class TestDecide(BaseTest, QueryMatchingTest):
                 },
             )
 
+    def test_rate_limits_replenish_over_time(self):
+        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_BUCKET_REPLENISH_RATE=1, DECIDE_BUCKET_CAPACITY=1):
+            self.client.logout()
+            Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
+            FeatureFlag.objects.create(
+                team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user
+            )
+            FeatureFlag.objects.create(
+                team=self.team,
+                filters={"groups": [{"properties": [], "rollout_percentage": None}]},
+                name="This is a feature flag with default params, no filters.",
+                key="default-flag",
+                created_by=self.user,
+            )  # Should be enabled for everyone
+
+            response = self._post_decide(api_version=3)
+            self.assertEqual(response.status_code, 200)
+
+            response = self._post_decide(api_version=3)
+            self.assertEqual(response.status_code, 429)
+
+            # wait for bucket to replenish
+            time.sleep(1)
+
+            response = self._post_decide(api_version=2)
+            self.assertEqual(response.status_code, 200)
+
+            response = self._post_decide(api_version=3)
+            self.assertEqual(response.status_code, 429)
+
     def test_rate_limits_work_with_invalid_tokens(self):
         self.client.logout()
-        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_RATE_LIMIT="3/m"):
-
+        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_BUCKET_REPLENISH_RATE=0.01, DECIDE_BUCKET_CAPACITY=3):
             for _ in range(3):
                 response = self._post_decide(api_version=3, data={"token": "aloha?", "distinct_id": "123"})
                 self.assertEqual(response.status_code, 401)
@@ -1693,8 +1724,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
     def test_rate_limits_work_with_missing_tokens(self):
         self.client.logout()
-        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_RATE_LIMIT="3/m"):
-
+        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_BUCKET_REPLENISH_RATE=0.1, DECIDE_BUCKET_CAPACITY=3):
             for _ in range(3):
                 response = self._post_decide(api_version=3, data={"distinct_id": "123"})
                 self.assertEqual(response.status_code, 401)
@@ -1713,7 +1743,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
     def test_rate_limits_work_with_malformed_request(self):
         self.client.logout()
-        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_RATE_LIMIT="4/m"):
+        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_BUCKET_REPLENISH_RATE=0.1, DECIDE_BUCKET_CAPACITY=4):
 
             def invalid_request():
                 return self.client.post("/decide/", {"data": "1==1"}, HTTP_ORIGIN="http://127.0.0.1:8000")
@@ -1755,8 +1785,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             ],
         )
         self.client.logout()
-
-        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_RATE_LIMIT="3/m"):
+        with self.settings(DECIDE_RATE_LIMIT_ENABLED="y", DECIDE_BUCKET_REPLENISH_RATE=0.1, DECIDE_BUCKET_CAPACITY=3):
 
             for _ in range(3):
                 response = self._post_decide(api_version=3)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -271,7 +271,9 @@ def shortcircuitmiddleware(f):
 class ShortCircuitMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-        self.decide_throttler = DecideRateThrottle(rate=settings.DECIDE_RATE_LIMIT)
+        self.decide_throttler = DecideRateThrottle(
+            replenish_rate=settings.DECIDE_BUCKET_REPLENISH_RATE, bucket_capacity=settings.DECIDE_BUCKET_CAPACITY
+        )
 
     def __call__(self, request: HttpRequest):
         if request.path == "/decide/" or request.path == "/decide":

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -1178,10 +1178,10 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2023-05-11 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), toDateTime('2023-05-11 23:59:59', 'UTC')))
+               toStartOfDay(toDateTime('2023-05-12 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-05 00:00:00', 'UTC')), toDateTime('2023-05-12 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC'))
+                         toStartOfDay(toDateTime('2023-05-05 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
@@ -1200,8 +1200,8 @@
            HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'event_name'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-11 23:59:59', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-05 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-12 23:59:59', 'UTC')
           AND (pdi.person_id IN
                  (SELECT DISTINCT person_id
                   FROM cohortpeople
@@ -1243,10 +1243,10 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2023-05-11 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), toDateTime('2023-05-11 23:59:59', 'UTC')))
+               toStartOfDay(toDateTime('2023-05-12 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2023-05-05 00:00:00', 'UTC')), toDateTime('2023-05-12 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC'))
+                         toStartOfDay(toDateTime('2023-05-05 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
@@ -1258,8 +1258,8 @@
            GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
         WHERE team_id = 2
           AND event = 'event_name'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-04 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-11 23:59:59', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2023-05-05 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-12 23:59:59', 'UTC')
           AND (if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) IN
                  (SELECT DISTINCT person_id
                   FROM cohortpeople

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -23,7 +23,9 @@ AXES_META_PRECEDENCE_ORDER = ["HTTP_X_FORWARDED_FOR", "REMOTE_ADDR"]
 # Decide rate limit setting
 
 DECIDE_RATE_LIMIT_ENABLED = get_from_env("DECIDE_RATE_LIMIT_ENABLED", False, type_cast=str_to_bool)
-DECIDE_RATE_LIMIT = os.getenv("DECIDE_RATE_LIMIT", "400/s")
+DECIDE_BUCKET_CAPACITY = get_from_env("DECIDE_BUCKET_CAPACITY", type_cast=int, default=500)
+DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type_cast=float, default=10.0)
+
 
 # Application definition
 


### PR DESCRIPTION
## Problem

Testing on dev showed that the DRF cache based throttle is abysmal performance wise: It was slower to rate limit than to just allow all requests through (assuming pgbouncer is working).

So, now switching to an in-memory token bucket rate limiter. The gotcha here is that this will rate limit per worker in a pod, and not globally.

This implies we'll have to spend a bit more effort figuring out how to tune these settings.

If it turns out to be a problem, will switch to a cache based storage. For now, I think this is fine, and I want to test on dev how well this performs.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
