### PR TITLE
fix: populate team-ids to DLQ ingestion errors

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -173,7 +173,7 @@ export class EventPipelineRunner {
 
         if (sentToDql) {
             try {
-                const message = generateEventDeadLetterQueueMessage(this.originalEvent, err)
+                const message = generateEventDeadLetterQueueMessage(this.originalEvent, err, teamId)
                 await this.hub.db.kafkaProducer!.queueMessage(message)
                 this.hub.statsd?.increment('events_added_to_dead_letter_queue')
             } catch (dlqError) {

--- a/plugin-server/src/worker/ingestion/utils.ts
+++ b/plugin-server/src/worker/ingestion/utils.ts
@@ -17,6 +17,7 @@ function getClickhouseTimestampOrNull(isoTimestamp?: string): string | null {
 export function generateEventDeadLetterQueueMessage(
     event: PipelineEvent | PluginEvent | ProcessedPluginEvent,
     error: unknown,
+    teamId: number,
     errorLocation = 'plugin_server_ingest_event'
 ): ProducerRecord {
     let errorMessage = 'ingestEvent failed. '
@@ -43,6 +44,7 @@ export function generateEventDeadLetterQueueMessage(
         error_location: safeClickhouseString(errorLocation),
         error: safeClickhouseString(errorMessage),
         tags: ['plugin_server', 'ingest_event'],
+        team_id: event.team_id || teamId,
     }
 
     const message = {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
When we added the teamId population to be the first step in plugin-server instead of capture we started logging all events to DLQ with teamId = 0, while we can pull the token out of the event, that's quite annoying to do and we have the teamId in most cases available.

## Changes

Populating the teamId value in DLQ.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
