### PR TITLE
chore: Relabelling Recordings to Replays

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -39,7 +39,7 @@ export function SessionsRecordings(): JSX.Element {
         // Margin bottom hacks the fact that our wrapping container has an annoyingly large padding
         <div className="-mb-16">
             <PageHeader
-                title={<div>Session Recordings</div>}
+                title={<div>Session Replays</div>}
                 buttons={
                     <>
                         {tab === SessionRecordingsTabs.Recent && !recordingsDisabled && (


### PR DESCRIPTION
## Problem

We call them replays now. All of our website content and tutorials are increasingly calling them replays. But the app still calls them recordings. That's confusing. 

This is probably a very broken PR that will break things more, but it's as much as I could figure out without spending days on it, so...

## Changes

Recordings title < Replays

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
