### PR TITLE
chore: count lz64 events ingested

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -43,6 +43,7 @@ from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import get_template
 from django.utils import timezone
+from prometheus_client import Counter
 from rest_framework.request import Request
 from sentry_sdk import configure_scope
 from sentry_sdk.api import capture_exception
@@ -72,6 +73,12 @@ logger = structlog.get_logger(__name__)
 
 # https://stackoverflow.com/questions/4060221/how-to-reliably-open-a-file-in-the-same-directory-as-a-python-script
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+
+counter_lz64_compressed_event = Counter(
+    "ingestion_lz64_compressed_event",
+    """Number of events compressed using lz64,
+    the theory is that we aren't receiving any of these and we can remove support to save on posthog-js bundle size""",
+)
 
 
 def format_label_date(date: datetime.datetime, interval: str) -> str:
@@ -642,6 +649,7 @@ def decompress(data: Any, compression: str):
             raise RequestParsingError("Failed to decompress data. %s" % (str(error)))
 
     if compression == "lz64":
+        counter_lz64_compressed_event.inc()
         if not isinstance(data, str):
             data = data.decode()
         data = data.replace(" ", "+")


### PR DESCRIPTION
## Problem

lz64 compression support is around 5% of the posthog-js bundle size.

I don't believe we receive any... let's double-check

## Changes

adds a counter to the lz64 branch.

does not add a counter to the gzip branch since we know receive them and know we receive a tonne so no point putting that load on prometheus

## How did you test this code?

opening this PR
