### PR TITLE
refactor: Do not detach kafka tables in Squash Workflow

### DIFF
--- a/posthog/temporal/workflows/__init__.py
+++ b/posthog/temporal/workflows/__init__.py
@@ -7,7 +7,6 @@ WORKFLOWS = [NoOpWorkflow, SquashPersonOverridesWorkflow]
 ACTIVITIES: Sequence[Callable] = [
     noop_activity,
     prepare_person_overrides,
-    re_attach_person_overrides,
     prepare_dictionary,
     select_persons_to_delete,
     squash_events_partition,


### PR DESCRIPTION
## Problem

Squash Workflow is failing when trying to re-attach `person_overrides_mv`. This is due to the underlying Kafka table not existing anymore. As far as I understand, we are moving away from Kafka tables, and dev is the testing ground. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

As we cannot prevent overrides arriving while we are running, we rely on the ClickHouse set `created_at` when selecting overrides and deleting. For clarity, I've renamed `*merged_at*` to `*created_at*`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
