### PR TITLE
fix: swallow unparse-able lines

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -436,13 +436,24 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                         const decompressedBlobs = strFromU8(decompressedBytes)
                         const jsonLines = decompressedBlobs.trim().split('\n')
                         const snapshots: RecordingSnapshot[] = jsonLines.flatMap((l) => {
-                            const snapshotLine = JSON.parse(l)
-                            const snapshotData = JSON.parse(snapshotLine['data'])
+                            try {
+                                const snapshotLine = JSON.parse(l)
+                                const snapshotData = JSON.parse(snapshotLine['data'])
 
-                            return snapshotData.map((d: any) => ({
-                                windowId: snapshotLine['window_id'],
-                                ...d,
-                            }))
+                                return snapshotData.map((d: any) => ({
+                                    windowId: snapshotLine['window_id'],
+                                    ...d,
+                                }))
+                            } catch (e) {
+                                captureException(e, {
+                                    tags: {
+                                        blob_key,
+                                        sessionRecordingId: props.sessionRecordingId,
+                                        jsonLine: l,
+                                    },
+                                })
+                                return []
+                            }
                         })
                         return {
                             blob_keys: snapshotDataClone.blob_keys,

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -93,6 +93,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 'loadRecording',
                 'loadRecordingSnapshotsSuccess',
                 'loadRecordingSnapshotsFailure',
+                'loadRecordingBlobSnapshotsFailure',
                 'loadRecordingMetaSuccess',
             ],
             playerSettingsLogic,
@@ -472,6 +473,14 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 actions.setErrorPlayerState(true)
             }
         },
+
+        loadRecordingBlobSnapshotsFailure: () => {
+            if (Object.keys(values.sessionPlayerData.snapshotsByWindowId).length === 0) {
+                console.error('PostHog Recording Playback Error: No snapshots loaded')
+                actions.setErrorPlayerState(true)
+            }
+        },
+
         setPlay: () => {
             actions.stopAnimation()
             actions.syncPlayerSpeed() // hotfix: speed changes on player state change


### PR DESCRIPTION
## Problem

Errors from the logging introduced in #15761 show the blob in question could be loaded but its first line contained invalid json, you can't see that from the error we capture

## Changes

* show the player in an error state if there is an error thrown from the blob loader
* capture line parsing errors specifically to sentry

## How did you test this code?

checked things still ran locally