### PR TITLE
chore: more logging on close

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -152,6 +152,7 @@ export async function startPluginsServer(
 
     process.on('beforeExit', async () => {
         // This makes async exit possible with the process waiting until jobs are closed
+        status.info('👋', 'process handling beforeExit event. Closing jobs...')
         await closeJobs()
         process.exit(0)
     })
@@ -424,6 +425,7 @@ export async function startPluginsServer(
         Sentry.captureException(error)
         status.error('💥', 'Launchpad failure!', { error: error.stack ?? error })
         void Sentry.flush().catch(() => null) // Flush Sentry in the background
+        status.error('💥', 'Exception while starting server, shutting down!', { error })
         await closeJobs()
         process.exit(1)
     }


### PR DESCRIPTION
## Problem

When looking at logs for a blob ingester that failed to delete files on shutdown

http://grafana-prod-us/explore?orgId=1&left=%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22builder%22,%22expr%22:%22%7Bcontainer%3D%5C%22posthog-recordings-blob-ingestion%5C%22%7D%20%7C%3D%20%60c84hf%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D

<img width="849" alt="Screenshot 2023-05-12 at 16 46 31" src="https://github.com/PostHog/posthog/assets/984817/81172cef-d2bc-4d99-a87a-72453e617cee">

I see partitions being assigned at the same second as I see a log message that comes from the `closeJobs` function

That is unexpected (to me). Not all of the paths that can call `closeJobs` log that they are happening so I can't see why this happened

## Changes

Adds logs to those paths

## How did you test this code?

🙈 