### PR TITLE
feat(jobs): don't execute queued jobs for disabled configs

### DIFF
--- a/plugin-server/functional_tests/jobs-worker.test.ts
+++ b/plugin-server/functional_tests/jobs-worker.test.ts
@@ -1,0 +1,85 @@
+import {
+    createAndReloadPluginConfig,
+    createOrganization,
+    createPlugin,
+    createTeam,
+    disablePluginConfig,
+    enablePluginConfig,
+    fetchPluginLogEntries,
+    getScheduledPluginJob,
+    schedulePluginJob,
+} from './api'
+import { waitForExpect } from './expectations'
+
+test.concurrent('graphile-worker does not run jobs for disabled plugins', async () => {
+    // Here we are validating that if a Graphile task has been scheduled for a
+    // pluginConfig that is disabled, then the task is not run. This is to avoid
+    // spending resources unnecessarily.
+    //
+    // This should allow e.g. the ability to disable troublesome plugins e.g.
+    // ones that have spawned too many tasks.
+    const indexJs = `
+        export const jobs = {
+            runMeAsync: async (payload) => {
+                console.info(JSON.stringify(payload))
+            }
+        }
+    `
+
+    const organizationId = await createOrganization()
+    const plugin = await createPlugin({
+        organization_id: organizationId,
+        name: 'jobs plugin',
+        plugin_type: 'source',
+        is_global: false,
+        source__index_ts: indexJs,
+    })
+    const teamId = await createTeam(organizationId)
+    const pluginConfig = await createAndReloadPluginConfig(teamId, plugin.id)
+
+    // Disable the plugin
+    await disablePluginConfig(teamId, pluginConfig.id)
+
+    // Schedule a task
+    const job = await schedulePluginJob({
+        teamId,
+        pluginConfigId: pluginConfig.id,
+        taskType: 'pluginJob',
+        type: 'runMeAsync',
+        payload: { identifier: 'should not run' },
+    })
+
+    // Wait for the task to run, it will become undefined
+    await waitForExpect(async () => {
+        const row = await getScheduledPluginJob(job.id)
+        expect(row).not.toBeDefined()
+    })
+
+    // Re-enable the plugin and schedule a task, such that we can watch plugin
+    // logs to see what ran.
+    await enablePluginConfig(teamId, pluginConfig.id)
+
+    // Schedule a task
+    const job2 = await schedulePluginJob({
+        teamId,
+        pluginConfigId: pluginConfig.id,
+        taskType: 'pluginJob',
+        type: 'runMeAsync',
+        payload: { identifier: 'should run' },
+    })
+
+    // Wait for the task to run, it will become undefined
+    await waitForExpect(async () => {
+        const row = await getScheduledPluginJob(job2.id)
+        expect(row).not.toBeDefined()
+    })
+
+    // Check the logs to see what ran
+    const logs = await waitForExpect(async () => {
+        const logs = (await fetchPluginLogEntries(pluginConfig.id)).map((log) => log.message)
+        expect(logs).toContain(JSON.stringify({ identifier: 'should run' }))
+        return logs
+    })
+
+    expect(logs).toContain(JSON.stringify({ identifier: 'should not run' }))
+})

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -4,6 +4,7 @@ import { Hub, PluginConfig, PluginTaskType, VMMethods } from '../../types'
 import { processError } from '../../utils/db/error'
 import { instrument } from '../../utils/metrics'
 import { runRetriableFunction } from '../../utils/retries'
+import { status } from '../../utils/status'
 import { IllegalOperationError } from '../../utils/utils'
 
 export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise<void> {
@@ -182,6 +183,15 @@ export async function runPluginTask(
             throw new Error(
                 `Task "${taskName}" not found for plugin "${pluginConfig?.plugin?.name}" with config id ${pluginConfigId}`
             )
+        }
+
+        if (!pluginConfig?.enabled) {
+            status.info('🚮', 'Skipping job for disabled pluginconfig', {
+                taskName: taskName,
+                taskType: taskType,
+                pluginConfigId: pluginConfigId,
+            })
+            return
         }
 
         shouldQueueAppMetric = taskType === PluginTaskType.Schedule && !task.__ignoreForAppMetrics

--- a/plugin-server/tests/worker/plugins/run.test.ts
+++ b/plugin-server/tests/worker/plugins/run.test.ts
@@ -17,6 +17,17 @@ describe('runPluginTask()', () => {
                     1,
                     {
                         team_id: 2,
+                        enabled: true,
+                        vm: {
+                            getTask,
+                        },
+                    },
+                ],
+                [
+                    2,
+                    {
+                        team_id: 2,
+                        enabled: false,
                         vm: {
                             getTask,
                         },
@@ -90,5 +101,13 @@ describe('runPluginTask()', () => {
             new Error('Task "some_task" not found for plugin "undefined" with config id -1')
         )
         expect(mockHub.appMetrics.queueError).not.toHaveBeenCalled()
+    })
+
+    it('skips the task if the pluginconfig is disabled', async () => {
+        await runPluginTask(mockHub, 'some_task', PluginTaskType.Schedule, 2)
+
+        expect(processError).not.toHaveBeenCalledWith()
+        expect(exec).not.toHaveBeenCalled()
+        expect(mockHub.appMetrics.queueMetric).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Problem

If a pluginconfig starts failing, disabling it will stop new tasks being created, but does not skip the execution of pending ones.

## Changes

- Check pluginconfig.enabled before executing a task, log and drop otherwise

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
