### PR TITLE
feat: add mgmt cmd to sync person overrides

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -214,7 +214,7 @@ class ClickhouseProducer:
         self.producer = KafkaProducer() if not TEST else None
 
     def produce(self, sql: str, topic: str, data: Dict[str, Any], sync: bool = True):
-        if self.producer is not None:
+        if self.producer is not None:  # TODO: this should be not sync and
             self.producer.produce(topic=topic, data=data)
         else:
             sync_execute(sql, data)

--- a/posthog/kafka_client/topics.py
+++ b/posthog/kafka_client/topics.py
@@ -8,6 +8,7 @@ KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW = f"{KAFKA_PREFIX}events_plugin_ingestion
 KAFKA_PERSON = f"{KAFKA_PREFIX}clickhouse_person{SUFFIX}"
 KAFKA_PERSON_UNIQUE_ID = f"{KAFKA_PREFIX}clickhouse_person_unique_id{SUFFIX}"  # DEPRECATED_DO_NOT_USE
 KAFKA_PERSON_DISTINCT_ID = f"{KAFKA_PREFIX}clickhouse_person_distinct_id{SUFFIX}"
+KAFKA_PERSON_OVERRIDES = f"{KAFKA_PREFIX}clickhouse_person_override{SUFFIX}"
 KAFKA_CLICKHOUSE_SESSION_RECORDING_EVENTS = f"{KAFKA_PREFIX}clickhouse_session_recording_events{SUFFIX}"
 KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS = f"{KAFKA_PREFIX}clickhouse_session_replay_events{SUFFIX}"
 KAFKA_PERFORMANCE_EVENTS = f"{KAFKA_PREFIX}clickhouse_performance_events{SUFFIX}"

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -4,13 +4,19 @@ from uuid import UUID
 
 import structlog
 from django.core.management.base import BaseCommand
+from django.utils.timezone import now
 
 from posthog.client import sync_execute
 from posthog.models.group.group import Group
 from posthog.models.group.util import raw_create_group_ch
 from posthog.models.person import PersonDistinctId
-from posthog.models.person.person import Person
-from posthog.models.person.util import _delete_ch_distinct_id, create_person, create_person_distinct_id
+from posthog.models.person.person import Person, PersonOverride
+from posthog.models.person.util import (
+    _delete_ch_distinct_id,
+    create_person,
+    create_person_distinct_id,
+    create_person_override,
+)
 
 logger = structlog.get_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -27,6 +33,7 @@ class Command(BaseCommand):
         parser.add_argument("--team-id", default=None, type=int, help="Specify a team to fix data for.")
         parser.add_argument("--person", action="store_true", help="Sync persons")
         parser.add_argument("--person-distinct-id", action="store_true", help="Sync person distinct IDs")
+        parser.add_argument("--person-override", action="store_true", help="Sync person overrides")
         parser.add_argument("--group", action="store_true", help="Sync groups")
         parser.add_argument(
             "--deletes", action="store_true", help="process deletes for data in ClickHouse but not Postgres"
@@ -52,6 +59,9 @@ def run(options, sync: bool = False):  # sync used for unittests
 
     if options["person_distinct_id"]:
         run_distinct_id_sync(team_id, live_run, deletes, sync)
+
+    if options["person_override"]:
+        run_person_override_sync(team_id, live_run, deletes, sync)
 
     if options["group"]:
         run_group_sync(team_id, live_run, sync)
@@ -155,6 +165,42 @@ def run_distinct_id_sync(team_id: int, live_run: bool, deletes: bool, sync: bool
                 logger.info(f"Deleting distinct ID {distinct_id}")
                 if live_run:
                     _delete_ch_distinct_id(team_id, UUID(int=0), distinct_id, version, sync=sync)
+
+
+def run_person_override_sync(team_id: int, live_run: bool, deletes: bool, sync: bool):
+    logger.info("Running person override sync")
+    # lookup what needs to be updated in ClickHouse and send kafka messages for only those
+    pg_overrides = PersonOverride.objects.filter(team_id=team_id).select_related("old_person_id", "override_person_id")
+    rows = sync_execute(
+        """
+            SELECT old_person_id, max(version) FROM person_overrides WHERE team_id = %(team_id)s GROUP BY old_person_id
+        """,
+        {
+            "team_id": team_id,
+        },
+    )
+    ch_override_to_version = {row[0]: row[1] for row in rows}
+    # Add / update missing rows in CH
+    for pg_override in pg_overrides:
+        ch_version = ch_override_to_version.get(pg_override.old_person_id.uuid, None)
+        if ch_version is None or ch_version < pg_override.version:
+            logger.info(
+                f"Updating {pg_override.old_person_id.uuid} to version {pg_override.version} and map to {pg_override.override_person_id.uuid}"
+            )
+            if live_run:
+                # Update ClickHouse via Kafka message
+                create_person_override(
+                    team_id,
+                    str(pg_override.old_person_id.uuid),
+                    str(pg_override.override_person_id.uuid),
+                    pg_override.version,
+                    now(),
+                    pg_override.oldest_event,
+                    sync=sync,
+                )
+
+    if deletes:
+        logger.info("Override deletes aren't supported at this point")
 
 
 def run_group_sync(team_id: int, live_run: bool, sync: bool):

--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -368,6 +368,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             "team_id": self.team.pk,
             "person": True,
             "person_distinct_id": True,
+            "person_override": True,
             "group": True,
             "deletes": True,
         }

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -323,6 +323,10 @@ BULK_INSERT_PERSON_DISTINCT_ID2 = """
 INSERT INTO person_distinct_id2 (distinct_id, person_id, team_id, is_deleted, version, _timestamp, _offset, _partition) VALUES
 """
 
+INSERT_PERSON_OVERRIDE = """
+INSERT INTO person_overrides (team_id, old_person_id, override_person_id, version, merged_at, oldest_event) SELECT %(team_id)s, %(old_person_id)s, %(override_person_id)s, %(version)s, %(merged_at)s, %(oldest_event)s VALUES
+"""
+
 
 INSERT_COHORT_ALL_PEOPLE_THROUGH_PERSON_ID = """
 INSERT INTO {cohort_table} SELECT generateUUIDv4(), actor_id, %(cohort_id)s, %(team_id)s, %(_timestamp)s, 0 FROM (

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -13,12 +13,13 @@ from django.utils.timezone import now
 
 from posthog.client import sync_execute
 from posthog.kafka_client.client import ClickhouseProducer
-from posthog.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_DISTINCT_ID
+from posthog.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_DISTINCT_ID, KAFKA_PERSON_OVERRIDES
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.person.sql import (
     BULK_INSERT_PERSON_DISTINCT_ID2,
     INSERT_PERSON_BULK_SQL,
     INSERT_PERSON_DISTINCT_ID2,
+    INSERT_PERSON_OVERRIDE,
     INSERT_PERSON_SQL,
 )
 from posthog.models.signals import mutable_receiver
@@ -158,6 +159,31 @@ def create_person_distinct_id(
             "team_id": team_id,
             "version": version,
             "is_deleted": int(is_deleted),
+        },
+        sync=sync,
+    )
+
+
+def create_person_override(
+    team_id: int,
+    old_person_uuid: str,
+    override_person_uuid: str,
+    version: int,
+    merged_at: datetime.datetime,
+    oldest_event: datetime.datetime,
+    sync: bool = False,
+) -> None:
+    p = ClickhouseProducer()
+    p.produce(
+        topic=KAFKA_PERSON_OVERRIDES,
+        sql=INSERT_PERSON_OVERRIDE,
+        data={
+            "team_id": team_id,
+            "old_person_id": old_person_uuid,
+            "override_person_id": override_person_uuid,
+            "version": version,
+            "merged_at": merged_at.strftime("%Y-%m-%d %H:%M:%S.%f"),
+            "oldest_event": oldest_event.strftime("%Y-%m-%d %H:%M:%S.%f"),
         },
         sync=sync,
     )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
person overrides similar to person and distinct ID can get out of sync. However there might be a fix for this in the near future 🤞  in the meanwhile this quick script will be helpful.

## Changes

Didn't want to change the code for the producer function as I didn't fully read everything, but it should probably take the sync param into account. sth to look at later.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

created some overrides locally, nuked the ch table entries (`delete from person_overrides where 1=1`) and ran the script (`DEBUG=1 python manage.py sync_persons_to_clickhouse --person-override --team-id 1 --live-run` hardcoding the function to use CH sync_execute ,... it didn't work going through kafka but neither for persons 🤷‍♀️ ).  Verified that the table was the same as before. except for created_at and merged_at columns.
