### PR TITLE
perf(ingestion): use rdkafka consumer for both ingestion queues

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -40,8 +40,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_SASL_USER: null,
         KAFKA_SASL_PASSWORD: null,
         KAFKA_CONSUMPTION_MAX_BYTES: 10_485_760, // Default value for kafkajs
-        KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: 1_048_576, // Default value for kafkajs, must be bigger than message size
-        KAFKA_CONSUMPTION_MAX_WAIT_MS: 1_000, // Down from the 5s default for kafkajs
+        KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: 5_242_880,
+        KAFKA_CONSUMPTION_MAX_WAIT_MS: 500, // Down from the 5s default for kafkajs
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_CONSUMPTION_OVERFLOW_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv() ? 0 : 1000,

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -1,6 +1,9 @@
 import {
     ClientMetrics,
     HighLevelProducer as RdKafkaProducer,
+    MessageHeader,
+    MessageKey,
+    MessageValue,
     NumberNullUndefined,
     ProducerGlobalConfig,
 } from 'node-rdkafka-acosom'
@@ -70,9 +73,9 @@ export const produce = async ({
 }: {
     producer: RdKafkaProducer
     topic: string
-    value: Buffer | null
-    key: Buffer | null
-    headers?: { [key: string]: Buffer }[]
+    value: MessageValue
+    key: MessageKey
+    headers?: MessageHeader[]
     waitForAck?: boolean
 }): Promise<number | null | undefined> => {
     status.debug('📤', 'Producing message', { topic: topic })

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
@@ -1,5 +1,4 @@
-import { EachBatchPayload } from 'kafkajs'
-import * as schedule from 'node-schedule'
+import { Message } from 'node-rdkafka-acosom'
 
 import { KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
 import { Hub } from '../../types'
@@ -34,8 +33,8 @@ export const startAnalyticsEventsIngestionOverflowConsumer = async ({
     // group id. In these cases, updating to this version will result in the
     // re-exporting of events still in Kafka `clickhouse_events_json` topic.
 
-    const batchHandler = async (payload: EachBatchPayload, queue: IngestionConsumer): Promise<void> => {
-        await eachBatchParallelIngestion(payload, queue, IngestionOverflowMode.Consume)
+    const batchHandler = async (messages: Message[], queue: IngestionConsumer): Promise<void> => {
+        await eachBatchParallelIngestion(messages, queue, IngestionOverflowMode.Consume)
     }
 
     const queue = new IngestionConsumer(
@@ -47,10 +46,6 @@ export const startAnalyticsEventsIngestionOverflowConsumer = async ({
     )
 
     await queue.start()
-
-    schedule.scheduleJob('0 * * * * *', async () => {
-        await queue.emitConsumerGroupMetrics()
-    })
 
     return queue
 }

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -4,10 +4,10 @@ import { RawClickHouseEvent } from '../../../types'
 import { convertToIngestionEvent } from '../../../utils/event'
 import { groupIntoBatches } from '../../../utils/utils'
 import { runInstrumentedFunction } from '../../utils'
-import { IngestionConsumer } from '../kafka-queue'
+import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
-export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: IngestionConsumer): Promise<void> {
+export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaJSIngestionConsumer): Promise<void> {
     const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
     const event = convertToIngestionEvent(clickHouseEvent)
 
@@ -21,6 +21,9 @@ export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: Ing
     })
 }
 
-export async function eachBatchAsyncHandlers(payload: EachBatchPayload, queue: IngestionConsumer): Promise<void> {
+export async function eachBatchAsyncHandlers(
+    payload: EachBatchPayload,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
     await eachBatch(payload, queue, eachMessageAsyncHandlers, groupIntoBatches, 'async_handlers')
 }

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node'
-import { EachBatchPayload, KafkaMessage } from 'kafkajs'
+import { Message } from 'node-rdkafka-acosom'
 import { exponentialBuckets, Histogram } from 'prom-client'
 
 import { KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW } from '../../../config/kafka-topics'
@@ -23,11 +23,11 @@ export enum IngestionOverflowMode {
 
 type IngestionSplitBatch = {
     toProcess: PipelineEvent[][]
-    toOverflow: KafkaMessage[]
+    toOverflow: Message[]
 }
 
 export async function eachBatchParallelIngestion(
-    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
+    messages: Message[],
     queue: IngestionConsumer,
     overflowMode: IngestionOverflowMode
 ): Promise<void> {
@@ -47,10 +47,10 @@ export async function eachBatchParallelIngestion(
          * We're sorting with biggest last and pop()ing. Ideally, we'd use a priority queue by length
          * and a separate array for single messages, but let's look at profiles before optimizing.
          */
-        const splitBatch = splitIngestionBatch(batch.messages, overflowMode)
+        const splitBatch = splitIngestionBatch(messages, overflowMode)
         splitBatch.toProcess.sort((a, b) => a.length - b.length)
 
-        queue.pluginsServer.statsd?.histogram('ingest_event_batching.input_length', batch.messages.length, {
+        queue.pluginsServer.statsd?.histogram('ingest_event_batching.input_length', messages.length, {
             key: metricKey,
         })
         queue.pluginsServer.statsd?.histogram('ingest_event_batching.batch_count', splitBatch.toProcess.length, {
@@ -77,7 +77,7 @@ export async function eachBatchParallelIngestion(
                 }
 
                 for (const message of currentBatch) {
-                    await Promise.all([eachMessage(message, queue), heartbeat()])
+                    await eachMessage(message, queue)
                 }
                 processedBatches++
                 batchSpan.finish()
@@ -111,36 +111,20 @@ export async function eachBatchParallelIngestion(
         }
         await Promise.all(tasks)
 
-        // Commit offsets once at the end of the batch. We run the risk of duplicates
-        // if the pod is prematurely killed in the middle of a batch, but this allows
-        // us to process events out of order within a batch, for higher throughput.
-        const commitSpan = transaction.startChild({ op: 'offsetCommit' })
-        const lastMessage = batch.messages.at(-1)
-        if (lastMessage) {
-            resolveOffset(lastMessage.offset)
-            await commitOffsetsIfNecessary()
-            latestOffsetTimestampGauge
-                .labels({ partition: batch.partition, topic: batch.topic, groupId: metricKey })
-                .set(Number.parseInt(lastMessage.timestamp))
+        for (const message of messages) {
+            if (message.timestamp) {
+                latestOffsetTimestampGauge
+                    .labels({ partition: message.partition, topic: message.topic, groupId: metricKey })
+                    .set(message.timestamp)
+            }
         }
-        commitSpan.finish()
 
         status.debug(
             '🧩',
-            `Kafka batch of ${batch.messages.length} events completed in ${
+            `Kafka batch of ${messages.length} events completed in ${
                 new Date().valueOf() - batchStartTimer.valueOf()
             }ms (${loggingKey})`
         )
-
-        if (!isRunning() || isStale()) {
-            status.info('🚪', `Ending the consumer loop`, {
-                isRunning: isRunning(),
-                isStale: isStale(),
-                msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
-            })
-            await heartbeat()
-            return
-        }
     } finally {
         queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
         transaction.finish()
@@ -174,22 +158,22 @@ function computeKey(pluginEvent: PipelineEvent): string {
     return `${pluginEvent.team_id ?? pluginEvent.token}:${pluginEvent.distinct_id}`
 }
 
-async function emitToOverflow(queue: IngestionConsumer, kafkaMessages: KafkaMessage[]) {
+async function emitToOverflow(queue: IngestionConsumer, kafkaMessages: Message[]) {
     await Promise.all(
         kafkaMessages.map((message) =>
-            queue.pluginsServer.kafkaProducer.queueMessage(
-                {
-                    topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
-                    messages: [message],
-                },
-                true
-            )
+            queue.pluginsServer.kafkaProducer.produce({
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
+                value: message.value,
+                key: message.key,
+                headers: message.headers,
+                waitForAck: true,
+            })
         )
     )
 }
 
 export function splitIngestionBatch(
-    kafkaMessages: KafkaMessage[],
+    kafkaMessages: Message[],
     overflowMode: IngestionOverflowMode
 ): IngestionSplitBatch {
     /**

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
 import { status } from '../../../utils/status'
-import { IngestionConsumer } from '../kafka-queue'
+import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { latestOffsetTimestampGauge } from '../metrics'
 
 // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
@@ -15,8 +15,8 @@ export async function eachBatch(
      * Events within a single micro-batch are processed in parallel.
      */
     { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
-    queue: IngestionConsumer,
-    eachMessage: (message: KafkaMessage, queue: IngestionConsumer) => Promise<void>,
+    queue: KafkaJSIngestionConsumer,
+    eachMessage: (message: KafkaMessage, queue: KafkaJSIngestionConsumer) => Promise<void>,
     groupIntoBatches: (messages: KafkaMessage[], batchSize: number) => KafkaMessage[][],
     key: string
 ): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
@@ -7,7 +7,7 @@ import { KAFKA_JOBS, KAFKA_JOBS_DLQ } from '../../config/kafka-topics'
 import { EnqueuedPluginJob, JobName } from '../../types'
 import { status } from '../../utils/status'
 import { GraphileWorker } from '../graphile-worker/graphile-worker'
-import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
+import { instrumentEachBatchKafkaJS, setupEventHandlers } from './kafka-queue'
 import { latestOffsetTimestampGauge } from './metrics'
 
 const jobsConsumerSuccessCounter = new Counter({
@@ -114,7 +114,7 @@ export const startJobsConsumer = async ({
     await consumer.subscribe({ topic: KAFKA_JOBS })
     await consumer.run({
         eachBatch: async (payload) => {
-            return await instrumentEachBatch(KAFKA_JOBS, eachBatch, payload, statsd)
+            return await instrumentEachBatchKafkaJS(KAFKA_JOBS, eachBatch, payload, statsd)
         },
     })
 

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -1,8 +1,12 @@
 import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
-import { Consumer, EachBatchHandler, EachBatchPayload, Kafka } from 'kafkajs'
+import { Consumer, EachBatchPayload, Kafka } from 'kafkajs'
+import { Message } from 'node-rdkafka-acosom'
 
+import { BatchConsumer, startBatchConsumer } from '../../kafka/batch-consumer'
+import { createRdConnectionConfigFromEnvVars } from '../../kafka/config'
 import { Hub, PipelineEvent, PostIngestionEvent, WorkerMethods } from '../../types'
+import { KafkaConfig } from '../../utils/db/hub'
 import { timeoutGuard } from '../../utils/db/utils'
 import { status } from '../../utils/status'
 import { killGracefully } from '../../utils/utils'
@@ -14,15 +18,15 @@ type ConsumerManagementPayload = {
     partitions?: number[] | undefined
 }
 
-type EachBatchFunction = (payload: EachBatchPayload, queue: IngestionConsumer) => Promise<void>
+type KafkaJSBatchFunction = (payload: EachBatchPayload, queue: KafkaJSIngestionConsumer) => Promise<void>
 
-export class IngestionConsumer {
+export class KafkaJSIngestionConsumer {
     public pluginsServer: Hub
     public workerMethods: WorkerMethods
     public consumerReady: boolean
     public topic: string
     public consumerGroupId: string
-    public eachBatch: EachBatchFunction
+    public eachBatch: KafkaJSBatchFunction
     public consumer: Consumer
     private kafka: Kafka
     private consumerGroupMemberId: string | null
@@ -33,13 +37,13 @@ export class IngestionConsumer {
         piscina: Piscina,
         topic: string,
         consumerGroupId: string,
-        batchHandler: EachBatchFunction
+        batchHandler: KafkaJSBatchFunction
     ) {
         this.pluginsServer = pluginsServer
         this.kafka = pluginsServer.kafka!
         this.topic = topic
         this.consumerGroupId = consumerGroupId
-        this.consumer = IngestionConsumer.buildConsumer(this.kafka, consumerGroupId)
+        this.consumer = KafkaJSIngestionConsumer.buildConsumer(this.kafka, consumerGroupId)
         this.wasConsumerRan = false
 
         // TODO: remove `this.workerMethods` and just rely on
@@ -104,7 +108,12 @@ export class IngestionConsumer {
 
     async eachBatchConsumer(payload: EachBatchPayload): Promise<void> {
         const topic = payload.batch.topic
-        await instrumentEachBatch(topic, (payload) => this.eachBatch(payload, this), payload, this.pluginsServer.statsd)
+        await instrumentEachBatchKafkaJS(
+            topic,
+            (payload) => this.eachBatch(payload, this),
+            payload,
+            this.pluginsServer.statsd
+        )
     }
 
     async pause(targetTopic: string, partition?: number): Promise<void> {
@@ -174,6 +183,87 @@ export class IngestionConsumer {
     }
 }
 
+type EachBatchFunction = (messages: Message[], queue: IngestionConsumer) => Promise<void>
+
+export class IngestionConsumer {
+    public pluginsServer: Hub
+    public workerMethods: WorkerMethods
+    public consumerReady: boolean
+    public topic: string
+    public consumerGroupId: string
+    public eachBatch: EachBatchFunction
+    public consumer?: BatchConsumer
+
+    constructor(
+        pluginsServer: Hub,
+        piscina: Piscina,
+        topic: string,
+        consumerGroupId: string,
+        batchHandler: EachBatchFunction
+    ) {
+        this.pluginsServer = pluginsServer
+        this.topic = topic
+        this.consumerGroupId = consumerGroupId
+
+        // TODO: remove `this.workerMethods` and just rely on
+        // `this.batchHandler`. At the time of writing however, there are some
+        // references to queue.workerMethods buried deep in the codebase
+        // #onestepatatime
+        this.workerMethods = {
+            runAsyncHandlersEventPipeline: (event: PostIngestionEvent) => {
+                this.pluginsServer.lastActivity = new Date().valueOf()
+                this.pluginsServer.lastActivityType = 'runAsyncHandlersEventPipeline'
+                return piscina.run({ task: 'runAsyncHandlersEventPipeline', args: { event } })
+            },
+            runEventPipeline: (event: PipelineEvent) => {
+                this.pluginsServer.lastActivity = new Date().valueOf()
+                this.pluginsServer.lastActivityType = 'runEventPipeline'
+                return piscina.run({ task: 'runEventPipeline', args: { event } })
+            },
+        }
+        this.consumerReady = false
+
+        this.eachBatch = batchHandler
+    }
+
+    async start(): Promise<BatchConsumer> {
+        this.consumer = await startBatchConsumer({
+            connectionConfig: createRdConnectionConfigFromEnvVars(this.pluginsServer as KafkaConfig),
+            topic: this.topic,
+            groupId: this.consumerGroupId,
+            sessionTimeout: 30000,
+            consumerMaxBytes: this.pluginsServer.KAFKA_CONSUMPTION_MAX_BYTES,
+            consumerMaxBytesPerPartition: this.pluginsServer.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
+            consumerMaxWaitMs: this.pluginsServer.KAFKA_CONSUMPTION_MAX_WAIT_MS,
+            fetchBatchSize: 500,
+            eachBatch: (payload) => this.eachBatchConsumer(payload),
+        })
+        this.consumerReady = true
+        return this.consumer
+    }
+
+    async eachBatchConsumer(messages: Message[]): Promise<void> {
+        await instrumentEachBatch(
+            this.topic,
+            (messages) => this.eachBatch(messages, this),
+            messages,
+            this.pluginsServer.statsd
+        )
+    }
+
+    async stop(): Promise<void> {
+        status.info('⏳', 'Stopping Kafka queue...')
+        try {
+            await this.consumer?.stop()
+            status.info('⏹', 'Kafka consumer stopped!')
+        } catch (error) {
+            status.error('⚠️', 'An error occurred while stopping Kafka queue:\n', error)
+        }
+
+        this.consumerReady = false
+    }
+}
+
 export const setupEventHandlers = (consumer: Consumer): void => {
     const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT, COMMIT_OFFSETS } = consumer.events
     let offsets: { [key: string]: string } = {} // Keep a record of offsets so we can report on process periodically
@@ -217,9 +307,29 @@ export const setupEventHandlers = (consumer: Consumer): void => {
     })
 }
 
+type EachBatchHandler = (messages: Message[]) => Promise<void>
+
 export const instrumentEachBatch = async (
     topic: string,
     eachBatch: EachBatchHandler,
+    messages: Message[],
+    statsd?: StatsD
+): Promise<void> => {
+    try {
+        await eachBatch(messages)
+    } catch (error) {
+        const eventCount = messages.length
+        statsd?.increment('kafka_queue_each_batch_failed_events', eventCount, {
+            topic: topic,
+        })
+        status.warn('💀', `Kafka batch of ${eventCount} events for topic ${topic} failed!`)
+        throw error
+    }
+}
+
+export const instrumentEachBatchKafkaJS = async (
+    topic: string,
+    eachBatch: (payload: EachBatchPayload) => Promise<void>,
     payload: EachBatchPayload,
     statsd?: StatsD
 ): Promise<void> => {

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -6,7 +6,7 @@ import { KAFKA_SCHEDULED_TASKS, KAFKA_SCHEDULED_TASKS_DLQ } from '../../config/k
 import { DependencyUnavailableError } from '../../utils/db/error'
 import { status } from '../../utils/status'
 import Piscina from '../../worker/piscina'
-import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
+import { instrumentEachBatchKafkaJS, setupEventHandlers } from './kafka-queue'
 import { latestOffsetTimestampGauge } from './metrics'
 
 // The valid task types that can be scheduled.
@@ -130,7 +130,7 @@ export const startScheduledTasksConsumer = async ({
     await consumer.run({
         partitionsConsumedConcurrently: partitionConcurrency,
         eachBatch: async (payload) => {
-            return await instrumentEachBatch(KAFKA_SCHEDULED_TASKS, eachBatch, payload, statsd)
+            return await instrumentEachBatchKafkaJS(KAFKA_SCHEDULED_TASKS, eachBatch, payload, statsd)
         },
     })
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/node'
 import { Server } from 'http'
-import { Consumer, KafkaJSProtocolError } from 'kafkajs'
-import { CompressionCodecs, CompressionTypes } from 'kafkajs'
+import { CompressionCodecs, CompressionTypes, Consumer, KafkaJSProtocolError } from 'kafkajs'
 // @ts-expect-error no type definitions
 import SnappyCodec from 'kafkajs-snappy'
 import * as schedule from 'node-schedule'
@@ -17,15 +16,14 @@ import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
 import { createPostgresPool, delay } from '../utils/utils'
 import { TeamManager } from '../worker/ingestion/team-manager'
-import { makePiscina as defaultMakePiscina } from '../worker/piscina'
-import Piscina from '../worker/piscina'
+import Piscina, { makePiscina as defaultMakePiscina } from '../worker/piscina'
 import { GraphileWorker } from './graphile-worker/graphile-worker'
 import { loadPluginSchedule } from './graphile-worker/schedule'
 import { startGraphileWorker } from './graphile-worker/worker-setup'
 import { startAnalyticsEventsIngestionConsumer } from './ingestion-queues/analytics-events-ingestion-consumer'
 import { startAnalyticsEventsIngestionOverflowConsumer } from './ingestion-queues/analytics-events-ingestion-overflow-consumer'
 import { startJobsConsumer } from './ingestion-queues/jobs-consumer'
-import { IngestionConsumer } from './ingestion-queues/kafka-queue'
+import { IngestionConsumer, KafkaJSIngestionConsumer } from './ingestion-queues/kafka-queue'
 import { startOnEventHandlerConsumer } from './ingestion-queues/on-event-handler-consumer'
 import { startScheduledTasksConsumer } from './ingestion-queues/scheduled-tasks-consumer'
 import { SessionRecordingBlobIngester } from './ingestion-queues/session-recording/session-recordings-blob-consumer'
@@ -83,8 +81,7 @@ export async function startPluginsServer(
     //    listening.
     let analyticsEventsIngestionConsumer: IngestionConsumer | undefined
     let analyticsEventsIngestionOverflowConsumer: IngestionConsumer | undefined
-
-    let onEventHandlerConsumer: IngestionConsumer | undefined
+    let onEventHandlerConsumer: KafkaJSIngestionConsumer | undefined
 
     // Kafka consumer. Handles events that we couldn't find an existing person
     // to associate. The buffer handles delaying the ingestion of these events

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -1,5 +1,5 @@
 import { Message, ProducerRecord } from 'kafkajs'
-import { HighLevelProducer, LibrdKafkaError } from 'node-rdkafka-acosom'
+import { HighLevelProducer, LibrdKafkaError, MessageHeader, MessageKey, MessageValue } from 'node-rdkafka-acosom'
 
 import { disconnectProducer, flushProducer, produce } from '../../kafka/producer'
 import { status } from '../../utils/status'
@@ -25,31 +25,30 @@ export class KafkaProducerWrapper {
         this.waitForAck = waitForAck
     }
 
-    async queueMessage(kafkaMessage: ProducerRecord, waitForAck?: boolean) {
+    async produce({
+        value,
+        key,
+        topic,
+        headers,
+        waitForAck,
+    }: {
+        value: MessageValue
+        key: MessageKey
+        topic: string
+        headers?: MessageHeader[]
+        waitForAck?: boolean
+    }) {
         try {
-            return await Promise.all(
-                kafkaMessage.messages.map((message) =>
-                    produce({
-                        producer: this.producer,
-                        topic: kafkaMessage.topic,
-                        key: message.key ? Buffer.from(message.key) : null,
-                        value: message.value ? Buffer.from(message.value) : null,
-                        // We need to convert from KafkaJS headers to rdkafka
-                        // headers format. The former has type
-                        // { [key: string]: string | Buffer | (string |
-                        // Buffer)[] | undefined }
-                        // while the latter has type
-                        // { [key: string]: Buffer }[]. The formers values that
-                        // are arrays need to be converted into an array of
-                        // objects with a single key-value pair, and the
-                        // undefined values need to be filtered out.
-                        headers: convertKafkaJSHeadersToRdKafkaHeaders(message.headers),
-                        waitForAck: waitForAck === undefined ? this.waitForAck : waitForAck,
-                    })
-                )
-            )
+            return await produce({
+                producer: this.producer,
+                topic: topic,
+                key: key,
+                value: value,
+                headers: headers,
+                waitForAck: waitForAck,
+            })
         } catch (error) {
-            status.error('⚠️', 'kafka_produce_error', { error: error, topic: kafkaMessage.topic })
+            status.error('⚠️', 'kafka_produce_error', { error: error, topic: topic })
 
             if ((error as LibrdKafkaError).isRetriable) {
                 // If we get a retriable error, bubble that up so that the
@@ -59,6 +58,20 @@ export class KafkaProducerWrapper {
 
             throw error
         }
+    }
+
+    async queueMessage(kafkaMessage: ProducerRecord, waitForAck?: boolean) {
+        return await Promise.all(
+            kafkaMessage.messages.map((message) =>
+                this.produce({
+                    topic: kafkaMessage.topic,
+                    key: message.key ? Buffer.from(message.key) : null,
+                    value: message.value ? Buffer.from(message.value) : null,
+                    headers: convertKafkaJSHeadersToRdKafkaHeaders(message.headers),
+                    waitForAck: waitForAck,
+                })
+            )
+        )
     }
 
     async queueMessages(kafkaMessages: ProducerRecord[], waitForAck?: boolean): Promise<void> {
@@ -90,13 +103,24 @@ export class KafkaProducerWrapper {
     }
 }
 
-export const convertKafkaJSHeadersToRdKafkaHeaders = (headers: Message['headers'] = {}) =>
-    Object.entries(headers)
-        .flatMap(([key, value]) =>
-            value === undefined
-                ? []
-                : Array.isArray(value)
-                ? value.map((v) => ({ key, value: Buffer.from(v) }))
-                : [{ key, value: Buffer.from(value) }]
-        )
-        .map(({ key, value }) => ({ [key]: value }))
+export const convertKafkaJSHeadersToRdKafkaHeaders = (headers: Message['headers'] = undefined) =>
+    // We need to convert from KafkaJS headers to rdkafka
+    // headers format. The former has type
+    // { [key: string]: string | Buffer | (string |
+    // Buffer)[] | undefined }
+    // while the latter has type
+    // { [key: string]: Buffer }[]. The formers values that
+    // are arrays need to be converted into an array of
+    // objects with a single key-value pair, and the
+    // undefined values need to be filtered out.
+    headers
+        ? Object.entries(headers)
+              .flatMap(([key, value]) =>
+                  value === undefined
+                      ? []
+                      : Array.isArray(value)
+                      ? value.map((v) => ({ key, value: Buffer.from(v) }))
+                      : [{ key, value: Buffer.from(value) }]
+              )
+              .map(({ key, value }) => ({ [key]: value }))
+        : undefined

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,5 +1,5 @@
 import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
-import { KafkaMessage } from 'kafkajs'
+import { Message } from 'node-rdkafka-acosom'
 
 import { ClickHouseEvent, PipelineEvent, PostIngestionEvent, RawClickHouseEvent } from '../types'
 import { convertDatabaseElementsToRawElements } from '../worker/vm/upgrades/utils/fetchEventsForInterval'
@@ -101,7 +101,7 @@ export function normalizeEvent(event: PluginEvent): PluginEvent {
     return event
 }
 
-export function formPipelineEvent(message: KafkaMessage): PipelineEvent {
+export function formPipelineEvent(message: Message): PipelineEvent {
     // TODO: inefficient to do this twice?
     const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
     const combinedEvent = { ...JSON.parse(dataStr), ...rawEvent }

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -1,4 +1,3 @@
-import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
 import {
     eachBatchParallelIngestion,
     IngestionOverflowMode,
@@ -27,23 +26,12 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
     let queue: any
 
     function createBatchWithMultipleEventsWithKeys(events: any[], timestamp?: any): any {
-        return {
-            batch: {
-                partition: 0,
-                topic: KAFKA_EVENTS_PLUGIN_INGESTION,
-                messages: events.map((event) => ({
-                    value: JSON.stringify(event),
-                    timestamp,
-                    offset: event.offset,
-                    key: event.team_id + ':' + event.distinct_id,
-                })),
-            },
-            resolveOffset: jest.fn(),
-            heartbeat: jest.fn(),
-            commitOffsetsIfNecessary: jest.fn(),
-            isRunning: jest.fn(() => true),
-            isStale: jest.fn(() => false),
-        }
+        return events.map((event) => ({
+            value: JSON.stringify(event),
+            timestamp,
+            offset: event.offset,
+            key: event.team_id + ':' + event.distinct_id,
+        }))
     }
 
     beforeEach(() => {

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -1,3 +1,4 @@
+import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
 import { eachBatch } from '../../../src/main/ingestion-queues/batch-processing/each-batch'
 import { eachBatchAsyncHandlers } from '../../../src/main/ingestion-queues/batch-processing/each-batch-async-handlers'
 import {
@@ -64,15 +65,17 @@ const captureEndpointEvent = {
 describe('eachBatchX', () => {
     let queue: any
 
-    function createBatchWithMultipleEvents(events: any[], timestamp?: any): any {
+    function createKafkaJSBatch(event: any, timestamp?: any): any {
         return {
             batch: {
                 partition: 0,
-                messages: events.map((event) => ({
-                    value: JSON.stringify(event),
-                    timestamp,
-                    offset: event.offset,
-                })),
+                messages: [
+                    {
+                        value: JSON.stringify(event),
+                        timestamp,
+                        offset: event.offset,
+                    },
+                ],
             },
             resolveOffset: jest.fn(),
             heartbeat: jest.fn(),
@@ -80,6 +83,16 @@ describe('eachBatchX', () => {
             isRunning: jest.fn(() => true),
             isStale: jest.fn(() => false),
         }
+    }
+
+    function createBatchWithMultipleEvents(events: any[], timestamp?: any): any {
+        return events.map((event, offset) => ({
+            value: JSON.stringify(event),
+            timestamp,
+            offset: offset,
+            partition: 0,
+            topic: KAFKA_EVENTS_PLUGIN_INGESTION,
+        }))
     }
 
     function createBatch(event: any, timestamp?: any): any {
@@ -114,7 +127,7 @@ describe('eachBatchX', () => {
     describe('eachBatch', () => {
         it('calls eachMessage with the correct arguments', async () => {
             const eachMessage = jest.fn()
-            const batch = createBatch(event)
+            const batch = createKafkaJSBatch(event)
             await eachBatch(batch, queue, eachMessage, groupIntoBatches, 'key')
 
             expect(eachMessage).toHaveBeenCalledWith({ value: JSON.stringify(event) }, queue)
@@ -122,7 +135,7 @@ describe('eachBatchX', () => {
 
         it('tracks metrics based on the key', async () => {
             const eachMessage = jest.fn()
-            await eachBatch(createBatch(event), queue, eachMessage, groupIntoBatches, 'my_key')
+            await eachBatch(createKafkaJSBatch(event), queue, eachMessage, groupIntoBatches, 'my_key')
 
             expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(
                 'kafka_queue.each_batch_my_key',
@@ -133,7 +146,7 @@ describe('eachBatchX', () => {
 
     describe('eachBatchAsyncHandlers', () => {
         it('calls runAsyncHandlersEventPipeline', async () => {
-            await eachBatchAsyncHandlers(createBatch(clickhouseEvent), queue)
+            await eachBatchAsyncHandlers(createKafkaJSBatch(clickhouseEvent), queue)
 
             expect(queue.workerMethods.runAsyncHandlersEventPipeline).toHaveBeenCalledWith({
                 ...event,
@@ -186,7 +199,7 @@ describe('eachBatchX', () => {
                 { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
             ])
             const stats = new Map()
-            for (const group of splitIngestionBatch(batch.batch.messages, IngestionOverflowMode.Disabled).toProcess) {
+            for (const group of splitIngestionBatch(batch, IngestionOverflowMode.Disabled).toProcess) {
                 const key = `${group[0].team_id}:${group[0].token}:${group[0].distinct_id}`
                 for (const event of group) {
                     expect(`${event.team_id}:${event.token}:${event.distinct_id}`).toEqual(key)
@@ -226,8 +239,6 @@ describe('eachBatchX', () => {
             ])
 
             await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)
-            expect(batch.resolveOffset).toBeCalledTimes(1)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(14)
             expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledTimes(14)
             expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
                 'ingest_event_batching.input_length',

--- a/plugin-server/tests/utils/kafka-producer-wrapper.test.ts
+++ b/plugin-server/tests/utils/kafka-producer-wrapper.test.ts
@@ -1,7 +1,7 @@
 import { convertKafkaJSHeadersToRdKafkaHeaders } from '../../src/utils/db/kafka-producer-wrapper'
 
 test('can convert from KafkaJS headers to rdkafka headers', () => {
-    expect(convertKafkaJSHeadersToRdKafkaHeaders()).toEqual([])
+    expect(convertKafkaJSHeadersToRdKafkaHeaders()).toEqual(undefined)
     expect(convertKafkaJSHeadersToRdKafkaHeaders({})).toEqual([])
     expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: 'bar' })).toEqual([{ foo: Buffer.from('bar') }])
     expect(convertKafkaJSHeadersToRdKafkaHeaders({ foo: ['bar', 'baz'] })).toEqual([


### PR DESCRIPTION
## Problem

Stop-the-world rebalances are causing ingestion latency, rdkafka consumer should handle rollouts more gracefully.

This is a partial port https://github.com/PostHog/posthog/pull/15432 over the latest concurrency changes. Only the ingestion and ingestion-overflow consumers are modified for now, other consumers still use kafkajs and will be moved in another PR.

To be rebased and merged after https://github.com/PostHog/posthog/pull/15689

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
