### PR TITLE
fix: commit sync and commit one more

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
@@ -123,10 +123,12 @@ export class OffsetManager {
         this.offsetsByPartitionTopic.set(key, inFlightOffsets)
 
         if (offsetToCommit !== undefined) {
-            this.consumer.commit({
+            this.consumer.commitSync({
                 topic,
                 partition,
-                offset: offsetToCommit,
+                // see https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html for example
+                // for some reason you commit the next offset you expect to read and not the one you actually have
+                offset: offsetToCommit + 1,
             })
         }
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
@@ -7,11 +7,11 @@ describe('offset-manager', () => {
 
     let offsetManager: OffsetManager
     const mockConsumer = {
-        commit: jest.fn(() => Promise.resolve()),
+        commitSync: jest.fn(() => Promise.resolve()),
     }
 
     beforeEach(() => {
-        mockConsumer.commit.mockClear()
+        mockConsumer.commitSync.mockClear()
         offsetManager = new OffsetManager(mockConsumer as unknown as KafkaConsumer)
     })
 
@@ -95,11 +95,11 @@ describe('offset-manager', () => {
 
         expect(result).toEqual(expectedCommittedOffset)
         if (result === undefined) {
-            expect(mockConsumer.commit).toHaveBeenCalledTimes(0)
+            expect(mockConsumer.commitSync).toHaveBeenCalledTimes(0)
         } else {
-            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
-            expect(mockConsumer.commit).toHaveBeenCalledWith({
-                offset: result,
+            expect(mockConsumer.commitSync).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commitSync).toHaveBeenCalledWith({
+                offset: result + 1, // why oh why
                 partition: 1,
                 topic: 'test-session-recordings',
             })
@@ -121,18 +121,18 @@ describe('offset-manager', () => {
 
         const resultOne = offsetManager.removeOffsets(TOPIC, 1, [1])
         expect(resultOne).toEqual(undefined)
-        expect(mockConsumer.commit).toHaveBeenCalledTimes(0)
+        expect(mockConsumer.commitSync).toHaveBeenCalledTimes(0)
 
-        mockConsumer.commit.mockClear()
+        mockConsumer.commitSync.mockClear()
 
         const resultTwo = offsetManager.removeOffsets(TOPIC, 2, [2])
         expect(resultTwo).toEqual(2)
-        expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
+        expect(mockConsumer.commitSync).toHaveBeenCalledTimes(1)
 
-        mockConsumer.commit.mockClear()
+        mockConsumer.commitSync.mockClear()
 
         const resultThree = offsetManager.removeOffsets(TOPIC, 3, [3])
         expect(resultThree).toEqual(3)
-        expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
+        expect(mockConsumer.commitSync).toHaveBeenCalledTimes(1)
     })
 })


### PR DESCRIPTION
## Problem

Two things in one 🙈 

1) for the blob ingester consistency is more important than latency
2) for no reason I can figure out you apparently commit offset + 1 and not offset 🤯 

## Changes

1) so change to using commitSync, this will block until a commit succeeds and throw if necessary
2) so add one when committing

## How did you test this code?

developer tests