### PR TITLE
fix: range without killing ingestion

### DIFF
--- a/cypress/e2e/insights.cy.ts
+++ b/cypress/e2e/insights.cy.ts
@@ -88,15 +88,13 @@ describe('Insights', () => {
         })
 
         it('Can navigate away from unchanged saved insight without confirm()', () => {
-            insight.newInsight()
-            cy.log('Add series')
-            cy.get('[data-attr=add-action-event-button]').click()
-            cy.log('Save')
-            cy.get('[data-attr="insight-save-button"]').click()
-            cy.wait(200)
-            cy.log('Navigate away')
+            const insightName = randomString('to save and then navigate away from')
+            insight.create(insightName)
+
             cy.get('[data-attr="menu-item-annotations"]').click()
-            cy.log('We should be on the Annotations page now')
+
+            // the annotations API call is made before the annotations page loads, so we can't wait for it
+            cy.get('[data-attr="annotations-table"]').should('exist')
             cy.url().should('include', '/annotations')
         })
 


### PR DESCRIPTION
## Problem

We started using events summary to track the range of times covered by a session buffer

But, when processing completed chunks to the buffer, we fake a message containing the correct data, and that is causing errors 

e.g. https://posthog.sentry.io/issues/4200179755/events/1acfb9a8d1f049b3a35bcc58d353c8c1/?project=6423401&query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-blob-ingestion&referrer=previous-event&statsPeriod=1h&stream_index=0

Right now the ingestion seems blocked and I can't see why, this is as good a candidate as any

## Changes

very safely read the events summary

## How did you test this code?

opening this PR