### PR TITLE
fix(dashboard): override compare when date range is set to all time

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -157,8 +157,9 @@ function DashboardScene(): JSX.Element {
                         {placement !== DashboardPlacement.Export && (
                             <div className="flex space-x-4 dashoard-items-actions">
                                 <div
-                                    className="left-item"
-                                    style={placement === DashboardPlacement.Public ? { textAlign: 'right' } : undefined}
+                                    className={`left-item ${
+                                        placement === DashboardPlacement.Public ? 'text-right' : ''
+                                    }`}
                                 >
                                     {[DashboardPlacement.Public].includes(placement) ? (
                                         <LastRefreshText />

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -118,6 +118,9 @@ class Insight(models.Model):
             if dashboard_date_to or insight_date_to:
                 filters["date_to"] = dashboard_date_to or insight_date_to
 
+            if dashboard_date_from == "all" and filters["compare"] == True:
+                filters["compare"] = None
+
             if dashboard_properties:
                 if isinstance(self.filters.get("properties"), list):
                     filters["properties"] = {

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -118,7 +118,7 @@ class Insight(models.Model):
             if dashboard_date_to or insight_date_to:
                 filters["date_to"] = dashboard_date_to or insight_date_to
 
-            if dashboard_date_from == "all" and filters["compare"] == True:
+            if dashboard_date_from == "all" and filters["compare"] is True:
                 filters["compare"] = None
 
             if dashboard_properties:

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -52,6 +52,14 @@ class TestInsightModel(BaseTest):
 
         assert filters_with_dashboard_with_same_date_from["date_from"] == "-30d"
 
+    def test_dashboard_with_date_from_all_overrides_compare(self) -> None:
+        insight = Insight.objects.create(team=self.team, filters={"date_from": "-30d", "compare": True})
+        dashboard = Dashboard.objects.create(team=self.team, filters={"date_from": "all"})
+
+        filters = insight.dashboard_filters(dashboard=dashboard)
+
+        assert filters["compare"] == None
+
     def test_dashboard_does_not_affect_filters_hash_with_absent_date_from(self) -> None:
         insight = Insight.objects.create(team=self.team, filters={"date_from": "-30d"})
         dashboard = Dashboard.objects.create(team=self.team, filters={})

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -58,7 +58,7 @@ class TestInsightModel(BaseTest):
 
         filters = insight.dashboard_filters(dashboard=dashboard)
 
-        assert filters["compare"] == None
+        assert filters["compare"] is None
 
     def test_dashboard_does_not_affect_filters_hash_with_absent_date_from(self) -> None:
         insight = Insight.objects.create(team=self.team, filters={"date_from": "-30d"})


### PR DESCRIPTION
## Problem

When a dashboard contains an insight with the compare against previous option set and is queried for the all time date range, this would result in an error "You need date_from and date_to to compare".

<img width="1151" alt="Screenshot 2023-05-16 at 12 10 40" src="https://github.com/PostHog/posthog/assets/1851359/c092d829-b81f-4b63-9ac4-2cc7784ddeb4">

This is a regression from data exploration, as previously we would handle this case in the cleanFilters function:

https://github.com/PostHog/posthog/blob/b7c21429bcfbcb55a320cb48865b5626187b4304/frontend/src/scenes/insights/utils/cleanFilters.ts#L314-L316

## Changes

This PR overrides the compare option when a dashboard set the date_from filter to all. I thought this is cleaner than introducing a cleanFilters function for data exploration.

## How did you test this code?

Added tests and verfied with an example