### PR TITLE
chore: worrying at ingestion still

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -118,8 +118,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
         // NOTE: 10 minutes
         SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,
-        // NOTE: 5x the max age, so that we don't flush too infrequently when backing off due to lag
-        SESSION_RECORDING_MAX_BUFFER_AGE_MULTIPLIER: 5,
         SESSION_RECORDING_MAX_BUFFER_SIZE_KB: ['dev', 'test'].includes(process.env.NODE_ENV || 'undefined')
             ? 1024 // NOTE: ~1MB in dev or test, so that even with gzipped content we still flush pretty frequently
             : 1024 * 50, // ~50MB after compression in prod

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -189,8 +189,6 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number
     SESSION_RECORDING_REMOTE_FOLDER: string
-    // maximum allowed back off of SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS
-    SESSION_RECORDING_MAX_BUFFER_AGE_MULTIPLIER: number
 }
 
 export interface Hub extends PluginsServerConfig {


### PR DESCRIPTION
* less logging of pending chunks being incomplete or not
* don't add a multiplier on top of the flush threshold it's confusing to operate
* log the number of lines that would have been flushed to s3 if we hadn't skipped on age
* and fix pending chunks handling 