### PR TITLE
feat: bump clickhouse version to 23.4 for really exciting features

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -236,7 +236,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.10.10']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:22.8']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:23.4']
                 segment: ['FOSS', 'EE']
                 person-on-events: [false, true]
                 # :NOTE: Keep concurrency and groups in sync

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -236,7 +236,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.10.10']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:23.4']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:22.8', 'clickhouse/clickhouse-server:23.4']
                 segment: ['FOSS', 'EE']
                 person-on-events: [false, true]
                 # :NOTE: Keep concurrency and groups in sync

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -24,7 +24,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:22.8}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.4}
         restart: on-failure
         depends_on:
             - kafka

--- a/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
@@ -60,7 +60,7 @@ def query_events() -> List[Dict]:
         FROM events
         ORDER BY distinct_id
         """,
-        {"format": "%Y-%m-%dT%H:%M:%SZ"},
+        {"format": "%Y-%m-%dT%H:%i:%sZ"},
     )
 
 
@@ -502,7 +502,6 @@ class Test0007PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         MIGRATION_DEFINITION._check_person_data()  # type: ignore
 
     def test_check_person_data_failure(self):
-
         for i in range(100):
             _uuid = UUIDT()
 
@@ -559,7 +558,6 @@ class Test0007PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
             MIGRATION_DEFINITION._check_person_data()  # type: ignore
 
     def test_check_groups_data_success(self):
-
         # don't run the backfill so we can test the postcheck based only on the data we create
         old_fn = MIGRATION_DEFINITION.operations[-4].fn
         MIGRATION_DEFINITION.operations[-4].fn = lambda *args: None

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -228,7 +228,7 @@
       distinct_id VARCHAR,
       person_id UUID,
       is_deleted Int8,
-      version Int64 DEFAULT 1
+      version Int64
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')
   
@@ -809,7 +809,7 @@
       distinct_id VARCHAR,
       person_id UUID,
       is_deleted Int8,
-      version Int64 DEFAULT 1
+      version Int64
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')
   
@@ -1025,7 +1025,7 @@
       distinct_id VARCHAR,
       person_id UUID,
       is_deleted Int8,
-      version Int64 DEFAULT 1
+      version Int64
       
       
   , _timestamp DateTime
@@ -1829,7 +1829,7 @@
       distinct_id VARCHAR,
       person_id UUID,
       is_deleted Int8,
-      version Int64 DEFAULT 1
+      version Int64
       
       
   , _timestamp DateTime

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -212,7 +212,7 @@
       team_id Int64,
       properties VARCHAR,
       is_identified Int8,
-      is_deleted Int8 DEFAULT 0,
+      is_deleted Int8,
       version UInt64
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_person_test', 'group1', 'JSONEachRow')
@@ -793,7 +793,7 @@
       team_id Int64,
       properties VARCHAR,
       is_identified Int8,
-      is_deleted Int8 DEFAULT 0,
+      is_deleted Int8,
       version UInt64
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_person_test', 'group1', 'JSONEachRow')
@@ -1001,7 +1001,7 @@
       team_id Int64,
       properties VARCHAR,
       is_identified Int8,
-      is_deleted Int8 DEFAULT 0,
+      is_deleted Int8,
       version UInt64
       
       
@@ -1805,7 +1805,7 @@
       team_id Int64,
       properties VARCHAR,
       is_identified Int8,
-      is_deleted Int8 DEFAULT 0,
+      is_deleted Int8,
       version UInt64
       
       

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     team_id Int64,
     properties VARCHAR,
     is_identified Int8,
-    is_deleted Int8 DEFAULT 0,
+    is_deleted Int8,
     version UInt64
     {extra_fields}
 ) ENGINE = {engine}

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -170,7 +170,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     distinct_id VARCHAR,
     person_id UUID,
     is_deleted Int8,
-    version Int64 DEFAULT 1
+    version Int64
     {extra_fields}
 ) ENGINE = {engine}
 """


### PR DESCRIPTION
## Problem

There are several improvements in new versions of CH. The feature that is pushing this right now is better backup functionality.

https://clickhouse.com/docs/en/operations/backup

There are also improvements around soft deleting and performance improvements. Let's get this in and make sure test continue to work

## Changes

bump clickhouse version to 23.4

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
