### PR TITLE
chore: less but more useful offset manager logging

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
@@ -135,7 +135,7 @@ export class OffsetManager {
             partition,
         }
 
-        if (offsetToCommit) {
+        if (offsetToCommit !== undefined) {
             this.consumer.commit({
                 topic,
                 partition,


### PR DESCRIPTION
## Problem

The offset manager logs some large lists of numbers. They're not super useful. If the ingester gets stuck the lists get very long which makes them _way_ less useful

![2023-05-16 18 20 12](https://github.com/PostHog/posthog/assets/984817/0f4ee51e-2f21-48c8-b4bc-e770efef8d93)

## Changes

* reduces the amount of logging
* for each flush to s3 we get a single log message
* it summarises the offsets and whether anything was committed to the kafka partition
* make it so it is possible to commit offset === 0

## How did you test this code?

🙈
