### PR TITLE
feat(hogql): add to dashboard filters

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -150,6 +150,7 @@ function DashboardScene(): JSX.Element {
                                         ...groupsTaxonomicTypes,
                                         TaxonomicFilterGroupType.Cohorts,
                                         TaxonomicFilterGroupType.Elements,
+                                        TaxonomicFilterGroupType.HogQLExpression,
                                     ]}
                                 />
                             </div>


### PR DESCRIPTION
## Problem

Users would like to filter by SQL also on the dashboard.

## Changes

Adds the missing HogQL filter:

<img width="1124" alt="image" src="https://github.com/PostHog/posthog/assets/53387/a8fcd5e4-ccc6-4e4d-ab7e-caa0ee261a15">

## How did you test this code?

In the browser. Adding the filter changed the results of the graphs.