### PR TITLE
fix: throw on impossible state

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/offset-manager.ts
@@ -34,7 +34,7 @@
  *
  */
 
-import { captureException } from '@sentry/react'
+import { captureException } from '@sentry/node'
 import { KafkaConsumer } from 'node-rdkafka-acosom'
 import { Gauge } from 'prom-client'
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -280,8 +280,10 @@ export class SessionRecordingBlobIngester {
             if (err.code === CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
                 /**
                  * The assign_partitions indicates that the consumer group has new assignments.
-                 * We don't need to do anything, but it is useful to log for debugging.
+                 * We explicitly ensire the offset manager is not treating these partitions as revoked
                  */
+                const assignedPartitions = topicPartitions.map((x) => x.partition)
+                this.offsetManager?.assignPartition(KAFKA_SESSION_RECORDING_EVENTS, assignedPartitions)
                 return
             }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -280,7 +280,7 @@ export class SessionRecordingBlobIngester {
             if (err.code === CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
                 /**
                  * The assign_partitions indicates that the consumer group has new assignments.
-                 * We explicitly ensire the offset manager is not treating these partitions as revoked
+                 * We explicitly ensure the offset manager is not treating these partitions as revoked
                  */
                 const assignedPartitions = topicPartitions.map((x) => x.partition)
                 this.offsetManager?.assignPartition(KAFKA_SESSION_RECORDING_EVENTS, assignedPartitions)

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/offset-manager.test.ts
@@ -110,29 +110,104 @@ describe('offset-manager', () => {
         ;[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((offset) => {
             offsetManager.addOffset(TOPIC, 1, 'session_id', offset)
         })
+        expect(offsetManager.offsetsByPartitionTopic.size).toEqual(1)
+        expect(offsetManager.offsetsByPartitionTopic.get(`${TOPIC}-1`)).toEqual([
+            { offset: 1, session_id: 'session_id' },
+            { offset: 2, session_id: 'session_id' },
+            { offset: 3, session_id: 'session_id' },
+            { offset: 4, session_id: 'session_id' },
+            { offset: 5, session_id: 'session_id' },
+            { offset: 6, session_id: 'session_id' },
+            { offset: 7, session_id: 'session_id' },
+            { offset: 8, session_id: 'session_id' },
+            { offset: 9, session_id: 'session_id' },
+            { offset: 10, session_id: 'session_id' },
+        ])
 
         offsetManager.addOffset(TOPIC, 1, 'session_id', 1)
+
+        expect(offsetManager.offsetsByPartitionTopic.get(`${TOPIC}-1`)).toEqual([
+            { offset: 1, session_id: 'session_id' },
+            { offset: 2, session_id: 'session_id' },
+            { offset: 3, session_id: 'session_id' },
+            { offset: 4, session_id: 'session_id' },
+            { offset: 5, session_id: 'session_id' },
+            { offset: 6, session_id: 'session_id' },
+            { offset: 7, session_id: 'session_id' },
+            { offset: 8, session_id: 'session_id' },
+            { offset: 9, session_id: 'session_id' },
+            { offset: 10, session_id: 'session_id' },
+            { offset: 1, session_id: 'session_id' },
+        ])
+
         offsetManager.addOffset(TOPIC, 2, 'session_id', 2)
+
+        expect(offsetManager.offsetsByPartitionTopic.size).toEqual(2)
+        expect(offsetManager.offsetsByPartitionTopic.get(`${TOPIC}-1`)).toEqual([
+            { offset: 1, session_id: 'session_id' },
+            { offset: 2, session_id: 'session_id' },
+            { offset: 3, session_id: 'session_id' },
+            { offset: 4, session_id: 'session_id' },
+            { offset: 5, session_id: 'session_id' },
+            { offset: 6, session_id: 'session_id' },
+            { offset: 7, session_id: 'session_id' },
+            { offset: 8, session_id: 'session_id' },
+            { offset: 9, session_id: 'session_id' },
+            { offset: 10, session_id: 'session_id' },
+            { offset: 1, session_id: 'session_id' },
+        ])
+        expect(offsetManager.offsetsByPartitionTopic.get(`${TOPIC}-2`)).toEqual([
+            { offset: 2, session_id: 'session_id' },
+        ])
+
         offsetManager.addOffset(TOPIC, 3, 'session_id', 3)
+
+        expect(offsetManager.offsetsByPartitionTopic.size).toEqual(3)
+        expect(offsetManager.offsetsByPartitionTopic.get(`${TOPIC}-1`)).toEqual([
+            { offset: 1, session_id: 'session_id' },
+            { offset: 2, session_id: 'session_id' },
+            { offset: 3, session_id: 'session_id' },
+            { offset: 4, session_id: 'session_id' },
+            { offset: 5, session_id: 'session_id' },
+            { offset: 6, session_id: 'session_id' },
+            { offset: 7, session_id: 'session_id' },
+            { offset: 8, session_id: 'session_id' },
+            { offset: 9, session_id: 'session_id' },
+            { offset: 10, session_id: 'session_id' },
+            { offset: 1, session_id: 'session_id' },
+        ])
+        expect(offsetManager.offsetsByPartitionTopic.get(`${TOPIC}-2`)).toEqual([
+            { offset: 2, session_id: 'session_id' },
+        ])
+        expect(offsetManager.offsetsByPartitionTopic.get(`${TOPIC}-3`)).toEqual([
+            { offset: 3, session_id: 'session_id' },
+        ])
 
         expect(offsetManager.offsetsByPartitionTopic.has(`${TOPIC}-1`)).toEqual(true)
         offsetManager.revokePartitions(TOPIC, [1])
         expect(offsetManager.offsetsByPartitionTopic.has(`${TOPIC}-1`)).toEqual(false)
 
-        const resultOne = offsetManager.removeOffsets(TOPIC, 1, [1])
-        expect(resultOne).toEqual(undefined)
+        expect(() => offsetManager.removeOffsets(TOPIC, 1, [1])).toThrow('No in-flight offsets found for partition 1')
         expect(mockConsumer.commitSync).toHaveBeenCalledTimes(0)
 
         mockConsumer.commitSync.mockClear()
 
         const resultTwo = offsetManager.removeOffsets(TOPIC, 2, [2])
         expect(resultTwo).toEqual(2)
-        expect(mockConsumer.commitSync).toHaveBeenCalledTimes(1)
+        expect(mockConsumer.commitSync).toHaveBeenCalledWith({
+            offset: 3,
+            partition: 2,
+            topic: 'test-session-recordings',
+        })
 
         mockConsumer.commitSync.mockClear()
 
         const resultThree = offsetManager.removeOffsets(TOPIC, 3, [3])
         expect(resultThree).toEqual(3)
-        expect(mockConsumer.commitSync).toHaveBeenCalledTimes(1)
+        expect(mockConsumer.commitSync).toHaveBeenCalledWith({
+            offset: 4,
+            partition: 3,
+            topic: 'test-session-recordings',
+        })
     })
 })


### PR DESCRIPTION
## Problem

I'm not sure why a partition can get stuck being processed by a session manager but not present in the offset manager

## Changes

But at least let's not stay in a loop forever

A partition could be removed from the offset manager while still processing so...

The question becomes

1) are we not removing session managers correctly on revoke of a partition
2) are we not tracking offsets correctly on assign

(or hopefully not 3) both)

So, explicitly track revoked and re-assigned partitions in the offset manager so we can distinguish between them

## How did you test this code?

developer tests