### PR TITLE
perf(ingestion): increase event processing concurrency

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -58,6 +58,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         WORKER_CONCURRENCY: 1,
         TASK_TIMEOUT: 30,
         TASKS_PER_WORKER: 10,
+        INGESTION_CONCURRENCY: 10,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,
         SENTRY_DSN: null,
         SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE: 0,

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -58,7 +58,14 @@ export async function eachBatchParallelIngestion(payload: EachBatchPayload, queu
         await ingestEvent(queue.pluginsServer, queue.workerMethods, event)
     }
 
-    await eachBatchParallel(payload, queue, eachMessage, groupByTeamDistinctId, 'ingestion')
+    await eachBatchParallel(
+        payload,
+        queue,
+        eachMessage,
+        groupByTeamDistinctId,
+        queue.pluginsServer.INGESTION_CONCURRENCY,
+        'ingestion'
+    )
 }
 
 export async function ingestEvent(

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -4,7 +4,7 @@ import { Hub, PipelineEvent, WorkerMethods } from '../../../types'
 import { formPipelineEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
 import { IngestionConsumer } from '../kafka-queue'
-import { eachBatch } from './each-batch'
+import { eachBatch, eachBatchParallel } from './each-batch'
 
 export async function eachMessageIngestion(message: KafkaMessage, queue: IngestionConsumer): Promise<void> {
     const event = formPipelineEvent(message)
@@ -35,6 +35,30 @@ export async function eachBatchIngestion(payload: EachBatchPayload, queue: Inges
     }
 
     await eachBatch(payload, queue, eachMessageIngestion, groupIntoBatchesIngestion, 'ingestion')
+}
+
+export async function eachBatchParallelIngestion(payload: EachBatchPayload, queue: IngestionConsumer): Promise<void> {
+    function groupByTeamDistinctId(kafkaMessages: KafkaMessage[]): PipelineEvent[][] {
+        const batches: Map<string, PipelineEvent[]> = new Map()
+        for (const message of kafkaMessages) {
+            const pluginEvent = formPipelineEvent(message)
+            const key = `${pluginEvent.team_id}:${pluginEvent.distinct_id}`
+            const siblings = batches.get(key)
+            if (siblings) {
+                siblings.push(pluginEvent)
+            } else {
+                batches.set(key, [pluginEvent])
+            }
+        }
+
+        return Array.from(batches.values())
+    }
+
+    async function eachMessage(event: PipelineEvent, queue: IngestionConsumer): Promise<void> {
+        await ingestEvent(queue.pluginsServer, queue.workerMethods, event)
+    }
+
+    await eachBatchParallel(payload, queue, eachMessage, groupByTeamDistinctId, 'ingestion')
 }
 
 export async function ingestEvent(

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -42,7 +42,7 @@ export async function eachBatchParallelIngestion(payload: EachBatchPayload, queu
         const batches: Map<string, PipelineEvent[]> = new Map()
         for (const message of kafkaMessages) {
             const pluginEvent = formPipelineEvent(message)
-            const key = `${pluginEvent.team_id}:${pluginEvent.distinct_id}`
+            const key = `${pluginEvent.team_id ?? pluginEvent.token}:${pluginEvent.distinct_id}`
             const siblings = batches.get(key)
             if (siblings) {
                 siblings.push(pluginEvent)

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -89,6 +89,7 @@ export async function eachBatchParallel(
     queue: IngestionConsumer,
     eachMessage: (message: PipelineEvent, queue: IngestionConsumer) => Promise<void>,
     groupIntoBatches: (messages: KafkaMessage[]) => PipelineEvent[][],
+    concurrency: number,
     key: string
 ): Promise<void> {
     const batchStartTimer = new Date()
@@ -129,7 +130,6 @@ export async function eachBatchParallel(
             return Promise.resolve()
         }
 
-        const concurrency = queue.pluginsServer.WORKER_CONCURRENCY * queue.pluginsServer.TASKS_PER_WORKER
         await Promise.all([...Array(concurrency)].map(() => processMicroBatches(messageBatches)))
 
         // Commit offsets once at the end of the batch. We run the risk of duplicates

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
+import { PipelineEvent } from '../../../types' // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 import { status } from '../../../utils/status'
 import { IngestionConsumer } from '../kafka-queue'
 import { latestOffsetTimestampGauge } from '../metrics'
@@ -9,6 +10,11 @@ import { latestOffsetTimestampGauge } from '../metrics'
 require('@sentry/tracing')
 
 export async function eachBatch(
+    /**
+     * Using the provided groupIntoBatches function, split the incoming batch into micro-batches
+     * that are executed **sequentially**, committing offsets after each of them.
+     * Events within a single micro-batch are processed in parallel.
+     */
     { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
     queue: IngestionConsumer,
     eachMessage: (message: KafkaMessage, queue: IngestionConsumer) => Promise<void>,
@@ -67,6 +73,95 @@ export async function eachBatch(
                 new Date().valueOf() - batchStartTimer.valueOf()
             }ms (${loggingKey})`
         )
+    } finally {
+        queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
+        transaction.finish()
+    }
+}
+
+export async function eachBatchParallel(
+    /**
+     * Using the provided groupIntoBatches function, split the incoming batch into micro-batches
+     * that are executed **in parallel**, committing offsets only at the end.
+     * Events within a single micro-batch are processed **sequentially**.
+     */
+    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
+    queue: IngestionConsumer,
+    eachMessage: (message: PipelineEvent, queue: IngestionConsumer) => Promise<void>,
+    groupIntoBatches: (messages: KafkaMessage[]) => PipelineEvent[][],
+    key: string
+): Promise<void> {
+    const batchStartTimer = new Date()
+    const loggingKey = `each_batch_${key}`
+
+    const transaction = Sentry.startTransaction(
+        { name: `eachBatchParallel(${eachMessage.name})` },
+        { topic: queue.topic }
+    )
+
+    try {
+        /**
+         * Micro-batches should be executed from biggest to smallest to enable the best concurrency.
+         * We're sorting with biggest last and pop()ing. Ideally, we'd use a priority queue by length
+         * and a separate array for single messages, but let's look at profiles before optimizing.
+         */
+        const messageBatches = groupIntoBatches(batch.messages)
+        messageBatches.sort((a, b) => a.length - b.length)
+
+        queue.pluginsServer.statsd?.histogram('ingest_event_batching.input_length', batch.messages.length, { key: key })
+        queue.pluginsServer.statsd?.histogram('ingest_event_batching.batch_count', messageBatches.length, { key: key })
+
+        async function processMicroBatches(batches: PipelineEvent[][]): Promise<void> {
+            let currentBatch
+            let processedBatches = 0
+            while ((currentBatch = batches.pop()) !== undefined) {
+                const batchSpan = transaction.startChild({
+                    op: 'messageBatch',
+                    data: { batchLength: currentBatch.length },
+                })
+                for (const message of currentBatch) {
+                    await Promise.all([eachMessage(message, queue), heartbeat()])
+                }
+                processedBatches++
+                batchSpan.finish()
+            }
+            status.debug('🧩', `Stopping worker after processing ${processedBatches} micro-batches`)
+            return Promise.resolve()
+        }
+
+        const concurrency = queue.pluginsServer.WORKER_CONCURRENCY * queue.pluginsServer.TASKS_PER_WORKER
+        await Promise.all([...Array(concurrency)].map(() => processMicroBatches(messageBatches)))
+
+        // Commit offsets once at the end of the batch. We run the risk of duplicates
+        // if the pod is prematurely killed in the middle of a batch, but this allows
+        // us to process events out of order within a batch, for higher throughput.
+        const commitSpan = transaction.startChild({ op: 'offsetCommit' })
+        const lastMessage = batch.messages.at(-1)
+        if (lastMessage) {
+            resolveOffset(lastMessage.offset)
+            await commitOffsetsIfNecessary()
+            latestOffsetTimestampGauge
+                .labels({ partition: batch.partition, topic: batch.topic, groupId: key })
+                .set(Number.parseInt(lastMessage.timestamp))
+        }
+        commitSpan.finish()
+
+        status.debug(
+            '🧩',
+            `Kafka batch of ${batch.messages.length} events completed in ${
+                new Date().valueOf() - batchStartTimer.valueOf()
+            }ms (${loggingKey})`
+        )
+
+        if (!isRunning() || isStale()) {
+            status.info('🚪', `Ending the consumer loop`, {
+                isRunning: isRunning(),
+                isStale: isStale(),
+                msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
+            })
+            await heartbeat()
+            return
+        }
     } finally {
         queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
         transaction.finish()

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -76,6 +76,7 @@ export enum KafkaSaslMechanism {
 export interface PluginsServerConfig {
     WORKER_CONCURRENCY: number // number of concurrent worker threads
     TASKS_PER_WORKER: number // number of parallel tasks per worker thread
+    INGESTION_CONCURRENCY: number // number of parallel event ingestion queues per batch
     TASK_TIMEOUT: number // how many seconds until tasks are timed out
     DATABASE_URL: string // Postgres database URL
     POSTHOG_DB_NAME: string | null

--- a/plugin-server/src/utils/env-utils.ts
+++ b/plugin-server/src/utils/env-utils.ts
@@ -44,3 +44,7 @@ export function isIngestionOverflowEnabled(): boolean {
     const ingestionOverflowEnabled = process.env.INGESTION_OVERFLOW_ENABLED
     return stringToBoolean(ingestionOverflowEnabled)
 }
+
+export function isIngestionParallelBatchingEnabled(): boolean {
+    return stringToBoolean(process.env.INGESTION_PARALLEL_BATCHING_ENABLED)
+}

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -1,7 +1,11 @@
 import { KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW } from '../../../src/config/kafka-topics'
 import { eachBatch } from '../../../src/main/ingestion-queues/batch-processing/each-batch'
 import { eachBatchAsyncHandlers } from '../../../src/main/ingestion-queues/batch-processing/each-batch-async-handlers'
-import { eachBatchIngestion } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
+import {
+    eachBatchIngestion,
+    eachBatchParallelIngestion,
+    groupByTeamDistinctId,
+} from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
 import {
     ClickHouseTimestamp,
     ClickHouseTimestampSecondPrecision,
@@ -236,6 +240,100 @@ describe('eachBatchX', () => {
                 }
             )
             expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 6, {
+                key: 'ingestion',
+            })
+        })
+    })
+
+    describe('eachBatchParallelIngestion', () => {
+        it('calls runEventPipeline', async () => {
+            const batch = createBatch(captureEndpointEvent)
+            await eachBatchParallelIngestion(batch, queue)
+
+            expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledWith({
+                distinct_id: 'id',
+                event: 'event',
+                properties: {},
+                ip: null,
+                now: null,
+                sent_at: null,
+                site_url: null,
+                team_id: 1,
+                uuid: 'uuid1',
+            })
+            expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(
+                'kafka_queue.each_batch_ingestion',
+                expect.any(Date)
+            )
+        })
+
+        it('batches events by team or token and distinct_id', () => {
+            const batch = createBatchWithMultipleEvents([
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'b' },
+                { ...captureEndpointEvent, team_id: 4, distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: 4, distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: 4, distinct_id: 'b' },
+                { ...captureEndpointEvent, team_id: undefined, token: 'tok', distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: undefined, token: 'tok', distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: undefined, token: 'tok', distinct_id: 'b' },
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'c' },
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'b' },
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
+            ])
+            const stats = new Map()
+            for (const group of groupByTeamDistinctId(batch.batch.messages)) {
+                const key = `${group[0].team_id}:${group[0].token}:${group[0].distinct_id}`
+                for (const event of group) {
+                    expect(`${event.team_id}:${event.token}:${event.distinct_id}`).toEqual(key)
+                }
+                stats.set(key, group.length)
+            }
+            expect(stats.size).toEqual(7)
+            expect(stats).toEqual(
+                new Map([
+                    ['3:undefined:a', 3],
+                    ['3:undefined:b', 2],
+                    ['3:undefined:c', 1],
+                    ['4:undefined:a', 2],
+                    ['4:undefined:b', 1],
+                    ['undefined:tok:a', 2],
+                    ['undefined:tok:b', 1],
+                ])
+            )
+        })
+
+        it('batches events but commits offsets only once', async () => {
+            const batch = createBatchWithMultipleEvents([
+                { ...captureEndpointEvent, offset: 1, team_id: 3 },
+                { ...captureEndpointEvent, offset: 2, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 3, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 4, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 5, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 6, team_id: 3, distinct_id: 'id2' },
+                { ...captureEndpointEvent, offset: 7, team_id: 4 },
+                { ...captureEndpointEvent, offset: 8, team_id: 5 },
+                { ...captureEndpointEvent, offset: 9, team_id: 5 }, // repeat
+                { ...captureEndpointEvent, offset: 10, team_id: 3, distinct_id: 'id2' }, // repeat
+                { ...captureEndpointEvent, offset: 11, team_id: 8 },
+                { ...captureEndpointEvent, offset: 12, team_id: 4 }, // repeat
+                { ...captureEndpointEvent, offset: 13, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 14, team_id: 5 }, // repeat
+            ])
+
+            await eachBatchParallelIngestion(batch, queue)
+            expect(batch.resolveOffset).toBeCalledTimes(1)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(14)
+            expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledTimes(14)
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
+                'ingest_event_batching.input_length',
+                14,
+                {
+                    key: 'ingestion',
+                }
+            )
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 5, {
                 key: 'ingestion',
             })
         })

--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 import structlog
@@ -9,6 +10,7 @@ from posthog.models.person import PersonDistinctId
 from posthog.models.person.util import create_person_distinct_id
 
 logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class Command(BaseCommand):

--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Optional
 
 import structlog
@@ -10,7 +9,6 @@ from posthog.models.person import PersonDistinctId
 from posthog.models.person.util import create_person_distinct_id
 
 logger = structlog.get_logger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
## Problem

To increase the throughput of `posthog-plugins-ingestion`, we want to benchmark turning the concurrency around.

This is a draft implementation of that goal, to test out the gains before we completely switch over to it.

## Changes

- Add a new `eachBatchParallelIngestion`, at processes up to `$INGESTION_CONCURRENCY` events concurrently, keeping events from the same teamXdistinct_id in order
- Use this loop if `$INGESTION_PARALLEL_BATCHING_ENABLED` is set, but `$INGESTION_OVERFLOW_ENABLED` disabled. We'll port the overflow logic over, after we confirm the performance gain


## How did you test this code?

`DEBUG=1 INGESTION_PARALLEL_BATCHING_ENABLED=1 INGESTION_OVERFLOW_ENABLED=0 ./bin/start`

Tried to test it on dev before merging, but it's currently not possible :(
The new code is disabled by default, we'll turn it on on dev after merging.
