### PR TITLE
fix: dashboard filters did not stack

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
@@ -1,0 +1,141 @@
+import { dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
+import { initKeaTests } from '~/test/init'
+import { useMocks } from '~/mocks/jest'
+import { DashboardType, UserBasicType } from '~/types'
+import dashboardJson from '../__mocks__/dashboard.json'
+import { dashboardsModel } from '~/models/dashboardsModel'
+import { expectLogic, truth } from 'kea-test-utils'
+
+let dashboardId = 1234
+const dashboard = (extras: Partial<DashboardType>): DashboardType => {
+    dashboardId = dashboardId + 1
+    return {
+        ...dashboardJson,
+        id: dashboardId,
+        name: 'Test dashboard: ' + dashboardId,
+        ...extras,
+    } as any as DashboardType
+}
+describe('dashboardsLogic', () => {
+    let logic: ReturnType<typeof dashboardsLogic.build>
+
+    const allDashboards = [
+        { ...dashboard({ created_by: { uuid: 'user1' } as UserBasicType, is_shared: true }) },
+        { ...dashboard({ created_by: { uuid: 'user1' } as UserBasicType, pinned: true }) },
+        { ...dashboard({ created_by: { uuid: 'user2' } as UserBasicType, pinned: true }) },
+        {
+            ...dashboard({
+                created_by: { uuid: 'user1' } as UserBasicType,
+                is_shared: true,
+                pinned: true,
+            }),
+        },
+        { ...dashboard({ created_by: { uuid: 'user1' } as UserBasicType }) },
+        { ...dashboard({ created_by: { uuid: 'user2' } as UserBasicType, name: 'needle' }) },
+    ]
+
+    beforeEach(async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team/dashboards/': {
+                    count: 6,
+                    next: null,
+                    previous: null,
+                    results: allDashboards,
+                },
+            },
+        })
+
+        initKeaTests()
+
+        dashboardsModel.mount()
+        await expectLogic(dashboardsModel).toDispatchActions(['loadDashboardsSuccess'])
+
+        logic = dashboardsLogic()
+        logic.mount()
+    })
+
+    it('shows all dashboards when no filters', async () => {
+        expect(logic.values.dashboards).toHaveLength(allDashboards.length)
+    })
+
+    it('shows correct dashboards when filtering by name', async () => {
+        expectLogic(logic, () => {
+            logic.actions.setFilters({ createdBy: 'user2' })
+        }).toMatchValues({
+            dashboards: truth((dashboards: DashboardType[]) => {
+                return (
+                    dashboards.length === 2 &&
+                    dashboards[0].created_by?.uuid === 'user2' &&
+                    dashboards[1].created_by?.uuid === 'user2'
+                )
+            }),
+        })
+    })
+
+    it('shows correct dashboards when filtering by name and shared', async () => {
+        expectLogic(logic, () => {
+            logic.actions.setFilters({ createdBy: 'user2', shared: true })
+        }).toMatchValues({
+            dashboards: [],
+        })
+    })
+
+    it('shows correct dashboards when filtering by name and pinned', async () => {
+        expectLogic(logic, () => {
+            logic.actions.setFilters({ createdBy: 'user2', pinned: true })
+        }).toMatchValues({
+            dashboards: truth((dashboards: DashboardType[]) => {
+                return dashboards.length === 1 && dashboards[0].pinned
+            }),
+        })
+    })
+
+    it('shows correct dashboards when only pinned', async () => {
+        expectLogic(logic, () => {
+            logic.actions.setFilters({ pinned: true })
+        }).toMatchValues({
+            dashboards: truth((dashboards: DashboardType[]) => {
+                return dashboards.length === 3 && dashboards.every((d) => d.pinned)
+            }),
+        })
+    })
+
+    it('shows correct dashboards when pinned and shared', async () => {
+        expectLogic(logic, () => {
+            logic.actions.setFilters({ pinned: true, shared: true })
+        }).toMatchValues({
+            dashboards: truth((dashboards: DashboardType[]) => {
+                return (
+                    dashboards.length === 1 &&
+                    dashboards.every((d) => d.pinned && d.is_shared) &&
+                    dashboards[0].created_by?.uuid === 'user1'
+                )
+            }),
+        })
+    })
+
+    it('shows correct dashboards when searching by name', async () => {
+        expectLogic(logic, () => {
+            logic.actions.setFilters({ pinned: true, shared: true })
+        }).toMatchValues({
+            dashboards: truth((dashboards: DashboardType[]) => {
+                return (
+                    dashboards.length === 1 &&
+                    dashboards.every((d) => d.pinned && d.is_shared) &&
+                    dashboards[0].created_by?.uuid === 'user1'
+                )
+            }),
+        })
+    })
+
+    it('shows correct dashboards when searching', async () => {
+        expectLogic(logic, () => {
+            logic.actions.setFilters({ search: 'needl' })
+        }).toMatchValues({
+            dashboards: truth((dashboards: DashboardType[]) => {
+                return dashboards.length === 1 && dashboards[0].name === 'needle'
+            }),
+        })
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -73,21 +73,22 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
         dashboards: [
             (s) => [dashboardsModel.selectors.nameSortedDashboards, s.filters, s.fuse],
             (dashboards, filters, fuse) => {
-                dashboards = dashboards
-                    .filter((d) => !d.deleted)
-                    .sort((a, b) => (a.name ?? 'Untitled').localeCompare(b.name ?? 'Untitled'))
-                if (filters.pinned) {
-                    dashboards = dashboards.filter((d) => d.pinned)
-                } else if (filters.shared) {
-                    dashboards = dashboards.filter((d) => d.is_shared)
-                } else if (filters.createdBy !== 'All users') {
-                    dashboards = dashboards.filter((d) => d.created_by?.uuid === filters.createdBy)
-                }
-                if (!filters.search) {
-                    return dashboards
+                let haystack = dashboards
+                if (filters.search) {
+                    haystack = fuse.search(filters.search).map((result: any) => result.item)
                 }
 
-                return fuse.search(filters.search).map((result: any) => result.item)
+                if (filters.pinned) {
+                    haystack = haystack.filter((d) => d.pinned)
+                }
+                if (filters.shared) {
+                    haystack = haystack.filter((d) => d.is_shared)
+                }
+                if (filters.createdBy !== 'All users') {
+                    haystack = haystack.filter((d) => d.created_by?.uuid === filters.createdBy)
+                }
+
+                return haystack
             },
         ],
 


### PR DESCRIPTION
## Problem

In checking if #15753 fixed what it was supposed to I noticed that dashboard filters don't stack

<img width="1244" alt="Screenshot 2023-05-28 at 14 25 43" src="https://github.com/PostHog/posthog/assets/984817/51dbfb33-bf1a-4598-b5a8-280ba614d62b">

I.e. here the shared filter is being applied and so even though we show that we are filtering by Simon we don't even try. This was fine in the past because they were tabs, but now they're not

## Changes

Let all of the filters apply all at the same time. 

## How did you test this code?

Added developer tests 