### PR TITLE
fix: Space out retries in detach and run after dropping dictionary

### DIFF
--- a/posthog/temporal/tests/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/test_squash_person_overrides_workflow.py
@@ -3,7 +3,6 @@ import random
 from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta
 from typing import TypedDict
-from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import psycopg2
@@ -120,19 +119,10 @@ def person_overrides_data(person_overrides_table):
 
 @pytest.fixture
 def query_inputs():
-    """A default set of QueryInputs to use in all tests.
+    """A default set of QueryInputs to use in all tests."""
+    query_inputs = QueryInputs()
 
-    Notice we are mocking the PG database name: Django creates a database exclusively for unit tests.
-    However, we don't use the Django ORM; we query the database directly. So, we need to update the
-    settings to point to the test database Django creates. Luckily, it's named the same but with a
-    `test_` prefix.
-    """
-    test_pg = {"default": settings.DATABASES["default"] | {"NAME": f"test_{settings.PG_DATABASE}"}}
-
-    with patch.dict(settings.DATABASES, test_pg):
-        query_inputs = QueryInputs()
-
-        return query_inputs
+    return query_inputs
 
 
 @pytest.mark.django_db
@@ -781,7 +771,24 @@ def django_db_setup_fixture():
 
 
 @pytest.fixture
-def organization_uuid(query_inputs, django_db_setup_fixture):
+def pg_connection():
+    """Manage a Postgres connection with psycopg2."""
+    conn = psycopg2.connect(
+        dbname=settings.DATABASES["default"]["NAME"],
+        user=settings.DATABASES["default"]["USER"],
+        password=settings.DATABASES["default"]["PASSWORD"],
+        host=settings.DATABASES["default"]["HOST"],
+        port=settings.DATABASES["default"]["PORT"],
+    )
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def organization_uuid(pg_connection, query_inputs, django_db_setup_fixture):
     """Create an Organization and return its UUID.
 
     We cannot use the Django ORM safely in an async context, so we INSERT INTO directly
@@ -790,14 +797,8 @@ def organization_uuid(query_inputs, django_db_setup_fixture):
     """
     organization_uuid = uuid4()
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute(
                 """
                 INSERT INTO posthog_organization (
@@ -834,33 +835,21 @@ def organization_uuid(query_inputs, django_db_setup_fixture):
 
     yield organization_uuid
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("DELETE FROM posthog_organization WHERE id = %s", [organization_uuid])
 
 
 @pytest.fixture
-def team_id(query_inputs, organization_uuid):
+def team_id(query_inputs, organization_uuid, pg_connection):
     """Create a Team and return its ID.
 
     We cannot use the Django ORM safely in an async context, so we INSERT INTO directly
     on the database. This means we need to clean up after ourselves, which we do after
     yielding.
     """
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute(
                 """
                 INSERT INTO posthog_team (
@@ -921,19 +910,13 @@ def team_id(query_inputs, organization_uuid):
 
     yield team_id
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("DELETE FROM posthog_team WHERE id = %s", [team_id])
 
 
 @pytest.fixture
-def person_overrides(query_inputs, team_id):
+def person_overrides(query_inputs, team_id, pg_connection):
     """Create a PersonOverrideMapping and a PersonOverride.
 
     We cannot use the Django ORM safely in an async context, so we INSERT INTO directly
@@ -944,14 +927,8 @@ def person_overrides(query_inputs, team_id):
     override_person_id = uuid4()
     person_override = PersonOverrideTuple(old_person_id, override_person_id)
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             person_ids = []
             for person_uuid in (override_person_id, old_person_id):
                 cursor.execute(
@@ -997,14 +974,8 @@ def person_overrides(query_inputs, team_id):
 
     yield person_override
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute(
                 "DELETE FROM posthog_personoverride WHERE team_id = %s AND old_person_id = %s",
                 [team_id, person_ids[1]],
@@ -1018,23 +989,17 @@ def person_overrides(query_inputs, team_id):
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_delete_squashed_person_overrides_from_postgres(
-    query_inputs, activity_environment, team_id, person_overrides
+    query_inputs, activity_environment, team_id, person_overrides, pg_connection
 ):
     """Test we can delete person overrides that have already been squashed.
 
     For the purposes of this unit test, we take the person overrides as given. A
     comprehensive test will cover the entire worflow end-to-end.
     """
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        # These are sanity checks to ensure the fixtures are working properly.
-        # If any assertions fail here, its likely a test setup issue.
-        with connection.cursor() as cursor:
+    # These are sanity checks to ensure the fixtures are working properly.
+    # If any assertions fail here, its likely a test setup issue.
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("SELECT id, team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
             assert len(mappings) == 2
@@ -1058,14 +1023,8 @@ async def test_delete_squashed_person_overrides_from_postgres(
 
     await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("SELECT team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
             assert len(mappings) == 1
@@ -1079,19 +1038,13 @@ async def test_delete_squashed_person_overrides_from_postgres(
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_delete_squashed_person_overrides_from_postgres_dry_run(
-    query_inputs, activity_environment, team_id, person_overrides
+    query_inputs, activity_environment, team_id, person_overrides, pg_connection
 ):
     """Test we do not delete person overrides when dry_run=True."""
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        # These are sanity checks to ensure the fixtures are working properly.
-        # If any assertions fail here, its likely a test setup issue.
-        with connection.cursor() as cursor:
+    # These are sanity checks to ensure the fixtures are working properly.
+    # If any assertions fail here, its likely a test setup issue.
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("SELECT id, team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
             assert len(mappings) == 2
@@ -1115,14 +1068,8 @@ async def test_delete_squashed_person_overrides_from_postgres_dry_run(
 
     await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("SELECT team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
             assert len(mappings) == 2
@@ -1136,23 +1083,17 @@ async def test_delete_squashed_person_overrides_from_postgres_dry_run(
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_delete_squashed_person_overrides_from_postgres_with_newer_override(
-    query_inputs, activity_environment, team_id, person_overrides
+    query_inputs, activity_environment, team_id, person_overrides, pg_connection
 ):
     """Test we do not delete a newer mapping from Postgres.
 
     For the purposes of this unit test, we take the person overrides as given. A
     comprehensive test will cover the entire worflow end-to-end.
     """
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        # These are sanity checks to ensure the fixtures are working properly.
-        # If any assertions fail here, its likely a test setup issue.
-        with connection.cursor() as cursor:
+    # These are sanity checks to ensure the fixtures are working properly.
+    # If any assertions fail here, its likely a test setup issue.
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("SELECT id, team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
             assert len(mappings) == 2
@@ -1161,14 +1102,8 @@ async def test_delete_squashed_person_overrides_from_postgres_with_newer_overrid
             overrides = cursor.fetchall()
             assert len(overrides) == 1
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             # Let's insert a newer mapping that arrives while we are running the squash job.
             # Since only one mapping can exist per old_person_id, we'll bump the version number.
             cursor.execute(
@@ -1203,14 +1138,8 @@ async def test_delete_squashed_person_overrides_from_postgres_with_newer_overrid
 
     await activity_environment.run(delete_squashed_person_overrides_from_postgres, query_inputs)
 
-    with psycopg2.connect(
-        dbname=settings.DATABASES["default"]["NAME"],
-        user=settings.DATABASES["default"]["USER"],
-        password=settings.DATABASES["default"]["PASSWORD"],
-        host=settings.DATABASES["default"]["HOST"],
-        port=settings.DATABASES["default"]["PORT"],
-    ) as connection:
-        with connection.cursor() as cursor:
+    with pg_connection:
+        with pg_connection.cursor() as cursor:
             cursor.execute("SELECT id, team_id, uuid FROM posthog_personoverridemapping")
             mappings = cursor.fetchall()
 

--- a/posthog/temporal/workflows/squash_person_overrides.py
+++ b/posthog/temporal/workflows/squash_person_overrides.py
@@ -226,7 +226,7 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
     """
     from django.conf import settings
 
-    activity.logger.info("Preparing %s.person_overrides table for squashing", settings.CLICKHOUSE_DATABASE)
+    activity.logger.info("Preparing person_overrides table for squashing")
 
     detach_query = "DETACH VIEW {database}.person_overrides_mv ON CLUSTER {cluster}".format(
         database=settings.CLICKHOUSE_DATABASE, cluster=settings.CLICKHOUSE_CLUSTER
@@ -243,11 +243,11 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
         activity.logger.info("Would have run query: %s", optimize_query)
         return
 
-    activity.logger.info("Detaching %s.person_overrides_mv", settings.CLICKHOUSE_DATABASE)
+    activity.logger.info("Detaching person_overrides_mv")
 
     sync_execute(detach_query)
 
-    activity.logger.info("Optimizing %s.person_overrides", settings.CLICKHOUSE_DATABASE)
+    activity.logger.info("Optimizing person_overrides")
 
     sync_execute(optimize_query)
 
@@ -257,7 +257,7 @@ async def re_attach_person_overrides(inputs: QueryInputs) -> None:
     """Re-attach the person_overrides mat view after it was used in a squash."""
     from django.conf import settings
 
-    activity.logger.info("Re-attaching %s.person_overrides_mv", settings.CLICKHOUSE_DATABASE)
+    activity.logger.info("Re-attaching person_overrides_mv")
 
     attach_query = "ATTACH TABLE IF NOT EXISTS {database}.person_overrides_mv ON CLUSTER {cluster}".format(
         database=settings.CLICKHOUSE_DATABASE, cluster=settings.CLICKHOUSE_CLUSTER
@@ -280,10 +280,10 @@ async def prepare_dictionary(inputs: QueryInputs) -> str:
     """
     from django.conf import settings
 
-    activity.logger.info("Preparing DICTIONARY %s.%s", settings.CLICKHOUSE_DATABASE, inputs.dictionary_name)
+    activity.logger.info("Preparing DICTIONARY %s", inputs.dictionary_name)
     latest_merged_at = sync_execute(SELECT_LATEST_MERGED_AT_QUERY.format(database=settings.CLICKHOUSE_DATABASE))[0][0]
 
-    activity.logger.info("Creating DICTIONARY %s.%s", settings.CLICKHOUSE_DATABASE, inputs.dictionary_name)
+    activity.logger.info("Creating DICTIONARY %s", inputs.dictionary_name)
     sync_execute(
         CREATE_DICTIONARY_QUERY.format(
             database=settings.CLICKHOUSE_DATABASE,
@@ -302,7 +302,7 @@ async def drop_dictionary(inputs: QueryInputs) -> None:
     """DROP the DICTIONARY used in the squash workflow."""
     from django.conf import settings
 
-    activity.logger.info("Dropping DICTIONARY %s.%s", settings.CLICKHOUSE_DATABASE, inputs.dictionary_name)
+    activity.logger.info("Dropping DICTIONARY %s", inputs.dictionary_name)
     sync_execute(
         DROP_DICTIONARY_QUERY.format(database=settings.CLICKHOUSE_DATABASE, dictionary_name=inputs.dictionary_name)
     )

--- a/posthog/temporal/workflows/squash_person_overrides.py
+++ b/posthog/temporal/workflows/squash_person_overrides.py
@@ -162,55 +162,6 @@ class SerializablePersonOverrideToDelete(NamedTuple):
 
 
 @dataclass
-class ClickHouseConnectionInputs:
-    """A dataclass of inputs required to connect to ClickHouse."""
-
-    host: str
-    password: str
-    database: str = "default"
-    username: str = "default"
-    port: int = 9000
-    cluster: str = ""
-
-    @classmethod
-    def from_posthog_settings(cls, settings) -> "ClickHouseConnectionInputs":
-        """Initialize from PostHog settings module."""
-        return cls(
-            host=settings.CLICKHOUSE_HOST,
-            password=settings.CLICKHOUSE_PASSWORD,
-            database=settings.CLICKHOUSE_DATABASE,
-            username=settings.CLICKHOUSE_USER,
-            cluster=settings.CLICKHOUSE_CLUSTER,
-        )
-
-
-@dataclass
-class PostgresConnectionInputs:
-    """A dataclass of inputs required to connect to Postgres."""
-
-    host: str
-    password: str
-    database: str = "posthog"
-    username: str = "posthog"
-    port: int = 5432
-
-    @classmethod
-    def from_posthog_settings(cls, settings) -> "PostgresConnectionInputs":
-        """Initialize from PostHog settings module."""
-        return cls(
-            host=settings.DATABASES["default"]["HOST"],
-            password=settings.DATABASES["default"]["PASSWORD"],
-            database=settings.DATABASES["default"]["NAME"],
-            username=settings.DATABASES["default"]["USER"],
-            port=int(settings.DATABASES["default"]["PORT"]),
-        )
-
-    @property
-    def database_url(self) -> str:
-        return f"postgres://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}"
-
-
-@dataclass
 class QueryInputs:
     """Inputs for activities that run queries in the SquashPersonOverrides workflow.
 
@@ -227,8 +178,6 @@ class QueryInputs:
             as the latest timestamp of a person merge.
     """
 
-    clickhouse: ClickHouseConnectionInputs
-    postgres: PostgresConnectionInputs
     partition_ids: list[str] = field(default_factory=list)
     team_ids: list[int] = field(default_factory=list)
     person_overrides_to_delete: list[SerializablePersonOverrideToDelete] = field(default_factory=list)
@@ -275,14 +224,16 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
     The activity re_attach_person_overrides should always be executed after the squash is done to clean
     up what we do here.
     """
-    activity.logger.info("Preparing %s.person_overrides table for squashing", inputs.clickhouse.database)
+    from django.conf import settings
+
+    activity.logger.info("Preparing %s.person_overrides table for squashing", settings.CLICKHOUSE_DATABASE)
 
     detach_query = "DETACH VIEW {database}.person_overrides_mv ON CLUSTER {cluster}".format(
-        database=inputs.clickhouse.database, cluster=inputs.clickhouse.cluster
+        database=settings.CLICKHOUSE_DATABASE, cluster=settings.CLICKHOUSE_CLUSTER
     )
     optimize_query = (
         "OPTIMIZE TABLE {database}.person_overrides ON CLUSTER {cluster} FINAL SETTINGS mutations_sync = 2".format(
-            database=inputs.clickhouse.database, cluster=inputs.clickhouse.cluster
+            database=settings.CLICKHOUSE_DATABASE, cluster=settings.CLICKHOUSE_CLUSTER
         )
     )
 
@@ -292,11 +243,11 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
         activity.logger.info("Would have run query: %s", optimize_query)
         return
 
-    activity.logger.info("Detaching %s.person_overrides_mv", inputs.clickhouse.database)
+    activity.logger.info("Detaching %s.person_overrides_mv", settings.CLICKHOUSE_DATABASE)
 
     sync_execute(detach_query)
 
-    activity.logger.info("Optimizing %s.person_overrides", inputs.clickhouse.database)
+    activity.logger.info("Optimizing %s.person_overrides", settings.CLICKHOUSE_DATABASE)
 
     sync_execute(optimize_query)
 
@@ -304,10 +255,12 @@ async def prepare_person_overrides(inputs: QueryInputs) -> None:
 @activity.defn
 async def re_attach_person_overrides(inputs: QueryInputs) -> None:
     """Re-attach the person_overrides mat view after it was used in a squash."""
-    activity.logger.info("Re-attaching %s.person_overrides_mv", inputs.clickhouse.database)
+    from django.conf import settings
+
+    activity.logger.info("Re-attaching %s.person_overrides_mv", settings.CLICKHOUSE_DATABASE)
 
     attach_query = "ATTACH TABLE IF NOT EXISTS {database}.person_overrides_mv ON CLUSTER {cluster}".format(
-        database=inputs.clickhouse.database, cluster=inputs.clickhouse.cluster
+        database=settings.CLICKHOUSE_DATABASE, cluster=settings.CLICKHOUSE_CLUSTER
     )
 
     if inputs.dry_run is True:
@@ -325,17 +278,19 @@ async def prepare_dictionary(inputs: QueryInputs) -> str:
     We also lock in the latest merged_at to ensure we do not process overrides that arrive after
     we have started the job.
     """
-    activity.logger.info("Preparing DICTIONARY %s.%s", inputs.clickhouse.database, inputs.dictionary_name)
-    latest_merged_at = sync_execute(SELECT_LATEST_MERGED_AT_QUERY.format(database=inputs.clickhouse.database))[0][0]
+    from django.conf import settings
 
-    activity.logger.info("Creating DICTIONARY %s.%s", inputs.clickhouse.database, inputs.dictionary_name)
+    activity.logger.info("Preparing DICTIONARY %s.%s", settings.CLICKHOUSE_DATABASE, inputs.dictionary_name)
+    latest_merged_at = sync_execute(SELECT_LATEST_MERGED_AT_QUERY.format(database=settings.CLICKHOUSE_DATABASE))[0][0]
+
+    activity.logger.info("Creating DICTIONARY %s.%s", settings.CLICKHOUSE_DATABASE, inputs.dictionary_name)
     sync_execute(
         CREATE_DICTIONARY_QUERY.format(
-            database=inputs.clickhouse.database,
+            database=settings.CLICKHOUSE_DATABASE,
             dictionary_name=inputs.dictionary_name,
-            user=inputs.clickhouse.username,
-            password=inputs.clickhouse.password,
-            cluster_name=inputs.clickhouse.cluster,
+            user=settings.CLICKHOUSE_USER,
+            password=settings.CLICKHOUSE_PASSWORD,
+            cluster_name=settings.CLICKHOUSE_CLUSTER,
         )
     )
 
@@ -345,9 +300,11 @@ async def prepare_dictionary(inputs: QueryInputs) -> str:
 @activity.defn
 async def drop_dictionary(inputs: QueryInputs) -> None:
     """DROP the DICTIONARY used in the squash workflow."""
-    activity.logger.info("Dropping DICTIONARY %s.%s", inputs.clickhouse.database, inputs.dictionary_name)
+    from django.conf import settings
+
+    activity.logger.info("Dropping DICTIONARY %s.%s", settings.CLICKHOUSE_DATABASE, inputs.dictionary_name)
     sync_execute(
-        DROP_DICTIONARY_QUERY.format(database=inputs.clickhouse.database, dictionary_name=inputs.dictionary_name)
+        DROP_DICTIONARY_QUERY.format(database=settings.CLICKHOUSE_DATABASE, dictionary_name=inputs.dictionary_name)
     )
 
 
@@ -367,9 +324,11 @@ async def select_persons_to_delete(inputs: QueryInputs) -> list[SerializablePers
     The output of this activity is a dictionary that maps integer team_ids to sets of
     person ids that are safe to delete. Team_id is used as a filter in later queries.
     """
+    from django.conf import settings
+
     latest_merged_at = inputs.latest_merged_at.timestamp() if inputs.latest_merged_at else inputs.latest_merged_at
     to_delete_rows = sync_execute(
-        SELECT_PERSONS_TO_DELETE_QUERY.format(database=inputs.clickhouse.database),
+        SELECT_PERSONS_TO_DELETE_QUERY.format(database=settings.CLICKHOUSE_DATABASE),
         # We pass this as a timestamp ourselves as clickhouse-driver will drop any microseconds from the datetime.
         # This would cause the latest merge event to be ignored.
         # See: https://github.com/mymarilyn/clickhouse-driver/issues/306
@@ -392,7 +351,7 @@ async def select_persons_to_delete(inputs: QueryInputs) -> list[SerializablePers
 
         try:
             absolute_oldest_event_at = sync_execute(
-                SELECT_CREATED_AT_FOR_PERSON_EVENT_QUERY.format(database=inputs.clickhouse.database),
+                SELECT_CREATED_AT_FOR_PERSON_EVENT_QUERY.format(database=settings.CLICKHOUSE_DATABASE),
                 {
                     "team_id": person_to_delete.team_id,
                     "old_person_id": person_to_delete.old_person_id,
@@ -449,8 +408,10 @@ async def squash_events_partition(inputs: QueryInputs) -> None:
     3. Perform ALTER TABLE UPDATE using dictGet to query the DICTIONARY.
     4. Clean up the DICTIONARY once done.
     """
+    from django.conf import settings
+
     query = SQUASH_EVENTS_QUERY.format(
-        database=inputs.clickhouse.database,
+        database=settings.CLICKHOUSE_DATABASE,
         dictionary_name=inputs.dictionary_name,
         team_id_filter="AND team_id in %(team_ids)s" if inputs.team_ids else "",
     )
@@ -480,12 +441,14 @@ async def squash_events_partition(inputs: QueryInputs) -> None:
 @activity.defn
 async def delete_squashed_person_overrides_from_clickhouse(inputs: QueryInputs) -> None:
     """Execute the query to delete persons from ClickHouse that have been squashed."""
+    from django.conf import settings
+
     activity.logger.info("Deleting squashed persons from ClickHouse")
 
     old_person_ids_to_delete = tuple(person.old_person_id for person in inputs.iter_person_overides_to_delete())
     activity.logger.debug("%s", old_person_ids_to_delete)
 
-    query = DELETE_SQUASHED_PERSON_OVERRIDES_QUERY.format(database=inputs.clickhouse.database)
+    query = DELETE_SQUASHED_PERSON_OVERRIDES_QUERY.format(database=settings.CLICKHOUSE_DATABASE)
     latest_merged_at = inputs.latest_merged_at.timestamp() if inputs.latest_merged_at else inputs.latest_merged_at
     parameters = {
         "old_person_ids": old_person_ids_to_delete,
@@ -510,9 +473,17 @@ async def delete_squashed_person_overrides_from_postgres(inputs: QueryInputs) ->
     We cannot use the Django ORM in an async context without enabling unsafe behavior.
     This may be a good excuse to unshackle ourselves from the ORM.
     """
-    activity.logger.info("Deleting squashed persons from Postgres")
+    from django.conf import settings
 
-    with psycopg2.connect(inputs.postgres.database_url) as connection:
+    activity.logger.info("Deleting squashed persons from Postgres")
+    with psycopg2.connect(
+        dbname=settings.DATABASES["default"]["NAME"],
+        user=settings.DATABASES["default"]["USER"],
+        password=settings.DATABASES["default"]["PASSWORD"],
+        host=settings.DATABASES["default"]["HOST"],
+        port=settings.DATABASES["default"]["PORT"],
+        **settings.DATABASES["default"].get("SSL_OPTIONS", {}),
+    ) as connection:
         with connection.cursor() as cursor:
             for person_override_to_delete in inputs.iter_person_overides_to_delete():
                 activity.logger.debug("%s", person_override_to_delete)
@@ -756,15 +727,11 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
     @workflow.run
     async def run(self, inputs: SquashPersonOverridesInputs):
         """Workflow implementation to squash person overrides into events table."""
-        from django.conf import settings
-
         workflow.logger.info("Starting squash workflow")
         workflow.logger.debug("%s", json.dumps(asdict(inputs)))
 
         retry_policy = RetryPolicy(maximum_attempts=3)
         query_inputs = QueryInputs(
-            clickhouse=ClickHouseConnectionInputs.from_posthog_settings(settings),
-            postgres=PostgresConnectionInputs.from_posthog_settings(settings),
             dictionary_name=inputs.dictionary_name,
             team_ids=inputs.team_ids,
             dry_run=inputs.dry_run,
@@ -775,7 +742,7 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
             query_inputs,
             # Let's be kinder to ClickHouse when running ON CLUSTER queries.
             # We use a higher initial_interval for retries so that we let ClickHouse finish up.
-            retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=timedelta(10)),
+            retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=timedelta(seconds=10)),
         ) as latest_merged_at:
             query_inputs._latest_merged_at = latest_merged_at
             query_inputs.partition_ids = list(inputs.iter_partition_ids())

--- a/posthog/temporal/workflows/squash_person_overrides.py
+++ b/posthog/temporal/workflows/squash_person_overrides.py
@@ -420,7 +420,7 @@ async def squash_events_partition(inputs: QueryInputs) -> None:
 
         if inputs.dry_run is True:
             activity.logger.info("This is a DRY RUN so nothing will be squashed.")
-            activity.logger.info("Would have run query: %s", query)
+            activity.logger.info("Would have run query: %s with parameters %s", query, parameters)
             continue
 
         sync_execute(
@@ -455,7 +455,7 @@ async def delete_squashed_person_overrides_from_clickhouse(inputs: QueryInputs) 
 
     if inputs.dry_run is True:
         activity.logger.info("This is a DRY RUN so nothing will be deleted.")
-        activity.logger.info("Would have run query: %s", query)
+        activity.logger.info("Would have run query: %s with parameters %s", query, parameters)
         return
 
     sync_execute(query.format(database=settings.CLICKHOUSE_DATABASE), parameters)
@@ -519,7 +519,9 @@ async def delete_squashed_person_overrides_from_postgres(inputs: QueryInputs) ->
 
                 if inputs.dry_run is True:
                     activity.logger.info("This is a DRY RUN so nothing will be deleted.")
-                    activity.logger.info("Would have run query: %s", DELETE_FROM_PERSON_OVERRIDES)
+                    activity.logger.info(
+                        "Would have run query: %s with parameters %s", DELETE_FROM_PERSON_OVERRIDES, parameters
+                    )
                     continue
 
                 cursor.execute(DELETE_FROM_PERSON_OVERRIDES, parameters)


### PR DESCRIPTION
## Problem

I spotted an error while re-attaching the ClickHouse `person_overrides_mv`:
* The first time we attempt to re-attach we fail as the table is still in use by some query.
* The second and third attempts fail as the table has already been re-attached

Ultimately, not a problem as the table is ultimately re-attached; this is likely a bit of a race condition.

Moreover, we also noticed Temporal logs everything passed as an input and returned as a result. For this reason, we should omit database connection details.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

In order to be nicer to ClickHouse, I opened this PR to:

* Drop the dictionary before re-attaching table. This way, any queries running on the dict should be waited on before dropping it (as we are not dropping with `SYNC`)
* Run the re-attach with `IF NOT EXISTS`. Just in case we manage to re-attach, we do not fail on a retry.
* Bumped the time between retries to let ClickHouse do its thing.

To address credentials being logged:
* We now import the settings at runtime from the Django module instead of using inputs.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
