### PR TITLE
chore: more logging

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,8 +24,24 @@ services:
         extends:
             file: docker-compose.base.yml
             service: redis
+        container_name: primary
         ports:
             - '6379:6379'
+        networks:
+            - redis-replication
+
+    redis-replica:
+        extends:
+            file: docker-compose.base.yml
+            service: redis
+        container_name: replica
+        ports:
+            - '6380:6379'
+        command: redis-server --replicaof primary 6379
+        depends_on:
+            - redis
+        networks:
+            - redis-replication
 
     clickhouse:
         extends:
@@ -93,3 +109,7 @@ services:
             service: temporal-ui
         ports:
             - 8081:8080
+
+networks:
+    redis-replication:
+        driver: bridge

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -125,11 +125,6 @@ export class SessionManager {
             return
         }
 
-        this.buffer.oldestKafkaTimestamp = Math.min(
-            this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
-            message.metadata.timestamp
-        )
-
         // TODO: Check that the offset is higher than the lastProcessed
         // If not - ignore it
         // If it is - update lastProcessed and process it
@@ -400,6 +395,11 @@ export class SessionManager {
      */
     private async addToBuffer(message: IncomingRecordingMessage): Promise<void> {
         try {
+            this.buffer.oldestKafkaTimestamp = Math.min(
+                this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
+                message.metadata.timestamp
+            )
+
             const messageData = convertToPersistedMessage(message)
             this.setEventsRangeFrom(message)
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -275,20 +275,10 @@ export class SessionManager {
      */
     public async flush(reason: 'buffer_size' | 'buffer_age'): Promise<void> {
         if (this.flushBuffer) {
-            status.warn('⚠️', "blob_ingester_session_manager Flush called but we're already flushing", {
-                sessionId: this.sessionId,
-                partition: this.partition,
-                reason,
-            })
             return
         }
 
         if (this.destroying) {
-            status.warn('⚠️', `blob_ingester_session_manager flush somehow called after destroy`, {
-                sessionId: this.sessionId,
-                partition: this.partition,
-                reason,
-            })
             return
         }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -287,17 +287,13 @@ export class SessionManager {
                     sessionId: this.sessionId,
                     partition: this.partition,
                     reason,
+                    instanceId: this.instanceId,
                 })
                 throw new Error("Can't flush empty buffer")
             }
 
             const eventsRange = this.flushBuffer.eventsRange
             if (!eventsRange) {
-                status.warn('⚠️', `blob_ingester_session_manager flush called but eventsRange is null`, {
-                    sessionId: this.sessionId,
-                    partition: this.partition,
-                    reason,
-                })
                 throw new Error("Can't flush buffer due to missing eventRange")
             }
 
@@ -331,6 +327,7 @@ export class SessionManager {
                 flushedAge: this.flushBuffer.oldestKafkaTimestamp,
                 flushedCount: this.flushBuffer.count,
                 reason,
+                instanceId: this.instanceId,
             })
         } catch (error) {
             if (error.name === 'AbortError' && this.destroying) {


### PR DESCRIPTION
* move tracking oldest timestamp into addToBuffer so we're not counting chunk timestamp until it is added to buffer

* add an "instance id" for the session manager to (most of) its logs to test if we're accidentally running more than one manager at a time on the same instance sometimes (I can't see how we're running more than one, but also I can't see how the stuck partitions are stuck)