### PR TITLE
fix(early-access): Make truthy matching string insensitive

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -611,7 +611,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:61 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:62 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -754,7 +754,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:63 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:64 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -611,7 +611,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:62 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:61 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -754,7 +754,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:64 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:63 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -14,6 +14,7 @@ interface Props {
 }
 
 export enum FeatureFlagMatchReason {
+    SuperConditionMatch = 'super_condition_value',
     ConditionMatch = 'condition_match',
     NoConditionMatch = 'no_condition_match',
     OutOfRolloutBound = 'out_of_rollout_bound',
@@ -26,6 +27,7 @@ const featureFlagMatchMapping = {
     [FeatureFlagMatchReason.NoConditionMatch]: "Doesn't match any conditions",
     [FeatureFlagMatchReason.OutOfRolloutBound]: 'Out of rollout bound',
     [FeatureFlagMatchReason.NoGroupType]: 'Missing group type',
+    [FeatureFlagMatchReason.SuperConditionMatch]: 'Matches super condition',
     [FeatureFlagMatchReason.Disabled]: 'Disabled',
 }
 

--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -27,7 +27,7 @@ const featureFlagMatchMapping = {
     [FeatureFlagMatchReason.NoConditionMatch]: "Doesn't match any conditions",
     [FeatureFlagMatchReason.OutOfRolloutBound]: 'Out of rollout bound',
     [FeatureFlagMatchReason.NoGroupType]: 'Missing group type',
-    [FeatureFlagMatchReason.SuperConditionMatch]: 'Matches super condition',
+    [FeatureFlagMatchReason.SuperConditionMatch]: 'Matches early access condition',
     [FeatureFlagMatchReason.Disabled]: 'Disabled',
 }
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -100,7 +100,7 @@ def match_property(property: Property, override_property_values: Dict[str, Any])
 
     if operator == "exact":
         parsed_value = property._parse_value(value)
-        if parsed_value in ("true", ["true"], [True], False, [False], "false", ["false"]) or parsed_value is True:
+        if is_truthy_property_value(parsed_value):
             # Do boolean handling, such that passing in "true" or "True" as override value is equivalent
             truthy = parsed_value in (True, [True], "true", ["true"])
             return str(override_value).lower() == str(truthy).lower()
@@ -188,7 +188,7 @@ def empty_or_null_with_value_q(
         value_as_given = Property._parse_value(value)
         value_as_coerced_to_number = Property._parse_value(value, convert_to_number=True)
         # TRICKY: Don't differentiate between 'true' and '"true"' when database matching (one is boolean, other is string)
-        if value_as_given in (False, [True], [False], "true", "false", ["true"], ["false"]) or value_as_given is True:
+        if is_truthy_property_value(value_as_given):
             truthy = value_as_given in (True, [True], "true", ["true"])
             target_filter = lookup_q(f"{column}__{key}", truthy) | lookup_q(f"{column}__{key}", str(truthy).lower())
         elif value_as_given == value_as_coerced_to_number:
@@ -338,3 +338,8 @@ def properties_to_Q(
     return property_group_to_Q(
         PropertyGroup(type=PropertyOperatorType.AND, values=properties), override_property_values, cohorts_cache
     )
+
+
+def is_truthy_property_value(value: Any) -> bool:
+    # Does not resolve 0 and 1 as true, but does resolve the strings as true
+    return value in ("true", ["true"], [True], [False], "false", ["false"]) or value is True or value is False

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -100,7 +100,7 @@ def match_property(property: Property, override_property_values: Dict[str, Any])
 
     if operator == "exact":
         parsed_value = property._parse_value(value)
-        if parsed_value in (True, "true", ["true"], [True], False, [False], "false", ["false"]):
+        if parsed_value in ("true", ["true"], [True], False, [False], "false", ["false"]) or parsed_value is True:
             # Do boolean handling, such that passing in "true" or "True" as override value is equivalent
             truthy = parsed_value in (True, [True], "true", ["true"])
             return str(override_value).lower() == str(truthy).lower()
@@ -188,7 +188,7 @@ def empty_or_null_with_value_q(
         value_as_given = Property._parse_value(value)
         value_as_coerced_to_number = Property._parse_value(value, convert_to_number=True)
         # TRICKY: Don't differentiate between 'true' and '"true"' when database matching (one is boolean, other is string)
-        if value_as_given in (True, False, [True], [False], "true", "false", ["true"], ["false"]):
+        if value_as_given in (False, [True], [False], "true", "false", ["true"], ["false"]) or value_as_given is True:
             truthy = value_as_given in (True, [True], "true", ["true"])
             target_filter = lookup_q(f"{column}__{key}", truthy) | lookup_q(f"{column}__{key}", str(truthy).lower())
         elif value_as_given == value_as_coerced_to_number:

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -246,14 +246,14 @@
   SELECT ((("posthog_person"."properties" -> 'is_enabled') = 'true'
            OR ("posthog_person"."properties" -> 'is_enabled') = '"true"')
           AND "posthog_person"."properties" ? 'is_enabled'
-          AND NOT (("posthog_person"."properties" -> 'is_enabled') = 'null')) AS "flag_286_super_condition", ("posthog_person"."properties" -> 'is_enabled') IS NOT NULL AS "flag_286_super_condition_is_set",
-                                                                                                                                                                            (("posthog_person"."properties" -> 'email') = '"fake@posthog.com"'
-                                                                                                                                                                             AND "posthog_person"."properties" ? 'email'
-                                                                                                                                                                             AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
-                                                                                                                                                                            (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
-                                                                                                                                                                             AND "posthog_person"."properties" ? 'email'
-                                                                                                                                                                             AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_1",
-                                                                                                                                                                            (true) AS "flag_X_condition_2"
+          AND NOT (("posthog_person"."properties" -> 'is_enabled') = 'null')) AS "flag_64_super_condition", ("posthog_person"."properties" -> 'is_enabled') IS NOT NULL AS "flag_64_super_condition_is_set",
+                                                                                                                                                                           (("posthog_person"."properties" -> 'email') = '"fake@posthog.com"'
+                                                                                                                                                                            AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                            AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
+                                                                                                                                                                           (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+                                                                                                                                                                            AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                            AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_1",
+                                                                                                                                                                           (true) AS "flag_X_condition_2"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -246,14 +246,14 @@
   SELECT ((("posthog_person"."properties" -> 'is_enabled') = 'true'
            OR ("posthog_person"."properties" -> 'is_enabled') = '"true"')
           AND "posthog_person"."properties" ? 'is_enabled'
-          AND NOT (("posthog_person"."properties" -> 'is_enabled') = 'null')) AS "flag_64_super_condition", ("posthog_person"."properties" -> 'is_enabled') IS NOT NULL AS "flag_64_super_condition_is_set",
-                                                                                                                                                                           (("posthog_person"."properties" -> 'email') = '"fake@posthog.com"'
-                                                                                                                                                                            AND "posthog_person"."properties" ? 'email'
-                                                                                                                                                                            AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
-                                                                                                                                                                           (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
-                                                                                                                                                                            AND "posthog_person"."properties" ? 'email'
-                                                                                                                                                                            AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_1",
-                                                                                                                                                                           (true) AS "flag_X_condition_2"
+          AND NOT (("posthog_person"."properties" -> 'is_enabled') = 'null')) AS "flag_X_super_condition", ("posthog_person"."properties" -> 'is_enabled') IS NOT NULL AS "flag_X_super_condition_is_set",
+                                                                                                                                                                          (("posthog_person"."properties" -> 'email') = '"fake@posthog.com"'
+                                                                                                                                                                           AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
+                                                                                                                                                                          (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+                                                                                                                                                                           AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_1",
+                                                                                                                                                                          (true) AS "flag_X_condition_2"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -241,6 +241,26 @@
          AND "posthog_group"."group_type_index" = 2)
   '
 ---
+# name: TestFeatureFlagMatcher.test_super_condition_matches_string
+  '
+  SELECT ((("posthog_person"."properties" -> 'is_enabled') = 'true'
+           OR ("posthog_person"."properties" -> 'is_enabled') = '"true"')
+          AND "posthog_person"."properties" ? 'is_enabled'
+          AND NOT (("posthog_person"."properties" -> 'is_enabled') = 'null')) AS "flag_286_super_condition", ("posthog_person"."properties" -> 'is_enabled') IS NOT NULL AS "flag_286_super_condition_is_set",
+                                                                                                                                                                            (("posthog_person"."properties" -> 'email') = '"fake@posthog.com"'
+                                                                                                                                                                             AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                             AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
+                                                                                                                                                                            (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+                                                                                                                                                                             AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                             AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_1",
+                                                                                                                                                                            (true) AS "flag_X_condition_2"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging
   '
   

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -331,6 +331,7 @@ class QueryMatchingTest:
             query = re.sub(r"(\"?) IN \(\d+(, \d+)*\)", r"\1 IN (1, 2, 3, 4, 5 /* ... */)", query)
             # feature flag conditions use primary keys as columns in queries, so replace those too
             query = re.sub(r"flag_\d+_condition", r"flag_X_condition", query)
+            query = re.sub(r"flag_\d+_super_condition", r"flag_X_super_condition", query)
         else:
             query = re.sub(r"(team|cohort)_id(\"?) = \d+", r"\1_id\2 = 2", query)
             query = re.sub(r"\d+ as (team|cohort)_id(\"?)", r"2 as \1_id\2", query)

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -646,6 +646,128 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 1),
         )
 
+    def test_coercion_of_booleans(self):
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["307"],
+            properties={
+                "enabled": True,
+                "string_enabled": "true",
+            },
+        )
+
+        feature_flag1 = self.create_feature_flag(
+            key="random1",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "enabled", "value": ["true"], "operator": "exact", "type": "person"}]}
+                ]
+            },
+        )
+        feature_flag2 = self.create_feature_flag(
+            key="random2",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "enabled", "value": True, "operator": "exact", "type": "person"}]},
+                    {"properties": [{"key": "enabled", "value": [True], "operator": "exact", "type": "person"}]},
+                ]
+            },
+        )
+        feature_flag3 = self.create_feature_flag(
+            key="random3",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "string_enabled", "value": [True], "operator": "exact", "type": "person"}]},
+                    {"properties": [{"key": "string_enabled", "value": True, "operator": "exact", "type": "person"}]},
+                ]
+            },
+        )
+        feature_flag4 = self.create_feature_flag(
+            key="random4",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "string_enabled", "value": ['"true"'], "operator": "exact", "type": "person"}
+                        ]
+                    },
+                    {
+                        "properties": [
+                            {"key": "string_enabled", "value": '"true"', "operator": "exact", "type": "person"}
+                        ]
+                    },
+                ]
+            },
+        )
+
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag1], "307").get_match(feature_flag1),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag2], "307").get_match(feature_flag2),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag3], "307").get_match(feature_flag3),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag4], "307").get_match(feature_flag4),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+
+        # confirm it works with overrides as well, which are computed locally
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag1], "307", property_value_overrides={"enabled": True}).get_match(
+                feature_flag1
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag2], "307", property_value_overrides={"enabled": True}).get_match(
+                feature_flag2
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag3], "307", property_value_overrides={"string_enabled": True}).get_match(
+                feature_flag3
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag4], "307", property_value_overrides={"string_enabled": True}).get_match(
+                feature_flag4
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag1], "307", property_value_overrides={"enabled": "true"}).get_match(
+                feature_flag1
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag2], "307", property_value_overrides={"enabled": "true"}).get_match(
+                feature_flag2
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag3], "307", property_value_overrides={"string_enabled": "true"}).get_match(
+                feature_flag3
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag4], "307", property_value_overrides={"string_enabled": "true"}).get_match(
+                feature_flag4
+            ),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+
     @snapshot_postgres_queries
     def test_db_matches_independent_of_string_or_number_type(self):
         Person.objects.create(
@@ -780,7 +902,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatch(False, None, FeatureFlagMatchReason.OUT_OF_ROLLOUT_BOUND, 1),
         )
 
-    def test_super_condition_matches(self):
+    def test_super_condition_matches_boolean(self):
         Person.objects.create(
             team=self.team, distinct_ids=["test_id"], properties={"email": "test@posthog.com", "is_enabled": True}
         )
@@ -804,7 +926,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 ],
                 "super_groups": [
                     {
-                        "properties": [{"key": "is_enabled", "type": "person", "operator": "exact", "value": True}],
+                        "properties": [{"key": "is_enabled", "type": "person", "operator": "exact", "value": ["true"]}],
                         "rollout_percentage": 100,
                     },
                 ],
@@ -823,6 +945,43 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatcher([feature_flag], "another_id").get_match(feature_flag),
             FeatureFlagMatch(False, None, FeatureFlagMatchReason.OUT_OF_ROLLOUT_BOUND, 2),
         )
+
+    def test_super_condition_matches_string(self):
+        Person.objects.create(
+            team=self.team, distinct_ids=["test_id"], properties={"email": "test@posthog.com", "is_enabled": "true"}
+        )
+
+        feature_flag = self.create_feature_flag(
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "email", "type": "person", "value": "fake@posthog.com", "operator": "exact"}
+                        ],
+                        "rollout_percentage": 0,
+                    },
+                    {
+                        "properties": [
+                            {"key": "email", "type": "person", "value": "test@posthog.com", "operator": "exact"}
+                        ],
+                        "rollout_percentage": 100,
+                    },
+                    {"rollout_percentage": 50},
+                ],
+                "super_groups": [
+                    {
+                        "properties": [{"key": "is_enabled", "type": "person", "operator": "exact", "value": "true"}],
+                        "rollout_percentage": 100,
+                    },
+                ],
+            },
+        )
+
+        with snapshot_postgres_queries_context(self):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag], "test_id").get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.SUPER_CONDITION_VALUE, 0),
+            )
 
     def test_super_condition_matches_and_false(self):
         Person.objects.create(


### PR DESCRIPTION
## Problem

With or without property overrides, truthy string matching has been problematic:

(1) Postgres doesn't handle matching 'true' vs '"true"' (i.e. when a json object is set as boolean true vs string true)
(2) property overrides don't handle the same^, when a user passes in the boolean, it fails to match the string.

This is annoying, and leads to incorrect evaluation results. This PR fixes that.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
