### PR TITLE
fix(routing): allow pipe in named segment values

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -67,9 +67,9 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
             history: routerHistory,
             location: routerLocation,
             urlPatternOptions: {
-                // :TRICKY: We override default url segment matching characters.
-                // This list includes all characters which are not escaped by encodeURIComponent
-                segmentValueCharset: "a-zA-Z0-9-_~ %.@()!'",
+                // :TRICKY: What chars to allow in named segment values i.e. ":key"
+                // in "/url/:key". Default: "a-zA-Z0-9-_~ %".
+                segmentValueCharset: "a-zA-Z0-9-_~ %.@()!'|",
             },
         }),
         formsPlugin,


### PR DESCRIPTION
## Problem

We have customers with a pipe character in the group.

## Changes

This PR adds the pipe character to the allowed values in named segments, similar to https://github.com/PostHog/posthog/pull/8064.

## How did you test this code?

- Tested with a group with pipe character in the group key
- Navigated around in the app to check normal navigation still works