### PR TITLE
fix: incomplete chunks are blocking flush while lagging

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -353,14 +353,11 @@ export class SessionManager {
      */
     private async addToChunks(message: IncomingRecordingMessage): Promise<void> {
         // If it is a chunked message we add to the collected chunks
-        let chunks: IncomingRecordingMessage[] = []
 
         if (!this.chunks.has(message.chunk_id)) {
             this.chunks.set(message.chunk_id, [])
-        } else {
-            chunks = this.chunks.get(message.chunk_id) || []
         }
-
+        const chunks: IncomingRecordingMessage[] = this.chunks.get(message.chunk_id) || []
         chunks.push(message)
 
         if (chunks.length === message.chunk_count) {


### PR DESCRIPTION
## Problem

With the blob ingesters we see them processing old sessions (e.g. 2 days old) and never committing an offset, so they're constantly reprocessing those sessions and any sessions that come after them

<img width="1188" alt="Screenshot 2023-05-18 at 12 15 25" src="https://github.com/PostHog/posthog/assets/984817/3123f97f-c29f-44bc-8553-d4e7295da9ed">

We see that those blocking sessions all have an incomplete set of chunks. Those chunks offsets are never passed to the offset manager for removal.

The theory is that the offsets in question are the ones that need to be checked and so are blocking commit.

## Changes

Rather than fix anything... (which we will/should do next)

This drops those chunks when flushing due to age _and_ lagging by more than ten hours.

While dropping them it processes their offsets.

## How did you test this code?

🙈 

If this is the source of the blockage. We'll see the log message `🚽 blob_ingester_session_manager would flush buffer due to age, but chunks are still pending` disappear or massively reduce. And we'll see the number of writes to S3 fall massively.

If there's a bug to fix here. We should then expect to see ingesters slowly get blocked, start to lag, and then drop the chunks. In which case we can then fix that properly but at least we're not hammering S3 while we figure it out
