### PR TITLE
fix: Return early after we are done squashing

### DIFF
--- a/posthog/temporal/workflows/squash_person_overrides.py
+++ b/posthog/temporal/workflows/squash_person_overrides.py
@@ -712,10 +712,6 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
                 retry_policy=retry_policy,
             )
 
-            if not persons_to_delete:
-                workflow.logger.info("No overrides to delete were found, workflow done")
-                return
-
             query_inputs.person_overrides_to_delete = persons_to_delete
 
             await workflow.execute_activity(
@@ -726,6 +722,10 @@ class SquashPersonOverridesWorkflow(CommandableWorkflow):
             )
 
             workflow.logger.info("Squash finished for all requested partitions, running clean up activities")
+
+            if not persons_to_delete:
+                workflow.logger.info("No overrides to delete were found, workflow done")
+                return
 
             await workflow.execute_activity(
                 delete_squashed_person_overrides_from_clickhouse,


### PR DESCRIPTION
## Problem

Made a mistake, the early return should happen after we squash. Even if there's nothing to delete, we still want to squash.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Move early return down.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
