### PR TITLE
chore: Track how useful lazy person loading is

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -92,6 +92,9 @@ export class EventPipelineRunner {
             return this.registerLastStep('pluginsProcessEventStep', event.team_id, [event])
         }
         const [normalizedEvent, newPersonContainer] = await this.runStep(processPersonsStep, [this, processedEvent])
+        this.hub.statsd?.increment('kafka_queue.event_pipeline.person_loaded_after_person_step', {
+            loaded: String(newPersonContainer.loaded),
+        })
 
         const preparedEvent = await this.runStep(prepareEventStep, [this, normalizedEvent])
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -125,7 +125,7 @@ describe('EventPipelineRunner', () => {
             await runner.runEventPipeline(pipelineEvent)
 
             expect(hub.statsd.timing).toHaveBeenCalledTimes(5)
-            expect(hub.statsd.increment).toHaveBeenCalledTimes(8)
+            expect(hub.statsd.increment).toHaveBeenCalledTimes(9)
 
             expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                 step: 'createEventStep',


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This would help understand the impact of https://github.com/PostHog/posthog/pull/15286 when we switch from lazily loading (potentially from Redis) to loading the person always from PG during person step.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
