### PR TITLE
feat: do more filtering before aggregation

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
@@ -26,10 +26,10 @@ const filtersToLocalFilters = (filters: RecordingFilters): LocalRecordingFilters
         actions: [],
         events: [
             {
-                id: null,
+                id: '$pageview',
                 type: EntityTypes.EVENTS,
                 order: 0,
-                name: 'All events',
+                name: '$pageview',
             },
         ],
     }

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -3,13 +3,13 @@ from typing import Any, Dict, List, Tuple, Union
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters.mixins.utils import cached_property
-from posthog.queries.session_recordings.session_recording_list import SessionRecordingList, EventFiltersSQL
+from posthog.queries.session_recordings.session_recording_list import SessionRecordingList
 
 
 @dataclasses.dataclass(frozen=True)
-class SummaryEventFiltersSQL(EventFiltersSQL):
-    simple_event_matching_select_condition_clause: str
-    non_aggregate_select_condition_summing_clause: str
+class SummaryEventFiltersSQL:
+    where_conditions: str
+    params: Dict[str, Any]
 
 
 class SessionRecordingListFromReplaySummary(SessionRecordingList):
@@ -53,13 +53,16 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
            round((sum(active_milliseconds)/1000)/duration, 2) as active_time
         FROM session_replay_events
         PREWHERE team_id = %(team_id)s
+        -- we can filter on the pre-aggregated timestamp columns
+        -- because any not-the-lowest min value is _more_ greater than the min value
+        -- and any not-the-highest max value is _less_ lower than the max value
+        AND min_first_timestamp >= %(start_time)s
+        AND max_last_timestamp <= %(end_time)s
         {person_cte_match_clause}
         -- may also need to match session ids from the query filter
         {session_ids_clause}
     GROUP BY session_id
-        HAVING start_time >= %(start_time)s
-        AND end_time <= %(end_time)s
-        {duration_clause}
+        HAVING 1=1 {duration_clause}
     ORDER BY start_time DESC
     LIMIT %(limit)s OFFSET %(offset)s
         """
@@ -70,22 +73,14 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
         with {person_cte}
         events_session_ids AS (
         -- this core query has to select the session_ids from the events table
-        -- because the non_aggregate_select_condition_clause is used to AND conditions together
-        -- but, we want to select a simple set of session ids
-        -- we have to group by session_id and sum any matching columns
-        SELECT session_id {non_aggregate_select_condition_summing_clause}
-         FROM
-            (SELECT
-                `$session_id` as session_id
-                {non_aggregate_select_condition_clause}
+            SELECT
+                distinct `$session_id` as session_id
             FROM events
             PREWHERE
                 team_id = %(team_id)s
                 {events_timestamp_clause}
                 {event_filter_where_conditions}
-                and notEmpty(session_id)) AS inner_event_q
-        GROUP BY session_id
-        HAVING 1=1 {event_matches_filter_conditions}
+                and notEmpty(session_id)
         )
         SELECT
            session_id,
@@ -101,29 +96,26 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
            round((sum(active_milliseconds)/1000)/duration, 2) as active_time
         FROM session_replay_events
         PREWHERE team_id = %(team_id)s
+         -- we can filter on the pre-aggregated timestamp columns
+        -- because any not-the-lowest min value is _more_ greater than the min value
+        -- and any not-the-highest max value is _less_ lower than the max value
+        AND min_first_timestamp >= %(start_time)s
+        AND max_last_timestamp <= %(end_time)s
         {person_cte_match_clause}
         -- matches session ids from events CTE
         AND session_id in (select session_id from events_session_ids)
         -- may also need to match session ids from the query filter
         {session_ids_clause}
         GROUP BY session_id
-        HAVING start_time >= %(start_time)s
-        AND end_time <= %(end_time)s
-        {duration_clause}
+        HAVING 1=1 {duration_clause}
         ORDER BY start_time DESC
         LIMIT %(limit)s OFFSET %(offset)s
         """
 
     @cached_property
-    def format_event_filters(self) -> SummaryEventFiltersSQL:
-        simple_event_matching_select_condition_clause = ""
-        non_aggregate_select_condition_clause = ""
-        non_aggregate_select_condition_summing_clause = ""
-        aggregate_event_select_clause = ""
-        aggregate_select_clause = ""
-        aggregate_having_clause = ""
+    def build_event_filters(self) -> SummaryEventFiltersSQL:
+        condition_sql = ""
         where_conditions = "AND event IN %(event_names)s"
-        # Always include $pageview events so the start_url and end_url can be extracted
         event_names_to_filter: List[Union[int, str]] = []
 
         params: Dict = {}
@@ -140,29 +132,8 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
                 entity, prepend=f"event_matcher_{index}", team_id=self._team_id
             )
 
-            aggregate_event_select_clause += f"""
-            , groupUniqArrayIf(100)((timestamp, uuid, session_id, window_id), event_match_{index} = 1) AS matching_events_{index}
-            , sum(event_match_{index}) AS matches_{index}
-            """
+            # todo use condition_sql as a where condidition....
 
-            aggregate_select_clause += f"""
-            , matches_{index}
-            , matching_events_{index}
-            """
-
-            non_aggregate_select_condition_clause += f"""
-            , if({condition_sql}, 1, 0) as event_match_{index}
-            """
-
-            simple_event_matching_select_condition_clause += f"""
-                        , if({condition_sql}, 1, 0) as matches_{index}
-                        """
-
-            non_aggregate_select_condition_summing_clause += f"""
-                                    , sum(matches_{index}) as matches_{index}
-                                    """
-
-            aggregate_having_clause += f"\nAND matches_{index} > 0"
             params = {**params, **filter_params}
 
         params = {**params, "event_names": list(event_names_to_filter)}
@@ -172,13 +143,7 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
             where_conditions = ""
 
         return SummaryEventFiltersSQL(
-            simple_event_matching_select_condition_clause=simple_event_matching_select_condition_clause,
-            non_aggregate_select_condition_clause=non_aggregate_select_condition_clause,
-            non_aggregate_select_condition_summing_clause=non_aggregate_select_condition_summing_clause,
-            aggregate_event_select_clause=aggregate_event_select_clause,
-            aggregate_select_clause=aggregate_select_clause,
-            aggregate_having_clause=aggregate_having_clause,
-            where_conditions=where_conditions,
+            where_conditions=where_conditions + f"AND {condition_sql}" if condition_sql else "",
             params=params,
         )
 
@@ -214,7 +179,7 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
 
         recording_person_query, recording_person_query_params = self._get_recording_person_query()
 
-        event_filters = self.format_event_filters
+        event_filters = self.build_event_filters
         events_timestamp_clause, events_timestamp_params = self._get_events_timestamp_clause
         _, recording_start_time_params = self._get_recording_start_time_clause
         session_ids_clause, session_ids_params = self.session_ids_clause
@@ -247,9 +212,6 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
                 person_id_clause=person_id_clause,
                 event_filter_where_conditions=event_filters.where_conditions,
                 events_timestamp_clause=events_timestamp_clause,
-                non_aggregate_select_condition_clause=event_filters.simple_event_matching_select_condition_clause,
-                event_matches_filter_conditions=event_filters.aggregate_having_clause,
-                non_aggregate_select_condition_summing_clause=event_filters.non_aggregate_select_condition_summing_clause,
                 duration_clause=duration_clause,
                 person_cte=f"{person_cte}," if person_cte else "",
                 person_cte_match_clause=person_cte_match_clause,

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -118,7 +118,6 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
                 entity, prepend=f"event_matcher_{index}", team_id=self._team_id
             )
 
-            # todo use condition_sql as a where condidition....
 
             params = {**params, **filter_params}
 

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -118,7 +118,6 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
                 entity, prepend=f"event_matcher_{index}", team_id=self._team_id
             )
 
-
             params = {**params, **filter_params}
 
         params = {**params, "event_names": list(event_names_to_filter)}

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -76,7 +76,6 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
         -- it adds the comma needed to have multiple CTEs if it is present
         with {person_cte}
         events_session_ids AS (
-        -- this core query has to select the session_ids from the events table
             SELECT
                 distinct `$session_id` as session_id
             FROM events


### PR DESCRIPTION
## Problem

In the session recording listing code we use `HAVING` queries for things we could query in `WHERE` before grouping.

That means we load data so that we can group it before using the HAVING to discard it.

## Changes

moves the HAVINGS that don't need to be in the HAVING to WHERE. This _should_ mean we load much less data, particularly when querying the events table. 

We were loading hundreds of millions of rows of event data to load 20 recordings 😱 

## How did you test this code?

developer tests