### PR TITLE
feat: back off buffer age threshold as lag grows

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -116,7 +116,10 @@ export function getDefaultConfig(): PluginsServerConfig {
 
         SESSION_RECORDING_BLOB_PROCESSING_TEAMS: '', // TODO: Change this to 'all' when we release it fully
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
-        SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10, // NOTE: 10 minutes
+        // NOTE: 10 minutes
+        SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,
+        // NOTE: 5x the max age, so that we don't flush too infrequently when backing off due to lag
+        SESSION_RECORDING_MAX_BUFFER_AGE_MULTIPLIER: 5,
         SESSION_RECORDING_MAX_BUFFER_SIZE_KB: ['dev', 'test'].includes(process.env.NODE_ENV || 'undefined')
             ? 1024 // NOTE: ~1MB in dev or test, so that even with gzipped content we still flush pretty frequently
             : 1024 * 50, // ~50MB after compression in prod

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -385,8 +385,8 @@ export class SessionRecordingBlobIngester {
         // for every ten minutes of lag add the same amount again
         const tenMinutesInMillis = 10 * 60 * 1000
         const age = serverNow - kafkaNow
-        const steps = Math.max(1, Math.ceil(age / tenMinutesInMillis))
-        return configuredAgeToleranceMillis * steps
+        const steps = Math.min(5, Math.ceil(age / tenMinutesInMillis))
+        return steps ? configuredAgeToleranceMillis * steps : configuredAgeToleranceMillis
     }
 
     public async stop(): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -355,7 +355,8 @@ export class SessionRecordingBlobIngester {
             const flushThresholdMillis = this.flushThreshold(
                 kafkaNow,
                 DateTime.now().toMillis(),
-                this.serverConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS * 1000
+                this.serverConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS * 1000,
+                this.serverConfig.SESSION_RECORDING_MAX_BUFFER_AGE_MULTIPLIER
             )
 
             this.sessions.forEach((sessionManager) => {
@@ -380,12 +381,17 @@ export class SessionRecordingBlobIngester {
         }, flushIntervalTimeoutMs)
     }
 
-    flushThreshold(kafkaNow: number, serverNow: number, configuredAgeToleranceMillis: number): number {
+    flushThreshold(
+        kafkaNow: number,
+        serverNow: number,
+        configuredAgeToleranceMillis: number,
+        maxBufferAgeMultiplier = 5
+    ): number {
         // return at least config milliseconds
         // for every ten minutes of lag add the same amount again
         const tenMinutesInMillis = 10 * 60 * 1000
         const age = serverNow - kafkaNow
-        const steps = Math.min(5, Math.ceil(age / tenMinutesInMillis))
+        const steps = Math.min(maxBufferAgeMultiplier, Math.ceil(age / tenMinutesInMillis))
         return steps ? configuredAgeToleranceMillis * steps : configuredAgeToleranceMillis
     }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -189,6 +189,8 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number
     SESSION_RECORDING_REMOTE_FOLDER: string
+    // maximum allowed back off of SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS
+    SESSION_RECORDING_MAX_BUFFER_AGE_MULTIPLIER: number
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
@@ -63,16 +63,25 @@ describe('ingester', () => {
     })
 
     it.each([
-        [0, 0, 1000, 1000], // when no log, use configuration
-        [0, 999, 1000, 1000], // when small lag, use configuration
-        [0, 10 * 60 * 1000 + 1, 1000, 2000], // over ten minutes, use configuration * 2
-        [0, 10 * 60 * 1000 * 2 + 1, 1000, 3000], // over twenty minutes, use configuration * 3
-        [10 * 60 * 1000 * 3, 10 * 60 * 1000 * 7 + 1, 1000, 5000], // etc
-        [10 * 60 * 1000 * 3, 10 * 60 * 1000 * 10 + 1, 1000, 5000], // but no more than five times
+        [undefined, 0, 0, 1000, 1000], // when no log, use configuration
+        [undefined, 0, 999, 1000, 1000], // when small lag, use configuration
+        [undefined, 0, 10 * 60 * 1000 + 1, 1000, 2000], // over ten minutes, use configuration * 2
+        [undefined, 0, 10 * 60 * 1000 * 2 + 1, 1000, 3000], // over twenty minutes, use configuration * 3
+        [undefined, 10 * 60 * 1000 * 3, 10 * 60 * 1000 * 7 + 1, 1000, 5000], // etc
+        [undefined, 10 * 60 * 1000 * 3, 10 * 60 * 1000 * 10 + 1, 1000, 5000], // but no more than five times
+        [12, 10 * 60 * 1000 * 3, 10 * 60 * 1000 * 40 + 1, 1000, 12000], // well no more than config times
     ])(
         'uses expected flush threshold for different things',
-        (kafkaNow: number, serverNow: number, configuredTolerance: number, expectedThreshold: number) => {
-            expect(ingester.flushThreshold(kafkaNow, serverNow, configuredTolerance)).toEqual(expectedThreshold)
+        (
+            configMax: number | undefined,
+            kafkaNow: number,
+            serverNow: number,
+            configuredTolerance: number,
+            expectedThreshold: number
+        ) => {
+            expect(ingester.flushThreshold(kafkaNow, serverNow, configuredTolerance, configMax)).toEqual(
+                expectedThreshold
+            )
         }
     )
 })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
@@ -68,7 +68,7 @@ describe('ingester', () => {
         [0, 10 * 60 * 1000 + 1, 1000, 2000], // over ten minutes, use configuration * 2
         [0, 10 * 60 * 1000 * 2 + 1, 1000, 3000], // over twenty minutes, use configuration * 3
         [10 * 60 * 1000 * 3, 10 * 60 * 1000 * 7 + 1, 1000, 5000], // etc
-        [10 * 60 * 1000 * 3, 10 * 60 * 1000 * 10 + 1, 1000, 8000], // etc
+        [10 * 60 * 1000 * 3, 10 * 60 * 1000 * 10 + 1, 1000, 5000], // but no more than five times
     ])(
         'uses expected flush threshold for different things',
         (kafkaNow: number, serverNow: number, configuredTolerance: number, expectedThreshold: number) => {


### PR DESCRIPTION
## Problem

When the blob ingester is lagging by _a lot_ we still chunk on time more than size.

## Changes

hopefully not any more 💰

## How did you test this code?

developer tests
