### PR TITLE
chore: track blocking session when committing offsets

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -110,7 +110,7 @@ export class SessionRecordingBlobIngester {
             })
         }
 
-        this.offsetManager?.addOffset(topic, partition, offset)
+        this.offsetManager?.addOffset(topic, partition, session_id, offset)
         await this.sessions.get(key)?.add(event)
         // TODO: If we error here, what should we do...?
         // If it is unrecoverable we probably want to remove the offset

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
@@ -16,12 +16,12 @@ describe('offset-manager', () => {
     })
 
     it('collects new offsets', () => {
-        offsetManager.addOffset(TOPIC, 1, 'session_id', 1)
+        offsetManager.addOffset(TOPIC, 1, 'session_id_1', 1)
         offsetManager.addOffset(TOPIC, 2, 'session_id', 1)
-        offsetManager.addOffset(TOPIC, 1, 'session_id', 2)
+        offsetManager.addOffset(TOPIC, 1, 'session_id_2', 2)
         offsetManager.addOffset(TOPIC, 3, 'session_id', 4)
-        offsetManager.addOffset(TOPIC, 1, 'session_id', 5)
-        offsetManager.addOffset(TOPIC, 3, 'session_id', 4)
+        offsetManager.addOffset(TOPIC, 1, 'session_id_1', 5)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 3)
         // even if the offsets arrive out of order
         offsetManager.addOffset(TOPIC, 3, 'session_id', 7)
         offsetManager.addOffset(TOPIC, 3, 'session_id', 6)
@@ -30,9 +30,28 @@ describe('offset-manager', () => {
 
         expect(offsetManager.offsetsByPartitionTopic).toEqual(
             new Map([
-                ['test-session-recordings-1', [1, 2, 5]],
-                ['test-session-recordings-2', [1]],
-                ['test-session-recordings-3', [0, 4, 4, 6, 7, 8]],
+                [
+                    'test-session-recordings-1',
+                    [
+                        { session_id: 'session_id_1', offset: 1 },
+                        { session_id: 'session_id_2', offset: 2 },
+                        { session_id: 'session_id_1', offset: 5 },
+                    ],
+                ],
+                ['test-session-recordings-2', [{ session_id: 'session_id', offset: 1 }]],
+                [
+                    'test-session-recordings-3',
+                    [
+                        // if received out of order, we don't sort them
+                        // we only sort them on removal, to avoid sorting too many times
+                        { session_id: 'session_id', offset: 4 },
+                        { session_id: 'session_id', offset: 3 },
+                        { session_id: 'session_id', offset: 7 },
+                        { session_id: 'session_id', offset: 6 },
+                        { session_id: 'session_id', offset: 8 },
+                        { session_id: 'session_id', offset: 0 },
+                    ],
+                ],
             ])
         )
     })
@@ -49,25 +68,32 @@ describe('offset-manager', () => {
 
         expect(offsetManager.offsetsByPartitionTopic).toEqual(
             new Map([
-                ['test-session-recordings-1', [5]],
-                ['test-session-recordings-2', [1]],
-                ['test-session-recordings-3', [4, 4]],
+                ['test-session-recordings-1', [{ session_id: 'session_id', offset: 5 }]],
+                ['test-session-recordings-2', [{ session_id: 'session_id', offset: 1 }]],
+                [
+                    'test-session-recordings-3',
+                    [
+                        { session_id: 'session_id', offset: 4 },
+                        { session_id: 'session_id', offset: 4 },
+                    ],
+                ],
             ])
         )
     })
 
     it.each([
+        [[], undefined],
         [[1], 1],
         [[2, 5, 10], undefined],
         [[1, 2, 3, 9], 3],
-    ])('commits the appropriate offset ', (removals: number[], expectation: number | null | undefined) => {
+    ])('commits the appropriate offset ', (removals: number[], expectedCommittedOffset: number | null | undefined) => {
         ;[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((offset) => {
             offsetManager.addOffset(TOPIC, 1, 'session_id', offset)
         })
 
         const result = offsetManager.removeOffsets(TOPIC, 1, removals)
 
-        expect(result).toEqual(expectation)
+        expect(result).toEqual(expectedCommittedOffset)
         if (result === undefined) {
             expect(mockConsumer.commit).toHaveBeenCalledTimes(0)
         } else {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
@@ -16,17 +16,17 @@ describe('offset-manager', () => {
     })
 
     it('collects new offsets', () => {
-        offsetManager.addOffset(TOPIC, 1, 1)
-        offsetManager.addOffset(TOPIC, 2, 1)
-        offsetManager.addOffset(TOPIC, 1, 2)
-        offsetManager.addOffset(TOPIC, 3, 4)
-        offsetManager.addOffset(TOPIC, 1, 5)
-        offsetManager.addOffset(TOPIC, 3, 4)
+        offsetManager.addOffset(TOPIC, 1, 'session_id', 1)
+        offsetManager.addOffset(TOPIC, 2, 'session_id', 1)
+        offsetManager.addOffset(TOPIC, 1, 'session_id', 2)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 4)
+        offsetManager.addOffset(TOPIC, 1, 'session_id', 5)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 4)
         // even if the offsets arrive out of order
-        offsetManager.addOffset(TOPIC, 3, 7)
-        offsetManager.addOffset(TOPIC, 3, 6)
-        offsetManager.addOffset(TOPIC, 3, 8)
-        offsetManager.addOffset(TOPIC, 3, 0)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 7)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 6)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 8)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 0)
 
         expect(offsetManager.offsetsByPartitionTopic).toEqual(
             new Map([
@@ -38,12 +38,12 @@ describe('offset-manager', () => {
     })
 
     it('removes offsets', () => {
-        offsetManager.addOffset(TOPIC, 1, 1)
-        offsetManager.addOffset(TOPIC, 2, 1)
-        offsetManager.addOffset(TOPIC, 3, 4)
-        offsetManager.addOffset(TOPIC, 1, 2)
-        offsetManager.addOffset(TOPIC, 1, 5)
-        offsetManager.addOffset(TOPIC, 3, 4)
+        offsetManager.addOffset(TOPIC, 1, 'session_id', 1)
+        offsetManager.addOffset(TOPIC, 2, 'session_id', 1)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 4)
+        offsetManager.addOffset(TOPIC, 1, 'session_id', 2)
+        offsetManager.addOffset(TOPIC, 1, 'session_id', 5)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 4)
 
         offsetManager.removeOffsets(TOPIC, 1, [1, 2])
 
@@ -62,7 +62,7 @@ describe('offset-manager', () => {
         [[1, 2, 3, 9], 3],
     ])('commits the appropriate offset ', (removals: number[], expectation: number | null | undefined) => {
         ;[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((offset) => {
-            offsetManager.addOffset(TOPIC, 1, offset)
+            offsetManager.addOffset(TOPIC, 1, 'session_id', offset)
         })
 
         const result = offsetManager.removeOffsets(TOPIC, 1, removals)
@@ -82,12 +82,12 @@ describe('offset-manager', () => {
 
     it('does not commits revoked partition offsets ', () => {
         ;[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((offset) => {
-            offsetManager.addOffset(TOPIC, 1, offset)
+            offsetManager.addOffset(TOPIC, 1, 'session_id', offset)
         })
 
-        offsetManager.addOffset(TOPIC, 1, 1)
-        offsetManager.addOffset(TOPIC, 2, 2)
-        offsetManager.addOffset(TOPIC, 3, 3)
+        offsetManager.addOffset(TOPIC, 1, 'session_id', 1)
+        offsetManager.addOffset(TOPIC, 2, 'session_id', 2)
+        offsetManager.addOffset(TOPIC, 3, 'session_id', 3)
 
         offsetManager.revokePartitions(TOPIC, [1])
 


### PR DESCRIPTION
## Problem

When an ingester can't commit a partition we can't see which session might be at fault. So we have to look at the many thousands of sessions that partition is processing - way too much information

## Changes

Track the session associated with the lowest offset in the partition

## How did you test this code?

🙈 