### PR TITLE
fix: even more maybe faster

### DIFF
--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -76,7 +76,7 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
     _session_recordings_query_with_events = """
         -- person_cte is optional,
         -- it adds the comma needed to have multiple CTEs if it is present
-        with {person_cte}
+        WITH {person_cte}
         events_session_ids AS (
             SELECT
                 distinct `$session_id` as session_id
@@ -84,8 +84,8 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
             PREWHERE
                 team_id = %(team_id)s
                 {events_timestamp_clause}
-                {event_filter_where_conditions}
                 and notEmpty(session_id)
+                WHERE 1=1 {event_filter_where_conditions}
         )
         {session_recordings_base_query}
         -- these condition are in the prewhere from the base query

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -62,9 +62,11 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
     _session_recordings_query: str = """
         {person_cte}
         {session_recordings_base_query}
-        {person_cte_match_clause}
+        -- these condition are in the prewhere from the base query
         -- may need to match fixed session ids from the query filter
         {session_ids_clause}
+        -- person cte is matched in a where clause
+        WHERE 1=1 {person_cte_match_clause}
     GROUP BY session_id
         HAVING 1=1 {duration_clause}
     ORDER BY start_time DESC
@@ -86,11 +88,13 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
                 and notEmpty(session_id)
         )
         {session_recordings_base_query}
+        -- these condition are in the prewhere from the base query
         -- matches session ids from events CTE
         AND session_id in (select session_id from events_session_ids)
-        {person_cte_match_clause}
         -- may need to match fixed session ids from the query filter
         {session_ids_clause}
+        -- person cte is matched in a where clause
+        WHERE 1=1 {person_cte_match_clause}
         GROUP BY session_id
         HAVING 1=1 {duration_clause}
         ORDER BY start_time DESC

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -1,3 +1,676 @@
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:14'
+     AND event IN ['custom-event']
+     AND ((event = 'custom-event'
+           AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
+                AND has(['test_action_filter-5601626c-f928-4b0d-a055-6d751ea37673'], "$session_id")
+                AND has(['e4fd0041-b962-433f-a12c-be0df2faacf5'], "$window_id"))))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:14'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:15'
+     AND event IN ['custom-event']
+     AND ((event = 'custom-event'
+           AND (has(['test_action_filter-5601626c-f928-4b0d-a055-6d751ea37673'], "$session_id")
+                AND has(['e4fd0041-b962-433f-a12c-be0df2faacf5'], "$window_id"))))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:15'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.2
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:15'
+     AND event IN ['custom-event']
+     AND ((event = 'custom-event'
+           AND (has(['test_action_filter-5601626c-f928-4b0d-a055-6d751ea37673'], "$session_id")
+                AND has(['e4fd0041-b962-433f-a12c-be0df2faacf5'], "$window_id"))))
+     AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:15'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_all_filters_at_once
+  '
+  with distinct_ids_for_person as
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2 as pdi
+     INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0
+     and person_id = '01881f12-59e9-0000-5ca6-17030369c913') ,
+       events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-04 12:00:00'
+     AND timestamp <= '2023-05-19 11:59:59'
+     AND event IN ['$pageview', 'custom-event']
+     AND ((event = 'custom-event'))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-05 00:00:00'
+  AND max_last_timestamp <= '2023-05-18 23:59:59'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  AND distinct_id in
+    (select distinct_id
+     from distinct_ids_for_person)
+  GROUP BY session_id
+  HAVING 1=1
+  AND duration > 60
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 08:00:00'
+     AND 1 = 1
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-01-14 00:00:00'
+  AND max_last_timestamp <= '2021-01-21 20:00:00'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 08:00:00'
+     AND 1 = 1
+     AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-01-14 00:00:00'
+  AND max_last_timestamp <= '2021-01-21 20:00:00'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties.2
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 08:00:00'
+     AND 1 = 1
+     AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-01-14 00:00:00'
+  AND max_last_timestamp <= '2021-01-21 20:00:00'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties_materialized
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 08:00:00'
+     AND 1 = 1
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-01-14 00:00:00'
+  AND max_last_timestamp <= '2021-01-21 20:00:00'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties_materialized.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 08:00:00'
+     AND 1 = 1
+     AND (has(['Chrome'], "mat_$browser"))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-01-14 00:00:00'
+  AND max_last_timestamp <= '2021-01-21 20:00:00'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties_materialized.2
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 08:00:00'
+     AND 1 = 1
+     AND (has(['Firefox'], "mat_$browser"))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-01-14 00:00:00'
+  AND max_last_timestamp <= '2021-01-21 20:00:00'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_basic_query
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_basic_query_with_paging
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 2
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_basic_query_with_paging.1
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 2
+  OFFSET 1
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_basic_query_with_paging.2
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 2
+  OFFSET 2
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_date_from_filter
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-15 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_date_from_filter.1
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-13 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_date_to_filter
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-11 23:59:59'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_date_to_filter.1
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-12 23:59:59'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_duration_filter
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  GROUP BY session_id
+  HAVING 1=1
+  AND duration > 60
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_duration_filter.1
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  GROUP BY session_id
+  HAVING 1=1
+  AND duration < 60
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:19'
+     AND event IN ['$pageview']
+     AND event = '$pageview'
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:19'
+     AND event IN ['$autocapture']
+     AND event = '$autocapture'
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_cohort_properties
   '
   
@@ -16,5 +689,403 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version = 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_cohort_properties.2
+  '
+  with distinct_ids_for_person as
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2 as pdi
+     INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0
+     AND (pdi.person_id IN
+            (SELECT DISTINCT person_id
+             FROM cohortpeople
+             WHERE team_id = 2
+               AND cohort_id = 2
+               AND version = 0 )))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-08-14 00:00:00'
+  AND max_last_timestamp <= '2021-08-21 20:00:00'
+  AND distinct_id in
+    (select distinct_id
+     from distinct_ids_for_person)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_matching_on_session_id
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:20'
+     AND event IN ['$pageview']
+     AND event = '$pageview'
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:20'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_matching_on_session_id.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:20'
+     AND event IN ['$autocapture']
+     AND event = '$autocapture'
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:20'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_person_properties
+  '
+  with distinct_ids_for_person as
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2 as pdi
+     INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0
+        AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id PREWHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0)
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:21'
+  AND distinct_id in
+    (select distinct_id
+     from distinct_ids_for_person)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:22'
+     AND event IN ['$pageview']
+     AND event = '$pageview'
+     AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:22'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:22'
+     AND event IN ['$pageview']
+     AND event = '$pageview'
+     AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:22'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties_materialized
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:23'
+     AND event IN ['$pageview']
+     AND event = '$pageview'
+     AND (has(['Chrome'], "mat_$browser"))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:23'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties_materialized.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:23'
+     AND event IN ['$pageview']
+     AND event = '$pageview'
+     AND (has(['Firefox'], "mat_$browser"))
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:23'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_multiple_event_filters
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:24'
+     AND event IN ['$pageview', 'new-event']
+     AND event = 'new-event'
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:24'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_multiple_event_filters.1
+  '
+  with events_session_ids AS
+    (SELECT distinct `$session_id` as session_id
+     FROM events PREWHERE team_id = 2
+     AND timestamp >= '2023-05-07 12:00:00'
+     AND timestamp <= '2023-05-15 23:01:24'
+     AND event IN ['$pageview', 'new-event2']
+     AND event = 'new-event2'
+     and notEmpty(session_id))
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:24'
+  AND session_id in
+    (select session_id
+     from events_session_ids)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_person_id_filter
+  '
+  with distinct_ids_for_person as
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2 as pdi
+     INNER JOIN
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0
+     and person_id = '01881f12-79b8-0000-5516-bc418fe0f321')
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2023-05-08 00:00:00'
+  AND max_last_timestamp <= '2023-05-15 11:01:24'
+  AND distinct_id in
+    (select distinct_id
+     from distinct_ids_for_person)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
   '
 ---

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -8,8 +8,8 @@
      AND event IN ['custom-event']
      AND ((event = 'custom-event'
            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                AND has(['test_action_filter-afbda398-6b48-4249-94d7-b3ce57a7b81f'], "$session_id")
-                AND has(['5065ac5b-4e87-4b3d-aeb4-e543899e7093'], "$window_id"))))
+                AND has(['test_action_filter-session-one'], "$session_id")
+                AND has(['test_action_filter-window-id'], "$window_id"))))
      and notEmpty(session_id))
   SELECT session_id,
          any(team_id),
@@ -45,8 +45,8 @@
      AND timestamp <= '2023-01-04 12:00:00'
      AND event IN ['custom-event']
      AND ((event = 'custom-event'
-           AND (has(['test_action_filter-afbda398-6b48-4249-94d7-b3ce57a7b81f'], "$session_id")
-                AND has(['5065ac5b-4e87-4b3d-aeb4-e543899e7093'], "$window_id"))))
+           AND (has(['test_action_filter-session-one'], "$session_id")
+                AND has(['test_action_filter-window-id'], "$window_id"))))
      and notEmpty(session_id))
   SELECT session_id,
          any(team_id),
@@ -82,8 +82,8 @@
      AND timestamp <= '2023-01-04 12:00:00'
      AND event IN ['custom-event']
      AND ((event = 'custom-event'
-           AND (has(['test_action_filter-afbda398-6b48-4249-94d7-b3ce57a7b81f'], "$session_id")
-                AND has(['5065ac5b-4e87-4b3d-aeb4-e543899e7093'], "$window_id"))))
+           AND (has(['test_action_filter-session-one'], "$session_id")
+                AND has(['test_action_filter-window-id'], "$window_id"))))
      AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
      and notEmpty(session_id))
   SELECT session_id,
@@ -125,7 +125,7 @@
         HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
-     and person_id = '01881f16-60dd-0000-db39-e075d4f65ecb') ,
+     and person_id = '01881f27-a0bd-0000-d643-897da6be1526') ,
        events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
@@ -387,7 +387,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  AND max_last_timestamp <= '2023-05-15 11:24:32'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -412,7 +412,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -437,7 +437,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -462,7 +462,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -487,7 +487,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-15 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -512,7 +512,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-13 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -587,7 +587,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -613,7 +613,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -629,7 +629,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:43'
+     AND timestamp <= '2023-05-15 23:24:33'
      AND event IN ['$pageview']
      AND event = '$pageview'
      and notEmpty(session_id))
@@ -646,7 +646,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -664,7 +664,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:43'
+     AND timestamp <= '2023-05-15 23:24:33'
      AND event IN ['$autocapture']
      AND event = '$autocapture'
      and notEmpty(session_id))
@@ -681,7 +681,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  AND max_last_timestamp <= '2023-05-15 11:24:33'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -764,7 +764,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:45'
+     AND timestamp <= '2023-05-15 23:24:35'
      AND event IN ['$pageview']
      AND event = '$pageview'
      and notEmpty(session_id))
@@ -781,7 +781,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:45'
+  AND max_last_timestamp <= '2023-05-15 11:24:35'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -799,7 +799,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:45'
+     AND timestamp <= '2023-05-15 23:24:35'
      AND event IN ['$autocapture']
      AND event = '$autocapture'
      and notEmpty(session_id))
@@ -816,7 +816,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:45'
+  AND max_last_timestamp <= '2023-05-15 11:24:35'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -856,7 +856,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:46'
+  AND max_last_timestamp <= '2023-05-15 11:24:36'
   WHERE 1=1
     AND distinct_id in
       (select distinct_id
@@ -874,7 +874,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:46'
+     AND timestamp <= '2023-05-15 23:24:37'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
@@ -892,7 +892,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:46'
+  AND max_last_timestamp <= '2023-05-15 11:24:37'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -910,7 +910,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:47'
+     AND timestamp <= '2023-05-15 23:24:37'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
@@ -928,7 +928,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:47'
+  AND max_last_timestamp <= '2023-05-15 11:24:37'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -946,7 +946,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:48'
+     AND timestamp <= '2023-05-15 23:24:38'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Chrome'], "mat_$browser"))
@@ -964,7 +964,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:48'
+  AND max_last_timestamp <= '2023-05-15 11:24:38'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -982,7 +982,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:48'
+     AND timestamp <= '2023-05-15 23:24:38'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Firefox'], "mat_$browser"))
@@ -1000,7 +1000,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:48'
+  AND max_last_timestamp <= '2023-05-15 11:24:38'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -1018,7 +1018,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:48'
+     AND timestamp <= '2023-05-15 23:24:38'
      AND event IN ['$pageview', 'new-event']
      AND event = 'new-event'
      and notEmpty(session_id))
@@ -1035,7 +1035,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:48'
+  AND max_last_timestamp <= '2023-05-15 11:24:38'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -1053,7 +1053,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:05:48'
+     AND timestamp <= '2023-05-15 23:24:38'
      AND event IN ['$pageview', 'new-event2']
      AND event = 'new-event2'
      and notEmpty(session_id))
@@ -1070,7 +1070,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:48'
+  AND max_last_timestamp <= '2023-05-15 11:24:38'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -1096,7 +1096,7 @@
         HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
-     and person_id = '01881f16-81fd-0000-edbd-02df1e996c97')
+     and person_id = '01881f27-c06d-0000-2dd3-54d0543f9087')
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -1110,7 +1110,7 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:05:48'
+  AND max_last_timestamp <= '2023-05-15 11:24:38'
   WHERE 1=1
     AND distinct_id in
       (select distinct_id

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -125,12 +125,12 @@
         HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
-     and person_id = '01881f27-a0bd-0000-d643-897da6be1526') ,
+     and person_id = '00000000-0000-0000-0000-000000000000') ,
        events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-04 12:00:00'
-     AND timestamp <= '2023-05-19 11:59:59'
+     AND timestamp >= '2020-12-21 12:00:00'
+     AND timestamp <= '2021-01-05 11:59:59'
      AND event IN ['$pageview', 'custom-event']
      AND ((event = 'custom-event'))
      and notEmpty(session_id))
@@ -146,8 +146,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-05 00:00:00'
-  AND max_last_timestamp <= '2023-05-18 23:59:59'
+  AND min_first_timestamp >= '2020-12-22 00:00:00'
+  AND max_last_timestamp <= '2021-01-04 23:59:59'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -386,8 +386,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:32'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -411,8 +411,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -436,8 +436,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -461,8 +461,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -486,8 +486,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-15 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2021-01-01 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -511,8 +511,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-13 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-30 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -536,8 +536,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-11 23:59:59'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2020-12-28 23:59:59'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -561,8 +561,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-12 23:59:59'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2020-12-29 23:59:59'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -586,8 +586,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -612,8 +612,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -628,8 +628,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:33'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview']
      AND event = '$pageview'
      and notEmpty(session_id))
@@ -645,8 +645,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -663,8 +663,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:33'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$autocapture']
      AND event = '$autocapture'
      and notEmpty(session_id))
@@ -680,8 +680,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:33'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -763,8 +763,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:35'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview']
      AND event = '$pageview'
      and notEmpty(session_id))
@@ -780,8 +780,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:35'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -798,8 +798,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:35'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$autocapture']
      AND event = '$autocapture'
      and notEmpty(session_id))
@@ -815,8 +815,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:35'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -855,8 +855,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:36'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
     AND distinct_id in
       (select distinct_id
@@ -873,8 +873,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:37'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
@@ -891,8 +891,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:37'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -909,8 +909,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:37'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
@@ -927,8 +927,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:37'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -945,8 +945,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:38'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Chrome'], "mat_$browser"))
@@ -963,8 +963,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:38'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -981,8 +981,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:38'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Firefox'], "mat_$browser"))
@@ -999,8 +999,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:38'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -1017,8 +1017,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:38'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview', 'new-event']
      AND event = 'new-event'
      and notEmpty(session_id))
@@ -1034,8 +1034,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:38'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -1052,8 +1052,8 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:24:38'
+     AND timestamp >= '2020-12-24 12:00:00'
+     AND timestamp <= '2021-01-02 01:46:23'
      AND event IN ['$pageview', 'new-event2']
      AND event = 'new-event2'
      and notEmpty(session_id))
@@ -1069,8 +1069,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:38'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
     (select session_id
      from events_session_ids)
@@ -1096,7 +1096,7 @@
         HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
-     and person_id = '01881f27-c06d-0000-2dd3-54d0543f9087')
+     and person_id = '00000000-0000-0000-0000-000000000000')
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -1109,8 +1109,8 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:24:38'
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
     AND distinct_id in
       (select distinct_id

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -1,16 +1,17 @@
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2022-12-27 12:00:00'
      AND timestamp <= '2023-01-04 12:00:00'
-     AND event IN ['custom-event']
-     AND ((event = 'custom-event'
-           AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                AND has(['test_action_filter-session-one'], "$session_id")
-                AND has(['test_action_filter-window-id'], "$window_id"))))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['custom-event']
+       AND ((event = 'custom-event'
+             AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
+                  AND has(['test_action_filter-session-one'], "$session_id")
+                  AND has(['test_action_filter-window-id'], "$window_id")))) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -38,16 +39,17 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2022-12-27 12:00:00'
      AND timestamp <= '2023-01-04 12:00:00'
-     AND event IN ['custom-event']
-     AND ((event = 'custom-event'
-           AND (has(['test_action_filter-session-one'], "$session_id")
-                AND has(['test_action_filter-window-id'], "$window_id"))))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['custom-event']
+       AND ((event = 'custom-event'
+             AND (has(['test_action_filter-session-one'], "$session_id")
+                  AND has(['test_action_filter-window-id'], "$window_id")))) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -75,17 +77,18 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.2
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2022-12-27 12:00:00'
      AND timestamp <= '2023-01-04 12:00:00'
-     AND event IN ['custom-event']
-     AND ((event = 'custom-event'
-           AND (has(['test_action_filter-session-one'], "$session_id")
-                AND has(['test_action_filter-window-id'], "$window_id"))))
-     AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['custom-event']
+       AND ((event = 'custom-event'
+             AND (has(['test_action_filter-session-one'], "$session_id")
+                  AND has(['test_action_filter-window-id'], "$window_id"))))
+       AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -113,7 +116,7 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_all_filters_at_once
   '
-  with distinct_ids_for_person as
+  WITH distinct_ids_for_person as
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2 as pdi
@@ -131,9 +134,10 @@
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-21 12:00:00'
      AND timestamp <= '2021-01-05 11:59:59'
-     AND event IN ['$pageview', 'custom-event']
-     AND ((event = 'custom-event'))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview', 'custom-event']
+       AND ((event = 'custom-event')) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -165,13 +169,14 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2021-01-13 12:00:00'
      AND timestamp <= '2021-01-22 08:00:00'
-     AND 1 = 1
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND 1 = 1 )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -199,14 +204,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2021-01-13 12:00:00'
      AND timestamp <= '2021-01-22 08:00:00'
-     AND 1 = 1
-     AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND 1 = 1
+       AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -234,14 +240,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties.2
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2021-01-13 12:00:00'
      AND timestamp <= '2021-01-22 08:00:00'
-     AND 1 = 1
-     AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND 1 = 1
+       AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -269,13 +276,14 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties_materialized
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2021-01-13 12:00:00'
      AND timestamp <= '2021-01-22 08:00:00'
-     AND 1 = 1
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND 1 = 1 )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -303,14 +311,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties_materialized.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2021-01-13 12:00:00'
      AND timestamp <= '2021-01-22 08:00:00'
-     AND 1 = 1
-     AND (has(['Chrome'], "mat_$browser"))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND 1 = 1
+       AND (has(['Chrome'], "mat_$browser")) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -338,14 +347,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_any_event_filter_with_properties_materialized.2
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2021-01-13 12:00:00'
      AND timestamp <= '2021-01-22 08:00:00'
-     AND 1 = 1
-     AND (has(['Firefox'], "mat_$browser"))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND 1 = 1
+       AND (has(['Firefox'], "mat_$browser")) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -625,14 +635,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview']
-     AND event = '$pageview'
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview']
+       AND event = '$pageview' )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -660,14 +671,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$autocapture']
-     AND event = '$autocapture'
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$autocapture']
+       AND event = '$autocapture' )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -760,14 +772,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_matching_on_session_id
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview']
-     AND event = '$pageview'
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview']
+       AND event = '$pageview' )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -795,14 +808,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_matching_on_session_id.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$autocapture']
-     AND event = '$autocapture'
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$autocapture']
+       AND event = '$autocapture' )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -870,15 +884,16 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview']
-     AND event = '$pageview'
-     AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview']
+       AND event = '$pageview'
+       AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -906,15 +921,16 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview']
-     AND event = '$pageview'
-     AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview']
+       AND event = '$pageview'
+       AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -942,15 +958,16 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties_materialized
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview']
-     AND event = '$pageview'
-     AND (has(['Chrome'], "mat_$browser"))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview']
+       AND event = '$pageview'
+       AND (has(['Chrome'], "mat_$browser")) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -978,15 +995,16 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_properties_materialized.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview']
-     AND event = '$pageview'
-     AND (has(['Firefox'], "mat_$browser"))
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview']
+       AND event = '$pageview'
+       AND (has(['Firefox'], "mat_$browser")) )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -1014,14 +1032,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_multiple_event_filters
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview', 'new-event']
-     AND event = 'new-event'
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview', 'new-event']
+       AND event = 'new-event' )
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -1049,14 +1068,15 @@
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_multiple_event_filters.1
   '
-  with events_session_ids AS
+  WITH events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2020-12-24 12:00:00'
      AND timestamp <= '2021-01-02 01:46:23'
-     AND event IN ['$pageview', 'new-event2']
-     AND event = 'new-event2'
-     and notEmpty(session_id))
+     and notEmpty(session_id)
+     WHERE 1=1
+       AND event IN ['$pageview', 'new-event2']
+       AND event = 'new-event2' )
   SELECT session_id,
          any(team_id),
          any(distinct_id),

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -3,13 +3,13 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:14'
+     AND timestamp >= '2022-12-27 12:00:00'
+     AND timestamp <= '2023-01-04 12:00:00'
      AND event IN ['custom-event']
      AND ((event = 'custom-event'
            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                AND has(['test_action_filter-5601626c-f928-4b0d-a055-6d751ea37673'], "$session_id")
-                AND has(['e4fd0041-b962-433f-a12c-be0df2faacf5'], "$window_id"))))
+                AND has(['test_action_filter-afbda398-6b48-4249-94d7-b3ce57a7b81f'], "$session_id")
+                AND has(['5065ac5b-4e87-4b3d-aeb4-e543899e7093'], "$window_id"))))
      and notEmpty(session_id))
   SELECT session_id,
          any(team_id),
@@ -23,11 +23,12 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:14'
+  AND min_first_timestamp >= '2022-12-28 00:00:00'
+  AND max_last_timestamp <= '2023-01-04 00:00:00'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -40,12 +41,12 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:15'
+     AND timestamp >= '2022-12-27 12:00:00'
+     AND timestamp <= '2023-01-04 12:00:00'
      AND event IN ['custom-event']
      AND ((event = 'custom-event'
-           AND (has(['test_action_filter-5601626c-f928-4b0d-a055-6d751ea37673'], "$session_id")
-                AND has(['e4fd0041-b962-433f-a12c-be0df2faacf5'], "$window_id"))))
+           AND (has(['test_action_filter-afbda398-6b48-4249-94d7-b3ce57a7b81f'], "$session_id")
+                AND has(['5065ac5b-4e87-4b3d-aeb4-e543899e7093'], "$window_id"))))
      and notEmpty(session_id))
   SELECT session_id,
          any(team_id),
@@ -59,11 +60,12 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:15'
+  AND min_first_timestamp >= '2022-12-28 00:00:00'
+  AND max_last_timestamp <= '2023-01-04 00:00:00'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -76,12 +78,12 @@
   with events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
-     AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:15'
+     AND timestamp >= '2022-12-27 12:00:00'
+     AND timestamp <= '2023-01-04 12:00:00'
      AND event IN ['custom-event']
      AND ((event = 'custom-event'
-           AND (has(['test_action_filter-5601626c-f928-4b0d-a055-6d751ea37673'], "$session_id")
-                AND has(['e4fd0041-b962-433f-a12c-be0df2faacf5'], "$window_id"))))
+           AND (has(['test_action_filter-afbda398-6b48-4249-94d7-b3ce57a7b81f'], "$session_id")
+                AND has(['5065ac5b-4e87-4b3d-aeb4-e543899e7093'], "$window_id"))))
      AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
      and notEmpty(session_id))
   SELECT session_id,
@@ -96,11 +98,12 @@
          sum(mouse_activity_count),
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
-  AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:15'
+  AND min_first_timestamp >= '2022-12-28 00:00:00'
+  AND max_last_timestamp <= '2023-01-04 00:00:00'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -122,7 +125,7 @@
         HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
-     and person_id = '01881f12-59e9-0000-5ca6-17030369c913') ,
+     and person_id = '01881f16-60dd-0000-db39-e075d4f65ecb') ,
        events_session_ids AS
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
@@ -148,9 +151,10 @@
   AND session_id in
     (select session_id
      from events_session_ids)
-  AND distinct_id in
-    (select distinct_id
-     from distinct_ids_for_person)
+  WHERE 1=1
+    AND distinct_id in
+      (select distinct_id
+       from distinct_ids_for_person)
   GROUP BY session_id
   HAVING 1=1
   AND duration > 60
@@ -185,6 +189,7 @@
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -219,6 +224,7 @@
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -253,6 +259,7 @@
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -286,6 +293,7 @@
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -320,6 +328,7 @@
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -354,6 +363,7 @@
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -377,7 +387,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -401,7 +412,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -425,7 +437,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -449,7 +462,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  AND max_last_timestamp <= '2023-05-15 11:05:42'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -473,7 +487,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-15 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -497,7 +512,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-13 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:18'
+  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -522,6 +538,7 @@
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
   AND max_last_timestamp <= '2023-05-11 23:59:59'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -546,6 +563,7 @@
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
   AND max_last_timestamp <= '2023-05-12 23:59:59'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -569,7 +587,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   AND duration > 60
@@ -594,7 +613,8 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  AND max_last_timestamp <= '2023-05-15 11:05:43'
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   AND duration < 60
@@ -609,7 +629,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:19'
+     AND timestamp <= '2023-05-15 23:05:43'
      AND event IN ['$pageview']
      AND event = '$pageview'
      and notEmpty(session_id))
@@ -626,10 +646,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  AND max_last_timestamp <= '2023-05-15 11:05:43'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -643,7 +664,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:19'
+     AND timestamp <= '2023-05-15 23:05:43'
      AND event IN ['$autocapture']
      AND event = '$autocapture'
      and notEmpty(session_id))
@@ -660,10 +681,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:19'
+  AND max_last_timestamp <= '2023-05-15 11:05:43'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -725,9 +747,10 @@
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-08-14 00:00:00'
   AND max_last_timestamp <= '2021-08-21 20:00:00'
-  AND distinct_id in
-    (select distinct_id
-     from distinct_ids_for_person)
+  WHERE 1=1
+    AND distinct_id in
+      (select distinct_id
+       from distinct_ids_for_person)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -741,7 +764,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:20'
+     AND timestamp <= '2023-05-15 23:05:45'
      AND event IN ['$pageview']
      AND event = '$pageview'
      and notEmpty(session_id))
@@ -758,10 +781,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:20'
+  AND max_last_timestamp <= '2023-05-15 11:05:45'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -775,7 +799,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:20'
+     AND timestamp <= '2023-05-15 23:05:45'
      AND event IN ['$autocapture']
      AND event = '$autocapture'
      and notEmpty(session_id))
@@ -792,10 +816,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:20'
+  AND max_last_timestamp <= '2023-05-15 11:05:45'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -831,10 +856,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:21'
-  AND distinct_id in
-    (select distinct_id
-     from distinct_ids_for_person)
+  AND max_last_timestamp <= '2023-05-15 11:05:46'
+  WHERE 1=1
+    AND distinct_id in
+      (select distinct_id
+       from distinct_ids_for_person)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -848,7 +874,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:22'
+     AND timestamp <= '2023-05-15 23:05:46'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
@@ -866,10 +892,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:22'
+  AND max_last_timestamp <= '2023-05-15 11:05:46'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -883,7 +910,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:22'
+     AND timestamp <= '2023-05-15 23:05:47'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
@@ -901,10 +928,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:22'
+  AND max_last_timestamp <= '2023-05-15 11:05:47'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -918,7 +946,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:23'
+     AND timestamp <= '2023-05-15 23:05:48'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Chrome'], "mat_$browser"))
@@ -936,10 +964,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:23'
+  AND max_last_timestamp <= '2023-05-15 11:05:48'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -953,7 +982,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:23'
+     AND timestamp <= '2023-05-15 23:05:48'
      AND event IN ['$pageview']
      AND event = '$pageview'
      AND (has(['Firefox'], "mat_$browser"))
@@ -971,10 +1000,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:23'
+  AND max_last_timestamp <= '2023-05-15 11:05:48'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -988,7 +1018,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:24'
+     AND timestamp <= '2023-05-15 23:05:48'
      AND event IN ['$pageview', 'new-event']
      AND event = 'new-event'
      and notEmpty(session_id))
@@ -1005,10 +1035,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:24'
+  AND max_last_timestamp <= '2023-05-15 11:05:48'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1022,7 +1053,7 @@
     (SELECT distinct `$session_id` as session_id
      FROM events PREWHERE team_id = 2
      AND timestamp >= '2023-05-07 12:00:00'
-     AND timestamp <= '2023-05-15 23:01:24'
+     AND timestamp <= '2023-05-15 23:05:48'
      AND event IN ['$pageview', 'new-event2']
      AND event = 'new-event2'
      and notEmpty(session_id))
@@ -1039,10 +1070,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:24'
+  AND max_last_timestamp <= '2023-05-15 11:05:48'
   AND session_id in
     (select session_id
      from events_session_ids)
+  WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1064,7 +1096,7 @@
         HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id PREWHERE team_id = 2
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
-     and person_id = '01881f12-79b8-0000-5516-bc418fe0f321')
+     and person_id = '01881f16-81fd-0000-edbd-02df1e996c97')
   SELECT session_id,
          any(team_id),
          any(distinct_id),
@@ -1078,10 +1110,11 @@
          round((sum(active_milliseconds)/1000)/duration, 2) as active_time
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2023-05-08 00:00:00'
-  AND max_last_timestamp <= '2023-05-15 11:01:24'
-  AND distinct_id in
-    (select distinct_id
-     from distinct_ids_for_person)
+  AND max_last_timestamp <= '2023-05-15 11:05:48'
+  WHERE 1=1
+    AND distinct_id in
+      (select distinct_id
+       from distinct_ids_for_person)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_replay_summaries.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_replay_summaries.ambr
@@ -15,7 +15,7 @@
   from session_replay_events prewhere team_id = 2
   and min_first_timestamp >= '2023-04-24 19:18:24.597000'
   and max_last_timestamp <= '2023-04-28 19:18:24.597000'
-  and session_id in ('b476f60b-9d50-4df8-a5db-fe64b25cccb9')
+  and session_id in ('test_session_replay_summaries_can_be_queried-session-id')
   group by session_id
   '
 ---

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_replay_summaries.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_replay_summaries.ambr
@@ -15,7 +15,7 @@
   from session_replay_events prewhere team_id = 2
   and min_first_timestamp >= '2023-04-24 19:18:24.597000'
   and max_last_timestamp <= '2023-04-28 19:18:24.597000'
-  and session_id in ('9740cd99-6b5f-4b05-9e3c-1ed35729195b')
+  and session_id in ('b476f60b-9d50-4df8-a5db-fe64b25cccb9')
   group by session_id
   '
 ---

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_replay_summaries.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_replay_summaries.ambr
@@ -1,0 +1,21 @@
+# name: TestReceiveSummarizedSessionReplays.test_session_replay_summaries_can_be_queried
+  '
+  
+  select session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp),
+         max(max_last_timestamp),
+         dateDiff('SECOND', min(min_first_timestamp), max(max_last_timestamp)) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         round((sum(active_milliseconds)/1000)/duration, 2) as active_time
+  from session_replay_events prewhere team_id = 2
+  and min_first_timestamp >= '2023-04-24 19:18:24.597000'
+  and max_last_timestamp <= '2023-04-28 19:18:24.597000'
+  and session_id in ('9740cd99-6b5f-4b05-9e3c-1ed35729195b')
+  group by session_id
+  '
+---

--- a/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
@@ -574,6 +574,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
 
     @snapshot_clickhouse_queries
     @also_test_with_materialized_columns(["$current_url", "$browser"])
+    @freeze_time("2023-01-04")
     def test_action_filter(self):
         user = "test_action_filter-user"
         Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})

--- a/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
@@ -578,8 +578,8 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
     def test_action_filter(self):
         user = "test_action_filter-user"
         Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})
-        session_id_one = f"test_action_filter-{str(uuid4())}"
-        window_id = str(uuid4())
+        session_id_one = f"test_action_filter-session-one"
+        window_id = "test_action_filter-window-id"
         action1 = self.create_action(
             "custom-event",
             properties=[

--- a/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
@@ -65,6 +65,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
     def base_time(self):
         return (now() - relativedelta(hours=1)).replace(microsecond=0, second=0)
 
+    @snapshot_clickhouse_queries
     def test_basic_query(self):
         user = "test_basic_query-user"
         Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})
@@ -149,6 +150,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
 
         self.assertEqual(more_recordings_available, False)
 
+    @snapshot_clickhouse_queries
     def test_basic_query_with_paging(self):
         user = "test_basic_query_with_paging-user"
         Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})
@@ -570,6 +572,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
         (session_recordings, _) = session_recording_list_instance.run()
         self.assertEqual(len(session_recordings), 0)
 
+    @snapshot_clickhouse_queries
     @also_test_with_materialized_columns(["$current_url", "$browser"])
     def test_action_filter(self):
         user = "test_action_filter-user"
@@ -681,6 +684,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
         self.assertEqual(session_recordings[0]["start_time"], self.base_time)
         self.assertEqual(session_recordings[0]["end_time"], self.base_time + relativedelta(seconds=60))
 
+    @snapshot_clickhouse_queries
     def test_duration_filter(self):
         another_team = Team.objects.create(organization=self.organization)
 
@@ -734,6 +738,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
         (session_recordings, _) = session_recording_list_instance.run()
         self.assertEqual([r["session_id"] for r in session_recordings], [session_id_one])
 
+    @snapshot_clickhouse_queries
     def test_date_from_filter(self):
         user = "test_date_from_filter-user"
         Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})
@@ -766,6 +771,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
         self.assertEqual(len(session_recordings), 1)
         self.assertEqual(session_recordings[0]["session_id"], "two days before base time")
 
+    @snapshot_clickhouse_queries
     def test_date_to_filter(self):
         user = "test_date_to_filter-user"
         Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})
@@ -825,6 +831,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
         self.assertEqual(session_recordings[0]["session_id"], "1")
         self.assertEqual(session_recordings[0]["duration"], 6 * 60 * 60)
 
+    @snapshot_clickhouse_queries
     def test_person_id_filter(self):
         three_user_ids = [str(uuid4()) for _ in range(3)]
         session_id_one = f"test_person_id_filter-{str(uuid4())}"
@@ -851,6 +858,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             sorted([r["session_id"] for r in session_recordings]), sorted([session_id_two, session_id_one])
         )
 
+    @snapshot_clickhouse_queries
     def test_all_filters_at_once(self):
         three_user_ids = [str(uuid4()) for _ in range(3)]
         target_session_id = f"test_all_filters_at_once-{str(uuid4())}"
@@ -913,22 +921,6 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
         (session_recordings, _) = session_recording_list_instance.run()
         self.assertEqual(len(session_recordings), 1)
         self.assertEqual(session_recordings[0]["session_id"], target_session_id)
-
-    #     TODO does it matter we're not recording if a summarised session has a full snapshot?
-
-    #     def test_recording_without_fullsnapshot_dont_appear(self):
-    #         Person.objects.create(team=self.team, distinct_ids=["user"], properties={"email": "bla"})
-    #         produce_replay_summary(
-    #             distinct_id="user",
-    #             session_id="1",
-    #             first_timestamp=self.base_time,
-    #             has_full_snapshot=False,
-    #             team_id=self.team.id,
-    #         )
-    #         filter = SessionRecordingsFilter(team=self.team, data={"no-filter": True})
-    #         session_recording_list_instance = session_recording_list(filter=filter, team=self.team)
-    #         (session_recordings, _) = session_recording_list_instance.run()
-    #         self.assertEqual(len(session_recordings), 0)
 
     def test_teams_dont_leak_event_filter(self):
         user = "test_teams_dont_leak_event_filter-user"

--- a/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
@@ -27,6 +27,7 @@ from posthog.test.base import (
 )
 
 
+@freeze_time("2021-01-01T13:46:23")
 class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, APIBaseTest):
     # this test does not create any session_recording_events, only writes to the session_replay summary table
     # it is a pair with test_session_recording_list

--- a/posthog/queries/session_recordings/test/test_session_replay_summaries.py
+++ b/posthog/queries/session_recordings/test/test_session_replay_summaries.py
@@ -61,7 +61,7 @@ class SessionReplaySummaryQuery:
 class TestReceiveSummarizedSessionReplays(ClickhouseTestMixin, BaseTest):
     @snapshot_clickhouse_queries
     def test_session_replay_summaries_can_be_queried(self):
-        session_id = str(uuid4())
+        session_id = "test_session_replay_summaries_can_be_queried-session-id"
 
         produce_replay_summary(
             session_id=session_id,

--- a/posthog/queries/session_recordings/test/test_session_replay_summaries.py
+++ b/posthog/queries/session_recordings/test/test_session_replay_summaries.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytz
 from dateutil.parser import isoparse
+from freezegun import freeze_time
 
 from posthog.clickhouse.client import sync_execute
 from posthog.models import Team
@@ -60,6 +61,7 @@ class SessionReplaySummaryQuery:
 
 class TestReceiveSummarizedSessionReplays(ClickhouseTestMixin, BaseTest):
     @snapshot_clickhouse_queries
+    @freeze_time("2023-01-04T12:34")
     def test_session_replay_summaries_can_be_queried(self):
         session_id = "test_session_replay_summaries_can_be_queried-session-id"
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -592,10 +592,10 @@ class ClickhouseTestMixin(QueryMatchingTest):
     snapshot: Any
 
     def capture_select_queries(self):
-        return self.capture_queries(("SELECT", "WITH"))
+        return self.capture_queries(("SELECT", "WITH", "select", "with"))
 
     @contextmanager
-    def capture_queries(self, query_prefixes: Union[str, Tuple[str, str]]):
+    def capture_queries(self, query_prefixes: Union[str, Tuple[str, ...]]):
         queries = []
         original_get_client = ch_pool.get_client
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -354,8 +354,9 @@ class QueryMatchingTest:
             query,
         )
 
+        # Replace person id (when querying session recording replay events)
         query = re.sub(
-            rf"and person_id = '\d{8}-\d{4}-\d{4}-\d{4}-\d{12}'",
+            "and person_id = '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'",
             r"and person_id = '00000000-0000-0000-0000-000000000000'",
             query,
         )

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -354,6 +354,12 @@ class QueryMatchingTest:
             query,
         )
 
+        query = re.sub(
+            rf"and person_id = '\d{8}-\d{4}-\d{4}-\d{4}-\d{12}'",
+            r"and person_id = '00000000-0000-0000-0000-000000000000'",
+            query,
+        )
+
         # Replace tag id lookups for postgres
         query = re.sub(
             rf"""("posthog_tag"\."id") IN \(('[^']+'::uuid)+(, ('[^']+'::uuid)+)*\)""",


### PR DESCRIPTION
## Problem

follow-up to https://github.com/PostHog/posthog/pull/15536#discussion_r1193654505

maybe the person cte condition in the prewhere is making things slower than they need to be

this makes sense... listing just by event takes around 1.5 seconds with the new table

listing by event and person property takes over 3 seconds... 

e.g. 

`https://app.posthog.com/api/projects/\d/session_recordings?session_recording_duration=%7B%22type%22%3A%22recording%22%2C%22key%22%3A%22duration%22%2C%22value%22%3A60%2C%22operator%22%3A%22gt%22%7D&properties=%5B%7B%22key%22%3A%22%24browser_version%22%2C%22value%22%3A%5B%2292%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D&events=%5B%7B%22id%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22name%22%3A%22%24pageview%22%7D%5D&actions=%5B%5D&date_from=-21d&person_uuid=&limit=20&version=3`

maybe this fixes that 👀 

## Changes

* fix snapshot queries
* move person cte to prewhere

## How did you test this code?

letting the tests run
