### PR TITLE
perf(ingestion): port overflow logic into eachBatchParallelIngestion

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -158,13 +158,14 @@ jobs:
               run: cd plugin-server && pnpm test -- --runInBand --forceExit tests/ --shard=${{matrix.shard}}
 
     functional-tests:
-        name: Functional tests (POE_EMBRACE_JOIN_FOR_TEAMS=${{matrix.POE_EMBRACE_JOIN_FOR_TEAMS}})
+        name: Functional tests (POE_TEAMS=${{matrix.POE_EMBRACE_JOIN_FOR_TEAMS}} BATCHING=${{matrix.INGESTION_PARALLEL_BATCHING_ENABLED}})
         runs-on: ubuntu-latest-8-cores
 
         strategy:
             fail-fast: false
             matrix:
                 POE_EMBRACE_JOIN_FOR_TEAMS: ['', '*']
+                INGESTION_PARALLEL_BATCHING_ENABLED: ['false', 'true']
 
         env:
             REDIS_URL: 'redis://localhost'
@@ -173,6 +174,7 @@ jobs:
             KAFKA_HOSTS: 'kafka:9092'
             DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
             POE_EMBRACE_JOIN_FOR_TEAMS: ${{matrix.POE_EMBRACE_JOIN_FOR_TEAMS}}
+            INGESTION_PARALLEL_BATCHING_ENABLED: ${{matrix.INGESTION_PARALLEL_BATCHING_ENABLED}}
 
         steps:
             - name: Code check out

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -1,10 +1,12 @@
+import * as Sentry from '@sentry/node'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
 import { Hub, PipelineEvent, WorkerMethods } from '../../../types'
 import { formPipelineEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
 import { IngestionConsumer } from '../kafka-queue'
-import { eachBatch, eachBatchParallel } from './each-batch'
+import { latestOffsetTimestampGauge } from '../metrics'
+import { eachBatch } from './each-batch'
 
 export async function eachMessageIngestion(message: KafkaMessage, queue: IngestionConsumer): Promise<void> {
     const event = formPipelineEvent(message)
@@ -37,19 +39,92 @@ export async function eachBatchIngestion(payload: EachBatchPayload, queue: Inges
     await eachBatch(payload, queue, eachMessageIngestion, groupIntoBatchesIngestion, 'ingestion')
 }
 
-export async function eachBatchParallelIngestion(payload: EachBatchPayload, queue: IngestionConsumer): Promise<void> {
+export async function eachBatchParallelIngestion(
+    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
+    queue: IngestionConsumer
+): Promise<void> {
     async function eachMessage(event: PipelineEvent, queue: IngestionConsumer): Promise<void> {
         await ingestEvent(queue.pluginsServer, queue.workerMethods, event)
     }
 
-    await eachBatchParallel(
-        payload,
-        queue,
-        eachMessage,
-        groupByTeamDistinctId,
-        queue.pluginsServer.INGESTION_CONCURRENCY,
-        'ingestion'
-    )
+    const batchStartTimer = new Date()
+    const metricKey = 'ingestion'
+    const loggingKey = `each_batch_parallel_ingestion`
+
+    const transaction = Sentry.startTransaction({ name: `eachBatchParallelIngestion` }, { topic: queue.topic })
+
+    try {
+        /**
+         * Micro-batches should be executed from biggest to smallest to enable the best concurrency.
+         * We're sorting with biggest last and pop()ing. Ideally, we'd use a priority queue by length
+         * and a separate array for single messages, but let's look at profiles before optimizing.
+         */
+        const messageBatches = groupByTeamDistinctId(batch.messages)
+        messageBatches.sort((a, b) => a.length - b.length)
+
+        queue.pluginsServer.statsd?.histogram('ingest_event_batching.input_length', batch.messages.length, {
+            key: metricKey,
+        })
+        queue.pluginsServer.statsd?.histogram('ingest_event_batching.batch_count', messageBatches.length, {
+            key: metricKey,
+        })
+
+        async function processMicroBatches(batches: PipelineEvent[][]): Promise<void> {
+            let currentBatch
+            let processedBatches = 0
+            while ((currentBatch = batches.pop()) !== undefined) {
+                const batchSpan = transaction.startChild({
+                    op: 'messageBatch',
+                    data: { batchLength: currentBatch.length },
+                })
+                for (const message of currentBatch) {
+                    await Promise.all([eachMessage(message, queue), heartbeat()])
+                }
+                processedBatches++
+                batchSpan.finish()
+            }
+            status.debug('🧩', `Stopping worker after processing ${processedBatches} micro-batches`)
+            return Promise.resolve()
+        }
+
+        await Promise.all(
+            [...Array(queue.pluginsServer.INGESTION_CONCURRENCY)].map(() => processMicroBatches(messageBatches))
+        )
+
+        // Commit offsets once at the end of the batch. We run the risk of duplicates
+        // if the pod is prematurely killed in the middle of a batch, but this allows
+        // us to process events out of order within a batch, for higher throughput.
+        const commitSpan = transaction.startChild({ op: 'offsetCommit' })
+        const lastMessage = batch.messages.at(-1)
+        if (lastMessage) {
+            resolveOffset(lastMessage.offset)
+            await commitOffsetsIfNecessary()
+            latestOffsetTimestampGauge
+                .labels({ partition: batch.partition, topic: batch.topic, groupId: metricKey })
+                .set(Number.parseInt(lastMessage.timestamp))
+        }
+        commitSpan.finish()
+
+        status.debug(
+            '🧩',
+            `Kafka batch of ${batch.messages.length} events completed in ${
+                new Date().valueOf() - batchStartTimer.valueOf()
+            }ms (${loggingKey})`
+        )
+
+        if (!isRunning() || isStale()) {
+            status.info('🚪', `Ending the consumer loop`, {
+                isRunning: isRunning(),
+                isStale: isStale(),
+                msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
+            })
+            await heartbeat()
+            return
+        }
+    } finally {
+        queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
+        transaction.finish()
+    }
 }
 
 export async function ingestEvent(

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/node'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
-import { PipelineEvent } from '../../../types' // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 import { status } from '../../../utils/status'
 import { IngestionConsumer } from '../kafka-queue'
 import { latestOffsetTimestampGauge } from '../metrics'
@@ -73,95 +72,6 @@ export async function eachBatch(
                 new Date().valueOf() - batchStartTimer.valueOf()
             }ms (${loggingKey})`
         )
-    } finally {
-        queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
-        transaction.finish()
-    }
-}
-
-export async function eachBatchParallel(
-    /**
-     * Using the provided groupIntoBatches function, split the incoming batch into micro-batches
-     * that are executed **in parallel**, committing offsets only at the end.
-     * Events within a single micro-batch are processed **sequentially**.
-     */
-    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
-    queue: IngestionConsumer,
-    eachMessage: (message: PipelineEvent, queue: IngestionConsumer) => Promise<void>,
-    groupIntoBatches: (messages: KafkaMessage[]) => PipelineEvent[][],
-    concurrency: number,
-    key: string
-): Promise<void> {
-    const batchStartTimer = new Date()
-    const loggingKey = `each_batch_${key}`
-
-    const transaction = Sentry.startTransaction(
-        { name: `eachBatchParallel(${eachMessage.name})` },
-        { topic: queue.topic }
-    )
-
-    try {
-        /**
-         * Micro-batches should be executed from biggest to smallest to enable the best concurrency.
-         * We're sorting with biggest last and pop()ing. Ideally, we'd use a priority queue by length
-         * and a separate array for single messages, but let's look at profiles before optimizing.
-         */
-        const messageBatches = groupIntoBatches(batch.messages)
-        messageBatches.sort((a, b) => a.length - b.length)
-
-        queue.pluginsServer.statsd?.histogram('ingest_event_batching.input_length', batch.messages.length, { key: key })
-        queue.pluginsServer.statsd?.histogram('ingest_event_batching.batch_count', messageBatches.length, { key: key })
-
-        async function processMicroBatches(batches: PipelineEvent[][]): Promise<void> {
-            let currentBatch
-            let processedBatches = 0
-            while ((currentBatch = batches.pop()) !== undefined) {
-                const batchSpan = transaction.startChild({
-                    op: 'messageBatch',
-                    data: { batchLength: currentBatch.length },
-                })
-                for (const message of currentBatch) {
-                    await Promise.all([eachMessage(message, queue), heartbeat()])
-                }
-                processedBatches++
-                batchSpan.finish()
-            }
-            status.debug('🧩', `Stopping worker after processing ${processedBatches} micro-batches`)
-            return Promise.resolve()
-        }
-
-        await Promise.all([...Array(concurrency)].map(() => processMicroBatches(messageBatches)))
-
-        // Commit offsets once at the end of the batch. We run the risk of duplicates
-        // if the pod is prematurely killed in the middle of a batch, but this allows
-        // us to process events out of order within a batch, for higher throughput.
-        const commitSpan = transaction.startChild({ op: 'offsetCommit' })
-        const lastMessage = batch.messages.at(-1)
-        if (lastMessage) {
-            resolveOffset(lastMessage.offset)
-            await commitOffsetsIfNecessary()
-            latestOffsetTimestampGauge
-                .labels({ partition: batch.partition, topic: batch.topic, groupId: key })
-                .set(Number.parseInt(lastMessage.timestamp))
-        }
-        commitSpan.finish()
-
-        status.debug(
-            '🧩',
-            `Kafka batch of ${batch.messages.length} events completed in ${
-                new Date().valueOf() - batchStartTimer.valueOf()
-            }ms (${loggingKey})`
-        )
-
-        if (!isRunning() || isStale()) {
-            status.info('🚪', `Ending the consumer loop`, {
-                isRunning: isRunning(),
-                isStale: isStale(),
-                msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
-            })
-            await heartbeat()
-            return
-        }
     } finally {
         queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
         transaction.finish()

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -4,7 +4,7 @@ import LRU from 'lru-cache'
 import { Client, Pool } from 'pg'
 
 import { ONE_MINUTE } from '../../config/constants'
-import { PluginsServerConfig, Team, TeamId } from '../../types'
+import { PipelineEvent, PluginsServerConfig, Team, TeamId } from '../../types'
 import { postgresQuery } from '../../utils/db/postgres'
 import { timeoutGuard } from '../../utils/db/utils'
 import { posthog } from '../../utils/posthog'
@@ -31,6 +31,16 @@ export class TeamManager {
             updateAgeOnGet: false, // Make default behaviour explicit
         })
         this.instanceSiteUrl = serverConfig.SITE_URL || 'unknown'
+    }
+
+    public async getTeamForEvent(event: PipelineEvent): Promise<Team | null> {
+        if (event.team_id) {
+            return this.fetchTeam(event.team_id)
+        } else if (event.token) {
+            return this.getTeamByToken(event.token)
+        } else {
+            return Promise.resolve(null)
+        }
     }
 
     public async fetchTeam(teamId: number): Promise<Team | null> {

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -1,5 +1,9 @@
 import { KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW } from '../../../src/config/kafka-topics'
 import { eachBatchIngestionWithOverflow } from '../../../src/main/ingestion-queues/analytics-events-ingestion-consumer'
+import {
+    eachBatchParallelIngestion,
+    IngestionOverflowMode,
+} from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
 import { ConfiguredLimiter } from '../../../src/utils/token-bucket'
 import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
 
@@ -129,5 +133,143 @@ describe('eachBatchIngestionWithOverflow', () => {
         })
         // This is "the rest of the pipeline"
         expect(queue.workerMethods.runEventPipeline).not.toHaveBeenCalled()
+    })
+})
+
+describe('eachBatchParallelIngestion with overflow reroute', () => {
+    let queue: any
+
+    function createBatchWithMultipleEventsWithKeys(events: any[], timestamp?: any): any {
+        return {
+            batch: {
+                partition: 0,
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION,
+                messages: events.map((event) => ({
+                    value: JSON.stringify(event),
+                    timestamp,
+                    offset: event.offset,
+                    key: event.team_id + ':' + event.distinct_id,
+                })),
+            },
+            resolveOffset: jest.fn(),
+            heartbeat: jest.fn(),
+            commitOffsetsIfNecessary: jest.fn(),
+            isRunning: jest.fn(() => true),
+            isStale: jest.fn(() => false),
+        }
+    }
+
+    beforeEach(() => {
+        queue = {
+            bufferSleep: jest.fn(),
+            pluginsServer: {
+                INGESTION_CONCURRENCY: 4,
+                statsd: {
+                    timing: jest.fn(),
+                    increment: jest.fn(),
+                    histogram: jest.fn(),
+                    gauge: jest.fn(),
+                },
+                kafkaProducer: {
+                    queueMessage: jest.fn(),
+                },
+                db: 'database',
+            },
+            workerMethods: {
+                runAsyncHandlersEventPipeline: jest.fn(),
+                runEventPipeline: jest.fn(),
+            },
+        }
+    })
+
+    it('reroutes events with no key to OVERFLOW topic', async () => {
+        const batch = {
+            batch: {
+                partition: 0,
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION,
+                messages: [
+                    {
+                        value: JSON.stringify(captureEndpointEvent),
+                        timestamp: captureEndpointEvent['timestamp'],
+                        offset: captureEndpointEvent['offset'],
+                        key: null,
+                    },
+                ],
+            },
+            resolveOffset: jest.fn(),
+            heartbeat: jest.fn(),
+            commitOffsetsIfNecessary: jest.fn(),
+            isRunning: jest.fn(() => true),
+            isStale: jest.fn(() => false),
+        }
+        const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => false)
+
+        await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Reroute)
+
+        expect(consume).not.toHaveBeenCalled()
+        expect(captureIngestionWarning).not.toHaveBeenCalled()
+        expect(queue.pluginsServer.kafkaProducer.queueMessage).toHaveBeenCalledWith(
+            {
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
+                messages: [
+                    {
+                        value: JSON.stringify(captureEndpointEvent),
+                        timestamp: captureEndpointEvent['timestamp'],
+                        offset: captureEndpointEvent['offset'],
+                        key: null,
+                    },
+                ],
+            },
+            true
+        )
+
+        // Event is not processed here
+        expect(queue.workerMethods.runEventPipeline).not.toHaveBeenCalled()
+    })
+
+    it('reroutes excess events to OVERFLOW topic', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => false)
+
+        await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Reroute)
+
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
+            1
+        )
+        expect(captureIngestionWarning).not.toHaveBeenCalled()
+        expect(queue.pluginsServer.kafkaProducer.queueMessage).toHaveBeenCalledWith(
+            {
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
+                messages: [
+                    {
+                        value: JSON.stringify(captureEndpointEvent),
+                        timestamp: captureEndpointEvent['timestamp'],
+                        offset: captureEndpointEvent['offset'],
+                        key: null,
+                    },
+                ],
+            },
+            true
+        )
+
+        // Event is not processed here
+        expect(queue.workerMethods.runEventPipeline).not.toHaveBeenCalled()
+    })
+
+    it('does not reroute if not over capacity limit', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => true)
+
+        await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Reroute)
+
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
+            1
+        )
+        expect(captureIngestionWarning).not.toHaveBeenCalled()
+        expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+        // Event is processed
+        expect(queue.workerMethods.runEventPipeline).toHaveBeenCalled()
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -1,5 +1,9 @@
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
 import { eachBatchIngestionFromOverflow } from '../../../src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer'
+import {
+    eachBatchParallelIngestion,
+    IngestionOverflowMode,
+} from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
 import { WarningLimiter } from '../../../src/utils/token-bucket'
 import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
 
@@ -71,7 +75,6 @@ describe('eachBatchIngestionWithOverflow', () => {
     it('raises warning when capacity available', async () => {
         const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
         const consume = jest.spyOn(WarningLimiter, 'consume').mockImplementation(() => true)
-
         await eachBatchIngestionFromOverflow(batch, queue)
 
         expect(consume).toHaveBeenCalledWith(
@@ -123,5 +126,98 @@ describe('eachBatchIngestionWithOverflow', () => {
         await eachBatchIngestionFromOverflow(batch, queue)
 
         expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+    })
+})
+
+describe('eachBatchParallelIngestion with overflow consume', () => {
+    let queue: any
+
+    function createBatchWithMultipleEventsWithKeys(events: any[], timestamp?: any): any {
+        return {
+            batch: {
+                partition: 0,
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION,
+                messages: events.map((event) => ({
+                    value: JSON.stringify(event),
+                    timestamp,
+                    offset: event.offset,
+                    key: event.team_id + ':' + event.distinct_id,
+                })),
+            },
+            resolveOffset: jest.fn(),
+            heartbeat: jest.fn(),
+            commitOffsetsIfNecessary: jest.fn(),
+            isRunning: jest.fn(() => true),
+            isStale: jest.fn(() => false),
+        }
+    }
+
+    beforeEach(() => {
+        queue = {
+            bufferSleep: jest.fn(),
+            pluginsServer: {
+                INGESTION_CONCURRENCY: 4,
+                statsd: {
+                    timing: jest.fn(),
+                    increment: jest.fn(),
+                    histogram: jest.fn(),
+                    gauge: jest.fn(),
+                },
+                kafkaProducer: {
+                    queueMessage: jest.fn(),
+                },
+                teamManager: {
+                    getTeamForEvent: jest.fn(),
+                },
+                db: 'database',
+            },
+            workerMethods: {
+                runAsyncHandlersEventPipeline: jest.fn(),
+                runEventPipeline: jest.fn(),
+            },
+        }
+    })
+
+    it('raises ingestion warning when consuming from overflow', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const consume = jest.spyOn(WarningLimiter, 'consume').mockImplementation(() => true)
+
+        queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
+        await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Consume)
+
+        expect(queue.pluginsServer.teamManager.getTeamForEvent).toHaveBeenCalledTimes(1)
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
+            1
+        )
+        expect(captureIngestionWarning).toHaveBeenCalledWith(
+            queue.pluginsServer.db,
+            captureEndpointEvent['team_id'],
+            'ingestion_capacity_overflow',
+            {
+                overflowDistinctId: captureEndpointEvent['distinct_id'],
+            }
+        )
+
+        // Event is processed
+        expect(queue.workerMethods.runEventPipeline).toHaveBeenCalled()
+    })
+
+    it('does not raise ingestion warning when under threshold', async () => {
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const consume = jest.spyOn(WarningLimiter, 'consume').mockImplementation(() => false)
+
+        queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
+        await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Consume)
+
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
+            1
+        )
+        expect(captureIngestionWarning).not.toHaveBeenCalled()
+        expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+
+        // Event is processed
+        expect(queue.workerMethods.runEventPipeline).toHaveBeenCalled()
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -4,7 +4,7 @@ import { eachBatchAsyncHandlers } from '../../../src/main/ingestion-queues/batch
 import {
     eachBatchIngestion,
     eachBatchParallelIngestion,
-    groupByTeamDistinctId,
+    splitIngestionBatch,
 } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
 import {
     ClickHouseTimestamp,
@@ -283,7 +283,7 @@ describe('eachBatchX', () => {
                 { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
             ])
             const stats = new Map()
-            for (const group of groupByTeamDistinctId(batch.batch.messages)) {
+            for (const group of splitIngestionBatch(batch.batch.messages)) {
                 const key = `${group[0].team_id}:${group[0].token}:${group[0].distinct_id}`
                 for (const event of group) {
                     expect(`${event.team_id}:${event.token}:${event.distinct_id}`).toEqual(key)

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -262,7 +262,7 @@ describe('eachBatchX', () => {
                 uuid: 'uuid1',
             })
             expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(
-                'kafka_queue.each_batch_ingestion',
+                'kafka_queue.each_batch_parallel_ingestion',
                 expect.any(Date)
             )
         })


### PR DESCRIPTION
## Problem

Sister PR to https://github.com/PostHog/posthog/pull/15612, port the overflow logic into it to make it prod-ready.

## Changes

- merge `eachBatchParallel` into `eachBatchParallelIngestion` to simplify code
- port the overflow rerouting logic into `eachBatchParallelIngestion`
- port the overflow consumer's ingestion warning, calling TeamManager to resolve token if needed
- use `eachBatchParallelIngestion` on both consumers if `INGESTION_PARALLEL_BATCHING_ENABLED` is set


The goal here is to improve concurrency to allow the rdkafka consumer transition. It marginally improves performance too, by making us unmarshall events only once instead of three times.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
