### PR TITLE
fix: deduplicate over-complete chunks

### DIFF
--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -216,6 +216,28 @@ def test_decompress_deduplicates_if_duplicate_chunks(raw_snapshot_events):
     )
 
 
+def test_decompress_ignores_if_too_few_chunks_even_after_deduplication(raw_snapshot_events):
+    snapshot_data_list = [
+        event["properties"]["$snapshot_data"] for event in compress_and_chunk_snapshots(raw_snapshot_events, 10)
+    ]  # makes 12 chunks
+    # take the first four chunks four times, then not quite all the remainder
+    # leaves more than 12 chunks in total, but not enough to decompress
+    snapshot_data_list = (
+        snapshot_data_list[:4]
+        + snapshot_data_list[:4]
+        + snapshot_data_list[:4]
+        + snapshot_data_list[:4]
+        + snapshot_data_list[4:-1]
+    )
+
+    window_id = "abc123"
+    snapshot_list = []
+    for snapshot_data in snapshot_data_list:
+        snapshot_list.append(SnapshotDataTaggedWithWindowId(window_id=window_id, snapshot_data=snapshot_data))
+
+    assert decompress_chunked_snapshot_data(2, "someid", snapshot_list)["snapshot_data_by_window_id"][window_id] == []
+
+
 def test_paginate_decompression(chunked_and_compressed_snapshot_events):
     snapshot_data = [
         SnapshotDataTaggedWithWindowId(

--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -191,6 +191,31 @@ def test_decompress_ignores_if_not_enough_chunks(raw_snapshot_events):
     )
 
 
+def test_decompress_deduplicates_if_duplicate_chunks(raw_snapshot_events):
+    raw_snapshot_data = [event["properties"]["$snapshot_data"] for event in raw_snapshot_events]
+    snapshot_data_list = [
+        event["properties"]["$snapshot_data"] for event in compress_and_chunk_snapshots(raw_snapshot_events, 10)
+    ]  # makes 12 chunks
+    # take the first four chunks twice, then the remainder, and then again the first four chunks twice from snapshot_data_list
+    snapshot_data_list = (
+        snapshot_data_list[:4]
+        + snapshot_data_list[:4]
+        + snapshot_data_list[4:]
+        + snapshot_data_list[:4]
+        + snapshot_data_list[:4]
+    )
+
+    window_id = "abc123"
+    snapshot_list = []
+    for snapshot_data in snapshot_data_list:
+        snapshot_list.append(SnapshotDataTaggedWithWindowId(window_id=window_id, snapshot_data=snapshot_data))
+
+    assert (
+        decompress_chunked_snapshot_data(2, "someid", snapshot_list)["snapshot_data_by_window_id"][window_id]
+        == raw_snapshot_data
+    )
+
+
 def test_paginate_decompression(chunked_and_compressed_snapshot_events):
     snapshot_data = [
         SnapshotDataTaggedWithWindowId(

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -241,7 +241,7 @@ def decompress_chunked_snapshot_data(
             chunks = list(deduplicated_chunks.values())
 
         # even after deduplication, we don't know we have the right number of chunks
-        if len(chunks) < chunks[0]["snapshot_data"]["chunk_count"]:
+        if len(chunks) != chunks[0]["snapshot_data"]["chunk_count"]:
             capture_message(
                 "Did not find all session recording chunks! Team: {}, Session: {}, Chunk-id: {}. Found {} of {} expected chunks".format(
                     team_id,

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -229,7 +229,19 @@ def decompress_chunked_snapshot_data(
 
     # Decompress the chunks and split the resulting events by window_id
     for chunks in chunk_list:
-        if len(chunks) != chunks[0]["snapshot_data"]["chunk_count"]:
+        was_originally_over_complete = False
+        if len(chunks) > chunks[0]["snapshot_data"]["chunk_count"]:
+            was_originally_over_complete = True
+            deduplicated_chunks = {}
+            for chunk in chunks:
+                # reduce the chunks into deduplicated chunks by chunk_id taking only the first seen for each chunk_id
+                if chunk["snapshot_data"]["chunk_index"] not in deduplicated_chunks:
+                    deduplicated_chunks[chunk["snapshot_data"]["chunk_index"]] = chunk
+
+            chunks = list(deduplicated_chunks.values())
+
+        # even after deduplication, we don't know we have the right number of chunks
+        if len(chunks) < chunks[0]["snapshot_data"]["chunk_count"]:
             capture_message(
                 "Did not find all session recording chunks! Team: {}, Session: {}, Chunk-id: {}. Found {} of {} expected chunks".format(
                     team_id,
@@ -237,7 +249,16 @@ def decompress_chunked_snapshot_data(
                     chunks[0]["snapshot_data"]["chunk_id"],
                     len(chunks),
                     chunks[0]["snapshot_data"]["chunk_count"],
-                )
+                ),
+                tags={
+                    "team_id": team_id,
+                },
+                extras={
+                    "session_recording_id": session_recording_id,
+                    "expected_chunk_count": chunks[0]["snapshot_data"]["chunk_count"],
+                    "received_chunk_count": len(chunks),
+                    "was_originally_over_complete": was_originally_over_complete,
+                },
             )
             continue
 


### PR DESCRIPTION
## Problem

Given we know from the blob ingestion work that we are (more likely to?) over complete a set of chunks than under complete it...

## Changes

Try to deduplicate chunks and only report to Sentry when we still don't have enough 

## How did you test this code?

developer tests
