### PR TITLE
chore: Drop Loaded plugin log line

### DIFF
--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -157,6 +157,7 @@ export class LazyPluginVM {
                         await this._setupPlugin(vm.vm)
                         this.ready = true
                     }
+                    status.debug('🔌', `Loaded ${logInfo}.`)
                     await this.createLogEntry(
                         `Plugin loaded (instance ID ${this.hub.instanceId}).`,
                         PluginLogEntryType.Debug

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -157,7 +157,6 @@ export class LazyPluginVM {
                         await this._setupPlugin(vm.vm)
                         this.ready = true
                     }
-                    status.info('🔌', `Loaded ${logInfo}.`)
                     await this.createLogEntry(
                         `Plugin loaded (instance ID ${this.hub.instanceId}).`,
                         PluginLogEntryType.Debug

--- a/plugin-server/tests/worker/vm.lazy.test.ts
+++ b/plugin-server/tests/worker/vm.lazy.test.ts
@@ -76,7 +76,6 @@ describe('LazyPluginVM', () => {
             void initializeVm(vm)
             await vm.resolveInternalVm
 
-            expect(status.info).toHaveBeenCalledWith('🔌', 'Loaded some plugin.')
             expect(mockServer.db.queuePluginLogEntry).toHaveBeenCalledWith(
                 expect.objectContaining({
                     instanceId: undefined,

--- a/plugin-server/tests/worker/vm.lazy.test.ts
+++ b/plugin-server/tests/worker/vm.lazy.test.ts
@@ -76,6 +76,7 @@ describe('LazyPluginVM', () => {
             void initializeVm(vm)
             await vm.resolveInternalVm
 
+            expect(status.debug).toHaveBeenCalledWith('🔌', 'Loaded some plugin.')
             expect(mockServer.db.queuePluginLogEntry).toHaveBeenCalledWith(
                 expect.objectContaining({
                     instanceId: undefined,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We're logging this ridiculously many times per minute sometimes (probably deploy):
<img width="288" alt="Screenshot 2023-05-18 at 18 09 33" src="https://github.com/PostHog/posthog/assets/890921/05780df2-862b-4ed0-a7a1-444117d4777e">

Because we log it at every start-up for every plugin for every organization that has it enabled

E.g. http://grafana-prod-us/explore?orgId=1&left=%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22builder%22,%22expr%22:%22%7Bcontainer%3D%5C%22posthog-plugins-ingestion%5C%22%7D%20%7C%3D%20%60Loaded%20plugin%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%221684422555574%22,%22to%22:%221684425814390%22%7D%7D

Can't think of a reason we'd need this and it being worth spamming the logs like this.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
