### PR TITLE
perf(persons): Optimize persons querying with pagination

### DIFF
--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -8,7 +8,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -22,7 +22,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND has(['another@gmail.com'], "pmat_email")
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -45,7 +45,7 @@
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0)
      where distinct_id = 'distinct_id' )
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -68,7 +68,7 @@
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0)
      where distinct_id = 'another_one' )
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -82,7 +82,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -96,7 +96,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND has(['inexistent'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -119,7 +119,7 @@
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0)
      where distinct_id = 'inexistent' )
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -138,7 +138,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'some_prop'), '^"|"$', '')))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -231,7 +231,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND (JSONHas(argMax(person.properties, version), 'email'))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -250,7 +250,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%another@gm%')
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -269,7 +269,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND (notEmpty(argMax(person."pmat_email", version)))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -288,7 +288,7 @@
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
   AND (argMax(person."pmat_email", version) ILIKE '%another@gm%')
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -327,7 +327,7 @@
              GROUP BY distinct_id
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'another@gm' ))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -366,7 +366,7 @@
              GROUP BY distinct_id
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'distinct_id_3' ))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -405,7 +405,7 @@
              GROUP BY distinct_id
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'another@gm' ))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---
@@ -444,7 +444,7 @@
              GROUP BY distinct_id
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'distinct_id_3' ))
-  ORDER BY max(created_at) DESC, id
+  ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '
 ---

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -91,7 +91,7 @@ class PersonQuery:
         multiple_cohorts_condition, multiple_cohorts_params = self._get_multiple_cohorts_clause(prepend=prepend)
         single_cohort_join, single_cohort_params = self._get_fast_single_cohort_clause()
         if paginate:
-            order = "ORDER BY max(created_at) DESC, id" if paginate else ""
+            order = "ORDER BY argMax(created_at, version) DESC, id" if paginate else ""
             limit_offset, limit_params = self._get_limit_offset_clause()
         else:
             order = ""


### PR DESCRIPTION
## Problem

For some of our largest customers, the plain persons list has begun to raise out-of-memory errors. This appears to be due to an inefficient way of pagination, where we aggregate by `created_by` twice for the whole dataset (which can get LARGE, as it's literally all persons) – once with `max(created_by)`, and once with `argMax(created_by, version)`.
[Sentry issue.](https://posthog.sentry.io/issues/4130439701/events/23e4fd566b3f46b986e377d65d76ebc9/?project=1899813&query=is%3Aunresolved+id%3A9aa58b9e819c40f9b1f54e425fcf313b&referrer=next-event&statsPeriod=14d&stream_index=0)

## Changes

The `version`-based variant is more accurate anyway, so switching to that here. This way pagination is 1. more accurate, 2. less memory-hungry. Seems to fix the issue (until we hit some larger scale milestones likely).

## How did you test this code?

Compared performance of variants via Metabase.