### PR TITLE
fix(data-management): fix calculate event property usage

### DIFF
--- a/posthog/models/entity/entity.py
+++ b/posthog/models/entity/entity.py
@@ -158,7 +158,6 @@ class ExclusionEntity(Entity, FunnelFromToStepsMixin):
         super().__init__(data)
 
     def to_dict(self) -> Dict[str, Any]:
-
         ret = super().to_dict()
 
         for _, func in inspect.getmembers(self, inspect.ismethod):

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -280,22 +280,25 @@ def _get_insight_query_usage(team_id: int, since: datetime) -> Tuple[List[str], 
     )
 
     for id, item_filters in insight_filters:
-        if item_filters is None:
-            logger.info(
-                "calculate_event_property_usage_for_team.insight_has_no_filters",
-                team=team_id,
-                insight_id=id,
-            )
-            continue
+        try:
+            if item_filters is None:
+                logger.info(
+                    "calculate_event_property_usage_for_team.insight_has_no_filters",
+                    team=team_id,
+                    insight_id=id,
+                )
+                continue
 
-        for item_filter_event in item_filters.events:
-            event_usage.append(str(item_filter_event.id))
+            for item_filter_event in item_filters.events:
+                event_usage.append(str(item_filter_event.id))
 
-        for item_filter_action in item_filters.actions:
-            action = item_filter_action.get_action()
-            event_usage.extend(action.get_step_events())
+            for item_filter_action in item_filters.actions:
+                action = item_filter_action.get_action()
+                event_usage.extend(action.get_step_events())
 
-        counted_properties.update(FOSSColumnOptimizer(item_filters, team_id).used_properties_with_type("event"))
+            counted_properties.update(FOSSColumnOptimizer(item_filters, team_id).used_properties_with_type("event"))
+        except KeyError:  # we've been running into issues with invalid filters (actions without ids)
+            pass
 
     statsd.gauge(
         "calculate_event_property_usage_for_team.counted_events_for_team_insights",


### PR DESCRIPTION
## Problem

Multiple customers ([1](https://posthoghelp.zendesk.com/agent/tickets/2922), [2](https://posthoghelp.zendesk.com/agent/tickets/2994)) have been complaining that the data on the data management page is stale. After digging into the issue it seems to stem from this error: https://posthog.sentry.io/issues/4044762655/?query=transaction%3Aposthog.celery.calculate_event_property_usage&referrer=issue-stream&statsPeriod=14d&stream_index=1.

## Changes

This PR gracefully handles filters with invalid actions (missing id).

Example
```py
{'actions': [{'name': 'invalid action without id', 'type': 'actions', 'order': 0}]}
```

## How did you test this code?

Added tests

## Post deployment

- [x] Sentry error should be resolved: https://posthog.sentry.io/issues/?query=transaction%3Aposthog.celery.calculate_event_property_usage&referrer=issue-list&statsPeriod=14d
- [x] Metrics should go from failure to success: https://metrics.posthog.net/d/tLt4bzGVk/calculate-event-property-usage?orgId=1&from=now-90d&to=now&var-manual_interval=1d&var-team_id=
- [ ] Update customer tickets
