### PR TITLE
test(insights): Clean up User Paths tests + snapshot CH queries

### DIFF
--- a/ee/api/test/test_session_recording_playlist.py
+++ b/ee/api/test/test_session_recording_playlist.py
@@ -211,8 +211,8 @@ class TestSessionRecordingPlaylist(APILicensedTest):
         ).json()
 
         assert len(result["results"]) == 2
-        assert result["results"][0]["id"] == "session2"
-        assert result["results"][1]["id"] == "session1"
+        assert result["results"][0]["id"] == "session1"
+        assert result["results"][1]["id"] == "session2"
 
         # Test get recordings
         result = self.client.get(

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -83,7 +83,7 @@
        (SELECT pdi.person_id AS person_id,
                countIf(timestamp > now() - INTERVAL 2 year
                        AND timestamp < now()
-                       AND event = '$pageview') > 0 AS performed_event_condition_21_level_level_0_level_0_level_0_0
+                       AND event = '$pageview') > 0 AS performed_event_condition_6_level_level_0_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -113,7 +113,7 @@
            HAVING max(is_deleted) = 0
            AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
      WHERE 1 = 1
-       AND ((((performed_event_condition_21_level_level_0_level_0_level_0_0)))) ) as person
+       AND ((((performed_event_condition_6_level_level_0_level_0_level_0_0)))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -148,7 +148,7 @@
                    (SELECT pdi.person_id AS person_id,
                            countIf(timestamp > now() - INTERVAL 2 year
                                    AND timestamp < now()
-                                   AND event = '$pageview') > 0 AS performed_event_condition_23_level_level_0_level_0_level_0_0
+                                   AND event = '$pageview') > 0 AS performed_event_condition_8_level_level_0_level_0_level_0_0
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
@@ -178,7 +178,7 @@
                        HAVING max(is_deleted) = 0
                        AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
                  WHERE 1 = 1
-                   AND ((((performed_event_condition_23_level_level_0_level_0_level_0_0)))) ) ))
+                   AND ((((performed_event_condition_8_level_level_0_level_0_level_0_0)))) ) ))
   '
 ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_for_behavioural_cohorts
@@ -195,7 +195,7 @@
      FROM
        (SELECT pdi.person_id AS person_id,
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
-        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_24_level_level_0_level_0_0
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_9_level_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -208,7 +208,7 @@
           AND event IN ['signup']
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND (((first_time_condition_24_level_level_0_level_0_0))) ) as person
+       AND (((first_time_condition_9_level_level_0_level_0_0))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -237,9 +237,9 @@
        (SELECT pdi.person_id AS person_id,
                countIf(timestamp > now() - INTERVAL 2 year
                        AND timestamp < now()
-                       AND event = '$pageview') > 0 AS performed_event_condition_25_level_level_0_level_0_level_0_0,
+                       AND event = '$pageview') > 0 AS performed_event_condition_10_level_level_0_level_0_level_0_0,
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
-        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_25_level_level_0_level_1_level_0_level_0_level_0_0
+        AND minIf(timestamp, event = 'signup') < now() as first_time_condition_10_level_level_0_level_1_level_0_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -252,8 +252,8 @@
           AND event IN ['$pageview', 'signup']
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND ((((performed_event_condition_25_level_level_0_level_0_level_0_0))
-             AND ((((NOT first_time_condition_25_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person
+       AND ((((performed_event_condition_10_level_level_0_level_0_level_0_0))
+             AND ((((NOT first_time_condition_10_level_level_0_level_1_level_0_level_0_level_0_0)))))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -146,7 +146,7 @@
       ))
     ',
     <class 'dict'> {
-      'global_cohort_id_0': 26,
+      'global_cohort_id_0': 38,
       'global_version_0': None,
     },
   )

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -1,3 +1,3330 @@
+# name: TestClickhousePaths.test_by_funnel_after_dropoff
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff.1
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '1_step one'
+    AND path_key = '2_step dropoff1'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff.2
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '2_step dropoff1'
+    AND path_key = '3_step dropoff2'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff.3
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '3_step dropoff2'
+    AND path_key = '4_step branch'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff.4
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '4_step branch'
+    AND path_key = '3_step dropoff2'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff_with_group_filter
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_0
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 0
+                    GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff_with_group_filter.1
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_0
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 0
+                    GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '1_step one'
+    AND path_key = '2_step dropoff1'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff_with_group_filter.2
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_0
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 0
+                    GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '2_step dropoff1'
+    AND path_key = '3_step dropoff2'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff_with_group_filter.3
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_0
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 0
+                    GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '3_step dropoff2'
+    AND path_key = '4_step branch'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_dropoff_with_group_filter.4
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_0, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_0,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 1
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_0
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 0
+                    GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '4_step branch'
+    AND path_key = '3_step dropoff2'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_step
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_after_step_limit
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_before_dropoff
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps = 2
+     ORDER BY aggregation_target)
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp <= target_timestamp + INTERVAL 7 DAY
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_before_step
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id , timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as timestamp,
+               argMax(latest_2, steps) as final_timestamp,
+               argMax(latest_0, steps) as first_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_2,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.timestamp AS target_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp <= target_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_between_step
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id,
+            max_timestamp,
+            min_timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as max_timestamp,
+               argMax(latest_0, steps) as min_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.min_timestamp as min_timestamp,
+                        funnel_actors.max_timestamp as max_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= min_timestamp
+                   AND e.timestamp <= max_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_between_step.1
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id,
+            max_timestamp,
+            min_timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as max_timestamp,
+               argMax(latest_0, steps) as min_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.min_timestamp as min_timestamp,
+                        funnel_actors.max_timestamp as max_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= min_timestamp
+                   AND e.timestamp <= max_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '1_step one'
+    AND path_key = '2_between_step_1_a'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_between_step.2
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id,
+            max_timestamp,
+            min_timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as max_timestamp,
+               argMax(latest_0, steps) as min_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.min_timestamp as min_timestamp,
+                        funnel_actors.max_timestamp as max_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= min_timestamp
+                   AND e.timestamp <= max_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '2_between_step_1_a'
+    AND path_key = '3_between_step_1_b'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_between_step.3
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id,
+            max_timestamp,
+            min_timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as max_timestamp,
+               argMax(latest_0, steps) as min_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.min_timestamp as min_timestamp,
+                        funnel_actors.max_timestamp as max_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= min_timestamp
+                   AND e.timestamp <= max_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '3_between_step_1_b'
+    AND path_key = '4_step two'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_between_step.4
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id,
+            max_timestamp,
+            min_timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as max_timestamp,
+               argMax(latest_0, steps) as min_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.min_timestamp as min_timestamp,
+                        funnel_actors.max_timestamp as max_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= min_timestamp
+                   AND e.timestamp <= max_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '3_between_step_1_b'
+    AND path_key = '4_between_step_1_c'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_by_funnel_between_step.5
+  '
+  WITH funnel_actors AS
+    (SELECT aggregation_target AS actor_id,
+            max_timestamp,
+            min_timestamp
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+               argMax(latest_1, steps) as max_timestamp,
+               argMax(latest_0, steps) as min_timestamp
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time ,
+                                  latest_1,
+                                  latest_0
+           FROM
+             (SELECT *,
+                     if(latest_0 <= latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 <= latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 <= latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          latest_1,
+                                                          step_2,
+                                                          if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target, timestamp, step_0,
+                                                             latest_0,
+                                                             step_1,
+                                                             min(latest_1) over (PARTITION by aggregation_target
+                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                                step_2,
+                                                                                min(latest_2) over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id ,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                            AND (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE steps IN [2, 3]
+     ORDER BY aggregation_target)
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(toDateTime('2018-01-01') + toIntervalSecond(x.3 / 1000) < toDateTime('2018-01-01') + INTERVAL 7 DAY, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        funnel_actors.min_timestamp as min_timestamp,
+                        funnel_actors.max_timestamp as max_timestamp,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                   AND e.timestamp >= min_timestamp
+                   AND e.timestamp <= max_timestamp
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '4_between_step_1_c'
+    AND path_key = '5_step two'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
 # name: TestClickhousePaths.test_end
   '
   

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -3704,7 +3704,7 @@
                    AND (event = '$pageview')
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -3784,7 +3784,7 @@
                    AND (event = '$pageview')
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -3863,7 +3863,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -3942,7 +3942,7 @@
                  WHERE team_id = 2
                    AND (event = '$screen')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4021,7 +4021,7 @@
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4100,7 +4100,7 @@
                  WHERE team_id = 2
                    AND (event IN ['/custom1', '/custom2'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4179,7 +4179,7 @@
                  WHERE team_id = 2
                    AND (event IN ['/custom3', 'blah'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4260,7 +4260,7 @@
                         OR event = '$screen'
                         OR NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4342,7 +4342,7 @@
                         OR NOT event LIKE '$%')
                    AND NOT path_item IN ['/custom1', '/1', '/2', '/3']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -7586,7 +7586,7 @@
   FROM session_recording_events
   WHERE team_id = 2
     and has_full_snapshot = 1
-    and session_id in ['s3', 's1', 's5']
+    and session_id in ['s1', 's3', 's5']
   '
 ---
 # name: TestClickhousePaths.test_recording_for_dropoff
@@ -8137,7 +8137,7 @@
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -8935,7 +8935,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -10158,7 +10158,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -10475,7 +10475,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-22 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -1,3 +1,1365 @@
+# name: TestClickhousePaths.test_end
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/about') as target_index ,
+               if(target_index > 0, arrayResize(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arrayResize(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, (-1) * 5) as limited_path ,
+               arraySlice(filtered_timings, (-1) * 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_end.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/about') as target_index ,
+               if(target_index > 0, arrayResize(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arrayResize(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, (-1) * 5) as limited_path ,
+               arraySlice(filtered_timings, (-1) * 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_end_materialized
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/about') as target_index ,
+               if(target_index > 0, arrayResize(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arrayResize(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, (-1) * 5) as limited_path ,
+               arraySlice(filtered_timings, (-1) * 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', "mat_$screen_name", if(e.event = '$pageview', if(length("mat_$current_url") > 1, replaceRegexpAll("mat_$current_url", '/$', ''), "mat_$current_url"), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_end_materialized.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/about') as target_index ,
+               if(target_index > 0, arrayResize(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arrayResize(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, (-1) * 5) as limited_path ,
+               arraySlice(filtered_timings, (-1) * 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', "mat_$screen_name", if(e.event = '$pageview', if(length("mat_$current_url") > 1, replaceRegexpAll("mat_$current_url", '/$', ''), "mat_$current_url"), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_exclusion_filters_with_wildcard_groups
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['/bar/.*/foo']) AS group_index,
+                        if(group_index > 0, ['/bar/*/foo'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND NOT path_item IN ['/bar/*/foo']
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_exclusion_filters_with_wildcard_groups.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['/xxx/invalid/.*']) AS group_index,
+                        if(group_index > 0, ['/xxx/invalid/*'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND NOT path_item IN ['/bar/*/foo']
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_inclusion_exclusion_filters
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_inclusion_exclusion_filters.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$screen')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_inclusion_exclusion_filters.2
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_inclusion_exclusion_filters.3
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event IN ['/custom1', '/custom2'])
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_inclusion_exclusion_filters.4
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event IN ['/custom3', 'blah'])
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_inclusion_exclusion_filters.5
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview'
+                        OR event = '$screen'
+                        OR NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_inclusion_exclusion_filters.6
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview'
+                        OR event = '$screen'
+                        OR NOT event LIKE '$%')
+                   AND NOT path_item IN ['/custom1', '/1', '/2', '/3']
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_event_ordering
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-03 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_groups_filtering_person_on_events
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        e.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_0
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 0
+                    GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+                 WHERE team_id = 2
+                   AND (event = '$pageview'
+                        OR event = '$screen'
+                        OR NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-02-01 23:59:59', 'UTC')
+                   AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+                   AND notEmpty(e.person_id)
+                 ORDER BY e.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_groups_filtering_person_on_events.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        e.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_0
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 0
+                    GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
+                 WHERE team_id = 2
+                   AND (event = '$pageview'
+                        OR event = '$screen'
+                        OR NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-02-01 23:59:59', 'UTC')
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
+                   AND notEmpty(e.person_id)
+                 ORDER BY e.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_groups_filtering_person_on_events.2
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        e.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 LEFT JOIN
+                   (SELECT group_key,
+                           argMax(group_properties, _timestamp) AS group_properties_1
+                    FROM groups
+                    WHERE team_id = 2
+                      AND group_type_index = 1
+                    GROUP BY group_key) groups_1 ON "$group_1" == groups_1.group_key
+                 WHERE team_id = 2
+                   AND (event = '$pageview'
+                        OR event = '$screen'
+                        OR NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-02-01 23:59:59', 'UTC')
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_1, 'industry'), '^"|"$', '')))
+                   AND notEmpty(e.person_id)
+                 ORDER BY e.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
 # name: TestClickhousePaths.test_path_by_funnel_after_dropoff_with_group_filter
   '
   WITH funnel_actors AS
@@ -2011,6 +3373,3861 @@
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-02-01 23:59:59', 'UTC')
                    AND notEmpty(e.person_id)
                  ORDER BY if(notEmpty(overrides.person_id), overrides.person_id, e.person_id),
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_dropoff_key = '2_step two'
+    AND path_dropoff_key = path_key
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.1
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_key = '2_step two'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.2
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '2_step two'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.3
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_dropoff_key = '3_step three'
+    AND path_dropoff_key = path_key
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.4
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_key = '3_step three'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.5
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '3_step three'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.6
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_dropoff_key = '4_step four'
+    AND path_dropoff_key = path_key
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.7
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_key = '4_step four'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_dropoffs.8
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(0, '', e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '4_step four'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_person_on_events_v2
+  '
+  
+  SELECT distinct_id,
+         person_id
+  FROM events
+  WHERE team_id = 2
+    AND distinct_id IN ('poev2_p1',
+                        'poev2_p2')
+  GROUP BY distinct_id,
+           person_id
+  ORDER BY if(distinct_id = 'poev2_p1', -1, 0)
+  '
+---
+# name: TestClickhousePaths.test_person_on_events_v2.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 LEFT OUTER JOIN
+                   (SELECT argMax(override_person_id, version) as person_id,
+                           old_person_id
+                    FROM person_overrides
+                    WHERE team_id = 2
+                    GROUP BY old_person_id) AS overrides ON e.person_id = overrides.old_person_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview'
+                        OR event = '$screen'
+                        OR NOT event LIKE '$%')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-02-01 23:59:59', 'UTC')
+                   AND notEmpty(e.person_id)
+                 ORDER BY if(notEmpty(overrides.person_id), overrides.person_id, e.person_id),
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_recording
+  '
+  
+  SELECT person_id AS actor_id ,
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
+  FROM
+    (SELECT person_id,
+            path,
+            final_uuid as uuid,
+            final_timestamp as timestamp,
+            final_$session_id as $session_id,
+            final_$window_id as $window_id,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               joined_path_tuple.4 as final_uuid,
+               joined_path_tuple.5 as final_timestamp,
+               joined_path_tuple.6 as final_$session_id,
+               joined_path_tuple.7 as final_$window_id ,
+               arrayFilter((x, y)->y, uuid, mapping) as uuids,
+               arrayFilter((x, y)->y, timestamp, mapping) as timestamps,
+               arrayFilter((x, y)->y, $session_id, mapping) as $session_ids,
+               arrayFilter((x, y)->y, $window_id, mapping) as $window_ids ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               if(target_index > 0, arraySlice(uuids, target_index), uuids) as filtered_uuids ,
+               arraySlice(filtered_uuids, 1, 5) as limited_uuids ,
+               if(target_index > 0, arraySlice(timestamps, target_index), timestamps) as filtered_timestamps ,
+               arraySlice(filtered_timestamps, 1, 5) as limited_timestamps ,
+               if(target_index > 0, arraySlice($session_ids, target_index), $session_ids) as filtered_$session_ids ,
+               arraySlice(filtered_$session_ids, 1, 5) as limited_$session_ids ,
+               if(target_index > 0, arraySlice($window_ids, target_index), $window_ids) as filtered_$window_ids ,
+               arraySlice(filtered_$window_ids, 1, 5) as limited_$window_ids ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, '')), limited_uuids, limited_timestamps, limited_$session_ids, limited_$window_ids) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  path_time_tuple.4 as uuid,
+                  path_time_tuple.5 as timestamp,
+                  path_time_tuple.6 as $session_id,
+                  path_time_tuple.7 as $window_id ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing), uuids, timestamps, $session_ids, $window_ids) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(uuid) as uuids,
+                     groupArray(timestamp) as timestamps,
+                     groupArray($session_id) as $session_ids,
+                     groupArray($window_id) as $window_ids,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        e.uuid AS uuid,
+                        e.timestamp AS timestamp,
+                        e."$session_id" as $session_id,
+                        e."$window_id" as $window_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_key = '2_/2'
+  GROUP BY person_id
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_recording.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s3', 's1', 's5']
+  '
+---
+# name: TestClickhousePaths.test_recording_for_dropoff
+  '
+  
+  SELECT person_id AS actor_id ,
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
+  FROM
+    (SELECT person_id,
+            path,
+            final_uuid as uuid,
+            final_timestamp as timestamp,
+            final_$session_id as $session_id,
+            final_$window_id as $window_id,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               joined_path_tuple.4 as final_uuid,
+               joined_path_tuple.5 as final_timestamp,
+               joined_path_tuple.6 as final_$session_id,
+               joined_path_tuple.7 as final_$window_id ,
+               arrayFilter((x, y)->y, uuid, mapping) as uuids,
+               arrayFilter((x, y)->y, timestamp, mapping) as timestamps,
+               arrayFilter((x, y)->y, $session_id, mapping) as $session_ids,
+               arrayFilter((x, y)->y, $window_id, mapping) as $window_ids ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               if(target_index > 0, arraySlice(uuids, target_index), uuids) as filtered_uuids ,
+               arraySlice(filtered_uuids, 1, 5) as limited_uuids ,
+               if(target_index > 0, arraySlice(timestamps, target_index), timestamps) as filtered_timestamps ,
+               arraySlice(filtered_timestamps, 1, 5) as limited_timestamps ,
+               if(target_index > 0, arraySlice($session_ids, target_index), $session_ids) as filtered_$session_ids ,
+               arraySlice(filtered_$session_ids, 1, 5) as limited_$session_ids ,
+               if(target_index > 0, arraySlice($window_ids, target_index), $window_ids) as filtered_$window_ids ,
+               arraySlice(filtered_$window_ids, 1, 5) as limited_$window_ids ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, '')), limited_uuids, limited_timestamps, limited_$session_ids, limited_$window_ids) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  path_time_tuple.4 as uuid,
+                  path_time_tuple.5 as timestamp,
+                  path_time_tuple.6 as $session_id,
+                  path_time_tuple.7 as $window_id ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing), uuids, timestamps, $session_ids, $window_ids) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(uuid) as uuids,
+                     groupArray(timestamp) as timestamps,
+                     groupArray($session_id) as $session_ids,
+                     groupArray($window_id) as $window_ids,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        e.uuid AS uuid,
+                        e.timestamp AS timestamp,
+                        e."$session_id" as $session_id,
+                        e."$window_id" as $window_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_dropoff_key = '2_/2'
+    AND path_dropoff_key = path_key
+  GROUP BY person_id
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_recording_for_dropoff.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in []
+  '
+---
+# name: TestClickhousePaths.test_recording_for_dropoff.2
+  '
+  
+  SELECT person_id AS actor_id ,
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
+  FROM
+    (SELECT person_id,
+            path,
+            final_uuid as uuid,
+            final_timestamp as timestamp,
+            final_$session_id as $session_id,
+            final_$window_id as $window_id,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               joined_path_tuple.4 as final_uuid,
+               joined_path_tuple.5 as final_timestamp,
+               joined_path_tuple.6 as final_$session_id,
+               joined_path_tuple.7 as final_$window_id ,
+               arrayFilter((x, y)->y, uuid, mapping) as uuids,
+               arrayFilter((x, y)->y, timestamp, mapping) as timestamps,
+               arrayFilter((x, y)->y, $session_id, mapping) as $session_ids,
+               arrayFilter((x, y)->y, $window_id, mapping) as $window_ids ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               if(target_index > 0, arraySlice(uuids, target_index), uuids) as filtered_uuids ,
+               arraySlice(filtered_uuids, 1, 5) as limited_uuids ,
+               if(target_index > 0, arraySlice(timestamps, target_index), timestamps) as filtered_timestamps ,
+               arraySlice(filtered_timestamps, 1, 5) as limited_timestamps ,
+               if(target_index > 0, arraySlice($session_ids, target_index), $session_ids) as filtered_$session_ids ,
+               arraySlice(filtered_$session_ids, 1, 5) as limited_$session_ids ,
+               if(target_index > 0, arraySlice($window_ids, target_index), $window_ids) as filtered_$window_ids ,
+               arraySlice(filtered_$window_ids, 1, 5) as limited_$window_ids ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, '')), limited_uuids, limited_timestamps, limited_$session_ids, limited_$window_ids) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  path_time_tuple.4 as uuid,
+                  path_time_tuple.5 as timestamp,
+                  path_time_tuple.6 as $session_id,
+                  path_time_tuple.7 as $window_id ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing), uuids, timestamps, $session_ids, $window_ids) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(uuid) as uuids,
+                     groupArray(timestamp) as timestamps,
+                     groupArray($session_id) as $session_ids,
+                     groupArray($window_id) as $window_ids,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        e.uuid AS uuid,
+                        e.timestamp AS timestamp,
+                        e."$session_id" as $session_id,
+                        e."$window_id" as $window_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_dropoff_key = '3_/3'
+    AND path_dropoff_key = path_key
+  GROUP BY person_id
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_recording_for_dropoff.3
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s1']
+  '
+---
+# name: TestClickhousePaths.test_recording_with_no_window_or_session_id
+  '
+  
+  SELECT person_id AS actor_id ,
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
+  FROM
+    (SELECT person_id,
+            path,
+            final_uuid as uuid,
+            final_timestamp as timestamp,
+            final_$session_id as $session_id,
+            final_$window_id as $window_id,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               joined_path_tuple.4 as final_uuid,
+               joined_path_tuple.5 as final_timestamp,
+               joined_path_tuple.6 as final_$session_id,
+               joined_path_tuple.7 as final_$window_id ,
+               arrayFilter((x, y)->y, uuid, mapping) as uuids,
+               arrayFilter((x, y)->y, timestamp, mapping) as timestamps,
+               arrayFilter((x, y)->y, $session_id, mapping) as $session_ids,
+               arrayFilter((x, y)->y, $window_id, mapping) as $window_ids ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               if(target_index > 0, arraySlice(uuids, target_index), uuids) as filtered_uuids ,
+               arraySlice(filtered_uuids, 1, 5) as limited_uuids ,
+               if(target_index > 0, arraySlice(timestamps, target_index), timestamps) as filtered_timestamps ,
+               arraySlice(filtered_timestamps, 1, 5) as limited_timestamps ,
+               if(target_index > 0, arraySlice($session_ids, target_index), $session_ids) as filtered_$session_ids ,
+               arraySlice(filtered_$session_ids, 1, 5) as limited_$session_ids ,
+               if(target_index > 0, arraySlice($window_ids, target_index), $window_ids) as filtered_$window_ids ,
+               arraySlice(filtered_$window_ids, 1, 5) as limited_$window_ids ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, '')), limited_uuids, limited_timestamps, limited_$session_ids, limited_$window_ids) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  path_time_tuple.4 as uuid,
+                  path_time_tuple.5 as timestamp,
+                  path_time_tuple.6 as $session_id,
+                  path_time_tuple.7 as $window_id ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing), uuids, timestamps, $session_ids, $window_ids) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(uuid) as uuids,
+                     groupArray(timestamp) as timestamps,
+                     groupArray($session_id) as $session_ids,
+                     groupArray($window_id) as $window_ids,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        e.uuid AS uuid,
+                        e.timestamp AS timestamp,
+                        e."$session_id" as $session_id,
+                        e."$window_id" as $window_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE path_key = '2_/2'
+  GROUP BY person_id
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_recording_with_no_window_or_session_id.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in []
+  '
+---
+# name: TestClickhousePaths.test_recording_with_start_and_end
+  '
+  
+  SELECT person_id AS actor_id ,
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
+  FROM
+    (SELECT person_id,
+            path,
+            final_uuid as uuid,
+            final_timestamp as timestamp,
+            final_$session_id as $session_id,
+            final_$window_id as $window_id,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               joined_path_tuple.4 as final_uuid,
+               joined_path_tuple.5 as final_timestamp,
+               joined_path_tuple.6 as final_$session_id,
+               joined_path_tuple.7 as final_$window_id ,
+               arrayFilter((x, y)->y, uuid, mapping) as uuids,
+               arrayFilter((x, y)->y, timestamp, mapping) as timestamps,
+               arrayFilter((x, y)->y, $session_id, mapping) as $session_ids,
+               arrayFilter((x, y)->y, $window_id, mapping) as $window_ids ,
+               indexOf(compact_path, '/1') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/3') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 5, arrayConcat(arraySlice(filtered_path, 1, intDiv(5, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 5, arrayConcat(arraySlice(filtered_timings, 1, intDiv(5, 2)), [filtered_timings[1+intDiv(5, 2)]], arraySlice(filtered_timings, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_timings) AS limited_timings ,
+               if(start_target_index > 0, arraySlice(uuids, start_target_index), uuids) as start_filtered_uuids ,
+               if(end_target_index > 0, arrayResize(start_filtered_uuids, end_target_index), start_filtered_uuids) as filtered_uuids ,
+               if(length(filtered_uuids) > 5, arrayConcat(arraySlice(filtered_uuids, 1, intDiv(5, 2)), [filtered_uuids[1+intDiv(5, 2)]], arraySlice(filtered_uuids, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_uuids) AS limited_uuids ,
+               if(start_target_index > 0, arraySlice(timestamps, start_target_index), timestamps) as start_filtered_timestamps ,
+               if(end_target_index > 0, arrayResize(start_filtered_timestamps, end_target_index), start_filtered_timestamps) as filtered_timestamps ,
+               if(length(filtered_timestamps) > 5, arrayConcat(arraySlice(filtered_timestamps, 1, intDiv(5, 2)), [filtered_timestamps[1+intDiv(5, 2)]], arraySlice(filtered_timestamps, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_timestamps) AS limited_timestamps ,
+               if(start_target_index > 0, arraySlice($session_ids, start_target_index), $session_ids) as start_filtered_$session_ids ,
+               if(end_target_index > 0, arrayResize(start_filtered_$session_ids, end_target_index), start_filtered_$session_ids) as filtered_$session_ids ,
+               if(length(filtered_$session_ids) > 5, arrayConcat(arraySlice(filtered_$session_ids, 1, intDiv(5, 2)), [filtered_$session_ids[1+intDiv(5, 2)]], arraySlice(filtered_$session_ids, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_$session_ids) AS limited_$session_ids ,
+               if(start_target_index > 0, arraySlice($window_ids, start_target_index), $window_ids) as start_filtered_$window_ids ,
+               if(end_target_index > 0, arrayResize(start_filtered_$window_ids, end_target_index), start_filtered_$window_ids) as filtered_$window_ids ,
+               if(length(filtered_$window_ids) > 5, arrayConcat(arraySlice(filtered_$window_ids, 1, intDiv(5, 2)), [filtered_$window_ids[1+intDiv(5, 2)]], arraySlice(filtered_$window_ids, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_$window_ids) AS limited_$window_ids ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, '')), limited_uuids, limited_timestamps, limited_$session_ids, limited_$window_ids) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  path_time_tuple.4 as uuid,
+                  path_time_tuple.5 as timestamp,
+                  path_time_tuple.6 as $session_id,
+                  path_time_tuple.7 as $window_id ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing), uuids, timestamps, $session_ids, $window_ids) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(uuid) as uuids,
+                     groupArray(timestamp) as timestamps,
+                     groupArray($session_id) as $session_ids,
+                     groupArray($window_id) as $window_ids,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        e.uuid AS uuid,
+                        e.timestamp AS timestamp,
+                        e."$session_id" as $session_id,
+                        e."$window_id" as $window_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE path_key = '2_/2'
+  GROUP BY person_id
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_recording_with_start_and_end.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s1']
+  '
+---
+# name: TestClickhousePaths.test_respect_session_limits
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_start_and_end
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/5') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 5, arrayConcat(arraySlice(filtered_path, 1, intDiv(5, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 5, arrayConcat(arraySlice(filtered_timings, 1, intDiv(5, 2)), [filtered_timings[1+intDiv(5, 2)]], arraySlice(filtered_timings, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  '
+---
+# name: TestClickhousePaths.test_start_and_end.1
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/5') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 5, arrayConcat(arraySlice(filtered_path, 1, intDiv(5, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 5, arrayConcat(arraySlice(filtered_timings, 1, intDiv(5, 2)), [filtered_timings[1+intDiv(5, 2)]], arraySlice(filtered_timings, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE last_path_key = '1_/5'
+    AND path_key = '2_/about'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_start_and_end.2
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/2') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 4, arrayConcat(arraySlice(filtered_path, 1, intDiv(4, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 4, arrayConcat(arraySlice(filtered_timings, 1, intDiv(4, 2)), [filtered_timings[1+intDiv(4, 2)]], arraySlice(filtered_timings, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  '
+---
+# name: TestClickhousePaths.test_start_and_end.3
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/2') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 4, arrayConcat(arraySlice(filtered_path, 1, intDiv(4, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 4, arrayConcat(arraySlice(filtered_timings, 1, intDiv(4, 2)), [filtered_timings[1+intDiv(4, 2)]], arraySlice(filtered_timings, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE last_path_key = '3_...'
+    AND path_key = '4_/5'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_start_and_end_materialized
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/5') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 5, arrayConcat(arraySlice(filtered_path, 1, intDiv(5, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 5, arrayConcat(arraySlice(filtered_timings, 1, intDiv(5, 2)), [filtered_timings[1+intDiv(5, 2)]], arraySlice(filtered_timings, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', "mat_$screen_name", if(e.event = '$pageview', if(length("mat_$current_url") > 1, replaceRegexpAll("mat_$current_url", '/$', ''), "mat_$current_url"), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  '
+---
+# name: TestClickhousePaths.test_start_and_end_materialized.1
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/5') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 5, arrayConcat(arraySlice(filtered_path, 1, intDiv(5, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 5, arrayConcat(arraySlice(filtered_timings, 1, intDiv(5, 2)), [filtered_timings[1+intDiv(5, 2)]], arraySlice(filtered_timings, (-1)*intDiv(5, 2), intDiv(5, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', "mat_$screen_name", if(e.event = '$pageview', if(length("mat_$current_url") > 1, replaceRegexpAll("mat_$current_url", '/$', ''), "mat_$current_url"), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE last_path_key = '1_/5'
+    AND path_key = '2_/about'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_start_and_end_materialized.2
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/2') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 4, arrayConcat(arraySlice(filtered_path, 1, intDiv(4, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 4, arrayConcat(arraySlice(filtered_timings, 1, intDiv(4, 2)), [filtered_timings[1+intDiv(4, 2)]], arraySlice(filtered_timings, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', "mat_$screen_name", if(e.event = '$pageview', if(length("mat_$current_url") > 1, replaceRegexpAll("mat_$current_url", '/$', ''), "mat_$current_url"), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  '
+---
+# name: TestClickhousePaths.test_start_and_end_materialized.3
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/2') as start_target_index ,
+               if(start_target_index > 0, arraySlice(compact_path, start_target_index), compact_path) as start_filtered_path ,
+               if(start_target_index > 0, arraySlice(timings, start_target_index), timings) as start_filtered_timings ,
+               indexOf(start_filtered_path, '/about') as end_target_index ,
+               if(end_target_index > 0, arrayResize(start_filtered_path, end_target_index), start_filtered_path) as filtered_path ,
+               if(end_target_index > 0, arrayResize(start_filtered_timings, end_target_index), start_filtered_timings) as filtered_timings ,
+               if(length(filtered_path) > 4, arrayConcat(arraySlice(filtered_path, 1, intDiv(4, 2)), ['...'], arraySlice(filtered_path, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_path) AS limited_path ,
+               if(length(filtered_timings) > 4, arrayConcat(arraySlice(filtered_timings, 1, intDiv(4, 2)), [filtered_timings[1+intDiv(4, 2)]], arraySlice(filtered_timings, (-1)*intDiv(4, 2), intDiv(4, 2))), filtered_timings) AS limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', "mat_$screen_name", if(e.event = '$pageview', if(length("mat_$current_url") > 1, replaceRegexpAll("mat_$current_url", '/$', ''), "mat_$current_url"), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE start_target_index > 0
+          AND end_target_index > 0 ))
+  WHERE last_path_key = '3_...'
+    AND path_key = '4_/5'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_start_dropping_orphaned_edges
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, '/2') as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index
+        WHERE target_index > 0 ))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 6
+  '
+---
+# name: TestClickhousePaths.test_step_conversion_times
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_step_limit
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 2) as limited_path ,
+               arraySlice(filtered_timings, 1, 2) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_step_limit.1
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 2) as limited_path ,
+               arraySlice(filtered_timings, 1, 2) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '1_/1'
+    AND path_key = '2_/2'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_step_limit.2
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 2) as limited_path ,
+               arraySlice(filtered_timings, 1, 2) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '2_/2'
+    AND path_key = '3_/3'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_step_limit.3
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 3) as limited_path ,
+               arraySlice(filtered_timings, 1, 3) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_step_limit.4
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 3) as limited_path ,
+               arraySlice(filtered_timings, 1, 3) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '2_/2'
+    AND path_key = '3_/3'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_step_limit.5
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_step_limit.6
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '1_/1'
+    AND path_key = '2_/2'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_step_limit.7
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '2_/2'
+    AND path_key = '3_/3'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_step_limit.8
+  '
+  
+  SELECT DISTINCT person_id AS actor_id
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE last_path_key = '3_/3'
+    AND path_key = '4_/4'
+  ORDER BY person_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: TestClickhousePaths.test_team_and_local_path_cleaning_rules
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') as path_item_0,
+                        replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') as path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_team_and_local_path_cleaning_rules.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') as path_item_0,
+                        replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') as path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_team_and_local_path_cleaning_rules.2
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') as path_item_0,
+                        replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') as path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_team_path_cleaning_rules
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
+                        if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_team_path_cleaning_rules.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') as path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_wildcard_groups
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
+                        if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_wildcard_groups_across_people
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 4) as limited_path ,
+               arraySlice(filtered_timings, 1, 4) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['/bar/.*/foo']) AS group_index,
+                        if(group_index > 0, ['/bar/*/foo'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_wildcard_groups_and_min_edge_weight
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
+                        if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  HAVING event_count >= 15
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_wildcard_groups_and_min_edge_weight.1
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
+                        if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  HAVING event_count >= 15
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 2
+  '
+---
+# name: TestClickhousePaths.test_wildcard_groups_and_min_edge_weight.2
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
+                        if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  HAVING event_count >= 6
+  AND event_count <= 11
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 20
+  '
+---
+# name: TestClickhousePaths.test_wildcard_groups_evil_input
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['\\(a\\+\\)\\+', '\\[aaa\\|aaaa\\]\\+', '1\\..*', '\\..*', '/3\\?q=1', '/3.*']) AS group_index,
+                        if(group_index > 0, ['(a+)+', '[aaa|aaaa]+', '1.*', '.*', '/3?q=1', '/3*'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND (event = '$pageview')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-19 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
+                          e.timestamp)
+              GROUP BY person_id) ARRAY
+           JOIN session_paths AS path_time_tuple,
+                arrayEnumerate(session_paths) AS session_index) ARRAY
+        JOIN limited_path_timings AS joined_path_tuple,
+             arrayEnumerate(limited_path_timings) AS event_in_session_index))
+  WHERE source_event IS NOT NULL
+  GROUP BY source_event,
+           target_event
+  ORDER BY event_count DESC,
+           source_event,
+           target_event
+  LIMIT 50
+  '
+---
+# name: TestClickhousePaths.test_wildcard_groups_with_sampling
+  '
+  
+  SELECT last_path_key as source_event,
+         path_key as target_event,
+         COUNT(*) AS event_count,
+         avg(conversion_time) AS average_conversion_time
+  FROM
+    (SELECT person_id,
+            path,
+            conversion_time,
+            event_in_session_index,
+            concat(toString(event_in_session_index), '_', path) as path_key,
+            if(event_in_session_index > 1, concat(toString(event_in_session_index-1), '_', prev_path), null) AS last_path_key,
+            path_dropoff_key
+     FROM
+       (SELECT person_id ,
+               joined_path_tuple.1 as path ,
+               joined_path_tuple.2 as conversion_time ,
+               joined_path_tuple.3 as prev_path ,
+               event_in_session_index ,
+               session_index ,
+               arrayPopFront(arrayPushBack(path_basic, '')) as path_basic_0 ,
+               arrayMap((x, y) -> if(x=y, 0, 1), path_basic, path_basic_0) as mapping ,
+               arrayFilter((x, y) -> y, time, mapping) as timings ,
+               arrayFilter((x, y)->y, path_basic, mapping) as compact_path ,
+               indexOf(compact_path, NULL) as target_index ,
+               if(target_index > 0, arraySlice(compact_path, target_index), compact_path) as filtered_path ,
+               if(target_index > 0, arraySlice(timings, target_index), timings) as filtered_timings ,
+               arraySlice(filtered_path, 1, 5) as limited_path ,
+               arraySlice(filtered_timings, 1, 5) as limited_timings ,
+               arrayDifference(limited_timings) as timings_diff ,
+               arrayZip(limited_path, timings_diff, arrayPopBack(arrayPushFront(limited_path, ''))) as limited_path_timings ,
+               concat(toString(length(limited_path)), '_', limited_path[-1]) as path_dropoff_key
+        FROM
+          (SELECT person_id ,
+                  path_time_tuple.1 as path_basic ,
+                  path_time_tuple.2 as time ,
+                  session_index ,
+                  arrayZip(paths, timing, arrayDifference(timing)) as paths_tuple ,
+                  arraySplit(x -> if(x.3 < 1800000, 0, 1), paths_tuple) as session_paths
+           FROM
+             (SELECT person_id,
+                     groupArray(toUnixTimestamp64Milli(timestamp)) as timing,
+                     groupArray(path_item) as paths
+              FROM
+                (SELECT e.timestamp AS timestamp,
+                        pdi.person_id AS person_id,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
+                        multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
+                        if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
+                 FROM events e SAMPLE 1.0
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                 WHERE team_id = 2
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
+                 ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -58,8 +58,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         _, serialized_actors, _ = PathsActors(person_filter, self.team, funnel_filter).get_actors()
         return [row["id"] for row in serialized_actors]
 
+    @snapshot_clickhouse_queries
     def test_step_limit(self):
-
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["fake"])
 
         _create_event(
@@ -130,8 +130,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual([p1.uuid], self._get_people_at_path(filter, "2_/2", "3_/3"))
             self.assertEqual([p1.uuid], self._get_people_at_path(filter, "3_/3", "4_/4"))
 
+    @snapshot_clickhouse_queries
     def test_step_conversion_times(self):
-
         _create_person(team_id=self.team.pk, distinct_ids=["fake"])
 
         _create_event(
@@ -199,8 +199,9 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    # this tests to make sure that paths don't get scrambled when there are several similar variations
-    def test_path_event_ordering(self):
+    @snapshot_clickhouse_queries
+    def test_event_ordering(self):
+        # this tests to make sure that paths don't get scrambled when there are several similar variations
         events = []
         for i in range(50):
             _create_person(distinct_ids=[f"user_{i}"], team=self.team)
@@ -391,7 +392,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
                 )
             events.extend(funnel_branching)
 
-    def test_path_by_grouping(self):
+    @snapshot_clickhouse_queries
+    def test_wildcard_groups(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -442,8 +444,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_by_grouping_replacement(self):
-
+    @snapshot_clickhouse_queries
+    def test_team_path_cleaning_rules(self):
         _create_person(distinct_ids=[f"user_1"], team=self.team)
         _create_person(distinct_ids=[f"user_2"], team=self.team)
         _create_person(distinct_ids=[f"user_3"], team=self.team)
@@ -581,8 +583,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_by_grouping_replacement_multiple(self):
-
+    @snapshot_clickhouse_queries
+    def test_team_and_local_path_cleaning_rules(self):
         _create_event(
             **{
                 "event": "$pageview",
@@ -725,7 +727,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         response = Paths(team=self.team, filter=path_filter).run()
         self.assertEqual(response, correct_response)
 
-    def test_path_by_funnel_after_dropoff(self):
+    @snapshot_clickhouse_queries
+    def test_by_funnel_after_dropoff(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -775,7 +778,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
 
     @snapshot_clickhouse_queries
-    def test_path_by_funnel_after_dropoff_with_group_filter(self):
+    def test_by_funnel_after_dropoff_with_group_filter(self):
         # complex case, joins funnel_actors and groups
         self._create_sample_data_multiple_dropoffs(use_groups=True)
         data = {
@@ -828,7 +831,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             0, len(self._get_people_at_path(path_filter, "4_step branch", "3_step dropoff2", funnel_filter))
         )
 
-    def test_path_by_funnel_after_step_respects_conversion_window(self):
+    def test_by_funnel_after_step_respects_conversion_window(self):
         # note events happen after 1 day
         events = []
         for i in range(5):
@@ -991,7 +994,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             0, len(self._get_people_at_path(path_filter, "4_step branch", "3_step dropoff2", funnel_filter))
         )
 
-    def test_path_by_funnel_after_step(self):
+    @snapshot_clickhouse_queries
+    def test_by_funnel_after_step(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -1030,7 +1034,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_by_funnel_after_step_limit(self):
+    @snapshot_clickhouse_queries
+    def test_by_funnel_after_step_limit(self):
         self._create_sample_data_multiple_dropoffs()
         events = []
         # add more than 100. Previously, the funnel limit at 100 was stopping all users from showing up
@@ -1119,7 +1124,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_by_funnel_before_dropoff(self):
+    @snapshot_clickhouse_queries
+    def test_by_funnel_before_dropoff(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -1169,7 +1175,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_by_funnel_before_step(self):
+    @snapshot_clickhouse_queries
+    def test_by_funnel_before_step(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -1225,7 +1232,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_by_funnel_between_step(self):
+    @snapshot_clickhouse_queries
+    def test_by_funnel_between_step(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -1297,7 +1305,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
 
     @also_test_with_materialized_columns(["$current_url", "$screen_name"])
-    def test_paths_end(self):
+    @snapshot_clickhouse_queries
+    def test_end(self):
         _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
         p1 = [
             _create_event(
@@ -1448,8 +1457,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
+    @snapshot_clickhouse_queries
     def test_event_inclusion_exclusion_filters(self):
-
         # P1 for pageview event
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
         p1 = [
@@ -1592,8 +1601,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_event_exclusion_filters_with_wildcards(self):
-
+    @snapshot_clickhouse_queries
+    def test_event_exclusion_filters_with_wildcard_groups(self):
         # P1 for pageview event /2/bar/1/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
         p1 = [
@@ -1811,7 +1820,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_respect_session_limits(self):
+    @snapshot_clickhouse_queries
+    def test_respect_session_limits(self):
         _create_person(team_id=self.team.pk, distinct_ids=["fake"])
 
         _create_event(
@@ -1868,7 +1878,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_removes_duplicates(self):
+    def test_removes_duplicates(self):
         _create_person(team_id=self.team.pk, distinct_ids=["fake"])
 
         _create_event(
@@ -1943,7 +1953,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
 
     @also_test_with_materialized_columns(["$current_url", "$screen_name"])
-    def test_paths_start_and_end(self):
+    @snapshot_clickhouse_queries
+    def test_start_and_end(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
 
         _create_event(
@@ -2074,6 +2085,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertCountEqual(self._get_people_at_path(filter, "3_...", "4_/5"), [p1.uuid])
 
+    @snapshot_clickhouse_queries
     def test_properties_queried_using_path_filter(self):
         def should_query_list(filter) -> Tuple[bool, bool]:
             path_query = PathEventQuery(filter, self.team)
@@ -2110,8 +2122,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(should_query_list(filter), (False, True))
 
-    def test_path_grouping_across_people(self):
-
+    @snapshot_clickhouse_queries
+    def test_wildcard_groups_across_people(self):
         # P1 for pageview event /2/bar/1/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
 
@@ -2205,8 +2217,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_grouping_with_evil_input(self):
-
+    @snapshot_clickhouse_queries
+    def test_wildcard_groups_evil_input(self):
         evil_string = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"
         # P1 for pageview event /2/bar/1/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
@@ -2280,7 +2292,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_paths_person_dropoffs(self):
+    @snapshot_clickhouse_queries
+    def test_person_dropoffs(self):
         events = []
 
         # 5 people do 2 events
@@ -2392,7 +2405,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             0, len(self._get_people_at_path(filter, path_start="4_step four"))
         )  # 0 total reach after step 4
 
-    def test_paths_start_dropping_orphaned_edges(self):
+    @snapshot_clickhouse_queries
+    def test_start_dropping_orphaned_edges(self):
         events = []
         for i in range(5):
             # 5 people going through this route to increase weights
@@ -2541,8 +2555,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_path_min_edge_weight(self):
-        # original data from test_path_by_grouping.py
+    @snapshot_clickhouse_queries
+    def test_wildcard_groups_and_min_edge_weight(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -2626,7 +2640,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
 
     # TODO: Delete this test when moved to person-on-events
-    def test_path_groups_filtering(self):
+    def test_groups_filtering(self):
         self._create_groups()
         # P1 for pageview event, org:5
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
@@ -2759,7 +2773,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         materialize_only_with_person_on_events=True,
     )
     @snapshot_clickhouse_queries
-    def test_path_groups_filtering_person_on_events(self):
+    def test_groups_filtering_person_on_events(self):
         self._create_groups()
         # P1 for pageview event, org:5
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
@@ -2899,7 +2913,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=True)
     @snapshot_clickhouse_queries
-    def test_paths_person_on_events_v2(self):
+    def test_person_on_events_v2(self):
         self._create_groups()
         # P1 for pageview event, org:5
         p1_person_id = str(uuid.uuid4())
@@ -2988,7 +3002,8 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
     # Note: not using `@snapshot_clickhouse_queries` here because the ordering of the session_ids in the recording
     # query is not guaranteed, so adding it would lead to a flaky test.
     @freeze_time("2012-01-01T03:21:34.000Z")
-    def test_path_recording(self):
+    @snapshot_clickhouse_queries
+    def test_recording(self):
         # User with 2 matching paths with recordings
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"])
         events = [
@@ -3091,7 +3106,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     @freeze_time("2012-01-01T03:21:34.000Z")
-    def test_path_recording_with_no_window_or_session_id(self):
+    def test_recording_with_no_window_or_session_id(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"])
 
         _create_event(
@@ -3126,7 +3141,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     @freeze_time("2012-01-01T03:21:34.000Z")
-    def test_path_recording_with_start_and_end(self):
+    def test_recording_with_start_and_end(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"])
 
         _create_event(
@@ -3189,7 +3204,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     @freeze_time("2012-01-01T03:21:34.000Z")
-    def test_path_recording_for_dropoff(self):
+    def test_recording_for_dropoff(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"])
 
         _create_event(
@@ -3264,7 +3279,7 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
 
     @snapshot_clickhouse_queries
-    def test_path_by_grouping_with_sampling(self):
+    def test_wildcard_groups_with_sampling(self):
         self._create_sample_data_multiple_dropoffs()
         data = {
             "insight": INSIGHT_FUNNELS,
@@ -3318,7 +3333,6 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
 
 
 class TestClickhousePathsEdgeValidation(TestCase):
-
     BASIC_PATH = [("1_a", "2_b"), ("2_b", "3_c"), ("3_c", "4_d")]  # a->b->c->d
     BASIC_PATH_2 = [("1_x", "2_y"), ("2_y", "3_z")]  # x->y->z
 

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -231,6 +231,9 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.ViewSet):
         session_ids = [
             recording_id for recording_id in json.loads(self.request.GET.get("session_ids", "[]")) if recording_id
         ]
+        for session_id in session_ids:
+            if not isinstance(session_id, str):
+                raise exceptions.ValidationError(f"Invalid session_id: {session_id} - not a string")
         session_recordings_properties = SessionRecordingProperties(
             team=self.team, filter=filter, session_ids=session_ids
         ).run()

--- a/posthog/models/filters/mixins/session_recordings.py
+++ b/posthog/models/filters/mixins/session_recordings.py
@@ -30,5 +30,6 @@ class SessionRecordingsMixin(BaseParamMixin):
 
         recordings_ids = json.loads(session_ids_str)
         if isinstance(recordings_ids, list) and all(isinstance(recording_id, str) for recording_id in recordings_ids):
-            return recordings_ids
+            # Sort for stable queries
+            return sorted(recordings_ids)
         return None

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -119,7 +119,7 @@ class ActorBaseQuery:
             and has_full_snapshot = 1
             and session_id in %(session_ids)s
         """
-        params = {"team_id": self._team.pk, "session_ids": list(session_ids)}
+        params = {"team_id": self._team.pk, "session_ids": sorted(list(session_ids))}  # Sort for stable queries
         raw_result = insight_sync_execute(
             query, params, query_type="actors_session_ids_with_recordings", filter=self._filter
         )

--- a/posthog/queries/session_recordings/session_recording_properties.py
+++ b/posthog/queries/session_recordings/session_recording_properties.py
@@ -1,10 +1,13 @@
 from datetime import timedelta
-from typing import Any, Dict, List, NamedTuple, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Tuple
 
 from posthog.client import sync_execute
 from posthog.models.event.util import parse_properties
 from posthog.models.filters.session_recordings_filter import SessionRecordingsFilter
 from posthog.queries.event_query import EventQuery
+
+if TYPE_CHECKING:
+    from posthog.models import Team
 
 
 class EventFiltersSQL(NamedTuple):
@@ -49,9 +52,9 @@ class SessionRecordingProperties(EventQuery):
              GROUP BY session_id
     """
 
-    def __init__(self, team, session_ids, filter):
+    def __init__(self, team: "Team", session_ids: List[str], filter: SessionRecordingsFilter):
         super().__init__(team=team, filter=filter)
-        self._session_ids = session_ids
+        self._session_ids = sorted(session_ids)  # Sort for stable queries
 
     def _determine_should_join_distinct_ids(self) -> None:
         self._should_join_distinct_ids = False
@@ -71,7 +74,7 @@ class SessionRecordingProperties(EventQuery):
 
     def format_session_recording_id_filters(self) -> Tuple[str, Dict]:
         where_conditions = "AND session_id IN %(session_ids)s"
-        return where_conditions, {"session_ids": list(self._session_ids)}
+        return where_conditions, {"session_ids": self._session_ids}
 
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
 

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -29,451 +29,430 @@ class MockEvent:
     properties: Dict
 
 
-def paths_test_factory(paths):
-    class TestPaths(ClickhouseTestMixin, APIBaseTest):
-        @also_test_with_materialized_columns(["$current_url", "$screen_name"], person_properties=["email"])
-        def test_current_url_paths_and_logic(self):
-            events = []
-            _create_person(team_id=self.team.pk, distinct_ids=["fake"])
-            events.extend(
-                [
-                    _create_event(
-                        properties={"$current_url": "/"},
-                        distinct_id="fake",
-                        event="$pageview",
-                        team=self.team,
-                        timestamp="2012-01-01 03:21:34",
-                    ),
-                    _create_event(
-                        properties={"$current_url": "/about"},
-                        distinct_id="fake",
-                        event="$pageview",
-                        team=self.team,
-                        timestamp="2012-01-01 03:21:34",
-                    ),
-                ]
-            )
-
-            _create_person(team_id=self.team.pk, distinct_ids=["person_1"], properties={"email": "test@posthog.com"})
-            events.append(
+class TestPaths(ClickhouseTestMixin, APIBaseTest):
+    @also_test_with_materialized_columns(["$current_url", "$screen_name"], person_properties=["email"])
+    def test_current_url_paths_and_logic(self):
+        events = []
+        _create_person(team_id=self.team.pk, distinct_ids=["fake"])
+        events.extend(
+            [
                 _create_event(
                     properties={"$current_url": "/"},
-                    distinct_id="person_1",
+                    distinct_id="fake",
                     event="$pageview",
                     team=self.team,
-                    timestamp="2012-01-14 03:21:34",
-                )
-            )
-            events.append(
+                    timestamp="2012-01-01 03:21:34",
+                ),
                 _create_event(
                     properties={"$current_url": "/about"},
-                    distinct_id="person_1",
+                    distinct_id="fake",
                     event="$pageview",
                     team=self.team,
-                    timestamp="2012-01-14 03:28:34",
-                )
-            )
+                    timestamp="2012-01-01 03:21:34",
+                ),
+            ]
+        )
 
-            _create_person(team_id=self.team.pk, distinct_ids=["person_2a", "person_2b"])
-            events.append(
-                _create_event(
-                    properties={"$current_url": "/"},
-                    distinct_id="person_2a",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2012-01-14 03:21:34",
-                )
-            )
-            events.append(
-                _create_event(
-                    properties={"$current_url": "/pricing"},
-                    distinct_id="person_2b",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2012-01-14 03:28:34",
-                )
-            )
-            events.append(
-                _create_event(
-                    properties={"$current_url": "/about"},
-                    distinct_id="person_2a",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2012-01-14 03:29:34",
-                )
-            )
-
-            _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
-            events.append(
-                _create_event(
-                    properties={"$current_url": "/pricing"},
-                    distinct_id="person_3",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2012-01-14 03:21:34",
-                )
-            )
-
-            events.append(
-                _create_event(
-                    properties={"$current_url": "/"},
-                    distinct_id="person_3",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2012-01-14 03:28:34",
-                )
-            )
-
-            _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
-            events.append(
-                _create_event(
-                    properties={"$current_url": "/"},
-                    distinct_id="person_4",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2012-01-14 03:21:34",
-                )
-            )
-            events.append(
-                _create_event(
-                    properties={"$current_url": "/pricing"},
-                    distinct_id="person_4",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2012-01-14 03:28:34",
-                )
-            )
-
-            with freeze_time("2012-01-15T03:21:34.000Z"):
-                filter = PathFilter(data={"dummy": "dummy"})
-                response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
-
-            self.assertEqual(response[0]["source"], "1_/", response)
-            self.assertEqual(response[0]["target"], "2_/pricing")
-            self.assertEqual(response[0]["value"], 2)
-
-            self.assertEqual(response[1]["source"], "1_/")
-            self.assertEqual(response[1]["target"], "2_/about")
-            self.assertEqual(response[1]["value"], 1)
-
-            self.assertEqual(response[2]["source"], "1_/pricing")
-            self.assertEqual(response[2]["target"], "2_/")
-            self.assertEqual(response[2]["value"], 1)
-
-            self.assertEqual(response[3]["source"], "2_/pricing", response[3])
-            self.assertEqual(response[3]["target"], "3_/about")
-            self.assertEqual(response[3]["value"], 1)
-
-            with freeze_time("2012-01-15T03:21:34.000Z"):
-                date_from = now() - relativedelta(days=7)
-                response = self.client.get(
-                    f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_from="
-                    + date_from.strftime("%Y-%m-%d")
-                ).json()
-                self.assertEqual(len(response["result"]), 4)
-
-                date_to = now()
-                response = self.client.get(
-                    f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
-                ).json()
-                self.assertEqual(len(response["result"]), 4)
-
-                date_from = now() + relativedelta(days=7)
-                response = self.client.get(
-                    f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_from="
-                    + date_from.strftime("%Y-%m-%d")
-                ).json()
-                self.assertEqual(len(response["result"]), 0)
-
-                date_to = now() - relativedelta(days=7)
-                response = self.client.get(
-                    f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
-                ).json()
-                self.assertEqual(len(response["result"]), 0)
-
-                date_from = now() - relativedelta(days=7)
-                date_to = now() + relativedelta(days=7)
-
-                date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
-
-                filter = PathFilter(data={**date_params})
-                response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
-                self.assertEqual(len(response), 4)
-
-                # Test account filter
-                filter = PathFilter(data={**date_params, FILTER_TEST_ACCOUNTS: True}, team=self.team)
-                response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
-                self.assertEqual(len(response), 3)
-
-                date_from = now() + relativedelta(days=7)
-                date_to = now() - relativedelta(days=7)
-                date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
-                filter = PathFilter(data={**date_params}, team=self.team)
-                response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
-                self.assertEqual(len(response), 0)
-
-        def test_custom_event_paths(self):
-            _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_2"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
-
-            _create_event(distinct_id="person_1", event="custom_event_1", team=self.team, properties={}),
-            _create_event(distinct_id="person_1", event="custom_event_3", team=self.team, properties={}),
+        _create_person(team_id=self.team.pk, distinct_ids=["person_1"], properties={"email": "test@posthog.com"})
+        events.append(
             _create_event(
-                properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team
-            ),  # should be ignored,
-            _create_event(distinct_id="person_2", event="custom_event_1", team=self.team, properties={}),
-            _create_event(distinct_id="person_2", event="custom_event_2", team=self.team, properties={}),
-            _create_event(distinct_id="person_2", event="custom_event_3", team=self.team, properties={}),
-            _create_event(distinct_id="person_3", event="custom_event_2", team=self.team, properties={}),
-            _create_event(distinct_id="person_3", event="custom_event_1", team=self.team, properties={}),
-            _create_event(distinct_id="person_4", event="custom_event_1", team=self.team, properties={}),
-            _create_event(distinct_id="person_4", event="custom_event_2", team=self.team, properties={}),
-
-            filter = PathFilter(data={"path_type": "custom_event"})
-            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
-
-            self.assertEqual(response[0]["source"], "1_custom_event_1", response)
-            self.assertEqual(response[0]["target"], "2_custom_event_2")
-            self.assertEqual(response[0]["value"], 2)
-
-            self.assertEqual(response[1]["source"], "1_custom_event_1")
-            self.assertEqual(response[1]["target"], "2_custom_event_3")
-            self.assertEqual(response[1]["value"], 1)
-
-            self.assertEqual(response[2]["source"], "1_custom_event_2")
-            self.assertEqual(response[2]["target"], "2_custom_event_1")
-            self.assertEqual(response[2]["value"], 1)
-
-            self.assertEqual(response[3]["source"], "2_custom_event_2", response[3])
-            self.assertEqual(response[3]["target"], "3_custom_event_3")
-            self.assertEqual(response[3]["value"], 1)
-
-        def test_screen_paths(self):
-            _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_2a", "person_2b"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
-
-            _create_event(properties={"$screen_name": "/"}, distinct_id="person_1", event="$screen", team=self.team),
-            _create_event(
-                properties={"$screen_name": "/about"}, distinct_id="person_1", event="$screen", team=self.team
-            ),
-            _create_event(properties={"$screen_name": "/"}, distinct_id="person_2b", event="$screen", team=self.team),
-            _create_event(
-                properties={"$screen_name": "/pricing"}, distinct_id="person_2a", event="$screen", team=self.team
-            ),
-            _create_event(
-                properties={"$screen_name": "/about"}, distinct_id="person_2b", event="$screen", team=self.team
-            ),
-            _create_event(
-                properties={"$screen_name": "/pricing"}, distinct_id="person_3", event="$screen", team=self.team
-            ),
-            _create_event(properties={"$screen_name": "/"}, distinct_id="person_3", event="$screen", team=self.team),
-            _create_event(properties={"$screen_name": "/"}, distinct_id="person_4", event="$screen", team=self.team),
-            _create_event(
-                properties={"$screen_name": "/pricing"}, distinct_id="person_4", event="$screen", team=self.team
-            ),
-
-            filter = PathFilter(data={"path_type": "$screen"})
-            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
-            self.assertEqual(response[0]["source"], "1_/", response)
-            self.assertEqual(response[0]["target"], "2_/pricing")
-            self.assertEqual(response[0]["value"], 2)
-
-            self.assertEqual(response[1]["source"], "1_/")
-            self.assertEqual(response[1]["target"], "2_/about")
-            self.assertEqual(response[1]["value"], 1)
-
-            self.assertEqual(response[2]["source"], "1_/pricing")
-            self.assertEqual(response[2]["target"], "2_/")
-            self.assertEqual(response[2]["value"], 1)
-
-            self.assertEqual(response[3]["source"], "2_/pricing", response[3])
-            self.assertEqual(response[3]["target"], "3_/about")
-            self.assertEqual(response[3]["value"], 1)
-
-        def test_paths_properties_filter(self):
-            _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_2"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
-
-            _create_event(
-                properties={"$current_url": "/", "$browser": "Chrome"},
+                properties={"$current_url": "/"},
                 distinct_id="person_1",
                 event="$pageview",
                 team=self.team,
-            ),
+                timestamp="2012-01-14 03:21:34",
+            )
+        )
+        events.append(
             _create_event(
-                properties={"$current_url": "/about", "$browser": "Chrome"},
+                properties={"$current_url": "/about"},
                 distinct_id="person_1",
                 event="$pageview",
                 team=self.team,
-            ),
+                timestamp="2012-01-14 03:28:34",
+            )
+        )
+
+        _create_person(team_id=self.team.pk, distinct_ids=["person_2a", "person_2b"])
+        events.append(
             _create_event(
-                properties={"$current_url": "/", "$browser": "Chrome"},
-                distinct_id="person_2",
+                properties={"$current_url": "/"},
+                distinct_id="person_2a",
                 event="$pageview",
                 team=self.team,
-            ),
+                timestamp="2012-01-14 03:21:34",
+            )
+        )
+        events.append(
             _create_event(
-                properties={"$current_url": "/pricing", "$browser": "Chrome"},
-                distinct_id="person_2",
+                properties={"$current_url": "/pricing"},
+                distinct_id="person_2b",
                 event="$pageview",
                 team=self.team,
-            ),
+                timestamp="2012-01-14 03:28:34",
+            )
+        )
+        events.append(
             _create_event(
-                properties={"$current_url": "/about", "$browser": "Chrome"},
-                distinct_id="person_2",
+                properties={"$current_url": "/about"},
+                distinct_id="person_2a",
                 event="$pageview",
                 team=self.team,
-            ),
-            _create_event(
-                properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team
-            ),
-            _create_event(properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team),
-            _create_event(properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team),
-            _create_event(
-                properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team
-            ),
+                timestamp="2012-01-14 03:29:34",
+            )
+        )
 
-            filter = PathFilter(data={"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]})
+        _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
+        events.append(
+            _create_event(
+                properties={"$current_url": "/pricing"},
+                distinct_id="person_3",
+                event="$pageview",
+                team=self.team,
+                timestamp="2012-01-14 03:21:34",
+            )
+        )
 
-            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+        events.append(
+            _create_event(
+                properties={"$current_url": "/"},
+                distinct_id="person_3",
+                event="$pageview",
+                team=self.team,
+                timestamp="2012-01-14 03:28:34",
+            )
+        )
 
-            self.assertEqual(response[0]["source"], "1_/")
-            self.assertEqual(response[0]["target"], "2_/about")
-            self.assertEqual(response[0]["value"], 1)
+        _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
+        events.append(
+            _create_event(
+                properties={"$current_url": "/"},
+                distinct_id="person_4",
+                event="$pageview",
+                team=self.team,
+                timestamp="2012-01-14 03:21:34",
+            )
+        )
+        events.append(
+            _create_event(
+                properties={"$current_url": "/pricing"},
+                distinct_id="person_4",
+                event="$pageview",
+                team=self.team,
+                timestamp="2012-01-14 03:28:34",
+            )
+        )
 
-            self.assertEqual(response[1]["source"], "1_/")
-            self.assertEqual(response[1]["target"], "2_/pricing")
-            self.assertEqual(response[1]["value"], 1)
+        with freeze_time("2012-01-15T03:21:34.000Z"):
+            filter = PathFilter(data={"dummy": "dummy"})
+            response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
 
-            self.assertEqual(response[2]["source"], "2_/pricing")
-            self.assertEqual(response[2]["target"], "3_/about")
-            self.assertEqual(response[2]["value"], 1)
+        self.assertEqual(response[0]["source"], "1_/", response)
+        self.assertEqual(response[0]["target"], "2_/pricing")
+        self.assertEqual(response[0]["value"], 2)
 
-        def test_paths_start(self):
-            _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_2"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
-            _create_person(team_id=self.team.pk, distinct_ids=["person_5a", "person_5b"])
+        self.assertEqual(response[1]["source"], "1_/")
+        self.assertEqual(response[1]["target"], "2_/about")
+        self.assertEqual(response[1]["value"], 1)
 
-            _create_event(properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team),
-            _create_event(
-                properties={"$current_url": "/about/"}, distinct_id="person_1", event="$pageview", team=self.team
-            ),
-            _create_event(properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team),
-            _create_event(
-                properties={"$current_url": "/pricing/"}, distinct_id="person_2", event="$pageview", team=self.team
-            ),
-            _create_event(
-                properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team
-            ),
-            _create_event(
-                properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team
-            ),
-            _create_event(properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team),
-            _create_event(
-                properties={"$current_url": "/about/"}, distinct_id="person_3", event="$pageview", team=self.team
-            ),
-            _create_event(properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team),
-            _create_event(
-                properties={"$current_url": "/pricing/"}, distinct_id="person_4", event="$pageview", team=self.team
-            ),
-            _create_event(
-                properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team
-            ),
-            _create_event(
-                properties={"$current_url": "/about"}, distinct_id="person_5b", event="$pageview", team=self.team
-            ),
-            _create_event(
-                properties={"$current_url": "/pricing/"}, distinct_id="person_5a", event="$pageview", team=self.team
-            ),
-            _create_event(
-                properties={"$current_url": "/help"}, distinct_id="person_5b", event="$pageview", team=self.team
-            ),
+        self.assertEqual(response[2]["source"], "1_/pricing")
+        self.assertEqual(response[2]["target"], "2_/")
+        self.assertEqual(response[2]["value"], 1)
 
+        self.assertEqual(response[3]["source"], "2_/pricing", response[3])
+        self.assertEqual(response[3]["target"], "3_/about")
+        self.assertEqual(response[3]["value"], 1)
+
+        with freeze_time("2012-01-15T03:21:34.000Z"):
+            date_from = now() - relativedelta(days=7)
             response = self.client.get(
-                f"/api/projects/{self.team.id}/insights/path/?type=%24pageview&start=%2Fpricing"
+                f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_from=" + date_from.strftime("%Y-%m-%d")
             ).json()
+            self.assertEqual(len(response["result"]), 4)
 
-            filter = PathFilter(data={"path_type": "$pageview", "start_point": "/pricing"})
-            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+            date_to = now()
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
+            ).json()
+            self.assertEqual(len(response["result"]), 4)
 
-            self.assertEqual(len(response), 5)
+            date_from = now() + relativedelta(days=7)
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_from=" + date_from.strftime("%Y-%m-%d")
+            ).json()
+            self.assertEqual(len(response["result"]), 0)
 
-            self.assertTrue(response[0].items() >= {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
-            self.assertTrue(response[1].items() >= {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
-            self.assertTrue(response[2].items() >= {"source": "2_/", "target": "3_/about", "value": 1}.items())
-            self.assertTrue(response[3].items() >= {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
-            self.assertTrue(response[4].items() >= {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
+            date_to = now() - relativedelta(days=7)
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/insights/path/?insight=PATHS&date_to=" + date_to.strftime("%Y-%m-%d")
+            ).json()
+            self.assertEqual(len(response["result"]), 0)
 
-            # ensure trailing slashes make no difference
-            filter = PathFilter(data={"path_type": "$pageview", "start_point": "/pricing/"})
-            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+            date_from = now() - relativedelta(days=7)
+            date_to = now() + relativedelta(days=7)
 
-            self.assertEqual(len(response), 5)
+            date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
 
-            self.assertTrue(response[0].items() >= {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
-            self.assertTrue(response[1].items() >= {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
-            self.assertTrue(response[2].items() >= {"source": "2_/", "target": "3_/about", "value": 1}.items())
-            self.assertTrue(response[3].items() >= {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
-            self.assertTrue(response[4].items() >= {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
+            filter = PathFilter(data={**date_params})
+            response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+            self.assertEqual(len(response), 4)
 
-            filter = PathFilter(data={"path_type": "$pageview", "start_point": "/"})
-            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
-
+            # Test account filter
+            filter = PathFilter(data={**date_params, FILTER_TEST_ACCOUNTS: True}, team=self.team)
+            response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
             self.assertEqual(len(response), 3)
 
-            self.assertTrue(response[0].items() >= {"source": "1_/", "target": "2_/about", "value": 2}.items())
-            self.assertTrue(response[1].items() >= {"source": "1_/", "target": "2_/pricing", "value": 2}.items())
-            self.assertTrue(response[2].items() >= {"source": "2_/pricing", "target": "3_/about", "value": 1}.items())
+            date_from = now() + relativedelta(days=7)
+            date_to = now() - relativedelta(days=7)
+            date_params = {"date_from": date_from.strftime("%Y-%m-%d"), "date_to": date_to.strftime("%Y-%m-%d")}
+            filter = PathFilter(data={**date_params}, team=self.team)
+            response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+            self.assertEqual(len(response), 0)
 
-        def test_paths_in_window(self):
-            _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
+    def test_custom_event_paths(self):
+        _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_2"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
 
-            _create_event(
-                properties={"$current_url": "/"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2020-04-14 03:25:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/about"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2020-04-14 03:30:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2020-04-15 03:25:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/about"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2020-04-15 03:30:34",
-            ),
+        _create_event(distinct_id="person_1", event="custom_event_1", team=self.team, properties={}),
+        _create_event(distinct_id="person_1", event="custom_event_3", team=self.team, properties={}),
+        _create_event(
+            properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team
+        ),  # should be ignored,
+        _create_event(distinct_id="person_2", event="custom_event_1", team=self.team, properties={}),
+        _create_event(distinct_id="person_2", event="custom_event_2", team=self.team, properties={}),
+        _create_event(distinct_id="person_2", event="custom_event_3", team=self.team, properties={}),
+        _create_event(distinct_id="person_3", event="custom_event_2", team=self.team, properties={}),
+        _create_event(distinct_id="person_3", event="custom_event_1", team=self.team, properties={}),
+        _create_event(distinct_id="person_4", event="custom_event_1", team=self.team, properties={}),
+        _create_event(distinct_id="person_4", event="custom_event_2", team=self.team, properties={}),
 
-            filter = PathFilter(data={"date_from": "2020-04-13"})
-            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+        filter = PathFilter(data={"path_type": "custom_event"})
+        response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
 
-            self.assertEqual(response[0]["source"], "1_/")
-            self.assertEqual(response[0]["target"], "2_/about")
-            self.assertEqual(response[0]["value"], 2)
+        self.assertEqual(response[0]["source"], "1_custom_event_1", response)
+        self.assertEqual(response[0]["target"], "2_custom_event_2")
+        self.assertEqual(response[0]["value"], 2)
 
-    return TestPaths
+        self.assertEqual(response[1]["source"], "1_custom_event_1")
+        self.assertEqual(response[1]["target"], "2_custom_event_3")
+        self.assertEqual(response[1]["value"], 1)
 
+        self.assertEqual(response[2]["source"], "1_custom_event_2")
+        self.assertEqual(response[2]["target"], "2_custom_event_1")
+        self.assertEqual(response[2]["value"], 1)
 
-class TestFOSSPaths(paths_test_factory(Paths)):  # type: ignore
-    pass
+        self.assertEqual(response[3]["source"], "2_custom_event_2", response[3])
+        self.assertEqual(response[3]["target"], "3_custom_event_3")
+        self.assertEqual(response[3]["value"], 1)
+
+    def test_screen_paths(self):
+        _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_2a", "person_2b"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
+
+        _create_event(properties={"$screen_name": "/"}, distinct_id="person_1", event="$screen", team=self.team),
+        _create_event(properties={"$screen_name": "/about"}, distinct_id="person_1", event="$screen", team=self.team),
+        _create_event(properties={"$screen_name": "/"}, distinct_id="person_2b", event="$screen", team=self.team),
+        _create_event(
+            properties={"$screen_name": "/pricing"}, distinct_id="person_2a", event="$screen", team=self.team
+        ),
+        _create_event(properties={"$screen_name": "/about"}, distinct_id="person_2b", event="$screen", team=self.team),
+        _create_event(properties={"$screen_name": "/pricing"}, distinct_id="person_3", event="$screen", team=self.team),
+        _create_event(properties={"$screen_name": "/"}, distinct_id="person_3", event="$screen", team=self.team),
+        _create_event(properties={"$screen_name": "/"}, distinct_id="person_4", event="$screen", team=self.team),
+        _create_event(properties={"$screen_name": "/pricing"}, distinct_id="person_4", event="$screen", team=self.team),
+
+        filter = PathFilter(data={"path_type": "$screen"})
+        response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+        self.assertEqual(response[0]["source"], "1_/", response)
+        self.assertEqual(response[0]["target"], "2_/pricing")
+        self.assertEqual(response[0]["value"], 2)
+
+        self.assertEqual(response[1]["source"], "1_/")
+        self.assertEqual(response[1]["target"], "2_/about")
+        self.assertEqual(response[1]["value"], 1)
+
+        self.assertEqual(response[2]["source"], "1_/pricing")
+        self.assertEqual(response[2]["target"], "2_/")
+        self.assertEqual(response[2]["value"], 1)
+
+        self.assertEqual(response[3]["source"], "2_/pricing", response[3])
+        self.assertEqual(response[3]["target"], "3_/about")
+        self.assertEqual(response[3]["value"], 1)
+
+    def test_paths_properties_filter(self):
+        _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_2"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
+
+        _create_event(
+            properties={"$current_url": "/", "$browser": "Chrome"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+        ),
+        _create_event(
+            properties={"$current_url": "/about", "$browser": "Chrome"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+        ),
+        _create_event(
+            properties={"$current_url": "/", "$browser": "Chrome"},
+            distinct_id="person_2",
+            event="$pageview",
+            team=self.team,
+        ),
+        _create_event(
+            properties={"$current_url": "/pricing", "$browser": "Chrome"},
+            distinct_id="person_2",
+            event="$pageview",
+            team=self.team,
+        ),
+        _create_event(
+            properties={"$current_url": "/about", "$browser": "Chrome"},
+            distinct_id="person_2",
+            event="$pageview",
+            team=self.team,
+        ),
+        _create_event(
+            properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team
+        ),
+        _create_event(properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team),
+        _create_event(properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team),
+        _create_event(
+            properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team
+        ),
+
+        filter = PathFilter(data={"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]})
+
+        response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+
+        self.assertEqual(response[0]["source"], "1_/")
+        self.assertEqual(response[0]["target"], "2_/about")
+        self.assertEqual(response[0]["value"], 1)
+
+        self.assertEqual(response[1]["source"], "1_/")
+        self.assertEqual(response[1]["target"], "2_/pricing")
+        self.assertEqual(response[1]["value"], 1)
+
+        self.assertEqual(response[2]["source"], "2_/pricing")
+        self.assertEqual(response[2]["target"], "3_/about")
+        self.assertEqual(response[2]["value"], 1)
+
+    def test_paths_start(self):
+        _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_2"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_5a", "person_5b"])
+
+        _create_event(properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team),
+        _create_event(
+            properties={"$current_url": "/about/"}, distinct_id="person_1", event="$pageview", team=self.team
+        ),
+        _create_event(properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team),
+        _create_event(
+            properties={"$current_url": "/pricing/"}, distinct_id="person_2", event="$pageview", team=self.team
+        ),
+        _create_event(properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team),
+        _create_event(
+            properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team
+        ),
+        _create_event(properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team),
+        _create_event(
+            properties={"$current_url": "/about/"}, distinct_id="person_3", event="$pageview", team=self.team
+        ),
+        _create_event(properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team),
+        _create_event(
+            properties={"$current_url": "/pricing/"}, distinct_id="person_4", event="$pageview", team=self.team
+        ),
+        _create_event(
+            properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team
+        ),
+        _create_event(
+            properties={"$current_url": "/about"}, distinct_id="person_5b", event="$pageview", team=self.team
+        ),
+        _create_event(
+            properties={"$current_url": "/pricing/"}, distinct_id="person_5a", event="$pageview", team=self.team
+        ),
+        _create_event(properties={"$current_url": "/help"}, distinct_id="person_5b", event="$pageview", team=self.team),
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/path/?type=%24pageview&start=%2Fpricing"
+        ).json()
+
+        filter = PathFilter(data={"path_type": "$pageview", "start_point": "/pricing"})
+        response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+
+        self.assertEqual(len(response), 5)
+
+        self.assertTrue(response[0].items() >= {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
+        self.assertTrue(response[1].items() >= {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
+        self.assertTrue(response[2].items() >= {"source": "2_/", "target": "3_/about", "value": 1}.items())
+        self.assertTrue(response[3].items() >= {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
+        self.assertTrue(response[4].items() >= {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
+
+        # ensure trailing slashes make no difference
+        filter = PathFilter(data={"path_type": "$pageview", "start_point": "/pricing/"})
+        response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+
+        self.assertEqual(len(response), 5)
+
+        self.assertTrue(response[0].items() >= {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
+        self.assertTrue(response[1].items() >= {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
+        self.assertTrue(response[2].items() >= {"source": "2_/", "target": "3_/about", "value": 1}.items())
+        self.assertTrue(response[3].items() >= {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
+        self.assertTrue(response[4].items() >= {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
+
+        filter = PathFilter(data={"path_type": "$pageview", "start_point": "/"})
+        response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+
+        self.assertEqual(len(response), 3)
+
+        self.assertTrue(response[0].items() >= {"source": "1_/", "target": "2_/about", "value": 2}.items())
+        self.assertTrue(response[1].items() >= {"source": "1_/", "target": "2_/pricing", "value": 2}.items())
+        self.assertTrue(response[2].items() >= {"source": "2_/pricing", "target": "3_/about", "value": 1}.items())
+
+    def test_paths_in_window(self):
+        _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
+
+        _create_event(
+            properties={"$current_url": "/"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2020-04-14 03:25:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2020-04-14 03:30:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2020-04-15 03:25:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2020-04-15 03:30:34",
+        ),
+
+        filter = PathFilter(data={"date_from": "2020-04-13"})
+        response = Paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
+
+        self.assertEqual(response[0]["source"], "1_/")
+        self.assertEqual(response[0]["target"], "2_/about")
+        self.assertEqual(response[0]["value"], 2)


### PR DESCRIPTION
## Changes

A couple improvements to the User Paths testing setup, as I'm making a fix for ZEN-2794 in a separate PR.