### PR TITLE
chore: dial the logging back in offset manager

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
@@ -34,7 +34,6 @@ export const gaugeOffsetRemovalImpossible = new Gauge({
 interface OffsetSummary {
     lowest: number | null
     highest: number | null
-    count: number | null
 }
 
 const offsetSummary = (offsets: number[] | undefined): OffsetSummary => {
@@ -42,7 +41,6 @@ const offsetSummary = (offsets: number[] | undefined): OffsetSummary => {
     return {
         lowest: !!offsets?.length ? offsets[0] : null,
         highest: !!offsets?.length ? offsets[offsets.length - 1] : null,
-        count: offsets?.length || null,
     }
 }
 
@@ -63,16 +61,6 @@ export class OffsetManager {
         current.push(offset)
         current.sort((a, b) => a - b)
         this.offsetsByPartitionTopic.set(key, current)
-
-        const additionSummary = offsetSummary(current)
-        const logContext = {
-            offset,
-            additionOffsetsCount: additionSummary.count,
-            lowestAdditionOffset: additionSummary.lowest,
-            highestAdditionOffset: additionSummary.highest,
-            partition,
-        }
-        status.info('💾', `offset_manager adding_offset`, logContext)
     }
 
     /**
@@ -137,10 +125,8 @@ export class OffsetManager {
         const offsetsToRemoveSummary = offsetSummary(offsetsToRemove)
         const logContext = {
             offsetToCommit,
-            inflightOffsetsCount: inflightOffsetSummary.count,
             lowestInflightOffset: inflightOffsetSummary.lowest,
             highestInflightOffset: inflightOffsetSummary.highest,
-            offsetsToRemoveCount: offsetsToRemoveSummary.count,
             lowestOffsetToRemove: offsetsToRemoveSummary.lowest,
             highestOffsetToRemove: offsetsToRemoveSummary.highest,
             partition,


### PR DESCRIPTION
## Problem

* logging a tonne of add offsets isn't helping see what is happening
* when we cache a chunk in memory we don't add its offsets to the buffer, but we have added them to the offset manager
* when we flush to s3 we don't check if there are unfinished chunks so could be orphaning offsets in the offset manager

## Changes

* reduce logging in the offset manager
* add partition to all the session manager logs
* skip flush to s3 and log it if there are pending chunks in memory

## How did you test this code?

🙈 