### PR TITLE
feat: error on every 'empty' message is not a chunked message, ignore non-zero chunks

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -286,6 +286,8 @@ const eachMessage =
                             tags: {
                                 team: team.id,
                                 session_id: clickHouseRecord.session_id,
+                                chunk_index: event.properties?.['$snapshot_data']?.chunk_index || 'unknown',
+                                chunk_count: event.properties?.['$snapshot_data']?.chunk_count || 'unknown',
                             },
                         })
                     }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -310,6 +310,8 @@ export const createSessionReplayEvent = (
         status.warn('🙈', 'ignoring an empty session recording event', {
             session_id: properties['$session_id'],
             properties: properties,
+            chunk_count: properties['chunk_count'],
+            chunk_index: properties['chunk_index'],
         })
         // it is safe to throw here as it caught a level up so that we can see this happening in Sentry
         throw new Error('ignoring an empty session recording event')

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -295,6 +295,14 @@ export const createSessionReplayEvent = (
     ip: string | null,
     properties: Properties
 ) => {
+    const chunkIndex = properties['$snapshot_data']?.chunk_index
+
+    // only the first chunk has the eventsSummary
+    // we can ignore subsequent chunks for calculating a replay event
+    if (chunkIndex > 0) {
+        return null
+    }
+
     const eventsSummaries: RRWebEventSummary[] = properties['$snapshot_data']?.['events_summary'] || []
 
     const timestamps = eventsSummaries
@@ -305,14 +313,6 @@ export const createSessionReplayEvent = (
             return castTimestampOrNow(DateTime.fromMillis(eventSummary.timestamp), TimestampFormat.ClickHouse)
         })
         .sort()
-
-    const chunkIndex = properties['$snapshot_data']?.chunk_index
-
-    // only the first chunk has the eventsSummary
-    // we can ignore subsequent chunks for calculating a replay event
-    if (chunkIndex > 0) {
-        return null
-    }
 
     // but every event where chunk index = 0 must have an eventsSummary
     if (eventsSummaries.length === 0 || timestamps.length === 0) {

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -306,6 +306,15 @@ export const createSessionReplayEvent = (
         })
         .sort()
 
+    const chunkIndex = properties['$snapshot_data']?.chunk_index
+
+    // only the first chunk has the eventsSummary
+    // we can ignore subsequent chunks for calculating a replay event
+    if (chunkIndex > 0) {
+        return null
+    }
+
+    // but every event where chunk index = 0 must have an eventsSummary
     if (eventsSummaries.length === 0 || timestamps.length === 0) {
         status.warn('🙈', 'ignoring an empty session recording event', {
             session_id: properties['$session_id'],

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -310,8 +310,6 @@ export const createSessionReplayEvent = (
         status.warn('🙈', 'ignoring an empty session recording event', {
             session_id: properties['$session_id'],
             properties: properties,
-            chunk_count: properties['chunk_count'],
-            chunk_index: properties['chunk_index'],
         })
         // it is safe to throw here as it caught a level up so that we can see this happening in Sentry
         throw new Error('ignoring an empty session recording event')


### PR DESCRIPTION
## Problem

In the plugin server we treat every session recording event as if it contains event summary data, but that's not true. Only events with chunk_index of 0 have an events summary.

## Changes

* Don't try and create replay records for subsequent chunks, they only exist to carry more data not more session info
* Error report only if there's a chunk of index 0 that must have events summary and doesn't

## How did you test this code?

🙈 