### PR TITLE
fix: Still commit offsets for empty buffer

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -261,6 +261,26 @@ describe('session-manager', () => {
         )
     })
 
+    it('flushes messages even if the buffer is empty', async () => {
+        // Create an event that ends up in the chunks rather than the buffer
+        const event = createIncomingRecordingMessage({
+            chunk_count: 2,
+        })
+        await sessionManager.add(event)
+        expect(sessionManager.buffer.count).toEqual(0)
+        expect(sessionManager.chunks.size).toEqual(1)
+
+        const afterResumeFlushPromise = sessionManager.flush('buffer_size')
+
+        expect(sessionManager.buffer.count).toEqual(0)
+        expect(sessionManager.flushBuffer?.count).toEqual(0)
+
+        await afterResumeFlushPromise
+
+        expect(sessionManager.flushBuffer).toEqual(undefined)
+        expect(mockFinish).toBeCalledTimes(1)
+    })
+
     it.each([
         [
             'incomplete and below threshold of 1000, we keep it in the chunks buffer',


### PR DESCRIPTION
## Problem

We might have finally found the issue with the offsetmanager due to the buffer being empty if it only contains partial chunks that end up being idle

## Changes

* Fixes this
* Reverts previous testing code

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
