### PR TITLE
feat(capture): add DUMP_CAPTURE_TO_FILE option for local use

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import json
 import re
@@ -256,6 +257,18 @@ def get_event(request):
 
     now = timezone.now()
 
+    # Optionally dump requests and Kafka messages to collect test cases
+    if settings.DUMP_CAPTURE_TO_FILE:
+        request_dump = {
+            "full_path": request.get_full_path(),
+            "content-encoding": request.headers.get("content-encoding", ""),
+            "body": base64.b64encode(request.body).decode(encoding="ascii"),
+            "now": now.isoformat(),
+            "output": [],
+        }
+    else:
+        request_dump = None
+
     data, error_response = get_data(request)
 
     if error_response:
@@ -340,12 +353,13 @@ def get_event(request):
             )
 
     futures: List[FutureRecordMetadata] = []
-
     with start_span(op="kafka.produce") as span:
         span.set_tag("event.count", len(processed_events))
         for event, event_uuid, distinct_id in processed_events:
             try:
-                futures.append(capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid, token))
+                futures.append(
+                    capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid, token, request_dump)
+                )
             except Exception as exc:
                 capture_exception(exc, {"data": data})
                 statsd.incr("posthog_cloud_raw_endpoint_failure", tags={"endpoint": "capture"})
@@ -360,6 +374,14 @@ def get_event(request):
                         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                     ),
                 )
+
+    if settings.DUMP_CAPTURE_TO_FILE:
+        try:
+            with open(settings.DUMP_CAPTURE_TO_FILE, "a") as dump_file:
+                json.dump(request_dump, dump_file, separators=(",", ":"))
+                dump_file.write("\n")
+        except Exception as exc:
+            logger.error("dump_capture_failure", exc_info=exc)
 
     with start_span(op="kafka.wait"):
         span.set_tag("future.count", len(futures))
@@ -422,7 +444,9 @@ def parse_event(event):
     return event
 
 
-def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=None, token=None):
+def capture_internal(
+    event, distinct_id, ip, site_url, now, sent_at, event_uuid=None, token=None, request_dump: Optional[Dict] = None
+):
     if event_uuid is None:
         event_uuid = UUIDT()
 
@@ -436,6 +460,9 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
         event_uuid=event_uuid,
         token=token,
     )
+
+    if request_dump:
+        request_dump["output"].append(parsed_event)
 
     # We aim to always partition by {team_id}:{distinct_id} but allow
     # overriding this to deal with hot partitions in specific cases.

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -260,10 +260,12 @@ def get_event(request):
     # Optionally dump requests and Kafka messages to collect test cases
     if settings.DUMP_CAPTURE_TO_FILE:
         request_dump = {
-            "full_path": request.get_full_path(),
-            "content-encoding": request.headers.get("content-encoding", ""),
-            "body": base64.b64encode(request.body).decode(encoding="ascii"),
+            "path": request.get_full_path(),
+            "method": request.method,
+            "content-encoding": request.META.get("content-encoding", ""),
+            "ip": request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR")),
             "now": now.isoformat(),
+            "body": base64.b64encode(request.body).decode(encoding="ascii"),
             "output": [],
         }
     else:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -262,7 +262,8 @@ def get_event(request):
         request_dump = {
             "path": request.get_full_path(),
             "method": request.method,
-            "content-encoding": request.META.get("content-encoding", ""),
+            "content_encoding": request.META.get("content-encoding", ""),
+            "content_type": request.content_type,
             "ip": request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR")),
             "now": now.isoformat(),
             "body": base64.b64encode(request.body).decode(encoding="ascii"),

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -26,3 +26,6 @@ PARTITION_KEY_BUCKET_CAPACITY = get_from_env("PARTITION_KEY_BUCKET_CAPACITY", ty
 PARTITION_KEY_BUCKET_REPLENTISH_RATE = get_from_env(
     "PARTITION_KEY_BUCKET_REPLENTISH_RATE", type_cast=float, default=1.0
 )
+
+# Used to capture test cases for new capture, meant to be used locally only
+DUMP_CAPTURE_TO_FILE = os.getenv("DUMP_CAPTURE_TO_FILE", "")


### PR DESCRIPTION
## Problem

Our capture input format is currently loosely defined, this will allow us to inspect inputs and outputs

## Changes

- add a DUMP_CAPTURE_TO_FILE envvar, that is the filename to dump info in, in jsonlines format
- only capturing the `content-type` header, as we don't seem to be using any of the other headers
- capturing `now` as it's used in the payload computation

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
