### PR TITLE
fix: Unset debug in temporal start django worker

### DIFF
--- a/bin/temporal-django-worker
+++ b/bin/temporal-django-worker
@@ -4,8 +4,6 @@ set -e
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-export DEBUG=${DEBUG:-1}
-
 python3 manage.py start_temporal_worker
 
 wait

--- a/posthog/temporal/workflows/squash_person_overrides.py
+++ b/posthog/temporal/workflows/squash_person_overrides.py
@@ -202,7 +202,7 @@ class PostgresConnectionInputs:
             password=settings.DATABASES["default"]["PASSWORD"],
             database=settings.DATABASES["default"]["NAME"],
             username=settings.DATABASES["default"]["USER"],
-            port=settings.DATABASES["default"]["PORT"],
+            port=int(settings.DATABASES["default"]["PORT"]),
         )
 
     @property


### PR DESCRIPTION
## Problem

We think this may be the problem why the worker is running in DEBUG mode.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
