### PR TITLE
ci: Try to fix sync with `posthog-foss`

### DIFF
--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -12,6 +12,10 @@ jobs:
         if: github.repository == 'PostHog/posthog'
         runs-on: ubuntu-latest
         steps:
+            - name: Avoid HTTP/2 woes # See https://github.com/orgs/community/discussions/55820
+              run: |
+                  git config --global http.version HTTP/1.1
+                  git config --global http.postBuffer 157286400
             - name: Sync repositories 1 to 1 - master branch
               uses: wei/git-sync@v3
               with:


### PR DESCRIPTION
## Problem

Looks like we're running into this error in syncing `posthog` and `posthog-foss`: https://github.com/orgs/community/discussions/55820.

## Changes

Let's see if running some commands solves this. Other people's experience suggest "yes", but we're using this action: https://github.com/wei/git-sync, so I'm not 100% sure if that will propagate. Let's see.
