### PR TITLE
perf(ingestion): don't batch events by distinct_id when consuming from overflow

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -220,6 +220,21 @@ describe('eachBatchX', () => {
             )
         })
 
+        it('does not batch events when consuming overflow', () => {
+            const input = createBatchWithMultipleEvents([
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: 3, distinct_id: 'b' },
+                { ...captureEndpointEvent, team_id: 4, distinct_id: 'a' },
+                { ...captureEndpointEvent, team_id: 4, distinct_id: 'a' },
+            ])
+            const batches = splitIngestionBatch(input, IngestionOverflowMode.Consume).toProcess
+            expect(batches.length).toEqual(input.length)
+            for (const group of batches) {
+                expect(group.length).toEqual(1)
+            }
+        })
+
         it('batches events but commits offsets only once', async () => {
             const batch = createBatchWithMultipleEvents([
                 { ...captureEndpointEvent, offset: 1, team_id: 3 },


### PR DESCRIPTION
## Problem

Our processing parallelism on the `ingestion-overflow` consumer is shite because we don’t have a lot of `distinct_id`s going there. Because we already threw away the ordering guarantees by going to overflow, let's not enforce it in `eachBatchParallelIngestion`, so help us increase throughput.

## Changes

- Change `splitIngestionBatch` to create batches of one when consuming from overflow

Data massaging could be more efficient, but that's TODO territory for then the workload is CPU-bound

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
