### PR TITLE
perf(ingestion): commit offsets once per batch only

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -219,13 +219,8 @@ describe('eachBatchX', () => {
 
             await eachBatchIngestion(batch, queue)
 
-            // Check the breakpoints in the batches matching repeating teamId:distinctId
-            expect(batch.resolveOffset).toBeCalledTimes(6)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(1)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(2)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(7)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(9)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(12)
+            // Offset is commited once per batch only
+            expect(batch.resolveOffset).toBeCalledTimes(1)
             expect(batch.resolveOffset).toHaveBeenCalledWith(13)
 
             expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(


### PR DESCRIPTION
## Problem

To increase processing concurrency, we'll start processing events out of order (within a 500 message batch). 

## Changes

- commit offsets once per read batch, instead of after each processing micro-batch
- try to finish the read batch before exiting, to reduce the risk of duplicates on rollouts. We might need to increase the gracefulTerminationTimout for that

## How did you test this code?

end-to-end + works on my machine 

![image](https://github.com/PostHog/posthog/assets/6241083/0cee6191-47ae-49ee-b51d-7711f1835c06)
