### PR TITLE
perf(ingestion): only ACK and update offsets once per batch

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -45,7 +45,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_CONSUMPTION_OVERFLOW_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv() ? 0 : 1000,
-        KAFKA_PRODUCER_WAIT_FOR_ACK: true, // Turning it off can lead to dropped data
         KAFKA_MAX_MESSAGE_BATCH_SIZE: isDevEnv() ? 0 : 900_000,
         KAFKA_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 500,
         APP_METRICS_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 20_000,

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -66,48 +66,27 @@ export const produce = async ({
     value,
     key,
     headers = [],
-    waitForAck = true,
 }: {
     producer: RdKafkaProducer
     topic: string
     value: Buffer | null
     key: Buffer | null
     headers?: { [key: string]: Buffer }[]
-    waitForAck?: boolean
-}): Promise<number | null | undefined> => {
+}): Promise<void> => {
     status.debug('📤', 'Producing message', { topic: topic })
     const produceSpan = getSpan()?.startChild({ op: 'kafka_produce' })
     return await new Promise((resolve, reject) => {
-        if (waitForAck) {
-            producer.produce(
-                topic,
-                null,
-                value,
-                key,
-                Date.now(),
-                headers,
-                (error: any, offset: NumberNullUndefined) => {
-                    if (error) {
-                        status.error('⚠️', 'produce_error', { error: error, topic: topic })
-                        reject(error)
-                    } else {
-                        status.debug('📤', 'Produced message', { topic: topic, offset: offset })
-                        resolve(offset)
-                    }
+        producer.produce(topic, null, value, key, Date.now(), headers, (error: any, offset: NumberNullUndefined) => {
+            if (error) {
+                status.error('⚠️', 'produce_error', { error: error, topic: topic })
+                reject(error)
+            } else {
+                status.debug('📤', 'Produced message', { topic: topic, offset: offset })
+                resolve()
+            }
 
-                    produceSpan?.finish()
-                }
-            )
-        } else {
-            producer.produce(topic, null, value, key, Date.now(), headers, (error: any, _: NumberNullUndefined) => {
-                if (error) {
-                    status.error('⚠️', 'produce_error', { error: error, topic: topic })
-                }
-
-                produceSpan?.finish()
-            })
-            resolve(undefined)
-        }
+            produceSpan?.finish()
+        })
     })
 }
 export const disconnectProducer = async (producer: RdKafkaProducer) => {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -107,7 +107,6 @@ export interface PluginsServerConfig {
     KAFKA_CONSUMPTION_TOPIC: string | null
     KAFKA_CONSUMPTION_OVERFLOW_TOPIC: string | null
     KAFKA_PRODUCER_MAX_QUEUE_SIZE: number
-    KAFKA_PRODUCER_WAIT_FOR_ACK: boolean
     KAFKA_MAX_MESSAGE_BATCH_SIZE: number
     KAFKA_FLUSH_FREQUENCY_MS: number
     APP_METRICS_FLUSH_FREQUENCY_MS: number

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -134,7 +134,7 @@ export async function createHub(
     const kafkaConnectionConfig = createRdConnectionConfigFromEnvVars(serverConfig as KafkaConfig)
     const producer = await createKafkaProducer({ ...kafkaConnectionConfig, 'linger.ms': 0 })
 
-    const kafkaProducer = new KafkaProducerWrapper(producer, serverConfig.KAFKA_PRODUCER_WAIT_FOR_ACK)
+    const kafkaProducer = new KafkaProducerWrapper(producer, false)
     status.info('👍', `Kafka ready`)
 
     status.info('🤔', `Connecting to Postgresql...`)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Remove the dangerous `KAFKA_PRODUCER_WAIT_FOR_ACK` option we added for benchmarking
- add a `delayedAck` option to `KafkaProducerWrapper`. The hub's wrapper does not use this (wait for ack on produce)
- TODO: `eachBatchIngestionWithOverflow` uses a new `KafkaProducerWrapper` per batch
- TODO: `eachBatchIngestionWithOverflow` commits consumer offsets after`KafkaProducerWrapper.waitForAck()`

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
