### PR TITLE
fix: protect schema and port in exporter urls

### DIFF
--- a/posthog/tasks/exports/test/test_csv_exporter_url_sanitising.py
+++ b/posthog/tasks/exports/test/test_csv_exporter_url_sanitising.py
@@ -1,0 +1,33 @@
+from parameterized import parameterized
+
+from posthog.test.base import APIBaseTest
+from posthog.utils import PotentialSecurityProblemException, absolute_uri
+
+
+class TestCSVExporterURLSanitization(APIBaseTest):
+    def test_sanitize_url_when_provided_path(self) -> None:
+        with self.settings(SITE_URL="https://something.posthog.com"):
+            sanitised = absolute_uri(None or "/some/location")
+            assert sanitised == "https://something.posthog.com/some/location"
+
+    def test_sanitize_url_when_provided_path_and_site_url_has_a_port(self) -> None:
+        with self.settings(SITE_URL="https://localhost:8000"):
+            sanitised = absolute_uri(None or "/some/location")
+            assert sanitised == "https://localhost:8000/some/location"
+
+    error_test_cases = [
+        ("changing scheme", "https://localhost:8000", "http://localhost:8000/some/location"),
+        ("changing port", "https://localhost:8000", "https://localhost:8123/some/location"),
+        ("changing port and url", "https://something.posthog.com:8000", "https://localhost:8123/some/location"),
+        ("changing domain", "https://app.posthog.com", "https://google.com/some/location"),
+    ]
+
+    @parameterized.expand(error_test_cases)
+    def test_sanitise_url_error_cases_as_paths(self, _name, site_url, provided_url_or_path) -> None:
+        with self.settings(SITE_URL=site_url), self.assertRaises(PotentialSecurityProblemException):
+            absolute_uri(None or provided_url_or_path)
+
+    @parameterized.expand(error_test_cases)
+    def test_sanitise_url_error_cases_as_next_url(self, _name, site_url, provided_url_or_path) -> None:
+        with self.settings(SITE_URL=site_url), self.assertRaises(PotentialSecurityProblemException):
+            absolute_uri(provided_url_or_path or None)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -104,7 +104,11 @@ def absolute_uri(url: Optional[str] = None) -> str:
     if provided_url.hostname and provided_url.scheme:
         site_url = urlparse(settings.SITE_URL)
         provided_url = provided_url
-        if site_url.hostname != provided_url.hostname:
+        if (
+            site_url.hostname != provided_url.hostname
+            or site_url.port != provided_url.port
+            or site_url.scheme != provided_url.scheme
+        ):
             raise PotentialSecurityProblemException(f"It is forbidden to provide an absolute URI using {url}")
 
     return urljoin(settings.SITE_URL.rstrip("/") + "/", url.lstrip("/"))

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -31,6 +31,7 @@ types-python-dateutil>=2.8.3
 types-pytz==2021.3.2
 types-redis==4.3.20
 types-requests==2.26.1
+parameterized==0.9.0
 pytest==6.2.5
 pytest-django==4.1.0
 pytest-env==0.6.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -152,6 +152,8 @@ packaging==23.1
     #   datamodel-code-generator
     #   prance
     #   pytest
+parameterized==0.9.0
+    # via -r requirements-dev.in
 pathable==0.4.3
     # via jsonschema-spec
 pathspec==0.9.0


### PR DESCRIPTION
## Problem

We use the `absolute_uri` mechanism to protect against malicious URIs in the CSV exporter. As the intention is that it only ever calls the web pod URL. 

However, that did not validate that scheme or port matched the SITE_URL setting

## Changes

* modifies the `absolute_uri` mechanism to protect against scheme or port not matching the SITE_URL setting
* adds the `parameterized` test library as a dev dependency for python
        * pytest.mark.parameterized can't be used with xunit style test classes
        * pytest.subTest reports test names and counts weirdly

NB this changes the behaviour of `absolute_uri` no matter where it is called but that's a good thing

## How did you test this code?

*developer tests