### PR TITLE
fix: support double decoding base64 on decompress

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
@@ -27,6 +27,7 @@ export function decompressFromString(input: string, doubleDecode = false): strin
     } catch (e: any) {
         if (e.code === 'Z_DATA_ERROR' && e.errno === -3 && !doubleDecode) {
             // some received data (particularly chunks) are double encoded
+            status.warn('🪞', 'attempting double decoding while decompressing snapshot data', { error: e, input })
             return decompressFromString(input, true)
         }
         let message = `Failed to decompress data: ${e.message}`

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
@@ -8,11 +8,27 @@ export function compressToString(input: string): string {
     return compressed_data.toString('base64')
 }
 
-export function decompressFromString(input: string): string {
+export function decompressFromString(input: string, doubleDecode = false): string {
+    if (doubleDecode) {
+        input = Buffer.from(input, 'base64').toString()
+    }
     const compressedData = Buffer.from(input, 'base64')
-    const uncompressed = zlib.gunzipSync(compressedData)
-    // Trim is quick way to get rid of BOMs created by python
-    return uncompressed.toString('utf16le').trim()
+    let uncompressed: Buffer | null = null
+    try {
+        uncompressed = zlib.gunzipSync(compressedData)
+        // Trim is a quick way to get rid of BOMs created by python
+        return uncompressed.toString('utf16le').trim()
+    } catch (e: any) {
+        if (e.code === 'Z_DATA_ERROR' && e.errno === -3 && !doubleDecode) {
+            // some received data (particularly chunks) are double encoded
+            return decompressFromString(input, true)
+        }
+        let message = `Failed to decompress data: ${e.message}`
+        if (doubleDecode) {
+            message += 'even accounting for double decoding'
+        }
+        throw new Error(message)
+    }
 }
 
 export const convertToPersistedMessage = (message: IncomingRecordingMessage): PersistedRecordingMessage => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
@@ -13,9 +13,8 @@ export function decompressFromString(input: string, doubleDecode = false): strin
         input = Buffer.from(input, 'base64').toString()
     }
     const compressedData = Buffer.from(input, 'base64')
-    let uncompressed: Buffer | null = null
     try {
-        uncompressed = zlib.gunzipSync(compressedData)
+        const uncompressed = zlib.gunzipSync(compressedData)
         // Trim is a quick way to get rid of BOMs created by python
         return uncompressed.toString('utf16le').trim()
     } catch (e: any) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
@@ -1,5 +1,6 @@
 import zlib from 'node:zlib'
 
+import { status } from '../../../../utils/status'
 import { IncomingRecordingMessage, PersistedRecordingMessage } from './types'
 
 // NOTE: These functions are meant to be identical to those in posthog/session_recordings/session_recording_helpers.py
@@ -16,7 +17,13 @@ export function decompressFromString(input: string, doubleDecode = false): strin
     try {
         const uncompressed = zlib.gunzipSync(compressedData)
         // Trim is a quick way to get rid of BOMs created by python
-        return uncompressed.toString('utf16le').trim()
+        const finalUncompressed = uncompressed.toString('utf16le').trim()
+        if (doubleDecode) {
+            status.warn('🪞', 'double decoding was necessary while decompressing snapshot data', {
+                finalUncompressed,
+            })
+        }
+        return finalUncompressed
     } catch (e: any) {
         if (e.code === 'Z_DATA_ERROR' && e.errno === -3 && !doubleDecode) {
             // some received data (particularly chunks) are double encoded

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/utils.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/utils.test.ts
@@ -19,4 +19,12 @@ describe('compression', () => {
             `[{"type": 3, "data": {"source": 1, "positions": [{"x": 679, "y": 790, "id": 3, "timeOffset": 0}]}, "timestamp": 1679569492338}]`
         )
     })
+
+    it('decompress doubly base64 encoded string', () => {
+        const doublyEncoded: string = btoa(compressedData)
+        const decompressed = decompressFromString(doublyEncoded)
+        expect(decompressed).toEqual(
+            `[{"type": 3, "data": {"source": 1, "positions": [{"x": 679, "y": 790, "id": 3, "timeOffset": 0}]}, "timestamp": 1679569492338}]`
+        )
+    })
 })


### PR DESCRIPTION
## Problem

fixes https://posthog.sentry.io/issues/4154255432/?query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-blob-ingestion&referrer=issue-stream&statsPeriod=7d&stream_index=0

## Changes

if decompression fails and it might be because the input is double base64 encoded try to base 64 decode twice

## How did you test this code?

added developer test