### PR TITLE
feat(persons): Prefer email-like distinct IDs for display names

### DIFF
--- a/frontend/src/scenes/persons/PersonHeader.test.ts
+++ b/frontend/src/scenes/persons/PersonHeader.test.ts
@@ -40,7 +40,7 @@ describe('the person header', () => {
             personDisplay: 'person@example.net',
 
             describe: 'when person is identified',
-            testName: 'if only email in person properties it shows identified people by email',
+            testName: 'if only email in person properties, shows identified people by email',
         },
         {
             isIdentified: true,
@@ -50,7 +50,7 @@ describe('the person header', () => {
             personDisplay: 'Mr Potato-head',
 
             describe: 'when person is identified',
-            testName: 'if only name in person properties it shows identified people by name',
+            testName: 'if only name in person properties, shows identified people by name',
         },
         {
             isIdentified: true,
@@ -60,7 +60,7 @@ describe('the person header', () => {
             personDisplay: 'mr.potato.head',
 
             describe: 'when person is identified',
-            testName: 'if only username in person properties it shows identified people by username',
+            testName: 'if only username in person properties, shows identified people by username',
         },
         {
             isIdentified: true,
@@ -72,7 +72,7 @@ describe('the person header', () => {
             personDisplay: 'person@example.com',
 
             describe: 'when person is identified',
-            testName: 'if there is a choice in person properties it shows identified people by email',
+            testName: 'if there is a choice in person properties, shows identified people by email',
         },
         {
             isIdentified: true,
@@ -83,18 +83,29 @@ describe('the person header', () => {
             personDisplay: '03b16e4c0b14ef-00000…c680-17878af3ba9d1c',
 
             describe: 'when person is identified',
-            testName: 'if there are no person properties it shows identified people by hash',
+            testName: 'if there are no person properties, shows identified people by distinct ID',
+        },
+        {
+            isIdentified: true,
+            distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c', 'juliatusk@gmail.com'],
+            props: {
+                email: null,
+            },
+            personDisplay: 'juliatusk@gmail.com',
+            describe: 'when person is identified',
+            testName: 'if there are no person properties, shows identified people by distinct ID, email-like ideally',
         },
         {
             isIdentified: false,
-            distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3babcde'],
+            // The second ID has an "@" and a "." but it's NOT an email
+            distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3babcde', 'fd.r34234-343@d'],
             props: {
                 email: null,
             },
             personDisplay: '03b16e4c0b14ef-00000…c680-17878af3babcde',
 
             describe: 'when person is unidentified',
-            testName: 'if there are no person properties it shows people by hash',
+            testName: 'if there are no person properties, shows people by distinct ID',
         },
         {
             isIdentified: false,
@@ -106,7 +117,7 @@ describe('the person header', () => {
             personDisplay: 'example@person.com',
 
             describe: 'when person is unidentified',
-            testName: 'if there are no person properties it shows people by hash',
+            testName: 'if there are no person properties, shows people by distinct ID',
         },
     ]
 

--- a/frontend/src/scenes/persons/PersonHeader.test.ts
+++ b/frontend/src/scenes/persons/PersonHeader.test.ts
@@ -87,18 +87,34 @@ describe('the person header', () => {
         },
         {
             isIdentified: true,
-            distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c', 'juliatusk@gmail.com'],
+            distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c', '1234abc'],
+            props: {
+                email: null,
+            },
+            personDisplay: '1234abc',
+            describe: 'when person is identified',
+            testName:
+                'if there are no person properties, shows identified people by distinct ID, preferring non-anon IDs',
+        },
+        {
+            isIdentified: true,
+            // The second ID has an "@" and a "." but is NOT an email
+            distinctIds: [
+                '03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3ba9d1c',
+                '1234.abc@',
+                'juliatusk@gmail.com',
+            ],
             props: {
                 email: null,
             },
             personDisplay: 'juliatusk@gmail.com',
             describe: 'when person is identified',
-            testName: 'if there are no person properties, shows identified people by distinct ID, email-like ideally',
+            testName:
+                'if there are no person properties, shows identified people by distinct ID, preferring email-like',
         },
         {
             isIdentified: false,
-            // The second ID has an "@" and a "." but it's NOT an email
-            distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3babcde', 'fd.r34234-343@d'],
+            distinctIds: ['03b16e4c0b14ef-00000000000000-1633685d-13c680-17878af3babcde'],
             props: {
                 email: null,
             },

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -18,8 +18,21 @@ export interface PersonHeaderProps {
     noEllipsis?: boolean
 }
 
-/** Very permissive email regex. */
+/** Very permissive email format. */
 const EMAIL_REGEX = /.+@.+\..+/i
+/** Very rough UUID format. It's loose around length, because the posthog-js UUID util returns non-normative IDs. */
+const BROWSER_ANON_ID_REGEX = /^(?:[a-fA-F0-9]+-){4}[a-fA-F0-9]+$/i
+/** Score distinct IDs for display: UUID-like (i.e. anon ID) gets 0, custom format gets 1, email-like gets 2. */
+function scoreDistinctId(id: string): number {
+    if (EMAIL_REGEX.test(id)) {
+        return 2
+    }
+    if (BROWSER_ANON_ID_REGEX.test(id) && id.length > 36) {
+        // posthog-js IDs have the shape of UUIDs but are longer
+        return 0
+    }
+    return 1
+}
 
 export function asDisplay(person: PersonPropType | null | undefined, maxLength?: number): string {
     if (!person) {
@@ -37,8 +50,9 @@ export function asDisplay(person: PersonPropType | null | undefined, maxLength?:
     const display: string | undefined = (
         customIdentifier ||
         person.distinct_id ||
-        (person.distinct_ids && // If there are multiple IDs, prefer the first one that has email characteristics
-            (person.distinct_ids.find((id) => EMAIL_REGEX.test(id)) || person.distinct_ids?.[0]))
+        (person.distinct_ids
+            ? person.distinct_ids.slice().sort((a, b) => scoreDistinctId(b) - scoreDistinctId(a))[0]
+            : undefined)
     )?.trim()
 
     return display ? midEllipsis(display, maxLength || 40) : 'Person without ID'


### PR DESCRIPTION
## Problem

When a person has no name properties (e.g. `email` or `name`), we display the first distinct IDs in the list as a display name. This is a bit too dumb if email is used as distinct IDs too, and the email just isn't the first in the list. In that case we show a random ID when a readable one could be used instead. [This was reported by a user.](https://posthog.slack.com/archives/C04J1TJ11UZ/p1685239289967799)

## Changes

We'll now be a bit smarter than that, and before we take the first random ID, we'll look for one that looks like an email – defined very simply by containing an `@` and a `.`.

## How did you test this code?

Added a unit test case.