### PR TITLE
fix: show experimentation properly in plan comparisons

### DIFF
--- a/frontend/src/scenes/billing/test/PlanComparisonModal.tsx
+++ b/frontend/src/scenes/billing/test/PlanComparisonModal.tsx
@@ -312,7 +312,10 @@ export const PlanComparisonModal = ({
                                                     </th>
                                                 </tr>
                                                 {includedProduct.plans
-                                                    .find((plan) => plan.included_if == 'has_subscription')
+                                                    .find(
+                                                        (plan: BillingV2PlanType) =>
+                                                            plan.included_if == 'has_subscription'
+                                                    )
                                                     ?.features?.map((feature, i) => (
                                                         <tr key={`tr-${feature.key}`}>
                                                             <th
@@ -333,15 +336,29 @@ export const PlanComparisonModal = ({
                                                                 </Tooltip>
                                                             </th>
                                                             {includedProduct.plans?.map((plan) => (
-                                                                <td key={`${plan.plan_key}-${feature.key}`}>
-                                                                    <PlanIcon
-                                                                        feature={plan.features?.find(
-                                                                            (thisPlanFeature) =>
-                                                                                feature.key === thisPlanFeature.key
-                                                                        )}
-                                                                        className={'text-base'}
-                                                                    />
-                                                                </td>
+                                                                <React.Fragment key={`${plan.plan_key}-${feature.key}`}>
+                                                                    {/* Some products don't have a free plan, so we need to pretend there is one 
+                                                                        so the features line up in the correct columns in the UI. This is kind of 
+                                                                        hacky because it assumes we only have 2 plans total, but it works for now.
+                                                                    */}
+                                                                    {includedProduct.plans?.length === 1 && (
+                                                                        <td>
+                                                                            <PlanIcon
+                                                                                feature={undefined}
+                                                                                className={'text-base'}
+                                                                            />
+                                                                        </td>
+                                                                    )}
+                                                                    <td>
+                                                                        <PlanIcon
+                                                                            feature={plan.features?.find(
+                                                                                (thisPlanFeature) =>
+                                                                                    feature.key === thisPlanFeature.key
+                                                                            )}
+                                                                            className={'text-base'}
+                                                                        />
+                                                                    </td>
+                                                                </React.Fragment>
                                                             ))}
                                                         </tr>
                                                     ))}


### PR DESCRIPTION
## Problem

If a product only has one plan (there is only a paid plan, not a free plan) like experimentation, it wasn't showing up in the UI. https://github.com/PostHog/billing/pull/238 fixes the data, but this pull is required to fix the UI. Since there is only one plan it wasn't properly lining up in the columns. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

We assume that there are two types of plan for any product - a "free" one and a "paid" one. If it's an `inclusion_only` product, one plan type can be `included_if == has_subscription` and the other type can be `included_if == no_active_subscription` which is essentially a free tier. Because there are only two values here I made the code assume that there are simply two plans here - one of each type. It now looks for a plan of each type, and if it does't find one (eg there is no free tier for experimentation) then it just says the features don't exist on that plan.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/PostHog/posthog/assets/18598166/0778e0dc-d9c2-468a-9c43-5e37c5757c82)  | ![image](https://github.com/PostHog/posthog/assets/18598166/3c23ec86-423c-4d44-a705-9d83f700f24e)  |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just visually. I don't like this solution but to make it a tiny it more future-proof I added a comment explaining the decision here so it doesn't get lost in the PR abyss forever.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
