### PR TITLE
feat: use readonly replica if available

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -210,8 +210,6 @@ if not REDIS_URL:
 # ElastiCache manages updating which nodes are used if a replica is failed-over to primary
 # so that we don't have to worry about changing config.
 REDIS_READER_URL = os.getenv("REDIS_READER_URL", None)
-if TEST or DEBUG or IS_COLLECT_STATIC:
-    REDIS_READER_URL = os.getenv("REDIS_URL", "redis://localhost:6380/")
 
 CACHES = {
     "default": {

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -203,10 +203,23 @@ if not REDIS_URL:
         "https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011"
     )
 
+# AWS ElastiCache supports "reader" endpoints.
+# See "Finding a Redis (Cluster Mode Disabled) Cluster's Endpoints (Console)"
+# on https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html#Endpoints.Find.Redis
+# A reader endpoint distributes read-only connections across all replicas in the cluster.
+# ElastiCache manages updating which nodes are used if a replica is failed-over to primary
+# so that we don't have to worry about changing config.
+REDIS_READER_URL = os.getenv("REDIS_READER_URL", None)
+if TEST or DEBUG or IS_COLLECT_STATIC:
+    REDIS_READER_URL = os.getenv("REDIS_URL", "redis://localhost:6380/")
+
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": REDIS_URL,
+        # the django redis default client can be replica aware
+        # if location is an array then the first element is the primary
+        # and the rest are replicas
+        "LOCATION": REDIS_URL if not REDIS_READER_URL else [REDIS_URL, REDIS_READER_URL],
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",


### PR DESCRIPTION
## Problem

stacked on top of #15749 

We use `django-redis` to access our Redis cache.

We use elasticache which provides a "reader" endpoint for access to read replicas.

But we don't use those replicas because we never tried to

## Changes

`django-redis` supports receiving an array of Redis urls and treats the first as the primary and any others as secondary.

So, let's do that.

## How did you test this code?

Edited my docker compose file to have a redis replica

added

```
    redis:
        extends:
            file: docker-compose.base.yml
            service: redis
        container_name: primary
        ports:
            - '6379:6379'
        networks:
            - redis-replication

    redis-replica:
        extends:
            file: docker-compose.base.yml
            service: redis
        container_name: replica
        ports:
            - "6380:6379"
        command: redis-server --replicaof primary 6379
        depends_on:
            - redis
        networks:
            - redis-replication

networks:
  redis-replication:
    driver: bridge
```

Started the application with the `REDIS_READER_URL` hard-coded to localhost:6380

Navigating the application I saw it use :6379 when setting values and :6380 when reading then

<img width="770" alt="Screenshot 2023-05-26 at 14 02 45" src="https://github.com/PostHog/posthog/assets/984817/b0ddd9e0-bbad-424a-ba4c-e382e2a916fb">
<img width="753" alt="Screenshot 2023-05-26 at 14 05 27" src="https://github.com/PostHog/posthog/assets/984817/1f040846-48c9-4e34-9832-41bbf0cfd2eb">

