### PR TITLE
chore(ingestion): dont wait on logs to be persisted to Kafka

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1275,7 +1275,15 @@ export class DB {
         })
 
         try {
-            await this.kafkaProducer.queueSingleJsonMessage(KAFKA_PLUGIN_LOG_ENTRIES, parsedEntry.id, parsedEntry)
+            await this.kafkaProducer.queueSingleJsonMessage(
+                KAFKA_PLUGIN_LOG_ENTRIES,
+                parsedEntry.id,
+                parsedEntry,
+                // For logs, we relax our durability requirements a little and
+                // do not wait for acks that Kafka has persisted the message to
+                // disk.
+                false
+            )
         } catch (e) {
             captureException(e)
             console.error('Failed to produce message', e, parsedEntry)

--- a/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
@@ -67,7 +67,7 @@ describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
     })
 
     afterEach(() => {
-        jest.runAllTimers()
+        jest.clearAllTimers()
         jest.useRealTimers()
         jest.clearAllMocks()
     })

--- a/plugin-server/tests/worker/console.test.ts
+++ b/plugin-server/tests/worker/console.test.ts
@@ -55,7 +55,8 @@ describe('console extension', () => {
                             timestamp: expect.any(String),
                             message: expectedFinalMessage,
                             instance_id: hub.instanceId.toString(),
-                        }
+                        },
+                        false
                     )
                 })
             })

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -691,17 +691,22 @@ describe('vm tests', () => {
         await vm.methods.processEvent!(event)
 
         expect(queueSingleJsonMessageSpy).toHaveBeenCalledTimes(1)
-        expect(queueSingleJsonMessageSpy).toHaveBeenCalledWith(KAFKA_PLUGIN_LOG_ENTRIES, expect.any(String), {
-            id: expect.any(String),
-            instance_id: hub.instanceId.toString(),
-            message: 'logged event',
-            plugin_config_id: pluginConfig39.id,
-            plugin_id: pluginConfig39.plugin_id,
-            source: PluginLogEntrySource.Console,
-            team_id: pluginConfig39.team_id,
-            timestamp: expect.any(String),
-            type: PluginLogEntryType.Log,
-        })
+        expect(queueSingleJsonMessageSpy).toHaveBeenCalledWith(
+            KAFKA_PLUGIN_LOG_ENTRIES,
+            expect.any(String),
+            {
+                id: expect.any(String),
+                instance_id: hub.instanceId.toString(),
+                message: 'logged event',
+                plugin_config_id: pluginConfig39.id,
+                plugin_id: pluginConfig39.plugin_id,
+                source: PluginLogEntrySource.Console,
+                team_id: pluginConfig39.team_id,
+                timestamp: expect.any(String),
+                type: PluginLogEntryType.Log,
+            },
+            false
+        )
     })
 
     test('fetch', async () => {


### PR DESCRIPTION
With how bad concurrency is atm re. batching, we end up waiting a long time on logs to be persisted to Kafka. We don't need to guarantee logs so instead we let these be async. We still want to await for the message to have been handled by librdkafka queuing internals though so we still await but ask that we resolve as soon as we've handed off the message to librdkafka.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
