### PR TITLE
chore: no need to delay the idle flush

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -243,6 +243,16 @@ export class SessionManager {
                     }
                 )
             }
+        } else {
+            status.info('🚽', `blob_ingester_session_manager not flushing buffer due to age`, {
+                bufferAge,
+                sessionId: this.sessionId,
+                partition: this.partition,
+                chunkSize: this.chunks.size,
+                oldestKafkaTimestamp: this.buffer.oldestKafkaTimestamp,
+                referenceTime: referenceNow,
+                flushThresholdMillis,
+            })
         }
     }
 
@@ -462,6 +472,14 @@ export class SessionManager {
             gaugePendingChunksCompleted.inc()
             await this.processChunksToBuffer(pendingChunks.completedChunks)
             this.chunks.delete(message.chunk_id)
+        } else {
+            status.info('🧩', 'blob_ingester_session_manager received incomplete chunk', {
+                chunk_id: message.chunk_id,
+                chunk_index: message.chunk_index,
+                chunk_count: message.chunk_count,
+                sessionId: this.sessionId,
+                partition: this.partition,
+            })
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -235,11 +235,16 @@ export class SessionManager {
                 return this.flush('buffer_age')
             } else {
                 gaugePendingChunksBlocking.inc()
+                const chunkStates: Record<string, any> = {}
+                for (const [key, chunk] of this.chunks.entries()) {
+                    chunkStates[key] = { expected: chunk.expectedSize, received: chunk.chunks.length }
+                }
                 status.warn(
                     '🚽',
                     `blob_ingester_session_manager would flush buffer due to age, but chunks are still pending`,
                     {
                         ...logContext,
+                        chunks: chunkStates,
                     }
                 )
             }

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -340,8 +340,7 @@ export class SessionRecordingBlobIngester {
         })
 
         // We trigger the flushes from this level to reduce the number of running timers
-        // the first flush is after a delay to give the consumer time to start
-        this.flushInterval = setTimeout(() => this.checkEachSession(), flushIntervalTimeoutMs * 5)
+        this.flushInterval = setTimeout(() => this.checkEachSession(), flushIntervalTimeoutMs)
     }
 
     private async checkEachSession() {


### PR DESCRIPTION
## Problem

delaying idle flush on blob ingestion start doesn't help, particularly when back-filling it pushes up RAM usage

## Changes

don't do it

## How did you test this code?

🙈 