### PR TITLE
fix: allow size flushing when there are pending chunks

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -107,6 +107,11 @@ export class SessionManager {
             return
         }
 
+        this.buffer.oldestKafkaTimestamp = Math.min(
+            this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
+            message.metadata.timestamp
+        )
+
         // TODO: Check that the offset is higher than the lastProcessed
         // If not - ignore it
         // If it is - update lastProcessed and process it
@@ -339,11 +344,6 @@ export class SessionManager {
      */
     private async addToBuffer(message: IncomingRecordingMessage): Promise<void> {
         try {
-            this.buffer.oldestKafkaTimestamp = Math.min(
-                this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
-                message.metadata.timestamp
-            )
-
             const messageData = convertToPersistedMessage(message)
             this.setEventsRangeFrom(message)
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -401,7 +401,6 @@ export class SessionManager {
             this.inProgressUpload = null
         }
 
-        status.debug('␡', `blob_ingester_session_manager Destroying session manager`, { sessionId: this.sessionId })
         const filePromises: Promise<void>[] = [this.flushBuffer?.file, this.buffer.file]
             .filter((x): x is string => x !== undefined)
             .map((x) =>

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -143,6 +143,7 @@ export class SessionManager {
                 gzippedCapacity,
                 gzipSizeKb,
                 sessionId: this.sessionId,
+                partition: this.partition,
             }
 
             if (this.chunks.size !== 0) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -304,7 +304,7 @@ export class SessionManager {
             this.flushBuffer = undefined
 
             // TODO: Sync the last processed offset to redis
-            this.onFinish(offsets.sort((a, b) => a - b))
+            this.onFinish(offsets)
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -107,11 +107,6 @@ export class SessionManager {
             return
         }
 
-        this.buffer.oldestKafkaTimestamp = Math.min(
-            this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
-            message.metadata.timestamp
-        )
-
         // TODO: Check that the offset is higher than the lastProcessed
         // If not - ignore it
         // If it is - update lastProcessed and process it
@@ -344,6 +339,11 @@ export class SessionManager {
      */
     private async addToBuffer(message: IncomingRecordingMessage): Promise<void> {
         try {
+            this.buffer.oldestKafkaTimestamp = Math.min(
+                this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
+                message.metadata.timestamp
+            )
+
             const messageData = convertToPersistedMessage(message)
             this.setEventsRangeFrom(message)
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -386,7 +386,7 @@ export class SessionManager {
         allOffsets.forEach((offset) => this.buffer.offsets.push(offset))
 
         await this.addToBuffer({
-            ...chunks[0], // send the first chunk as the message, it should have the events summary
+            ...chunks[0],
             data: chunks
                 .sort((a, b) => a.chunk_index - b.chunk_index)
                 .map((c) => c.data)


### PR DESCRIPTION
## Problem

There are still two stuck partitions on EU for the blob ingester. 

Each has many logs lines like

```
🚽 blob_ingester_session_manager would flush buffer due to size, but chunks are still pending"
```

We allowed age flush to continue despite pending chunks but not size flush.

## Changes

* allow the buffer to flush when there are chunks
* remove a bunch of logging that was only there for debugging

## How did you test this code?

👀 
