### PR TITLE
fix: only add addons plan key if it exists

### DIFF
--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -122,7 +122,9 @@ export const getUpgradeAllProductsLink = (
     url += `${product.type}:${upgradeToPlanKey},`
     if (product.addons?.length) {
         for (const addon of product.addons) {
-            url += `${addon.type}:${addon.plans[0].plan_key},`
+            if (addon.plans?.[0]?.plan_key) {
+                url += `${addon.type}:${addon.plans[0].plan_key},`
+            }
         }
     }
     // remove the trailing comma that will be at the end of the url


### PR DESCRIPTION
## Problem

If someone has already sub'd to an addon they don't get plan info in the response (should maybe change that). If they go back to ingestion then they get an error because the addons are missing plan info. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Forgives missing plan info for addons.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

🖱️ ... Need to test the ingestion screens fully. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
