### PR TITLE
chore(mgmt): fix logger level in mgmt commands

### DIFF
--- a/posthog/management/commands/backfill_persons_and_groups_on_events.py
+++ b/posthog/management/commands/backfill_persons_and_groups_on_events.py
@@ -1,3 +1,4 @@
+import logging
 from time import sleep
 from typing import Any
 from uuid import uuid4
@@ -39,6 +40,7 @@ Also note that minor inconsitencies can occur from distinct IDs and properties c
 
 
 logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 backfill_query_id = str(uuid4())
 

--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 import structlog
@@ -9,6 +10,7 @@ from posthog.models.person import PersonDistinctId
 from posthog.models.person.util import create_person_distinct_id
 
 logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class Command(BaseCommand):

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Sequence
 
 import structlog
@@ -17,6 +18,7 @@ from posthog.models.async_migration import (
 from posthog.models.instance_setting import get_instance_setting
 
 logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def get_necessary_migrations() -> Sequence[AsyncMigration]:

--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -1,9 +1,12 @@
+import logging
+
 import structlog
 from django.core.management.base import BaseCommand
 
 from posthog.tasks.sync_all_organization_available_features import sync_all_organization_available_features
 
 logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class Command(BaseCommand):

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from uuid import UUID
 
 import structlog
@@ -12,6 +13,7 @@ from posthog.models.person.person import Person
 from posthog.models.person.util import _delete_ch_distinct_id, create_person, create_person_distinct_id
 
 logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class Command(BaseCommand):

--- a/posthog/management/commands/sync_replicated_schema.py
+++ b/posthog/management/commands/sync_replicated_schema.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from collections import defaultdict
 from typing import Dict, Set
@@ -11,6 +12,7 @@ from posthog.client import sync_execute
 from posthog.cloud_utils import is_cloud
 
 logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 TableName = str
 Query = str


### PR DESCRIPTION
## Problem

The default log level for management commands has been raised to reduce noise, but this removes all the progress output.

## Changes

When mgmt commands instanciate a logger for business logic, set that logger to INFO

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
