### PR TITLE
fix: ensure that offsets are sorted

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
@@ -60,8 +60,10 @@ export class OffsetManager {
             this.offsetsByPartitionTopic.set(key, [])
         }
 
-        // TODO: We should parseInt when we handle the message
-        this.offsetsByPartitionTopic.get(key)?.push(offset)
+        const current = this.offsetsByPartitionTopic.get(key) || []
+        current.push(offset)
+        current.sort((a, b) => a - b)
+        this.offsetsByPartitionTopic.set(key, current)
     }
 
     /**

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
@@ -18,16 +18,21 @@ describe('offset-manager', () => {
     it('collects new offsets', () => {
         offsetManager.addOffset(TOPIC, 1, 1)
         offsetManager.addOffset(TOPIC, 2, 1)
-        offsetManager.addOffset(TOPIC, 3, 4)
         offsetManager.addOffset(TOPIC, 1, 2)
+        offsetManager.addOffset(TOPIC, 3, 4)
         offsetManager.addOffset(TOPIC, 1, 5)
         offsetManager.addOffset(TOPIC, 3, 4)
+        // even if the offsets arrive out of order
+        offsetManager.addOffset(TOPIC, 3, 7)
+        offsetManager.addOffset(TOPIC, 3, 6)
+        offsetManager.addOffset(TOPIC, 3, 8)
+        offsetManager.addOffset(TOPIC, 3, 0)
 
         expect(offsetManager.offsetsByPartitionTopic).toEqual(
             new Map([
                 ['test-session-recordings-1', [1, 2, 5]],
                 ['test-session-recordings-2', [1]],
-                ['test-session-recordings-3', [4, 4]],
+                ['test-session-recordings-3', [0, 4, 4, 6, 7, 8]],
             ])
         )
     })


### PR DESCRIPTION
## Problem

Sometimes we see blob ingestion session managers try to remove and potentially commit offsets that are lower than the offset being tracked for that partition

## Changes

sort the offsets whenever we add one

## How did you test this code?

developer test