### PR TITLE
chore: Add PG bouncer error to be retried not DLQ

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -140,6 +140,7 @@ export const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'Connection terminated unexpectedly',
     'ECONNREFUSED',
     'ETIMEDOUT',
+    'query_wait_timeout', // Waiting on PG bouncer to give us a slot
 ]
 
 /** The recommended way of accessing the database. */


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Saw these errors on EU DLQ - we should not drop events here

```
select
team_id, substring(error, 1, 65) as err, toStartOfMonth(error_timestamp) as ts
, count() as cnt
from events_dead_letter_queue
where error_timestamp > today() - 2
group by err, ts, team_id
order by cnt desc
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
