### PR TITLE
fix(early-access): spelling error in type

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,7 +37,7 @@ import {
     RecentPerformancePageView,
     DashboardTemplateType,
     DashboardTemplateEditorType,
-    EarlyAccsesFeatureType,
+    EarlyAccessFeatureType,
     NewEarlyAccessFeatureType,
 } from '~/types'
 import { getCurrentOrganizationId, getCurrentTeamId } from './utils/logics'
@@ -391,7 +391,7 @@ class ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('early_access_feature')
     }
 
-    public earlyAccessFeature(id: EarlyAccsesFeatureType['id'], teamId?: TeamType['id']): ApiRequest {
+    public earlyAccessFeature(id: EarlyAccessFeatureType['id'], teamId?: TeamType['id']): ApiRequest {
         return this.earlyAccessFeatures(teamId).addPathComponent(id)
     }
 
@@ -1099,25 +1099,25 @@ const api = {
     },
 
     earlyAccessFeatures: {
-        async get(featureId: EarlyAccsesFeatureType['id']): Promise<EarlyAccsesFeatureType> {
+        async get(featureId: EarlyAccessFeatureType['id']): Promise<EarlyAccessFeatureType> {
             return await new ApiRequest().earlyAccessFeature(featureId).get()
         },
-        async create(data: NewEarlyAccessFeatureType): Promise<EarlyAccsesFeatureType> {
+        async create(data: NewEarlyAccessFeatureType): Promise<EarlyAccessFeatureType> {
             return await new ApiRequest().earlyAccessFeatures().create({ data })
         },
-        async delete(featureId: EarlyAccsesFeatureType['id']): Promise<void> {
+        async delete(featureId: EarlyAccessFeatureType['id']): Promise<void> {
             await new ApiRequest().earlyAccessFeature(featureId).delete()
         },
         async update(
-            featureId: EarlyAccsesFeatureType['id'],
-            data: Pick<EarlyAccsesFeatureType, 'name' | 'description' | 'stage' | 'documentation_url'>
-        ): Promise<EarlyAccsesFeatureType> {
+            featureId: EarlyAccessFeatureType['id'],
+            data: Pick<EarlyAccessFeatureType, 'name' | 'description' | 'stage' | 'documentation_url'>
+        ): Promise<EarlyAccessFeatureType> {
             return await new ApiRequest().earlyAccessFeature(featureId).update({ data })
         },
-        async list(): Promise<PaginatedResponse<EarlyAccsesFeatureType>> {
+        async list(): Promise<PaginatedResponse<EarlyAccessFeatureType>> {
             return await new ApiRequest().earlyAccessFeatures().get()
         },
-        async promote(featureId: EarlyAccsesFeatureType['id']): Promise<PaginatedResponse<EarlyAccsesFeatureType>> {
+        async promote(featureId: EarlyAccessFeatureType['id']): Promise<PaginatedResponse<EarlyAccessFeatureType>> {
             return await new ApiRequest().earlyAccessFeature(featureId).withAction('promote').create()
         },
     },

--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -5,7 +5,7 @@ import { Field, PureField } from 'lib/forms/Field'
 import { SceneExport } from 'scenes/sceneTypes'
 import { earlyAccessFeatureLogic } from './earlyAccessFeatureLogic'
 import { Form } from 'kea-forms'
-import { EarlyAccessFeatureStage, EarlyAccsesFeatureType, PropertyFilterType, PropertyOperator } from '~/types'
+import { EarlyAccessFeatureStage, EarlyAccessFeatureType, PropertyFilterType, PropertyOperator } from '~/types'
 import { urls } from 'scenes/urls'
 import { PersonsScene } from 'scenes/persons/Persons'
 import { IconFlag, IconHelpOutline } from 'lib/lemon-ui/icons'
@@ -78,7 +78,7 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                                     placement="topLeft"
                                     onConfirm={() => {
                                         // conditional above ensures earlyAccessFeature is not NewEarlyAccessFeature
-                                        deleteEarlyAccessFeature((earlyAccessFeature as EarlyAccsesFeatureType)?.id)
+                                        deleteEarlyAccessFeature((earlyAccessFeature as EarlyAccessFeatureType)?.id)
                                     }}
                                 >
                                     <LemonButton data-attr="delete-feature" status="danger" type="secondary">
@@ -255,7 +255,7 @@ function FlagSelector({ value, onChange }: FlagSelectorProps): JSX.Element {
 }
 
 interface PersonListProps {
-    earlyAccessFeature: EarlyAccsesFeatureType
+    earlyAccessFeature: EarlyAccessFeatureType
 }
 
 function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element {

--- a/frontend/src/scenes/early-access-features/EarlyAccessFeatures.stories.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeatures.stories.tsx
@@ -4,7 +4,7 @@ import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { App } from 'scenes/App'
 import { mswDecorator, useFeatureFlags } from '~/mocks/browser'
-import { EarlyAccsesFeatureType } from '~/types'
+import { EarlyAccessFeatureType } from '~/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 
 const EARLY_ACCESS_FEATURE_RESULT = [
@@ -127,7 +127,7 @@ export default {
                     previous: null,
                 },
                 '/api/projects/:team_id/early-access-feature/:flagId/':
-                    EARLY_ACCESS_FEATURE_RESULT[0] as EarlyAccsesFeatureType,
+                    EARLY_ACCESS_FEATURE_RESULT[0] as EarlyAccessFeatureType,
             },
         }),
     ],

--- a/frontend/src/scenes/early-access-features/EarlyAccessFeatures.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeatures.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
-import { EarlyAccsesFeatureType } from '~/types'
+import { EarlyAccessFeatureType } from '~/types'
 import { earlyAccessFeaturesLogic } from './earlyAccessFeaturesLogic'
 
 export const scene: SceneExport = {
@@ -11,7 +11,7 @@ export const scene: SceneExport = {
     logic: earlyAccessFeaturesLogic,
 }
 
-const STAGES_IN_ORDER: Record<EarlyAccsesFeatureType['stage'], number> = {
+const STAGES_IN_ORDER: Record<EarlyAccessFeatureType['stage'], number> = {
     concept: 0,
     alpha: 1,
     beta: 2,

--- a/frontend/src/scenes/early-access-features/earlyAccessFeatureLogic.ts
+++ b/frontend/src/scenes/early-access-features/earlyAccessFeatureLogic.ts
@@ -4,7 +4,7 @@ import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { urls } from 'scenes/urls'
-import { Breadcrumb, EarlyAccessFeatureStage, EarlyAccsesFeatureType, NewEarlyAccessFeatureType } from '~/types'
+import { Breadcrumb, EarlyAccessFeatureStage, EarlyAccessFeatureType, NewEarlyAccessFeatureType } from '~/types'
 import type { earlyAccessFeatureLogicType } from './earlyAccessFeatureLogicType'
 import { earlyAccessFeaturesLogic } from './earlyAccessFeaturesLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -36,7 +36,7 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
         cancel: true,
         editFeature: (editing: boolean) => ({ editing }),
         promote: true,
-        deleteEarlyAccessFeature: (earlyAccessFeatureId: EarlyAccsesFeatureType['id']) => ({ earlyAccessFeatureId }),
+        deleteEarlyAccessFeature: (earlyAccessFeatureId: EarlyAccessFeatureType['id']) => ({ earlyAccessFeatureId }),
     }),
     loaders(({ props }) => ({
         earlyAccessFeature: {
@@ -47,8 +47,8 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
                 }
                 return NEW_EARLY_ACCESS_FEATURE
             },
-            saveEarlyAccessFeature: async (updatedEarlyAccessFeature: Partial<EarlyAccsesFeatureType>) => {
-                let result: EarlyAccsesFeatureType
+            saveEarlyAccessFeature: async (updatedEarlyAccessFeature: Partial<EarlyAccessFeatureType>) => {
+                let result: EarlyAccessFeatureType
                 if (props.id === 'new') {
                     result = await api.earlyAccessFeatures.create(
                         updatedEarlyAccessFeature as NewEarlyAccessFeatureType
@@ -57,7 +57,7 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
                 } else {
                     result = await api.earlyAccessFeatures.update(
                         props.id,
-                        updatedEarlyAccessFeature as EarlyAccsesFeatureType
+                        updatedEarlyAccessFeature as EarlyAccessFeatureType
                     )
                 }
                 return result
@@ -66,7 +66,7 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
     })),
     forms(({ actions }) => ({
         earlyAccessFeature: {
-            defaults: { ...NEW_EARLY_ACCESS_FEATURE } as NewEarlyAccessFeatureType | EarlyAccsesFeatureType,
+            defaults: { ...NEW_EARLY_ACCESS_FEATURE } as NewEarlyAccessFeatureType | EarlyAccessFeatureType,
             errors: (payload) => ({
                 name: !payload.name ? 'Feature name must be set' : undefined,
             }),
@@ -93,7 +93,7 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
         mode: [(_, p) => [p.id], (id): 'view' | 'edit' => (id === 'new' ? 'edit' : 'view')],
         breadcrumbs: [
             (s) => [s.earlyAccessFeature],
-            (earlyAccessFeature: EarlyAccsesFeatureType): Breadcrumb[] => [
+            (earlyAccessFeature: EarlyAccessFeatureType): Breadcrumb[] => [
                 {
                     name: 'Early Access Management',
                     path: urls.earlyAccessFeatures(),

--- a/frontend/src/scenes/early-access-features/earlyAccessFeaturesLogic.ts
+++ b/frontend/src/scenes/early-access-features/earlyAccessFeaturesLogic.ts
@@ -1,7 +1,7 @@
 import { afterMount, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
-import { Breadcrumb, EarlyAccsesFeatureType } from '~/types'
+import { Breadcrumb, EarlyAccessFeatureType } from '~/types'
 
 import type { earlyAccessFeaturesLogicType } from './earlyAccessFeaturesLogicType'
 import { urls } from 'scenes/urls'
@@ -10,7 +10,7 @@ export const earlyAccessFeaturesLogic = kea<earlyAccessFeaturesLogicType>([
     path(['scenes', 'features', 'featuresLogic']),
     loaders({
         earlyAccessFeatures: {
-            __default: [] as EarlyAccsesFeatureType[],
+            __default: [] as EarlyAccessFeatureType[],
             loadEarlyAccessFeatures: async () => {
                 const response = await api.earlyAccessFeatures.list()
                 return response.results

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2031,7 +2031,7 @@ export interface FeatureFlagType extends Omit<FeatureFlagBasicType, 'id' | 'team
     is_simple_flag: boolean
     rollout_percentage: number | null
     experiment_set: string[] | null
-    features: EarlyAccsesFeatureType[] | null
+    features: EarlyAccessFeatureType[] | null
     rollback_conditions: FeatureFlagRollbackConditions[]
     performed_rollback: boolean
     can_edit: boolean
@@ -2058,7 +2058,7 @@ export enum EarlyAccessFeatureStage {
     GeneralAvailability = 'general-availability',
 }
 
-export interface EarlyAccsesFeatureType {
+export interface EarlyAccessFeatureType {
     /** UUID */
     id: string
     feature_flag: FeatureFlagBasicType
@@ -2070,7 +2070,7 @@ export interface EarlyAccsesFeatureType {
     created_at: string
 }
 
-export interface NewEarlyAccessFeatureType extends Omit<EarlyAccsesFeatureType, 'id' | 'created_at' | 'feature_flag'> {
+export interface NewEarlyAccessFeatureType extends Omit<EarlyAccessFeatureType, 'id' | 'created_at' | 'feature_flag'> {
     feature_flag_id: number | undefined
 }
 


### PR DESCRIPTION
## Problem

`EarlyAccses` typo everywhere 😅 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
