### PR TITLE
fix(ingestion): don't log geoip AddressNotFoundError

### DIFF
--- a/plugin-server/src/worker/vm/extensions/geoip.ts
+++ b/plugin-server/src/worker/vm/extensions/geoip.ts
@@ -10,7 +10,9 @@ export function createGeoIp(server: Hub): GeoIPExtension {
                 try {
                     return Promise.resolve(server.mmdb.city(ipAddress))
                 } catch (e) {
-                    status.warn('⚠️', 'geoip lookup failed', { ip: ipAddress, error: e })
+                    if (e.name != 'AddressNotFoundError') {
+                        status.warn('⚠️', 'geoip lookup failed', { ip: ipAddress, error: e })
+                    }
                     return Promise.resolve(null)
                 }
             } else {


### PR DESCRIPTION
## Problem

We added logging of the mmdb errors in https://github.com/PostHog/posthog/pull/15173, and we log a significant amount of un-actionable `AddressNotFoundError` warnings (IPs are private or invalid), silence these logs to be nice to Loki.
 
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
