### PR TITLE
chore: Rekey posthog_persondistinctid table. PK id => (team_id, distinct_id)

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -3704,7 +3704,7 @@
                    AND (event = '$pageview')
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -3784,7 +3784,7 @@
                    AND (event = '$pageview')
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -3863,7 +3863,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -3942,7 +3942,7 @@
                  WHERE team_id = 2
                    AND (event = '$screen')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4021,7 +4021,7 @@
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4100,7 +4100,7 @@
                  WHERE team_id = 2
                    AND (event IN ['/custom1', '/custom2'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4179,7 +4179,7 @@
                  WHERE team_id = 2
                    AND (event IN ['/custom3', 'blah'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4260,7 +4260,7 @@
                         OR event = '$screen'
                         OR NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -4342,7 +4342,7 @@
                         OR NOT event LIKE '$%')
                    AND NOT path_item IN ['/custom1', '/1', '/2', '/3']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -7954,7 +7954,7 @@
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -8752,7 +8752,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -9983,7 +9983,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -10300,7 +10300,7 @@
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-24 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-25 23:59:59', 'UTC')
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY

--- a/ee/clickhouse/test/test_journeys.py
+++ b/ee/clickhouse/test/test_journeys.py
@@ -52,7 +52,6 @@ def journeys_for(
             )
 
         for event in events:
-
             # Populate group properties as well
             group_props = {}
             for property_key, value in (event.get("properties") or {}).items():
@@ -143,6 +142,9 @@ class InMemoryEvent:
     group4_properties: Dict
 
 
+monotonic_id = 1
+
+
 def update_or_create_person(distinct_ids: List[str], team_id: int, **kwargs):
     (person, _) = Person.objects.update_or_create(
         persondistinctid__distinct_id__in=distinct_ids,
@@ -150,9 +152,17 @@ def update_or_create_person(distinct_ids: List[str], team_id: int, **kwargs):
         defaults={**kwargs, "team_id": team_id},
     )
     for distinct_id in distinct_ids:
-        PersonDistinctId.objects.update_or_create(
-            distinct_id=distinct_id,
-            team_id=person.team_id,
-            defaults={"person_id": person.id, "team_id": team_id, "distinct_id": distinct_id},
-        )
+        defaults = {**kwargs, "team_id": team_id, "distinct_id": distinct_id}
+        try:
+            obj = PersonDistinctId.objects.get(team_id=team_id, distinct_id=distinct_id)
+            for key, value in defaults.items():
+                setattr(obj, key, value)
+            obj.save()
+        except PersonDistinctId.DoesNotExist:
+            global monotonic_id
+            monotonic_id += 1
+            new_values = {"id": monotonic_id, "person_id": person.id}
+            new_values.update(defaults)
+            obj = PersonDistinctId(**new_values)
+            obj.save()
     return person

--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -5,7 +5,7 @@ contenttypes: 0002_remove_content_type_name
 ee: 0014_roles_memberships_and_resource_access
 otp_static: 0002_throttling
 otp_totp: 0002_auto_20190420_0723
-posthog: 0313_early_access_feature
+posthog: 0314_rekey_persondistinctid
 sessions: 0001_initial
 social_django: 0010_uid_db_index
 two_factor: 0007_auto_20201201_1019

--- a/posthog/migrations/0314_rekey_persondistinctid.py
+++ b/posthog/migrations/0314_rekey_persondistinctid.py
@@ -3,9 +3,9 @@ from django.db import migrations
 
 REKEY_PERSON_DISTINCT_ID_SQL = """
     BEGIN;
+    ALTER TABLE posthog_persondistinctid ALTER COLUMN id SET DEFAULT 2147483647;
     DROP SEQUENCE posthog_persondistinctid_id_seq;
     ALTER TABLE posthog_persondistinctid DROP CONSTRAINT posthog_persondistinctid_pkey;
-    ALTER TABLE posthog_persondistinctid ALTER COLUMN id SET DEFAULT 2147483647;
     ALTER TABLE posthog_persondistinctid ADD PRIMARY KEY (team_id, distinct_id);
     COMMIT;
 """

--- a/posthog/migrations/0314_rekey_persondistinctid.py
+++ b/posthog/migrations/0314_rekey_persondistinctid.py
@@ -3,7 +3,7 @@ from django.db import migrations
 
 REKEY_PERSON_DISTINCT_ID_SQL = """
     BEGIN;
-    DROP SEQUENCE IF EXISTS posthog_persondistinctid_id_seq;
+    DROP SEQUENCE posthog_persondistinctid_id_seq;
     ALTER TABLE posthog_persondistinctid DROP CONSTRAINT posthog_persondistinctid_pkey;
     ALTER TABLE posthog_persondistinctid ALTER COLUMN id SET DEFAULT 2147483647;
     ALTER TABLE posthog_persondistinctid ADD PRIMARY KEY (team_id, distinct_id);

--- a/posthog/migrations/0314_rekey_persondistinctid.py
+++ b/posthog/migrations/0314_rekey_persondistinctid.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+REKEY_PERSON_DISTINCT_ID_SQL = """
+    BEGIN;
+    DROP SEQUENCE IF EXISTS posthog_persondistinctid_id_seq;
+    ALTER TABLE posthog_persondistinctid DROP CONSTRAINT posthog_persondistinctid_pkey;
+    ALTER TABLE posthog_persondistinctid ALTER COLUMN id SET DEFAULT 2147483647;
+    ALTER TABLE posthog_persondistinctid ADD PRIMARY KEY (team_id, distinct_id);
+    COMMIT;
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "0313_early_access_feature"),
+    ]
+
+    operations = [
+        migrations.RunSQL(REKEY_PERSON_DISTINCT_ID_SQL, reverse_sql=migrations.RunSQL.noop),
+    ]

--- a/posthog/test/test_journeys.py
+++ b/posthog/test/test_journeys.py
@@ -187,12 +187,9 @@ def update_or_create_person(distinct_ids: List[str], team_id: int, **kwargs):
         defaults={**kwargs, "team_id": team_id},
     )
     for distinct_id in distinct_ids:
-        if PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).exists():
-            PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).update(person_id=person.id)
-        else:
-            PersonDistinctId.objects.create(
-                distinct_id=distinct_id,
-                team_id=person.team_id,
-                defaults={"person_id": person.id, "team_id": team_id, "distinct_id": distinct_id},
-            )
+        PersonDistinctId.objects.update_or_create(
+            distinct_id=distinct_id,
+            team_id=person.team_id,
+            defaults={"person_id": person.id, "team_id": team_id, "distinct_id": distinct_id},
+        )
     return person

--- a/posthog/test/test_journeys.py
+++ b/posthog/test/test_journeys.py
@@ -187,10 +187,12 @@ def update_or_create_person(distinct_ids: List[str], team_id: int, **kwargs):
         defaults={**kwargs, "team_id": team_id},
     )
     for distinct_id in distinct_ids:
-        PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).delete()
-        PersonDistinctId.objects.create(
-            distinct_id=distinct_id,
-            team_id=person.team_id,
-            defaults={"person_id": person.id, "team_id": team_id, "distinct_id": distinct_id},
-        )
+        if PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).exists():
+            PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).update(person_id=person.id)
+        else:
+            PersonDistinctId.objects.create(
+                distinct_id=distinct_id,
+                team_id=person.team_id,
+                defaults={"person_id": person.id, "team_id": team_id, "distinct_id": distinct_id},
+            )
     return person

--- a/posthog/test/test_journeys.py
+++ b/posthog/test/test_journeys.py
@@ -52,7 +52,6 @@ def journeys_for(
             )
 
         for event in events:
-
             # Populate group properties as well
             group_mapping = {}
             for property_key, value in (event.get("properties") or {}).items():
@@ -188,7 +187,8 @@ def update_or_create_person(distinct_ids: List[str], team_id: int, **kwargs):
         defaults={**kwargs, "team_id": team_id},
     )
     for distinct_id in distinct_ids:
-        PersonDistinctId.objects.update_or_create(
+        PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).delete()
+        PersonDistinctId.objects.create(
             distinct_id=distinct_id,
             team_id=person.team_id,
             defaults={"person_id": person.id, "team_id": team_id, "distinct_id": distinct_id},


### PR DESCRIPTION
## Problem

The pk of `posthog_persondistinctid` is an integer `id` that we actually don't use (thanks for the tip @timgl)
This `id` is quickly approaching the maximum integer value it can have, after which the table will be broken.

## Changes

This change
- removes `id` as a primary key
- removes the `seq` that is incrementing the `id` value
- sets a new default value to the max value an int can have in postgres
- adds a new primary key that is a composite key of `(team_id, distinct_id)` which we already enforce as `unique` and `not null`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
