### PR TITLE
fix(experiments): re-enable data fetching with data exploration feature flag

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -100,6 +100,7 @@ export function Experiment(): JSX.Element {
     const { insightProps } = useValues(
         insightLogic({
             dashboardItemId: experimentInsightId,
+            disableDataExploration: true,
         })
     )
     const {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -882,7 +882,7 @@ export const insightLogic = kea<insightLogicType>([
 
             // (Re)load results when filters have changed or if there's no result yet
             if (backendFilterChanged || !values.insight?.result) {
-                if (!values.isUsingDataExploration && !values.insight?.query) {
+                if ((!values.isUsingDataExploration || props.disableDataExploration) && !values.insight?.query) {
                     actions.loadResults()
                 }
             }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1977,6 +1977,8 @@ export interface InsightLogicProps {
     doNotLoad?: boolean
     /** If showing a shared insight/dashboard, we need the access token for refreshing. */
     sharingAccessToken?: string
+    /** Temporary hack to disable data exploration to enable result fetching. */
+    disableDataExploration?: boolean
 }
 
 export interface SetInsightOptions {


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C045L1VEG87/p1684487340711989.

The issue here is that we have a circuit breaker in the insightLogic that disables fetching results from the api when data exploration is active. Experiments needs to be converted to the new data exploration format, but that is a bigger effort, hence this PR.

## Changes

This PR adds an additional prop to insightLogic which deactivates the circuit breaker.

## How did you test this code?

Verfied that experiment insight results load again.