### PR TITLE
fix: from logs to changes

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -187,15 +187,15 @@ export const startBatchConsumer = async ({
 
     const isHealthy = () => {
         // We define health as the last consumer loop having run in the last
-        // minute. This might not be bullet proof, let's see.
+        // minute. This might not be bullet-proof, let's see.
         return Date.now() - lastLoopTime < 60000
     }
 
     const stop = async () => {
-        status.info('🔁', 'Stopping session recordings consumer')
+        status.info('🔁', 'Stopping kafka batch consumer')
 
         // First we signal to the mainLoop that we should be stopping. The main
-        // loop should complete one loop, flush the producer, and store it's offsets.
+        // loop should complete one loop, flush the producer, and store its offsets.
         isShuttingDown = true
 
         // Wait for the main loop to finish, but only give it 30 seconds

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -174,7 +174,7 @@ export const disconnectConsumer = async (consumer: RdKafkaConsumer) => {
                 status.error('🔥', 'Failed to disconnect node-rdkafka consumer', { error })
                 reject(error)
             } else {
-                status.info('🔁', 'Disconnected session node-rdkafka consumer')
+                status.info('🔁', 'Disconnected node-rdkafka consumer')
                 resolve(data)
             }
         })

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -43,7 +43,7 @@ async function deleteFile(file: string, context: string) {
     } catch (err) {
         if (err && err.code === 'ENOENT') {
             status.warn(
-                '⚠️',
+                '🤷‍♀️',
                 `blob_ingester_session_manager failed deleting file ${context} path: ${file}, file not found. That's probably fine 🤷‍♀️`,
                 {
                     err,

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -44,7 +44,7 @@ async function deleteFile(file: string, context: string) {
         if (err && err.code === 'ENOENT') {
             status.warn(
                 '⚠️',
-                `blob_ingester_session_manager failed deleting file ${context} path: ${file}, file not found`,
+                `blob_ingester_session_manager failed deleting file ${context} path: ${file}, file not found. That's probably fine 🤷‍♀️`,
                 {
                     err,
                     file,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
@@ -10,7 +10,7 @@ export function createIncomingRecordingMessage(data: Partial<IncomingRecordingMe
             topic: 'session_recording_events',
             partition: 1,
             offset: 1,
-            timestamp: undefined,
+            timestamp: 1,
         },
 
         team_id: 1,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
@@ -29,6 +29,20 @@ describe('ingester', () => {
         expect(ingester.sessions.has('1-session_id_1')).toEqual(true)
     })
 
+    it('removes sessions on destroy', async () => {
+        await ingester.consume(createIncomingRecordingMessage({ team_id: 2, session_id: 'session_id_1' }))
+        await ingester.consume(createIncomingRecordingMessage({ team_id: 2, session_id: 'session_id_2' }))
+
+        expect(ingester.sessions.size).toBe(2)
+        expect(ingester.sessions.has('2-session_id_1')).toEqual(true)
+        expect(ingester.sessions.has('2-session_id_2')).toEqual(true)
+
+        await ingester.destroySessions([ingester.sessions.get('2-session_id_1')!])
+
+        expect(ingester.sessions.size).toBe(1)
+        expect(ingester.sessions.has('2-session_id_2')).toEqual(true)
+    })
+
     it('handles multiple incoming sessions', async () => {
         const event = createIncomingRecordingMessage()
         const event2 = createIncomingRecordingMessage({

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
@@ -37,7 +37,7 @@ describe('ingester', () => {
         expect(ingester.sessions.has('2-session_id_1')).toEqual(true)
         expect(ingester.sessions.has('2-session_id_2')).toEqual(true)
 
-        await ingester.destroySessions([ingester.sessions.get('2-session_id_1')!])
+        await ingester.destroySessions([['2-session_id_1', ingester.sessions.get('2-session_id_1')!]])
 
         expect(ingester.sessions.size).toBe(1)
         expect(ingester.sessions.has('2-session_id_2')).toEqual(true)


### PR DESCRIPTION
## Problem

A grab bag of changes from looking at the logs as the blob ingester runs

## Changes

* a few log changes to make it clearer what is happening
* let the future traveller know we don't mind if we can't delete a file because it's not on the disk 🙃 
* log a little more information when team is not found

most importantly

* use the correct key when removing a session on destroy
* cos pods are getting stuck trying to handle messages for session managers that should be being recreated but the dead instance is around still 

## How did you test this code?

mostly 🧠 , a little developer test addition