### PR TITLE
fix(ingestion): fix consumer shutdown

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -147,10 +147,14 @@ export const startBatchConsumer = async ({
 
                 status.debug('🔁', 'main_loop_consuming')
                 const messages = await consumeMessages(consumer, fetchBatchSize)
-                status.debug('🔁', 'main_loop_consumed', { messagesLength: messages.length })
+                if (!messages) {
+                    status.debug('🔁', 'main_loop_empty_batch', { cause: 'undefined' })
+                    continue
+                }
 
+                status.debug('🔁', 'main_loop_consumed', { messagesLength: messages.length })
                 if (!messages.length) {
-                    // For now
+                    status.debug('🔁', 'main_loop_empty_batch', { cause: 'empty' })
                     continue
                 }
 


### PR DESCRIPTION
## Problem

rdkafka ingestion consumers don't gracefully shutdown, and hold on to partitions, creating lag.

```
{"level":"info","time":1685020843267,"pid":73,"hostname":"posthog-plugins-ingestion-66fbddf68b-stng7","msg":"[ANALYTICS-INGESTION] 💤  Shutting down gracefully..."}
{"level":"info","time":1685020843268,"pid":73,"hostname":"posthog-plugins-ingestion-66fbddf68b-stng7","msg":"[ANALYTICS-INGESTION] ⏳ Stopping Kafka queue..."}
{"level":"info","time":1685020843268,"pid":73,"hostname":"posthog-plugins-ingestion-66fbddf68b-stng7","msg":"[ANALYTICS-INGESTION] 🔁 Stopping kafka batch consumer"}
{"level":"error","time":1685020843285,"pid":73,"hostname":"posthog-plugins-ingestion-66fbddf68b-stng7","error":{},"stack":"TypeError: Cannot read properties of undefined (reading 'length')\n    at Job.cancel (/code/plugin-server/node_modules/.pnpm/node-schedule@2.1.1/node_modules/node-schedule/lib/Job.js:92:49)\n    at process.emit (node:events:525:35)\n    at process.emit (node:domain:489:12)\n    at Signal.callbackTrampoline (node:internal/async_hooks:130:17)","msg":"[ANALYTICS-INGESTION] 🤮 uncaughtException!"}
{"level":"info","time":1685020843343,"pid":73,"hostname":"posthog-plugins-ingestion-66fbddf68b-stng7","msg":"[ANALYTICS-INGESTION] 🛑 Pub-sub stopped for channels: reload-plugins, reset-available-features-cache"}
```

## Changes

- Try to fix this `TypeError: Cannot read properties of undefined (reading 'length')`, consume might return an empty array when it's shutting down
