### PR TITLE
feat: how we pick recordings for billings

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, List
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 from uuid import uuid4
@@ -195,6 +196,32 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                         team_id=self.org_1_team_2.id,
                     )
 
+            # ensure there is a recording that starts before the period and ends during the period
+            # report is going to be for "yesterday" relative to the test so...
+            start_of_day = datetime.combine(now().date(), datetime.min.time()) - relativedelta(days=1)
+            session_that_will_not_match = "session-that-will-not-match-because-it-starts-before-the-period"
+            create_snapshot(
+                has_full_snapshot=True,
+                distinct_id=distinct_id,
+                session_id=session_that_will_not_match,
+                timestamp=start_of_day - relativedelta(hours=1),
+                team_id=self.org_1_team_2.id,
+            )
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id=distinct_id,
+                session_id=session_that_will_not_match,
+                timestamp=start_of_day,
+                team_id=self.org_1_team_2.id,
+            )
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id=distinct_id,
+                session_id=session_that_will_not_match,
+                timestamp=start_of_day + relativedelta(hours=1),
+                team_id=self.org_1_team_2.id,
+            )
+
             # Events for org 2 team 3
             distinct_id = str(uuid4())
             _create_person(distinct_ids=[distinct_id], team=self.org_2_team_3)
@@ -259,7 +286,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "event_count_in_month": 32,
                     "event_count_with_groups_in_period": 2,
                     "recording_count_in_period": 5,
-                    "recording_count_total": 15,
+                    "recording_count_total": 16,
                     "group_types_total": 2,
                     "dashboard_count": 2,
                     "dashboard_template_count": 0,
@@ -295,7 +322,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "event_count_in_month": 10,
                             "event_count_with_groups_in_period": 0,
                             "recording_count_in_period": 5,
-                            "recording_count_total": 15,
+                            "recording_count_total": 16,
                             "group_types_total": 0,
                             "dashboard_count": 0,
                             "dashboard_template_count": 0,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -365,7 +365,7 @@ def get_teams_with_recording_count_in_period(begin: datetime, end: datetime) -> 
             -- begin is the very first instant of the period we are interested in
             -- we assume it is also the very first instant of a day
             -- so we can to subtract 1 second to get the day before
-            WHERE toDate(first_event_timestamp) = toDate(toDateTime(%(begin)s) - INTERVAL 1 SECOND)
+            WHERE toDate(first_event_timestamp) = toDate(%(begin)s) - INTERVAL 1 DAY
             GROUP BY session_id
         )
         GROUP BY team_id

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -356,7 +356,18 @@ def get_teams_with_recording_count_in_period(begin: datetime, end: datetime) -> 
         """
         SELECT team_id, count(distinct session_id) as count
         FROM session_recording_events
-        WHERE timestamp between %(begin)s AND %(end)s
+        WHERE first_event_timestamp BETWEEN %(begin)s AND %(end)s
+        AND session_id NOT IN (
+            -- we want to exclude sessions that might have events with timestamps
+            -- before the period we are interested in
+            SELECT DISTINCT session_id
+            FROM session_recording_events
+            -- begin is the very first instant of the period we are interested in
+            -- we assume it is also the very first instant of a day
+            -- so we can to subtract 1 second to get the day before
+            WHERE toDate(first_event_timestamp) = toDate(toDateTime(%(begin)s) - INTERVAL 1 SECOND)
+            GROUP BY session_id
+        )
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -175,13 +175,13 @@ def get_current_day(at: Optional[datetime.datetime] = None) -> Tuple[datetime.da
         at,
         datetime.time.max,
         tzinfo=pytz.UTC,
-    )  # very end of the previous day
+    )  # very end of the reference day
 
     period_start: datetime.datetime = datetime.datetime.combine(
         period_end,
         datetime.time.min,
         tzinfo=pytz.UTC,
-    )  # very start of the previous day
+    )  # very start of the reference day
 
     return (period_start, period_end)
 


### PR DESCRIPTION
## Problem

We want to ensure we don't count recordings being in two days.

They are already limited to less than 24 hours. 

## Changes

For a given day count only recordings which have a timestamp on that day _and_ don't have a timestamp on the previous day

## How did you test this code?

* added a developer test
* checked prod data
