### PR TITLE
fix: session manager must not flush offsets if destroying

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -390,7 +390,13 @@ export class SessionManager {
             this.flushBuffer = undefined
 
             // TODO: Sync the last processed offset to redis
-            this.onFinish(offsets.sort((a, b) => a - b))
+            if (!this.destroying) {
+                // it is possible that destroy was called while we were flushing to S3
+                // if we are destroying then we don't want to call onFinish
+                // because any commit will fail
+                // the blob consumer must always revoke partitions when destroying session managers
+                this.onFinish(offsets.sort((a, b) => a - b))
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

We think we intermittently see session managers attempt to commit offsets after a rebalance

https://posthog.sentry.io/issues/4207087139/?query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-blob-ingestion&referrer=issue-stream&statsPeriod=24h&stream_index=0

## Changes

It is possibly safer for the offset manager to track what partitions have been revoked and subsequently ignore them.... but that requires more coordination between the blob consumer and the offset manager.

Instead, the session manager knows when it has been destroyed and can skip removing offsets. Implicitly the contract is that the blob consumer must revoke partitions before destroying session managers

## How did you test this code?

The amount of mocking needed to cause the session manager to destroy while flushing was super ugly so tested with my 🧠 
