### PR TITLE
fix: flaky person-state test

### DIFF
--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -1909,8 +1909,7 @@ describe('PersonState.update()', () => {
                     ).handleIdentifyOrAlias(),
                 ])
 
-                let persons = await fetchPostgresPersonsH()
-                expect(persons.length).toEqual(2) // only one of them succeeded
+                // Note: we can't verify anything here because the concurrency might have enabled both merges to already happen.
 
                 await Promise.all([
                     personState(
@@ -1938,7 +1937,7 @@ describe('PersonState.update()', () => {
                 ])
 
                 // verify Postgres persons
-                persons = await fetchPostgresPersonsH()
+                const persons = await fetchPostgresPersonsH()
                 expect(persons.length).toEqual(1)
                 expect(persons[0]).toEqual(
                     expect.objectContaining({


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The test got flaky when it ran concurrently in the same order as if they were ran non-concurrently. We could make the test more complex by adding waits to the right places, but for now let's make it non-flaky.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
