### PR TITLE
chore: capture info on what was flushed to s3

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -194,7 +194,12 @@ export class SessionManager {
             fileStream.close()
 
             counterS3FilesWritten.inc(1)
-            status.info('🚽', `blob_ingester_session_manager Flushed buffer`, { sessionId: this.sessionId })
+            status.info('🚽', `blob_ingester_session_manager - flushed buffer to S3`, {
+                sessionId: this.sessionId,
+                flushedSize: this.flushBuffer.size,
+                flushedAge: this.flushBuffer.oldestKafkaTimestamp,
+                flushedCount: this.flushBuffer.count,
+            })
         } catch (error) {
             // TODO: If we fail to write to S3 we should be do something about it
             status.error('🧨', 'blob_ingester_session_manager failed writing session recording blob to S3', {


### PR DESCRIPTION
## Problem

Loki isn't coping with range searches with few filters over blob ingestion logs

## Changes

Let's add something specific to search for

## How did you test this code?

🙈 