### PR TITLE
chore: don't wait for e2e tests if only changing the plugin server

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -13,8 +13,46 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changes:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: github.repository == 'PostHog/posthog'
+        name: Determine need to run backend checks
+        # Set job outputs to values from filter step
+        outputs:
+            backend: ${{ steps.filter.outputs.backend }}
+        steps:
+            # For pull requests it's not necessary to checkout the code, but we
+            # also want this to run on master so we need to checkout
+            - uses: actions/checkout@v3
+            - uses: dorny/paths-filter@v2
+              id: filter
+              with:
+                  filters: |
+                      pathsToTest:
+                        # Avoid running E2E tests for irrelevant changes
+                        # NOTE: we are at risk of missing a dependency here. We could make
+                        # the dependencies more clear if we separated the backend/frontend
+                        # code completely
+                        - 'ee/**/*'
+                        - 'posthog/**/*'
+                        - 'bin/*.py'
+                        - requirements.txt
+                        - requirements-dev.txt
+                        - mypy.ini
+                        - pytest.ini
+                        - frontend/src/queries/schema.json # Used for generating schema.py
+                        # Make sure we run if someone is explicitly change the workflow
+                        - .github/workflows/ci-e2e.yml
+                        # We use docker compose for tests, make sure we rerun on
+                        # changes to docker-compose.dev.yml e.g. dependency
+                        # version changes
+                        - docker-compose.dev.yml
+                        - frontend/**/*
+
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:
+        needs: changes
         name: Cypress preparation
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -41,7 +79,7 @@ jobs:
         name: Cypress E2E tests (${{ strategy.job-index }})
         runs-on: ubuntu-latest
         timeout-minutes: 30
-        needs: [cypress_prep]
+        needs: [cypress_prep, changes]
         permissions:
             packages: read # allow pull from ghcr.io
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -17,10 +17,10 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
-        name: Determine need to run backend checks
+        name: Determine need to run E2D checks
         # Set job outputs to values from filter step
         outputs:
-            backend: ${{ steps.filter.outputs.backend }}
+            pathsToTest: ${{ steps.filter.outputs.pathsToTest }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -172,6 +172,9 @@ jobs:
 
                   $DOCKER_RUN ./bin/migrate
                   $DOCKER_RUN python manage.py setup_dev
+
+                  # only starts the plugin server so that the "wait for PostHog" step passes
+                  $DOCKER_RUN ./bin/docker-worker &> /tmp/logs/worker.txt &
 
             - name: Wait for PostHog
               uses: iFaxity/wait-on-action@v1

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -135,9 +135,6 @@ jobs:
                   $DOCKER_RUN ./bin/migrate
                   $DOCKER_RUN python manage.py setup_dev
 
-                  $DOCKER_RUN ./bin/docker-worker &> /tmp/logs/worker.txt &
-                  $DOCKER_RUN ./bin/docker-server &> /tmp/logs/server.txt &
-
             - name: Wait for PostHog
               uses: iFaxity/wait-on-action@v1
               with:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -175,6 +175,7 @@ jobs:
 
                   # only starts the plugin server so that the "wait for PostHog" step passes
                   $DOCKER_RUN ./bin/docker-worker &> /tmp/logs/worker.txt &
+                  $DOCKER_RUN ./bin/docker-server &> /tmp/logs/server.txt &
 
             - name: Wait for PostHog
               uses: iFaxity/wait-on-action@v1

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
-        name: Determine need to run E2D checks
+        name: Determine need to run E2E checks
         # Set job outputs to values from filter step
         outputs:
             pathsToTest: ${{ steps.filter.outputs.pathsToTest }}

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -175,6 +175,7 @@ jobs:
 
             - name: Wait for PostHog
               uses: iFaxity/wait-on-action
+              timeout-minutes: 3
               with:
                   verbose: true
                   log: true

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -174,7 +174,7 @@ jobs:
                   $DOCKER_RUN python manage.py setup_dev
 
             - name: Wait for PostHog
-              uses: iFaxity/wait-on-action
+              uses: iFaxity/wait-on-action@v1
               timeout-minutes: 3
               with:
                   verbose: true

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -41,7 +41,6 @@ jobs:
                         - requirements-dev.txt
                         - mypy.ini
                         - pytest.ini
-                        - frontend/src/queries/schema.json # Used for generating schema.py
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-e2e.yml
                         # We use docker compose for tests, make sure we rerun on

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -174,8 +174,10 @@ jobs:
                   $DOCKER_RUN python manage.py setup_dev
 
             - name: Wait for PostHog
-              uses: iFaxity/wait-on-action@v1
+              uses: iFaxity/wait-on-action
               with:
+                  verbose: true
+                  log: true
                   resource: http://localhost:8000
 
             - name: Cypress run

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -100,7 +100,6 @@ $SKIP_MIGRATE || migrateDatabases
 $SKIP_SETUP_DEV || setupDev
 
 # parallel block
-./bin/plugin-server &
 # Only start webpack if not already running
 nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &
 pnpm dlx cypress open --config-file cypress.e2e.config.ts &

--- a/cypress/e2e/preflight.cy.ts
+++ b/cypress/e2e/preflight.cy.ts
@@ -1,10 +1,30 @@
+const preflightSuccessResponse = {
+    django: true,
+    redis: true,
+    plugins: true,
+    celery: true,
+    clickhouse: true,
+    kafka: true,
+    db: true,
+    initiated: true,
+    cloud: false,
+    demo: false,
+    realm: 'hosted-clickhouse',
+    region: null,
+    available_social_auth_providers: { github: false, gitlab: false, 'google-oauth2': false },
+    can_create_org: true,
+    email_service_available: true,
+    slack_service: { available: false, client_id: null },
+    object_storage: true,
+}
+
 describe('Preflight', () => {
-    beforeEach(() => {
+    it('Preflight experimentation', () => {
+        cy.intercept('GET', '/_preflight', preflightSuccessResponse)
+
         cy.visit('/logout')
         cy.visit('/preflight')
-    })
 
-    it('Preflight experimentation', () => {
         cy.get('[data-attr=preflight-experimentation]').click()
         cy.get('[data-attr=preflight-refresh]').should('be.visible')
         cy.get('[data-attr=caption]').should('contain', 'Not required for experimentation mode')
@@ -15,10 +35,38 @@ describe('Preflight', () => {
     })
 
     it('Preflight live mode', () => {
+        cy.intercept('GET', '/_preflight', preflightSuccessResponse)
+
+        cy.visit('/logout')
+        cy.visit('/preflight')
+
         cy.get('[data-attr=preflight-live]').click()
-        cy.get('[data-attr=preflight-refresh]').click()
+
+        cy.get('.PreflightItem').should('have.length', 10)
+        cy.get('[data-attr="status-text"]').filter(':contains("Validated")').should('have.length', 9)
+        cy.get('[data-attr="status-text"]').filter(':contains("Warning")').should('have.length', 1)
+
         cy.get('[data-attr=caption]').should('contain', 'Set up before ingesting real user data')
-        cy.wait(200)
         cy.get('[data-attr=preflight-complete]').should('be.visible')
+    })
+
+    it('Preflight can have errors too', () => {
+        cy.intercept('GET', '/_preflight', { ...preflightSuccessResponse, celery: false })
+
+        cy.visit('/logout')
+        cy.visit('/preflight')
+
+        cy.get('[data-attr=preflight-live]').click()
+
+        cy.get('.PreflightItem').should('have.length', 10)
+        cy.get('[data-attr="status-text"]').filter(':contains("Validated")').should('have.length', 8)
+        cy.get('[data-attr="status-text"]').filter(':contains("Warning")').should('have.length', 1)
+        cy.get('[data-attr="status-text"]').filter(':contains("Error")').should('have.length', 1)
+
+        cy.get('[data-attr=caption]').should('contain', 'Set up before ingesting real user data')
+        cy.get('[data-attr=preflight-complete]').should('not.exist')
+        cy.get('.Preflight__cannot-continue')
+            .filter(':contains("All required checks must pass before you can continue")')
+            .should('have.length', 1)
     })
 })


### PR DESCRIPTION
If you only change the plugin server you spend a long time waiting for e2e CI to run.

It doesn't use the plugin server (I don't think)

So, don't run it...