### PR TITLE
feat(jobs): add JOB_QUEUE_SKIP_PLUGINCONFIG_IDS option

### DIFF
--- a/plugin-server/functional_tests/jobs-consumer.test.ts
+++ b/plugin-server/functional_tests/jobs-consumer.test.ts
@@ -57,11 +57,11 @@ describe('dlq handling', () => {
         })
     })
 
-    test.concurrent('consumer updates timestamp exported to prometheus', async () => {
+    test.concurrent('consumer updates prometheus metrics', async () => {
         // NOTE: it may be another event other than the one we emit here that causes
         // the gauge to increase, but pushing this event through should at least
         // ensure that the gauge is updated.
-        const metricBefore = await getMetric({
+        const timestampBefore = await getMetric({
             name: 'latest_processed_timestamp_ms',
             type: 'GAUGE',
             labels: { topic: 'jobs', partition: '0', groupId: 'jobs-inserter' },
@@ -75,7 +75,7 @@ describe('dlq handling', () => {
                 type: 'GAUGE',
                 labels: { topic: 'jobs', partition: '0', groupId: 'jobs-inserter' },
             })
-            expect(metricAfter).toBeGreaterThan(metricBefore)
+            expect(metricAfter).toBeGreaterThan(timestampBefore)
             expect(metricAfter).toBeLessThan(Date.now()) // Make sure, e.g. we're not setting micro seconds
             expect(metricAfter).toBeGreaterThan(Date.now() - 60_000) // Make sure, e.g. we're not setting seconds
         }, 10_000)

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -81,6 +81,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         JOB_QUEUE_S3_AWS_REGION: 'us-west-1',
         JOB_QUEUE_S3_BUCKET_NAME: '',
         JOB_QUEUE_S3_PREFIX: '',
+        JOB_QUEUE_SKIP_PLUGINCONFIG_IDS: '',
         CRASH_IF_NO_PERSISTENT_JOB_QUEUE: false,
         HEALTHCHECK_MAX_STALE_SECONDS: 2 * 60 * 60, // 2 hours
         PISCINA_USE_ATOMICS: true,

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -256,6 +256,7 @@ export async function startPluginsServer(
                     producer: hub.kafkaProducer,
                     graphileWorker: graphileWorker,
                     statsd: hub.statsd,
+                    skipPluginConfigIds: hub.JOB_QUEUE_SKIP_PLUGINCONFIG_IDS,
                 })
             }
         }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -140,6 +140,7 @@ export interface PluginsServerConfig {
     JOB_QUEUE_S3_AWS_REGION: string
     JOB_QUEUE_S3_BUCKET_NAME: string
     JOB_QUEUE_S3_PREFIX: string // S3 filename prefix for the S3 job queue
+    JOB_QUEUE_SKIP_PLUGINCONFIG_IDS: string // coma-separated list of pluginconfig to drop when queuing graphile jobs from kafka
     CRASH_IF_NO_PERSISTENT_JOB_QUEUE: boolean // refuse to start unless there is a properly configured persistent job queue (e.g. graphile)
     HEALTHCHECK_MAX_STALE_SECONDS: number // maximum number of seconds the plugin server can go without ingesting events before the healthcheck fails
     PISCINA_USE_ATOMICS: boolean // corresponds to the piscina useAtomics config option (https://github.com/piscinajs/piscina#constructor-new-piscinaoptions)


### PR DESCRIPTION
## Problem

Our jobs kafka queue is stuffed with millions of tasks from a bad pluginconfig, instead of getting them through to graphile, let's skip them.

Ideally, we'd skip queuing and executing of all disabled pluginconfigids, but I'm not sure how to do that safely for the queueing part. https://github.com/PostHog/posthog/pull/15738 handles the executing part.

## Changes
- Add JOB_QUEUE_SKIP_PLUGINCONFIG_IDS option
- If job payload matches one of these ids, don't queue it in graphile and log it

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
