### PR TITLE
feat: remove summary config guard

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -120,8 +120,6 @@ export function getDefaultConfig(): PluginsServerConfig {
             ? 1024 // NOTE: ~1MB in dev or test, so that even with gzipped content we still flush pretty frequently
             : 1024 * 50, // ~50MB after compression in prod
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
-
-        SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS: '', // TODO: Change this to 'all' when we release it fully
     }
 }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -32,14 +32,12 @@ export const startSessionRecordingEventsConsumer = async ({
     consumerMaxBytes,
     consumerMaxBytesPerPartition,
     consumerMaxWaitMs,
-    summaryIngestionEnabledTeams,
 }: {
     teamManager: TeamManager
     kafkaConfig: KafkaConfig
     consumerMaxBytes: number
     consumerMaxBytesPerPartition: number
     consumerMaxWaitMs: number
-    summaryIngestionEnabledTeams: string
 }) => {
     /*
         For Session Recordings we need to prepare the data for ClickHouse.
@@ -72,8 +70,6 @@ export const startSessionRecordingEventsConsumer = async ({
     const eachBatchWithContext = eachBatch({
         teamManager,
         producer,
-        summaryEnabledTeams:
-            summaryIngestionEnabledTeams === 'all' ? null : summaryIngestionEnabledTeams.split(',').map(parseInt),
     })
 
     // Create a node-rdkafka consumer that fetches batches of messages, runs
@@ -99,15 +95,7 @@ export const startSessionRecordingEventsConsumer = async ({
 }
 
 export const eachBatch =
-    ({
-        teamManager,
-        producer,
-        summaryEnabledTeams,
-    }: {
-        teamManager: TeamManager
-        producer: RdKafkaProducer
-        summaryEnabledTeams: number[] | null
-    }) =>
+    ({ teamManager, producer }: { teamManager: TeamManager; producer: RdKafkaProducer }) =>
     async (messages: Message[]) => {
         // To start with, we simply process each message in turn,
         // without attempting to perform any concurrency. There is a lot
@@ -128,7 +116,7 @@ export const eachBatch =
         // DependencyUnavailableError error to distinguish between
         // intermittent and permanent errors.
         const pendingProduceRequests: Promise<NumberNullUndefined>[] = []
-        const eachMessageWithContext = eachMessage({ teamManager, producer, summaryEnabledTeams })
+        const eachMessageWithContext = eachMessage({ teamManager, producer })
 
         for (const message of messages) {
             const results = await retryOnDependencyUnavailableError(() => eachMessageWithContext(message))
@@ -171,15 +159,7 @@ export const eachBatch =
     }
 
 const eachMessage =
-    ({
-        teamManager,
-        producer,
-        summaryEnabledTeams,
-    }: {
-        teamManager: TeamManager
-        producer: RdKafkaProducer
-        summaryEnabledTeams: number[] | null
-    }) =>
+    ({ teamManager, producer }: { teamManager: TeamManager; producer: RdKafkaProducer }) =>
     async (message: Message) => {
         // For each message, we:
         //
@@ -285,18 +265,29 @@ const eachMessage =
 
                     let replayRecord: null | SummarizedSessionRecordingEvent = null
                     try {
-                        if (summaryEnabledTeams === null || summaryEnabledTeams?.includes(team.id)) {
-                            replayRecord = createSessionReplayEvent(
-                                messagePayload.uuid,
-                                team.id,
-                                messagePayload.distinct_id,
-                                event.ip,
-                                event.properties || {}
-                            )
-                        }
+                        replayRecord = createSessionReplayEvent(
+                            messagePayload.uuid,
+                            team.id,
+                            messagePayload.distinct_id,
+                            event.ip,
+                            event.properties || {}
+                        )
                     } catch (e) {
                         status.warn('??', 'session_replay_summarizer_error', { error: e })
-                        captureException(e)
+                        captureException(e, {
+                            extra: {
+                                clickHouseRecord: {
+                                    uuid: clickHouseRecord.uuid,
+                                    timestamp: clickHouseRecord.timestamp,
+                                    snapshot_data: clickHouseRecord.snapshot_data,
+                                },
+                                replayRecord,
+                            },
+                            tags: {
+                                team: team.id,
+                                session_id: clickHouseRecord.session_id,
+                            },
+                        })
                     }
 
                     const producePromises = [

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -367,7 +367,6 @@ export async function startPluginsServer(
                 consumerMaxBytes: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES,
                 consumerMaxBytesPerPartition: serverConfig.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
                 consumerMaxWaitMs: serverConfig.KAFKA_CONSUMPTION_MAX_WAIT_MS,
-                summaryIngestionEnabledTeams: serverConfig.SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS,
             })
             stopSessionRecordingEventsConsumer = stop
             joinSessionRecordingEventsConsumer = join

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -188,8 +188,6 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number
     SESSION_RECORDING_REMOTE_FOLDER: string
-
-    SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS: string
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -311,7 +311,8 @@ export const createSessionReplayEvent = (
             session_id: properties['$session_id'],
             properties: properties,
         })
-        return null
+        // it is safe to throw here as it caught a level up so that we can see this happening in Sentry
+        throw new Error('ignoring an empty session recording event')
     }
 
     let clickCount = 0

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1325,39 +1325,39 @@ sessionReplayEventTestCases.forEach(({ snapshotData, expected }) => {
 })
 
 test(`snapshot event with no event summary is ignored`, () => {
-    const data = createSessionReplayEvent('some-id', team.id, '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4', '', {
-        $session_id: 'abcf-efg',
-        $snapshot_data: {},
-    } as any as Properties)
-
-    expect(data).toEqual(null)
+    expect(() => {
+        createSessionReplayEvent('some-id', team.id, '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4', '', {
+            $session_id: 'abcf-efg',
+            $snapshot_data: {},
+        } as any as Properties)
+    }).toThrowError()
 })
 
 test(`snapshot event with no event summary timestamps is ignored`, () => {
-    const data = createSessionReplayEvent('some-id', team.id, '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4', '', {
-        $session_id: 'abcf-efg',
-        $snapshot_data: {
-            events_summary: [
-                {
-                    type: 5,
-                    data: {
-                        payload: {
-                            // doesn't match because href is nested in payload
-                            href: 'http://127.0.0.1:8000/home',
+    expect(() => {
+        createSessionReplayEvent('some-id', team.id, '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4', '', {
+            $session_id: 'abcf-efg',
+            $snapshot_data: {
+                events_summary: [
+                    {
+                        type: 5,
+                        data: {
+                            payload: {
+                                // doesn't match because href is nested in payload
+                                href: 'http://127.0.0.1:8000/home',
+                            },
                         },
                     },
-                },
-                {
-                    type: 4,
-                    data: {
-                        href: 'http://127.0.0.1:8000/second/url',
+                    {
+                        type: 4,
+                        data: {
+                            href: 'http://127.0.0.1:8000/second/url',
+                        },
                     },
-                },
-            ],
-        },
-    } as any as Properties)
-
-    expect(data).toEqual(null)
+                ],
+            },
+        } as any as Properties)
+    }).toThrowError()
 })
 
 test('performance event stored as performance_event', () => {


### PR DESCRIPTION
## Problem

We are (apparently) not producing as many session replay events as session recording events

## Changes

* removes the config guard from session replay in ingestion since it is on for all
* makes skipping an "empty" session replay an error so that we see it in Sentry

## How did you test this code?

opening this PR to see if the tests fail