### PR TITLE
chore: very specific logging

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/pending-chunks.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/pending-chunks.ts
@@ -24,8 +24,6 @@ export class PendingChunks {
         return Object.values(
             // keep only one of each chunk_index, assumes any duplicates are ignorable duplicates
             this.chunks.reduce((acc, curr) => {
-                // If the chunk_index doesn't exist in the accumulator or
-                // the existing object is older than the current one, update the accumulator
                 if (!acc[curr.chunk_index]) {
                     acc[curr.chunk_index] = curr
                 }

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -380,6 +380,23 @@ export class SessionManager {
             // We want to add all the chunk offsets as well so that they are tracked correctly
             await this.processChunksToBuffer(pendingChunks)
             this.chunks.delete(message.chunk_id)
+        } else {
+            // A very specific log line to help debug chunking issues
+            // partition 50 is stuck and at the point it is stuck it has two apparently complete chunks
+            // still in the pendingChunks map
+            // that should be impossible... but it is apparently happening
+            if (this.partition === 50) {
+                status.info('🧩', 'blob_ingester_session_manager received chunked message', {
+                    chunk_id: message.chunk_id,
+                    partition: this.partition,
+                    team: this.teamId,
+                    session: this.sessionId,
+                    chunk_index: message.chunk_index,
+                    pendingChunks: pendingChunks?.logContext,
+                    pendingChunksIsPresent: !!pendingChunks,
+                    pendingChunksIsComplete: pendingChunks?.isComplete,
+                })
+            }
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -380,6 +380,16 @@ export class SessionManager {
             // We want to add all the chunk offsets as well so that they are tracked correctly
             await this.processChunksToBuffer(pendingChunks)
             this.chunks.delete(message.chunk_id)
+            if (this.partition === 50) {
+                status.info('🧩', 'blob_ingester_session_manager completed chunked message', {
+                    chunk_id: message.chunk_id,
+                    partition: this.partition,
+                    team: this.teamId,
+                    session: this.sessionId,
+                    chunk_index: message.chunk_index,
+                    stillHasPendingChunks: !!this.chunks.get(message.chunk_id),
+                })
+            }
         } else {
             // A very specific log line to help debug chunking issues
             // partition 50 is stuck and at the point it is stuck it has two apparently complete chunks

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -388,6 +388,7 @@ export class SessionManager {
                     session: this.sessionId,
                     chunk_index: message.chunk_index,
                     stillHasPendingChunks: !!this.chunks.get(message.chunk_id),
+                    offsetsThatWereJustAdded: pendingChunks?.allChunkOffsets,
                 })
             }
         } else {
@@ -405,6 +406,7 @@ export class SessionManager {
                     pendingChunks: pendingChunks?.logContext,
                     pendingChunksIsPresent: !!pendingChunks,
                     pendingChunksIsComplete: pendingChunks?.isComplete,
+                    offsetsPending: pendingChunks?.allChunkOffsets,
                 })
             }
         }

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/pending-chunks.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/pending-chunks.test.ts
@@ -2,6 +2,16 @@ import { DateTime } from 'luxon'
 
 import { PendingChunks } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/pending-chunks'
 import { IncomingRecordingMessage } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/types'
+
+function shuffleArray(array: Array<any>) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[array[i], array[j]] = [array[j], array[i]]
+    }
+    // alters the original array, but returns it to make life easier
+    return array
+}
+
 describe('pending chunks', () => {
     const now = DateTime.now()
 
@@ -23,5 +33,29 @@ describe('pending chunks', () => {
         const actual = pc.isIdle(now.toMillis(), idleThreshold)
 
         expect(actual).toBe(expectedIdle)
+    })
+
+    it('can complete an array regardless of order it receives chunks', () => {
+        const pc = new PendingChunks({
+            chunk_id: 'testme',
+            chunk_index: 0,
+            chunk_count: 28,
+        } as IncomingRecordingMessage)
+
+        const numbers = shuffleArray(Array.from(Array(27).keys()))
+        numbers.forEach((i) => {
+            pc.add({
+                chunk_id: 'testme',
+                chunk_index: i + 1,
+                chunk_count: 28,
+            } as IncomingRecordingMessage)
+        })
+
+        expect(pc.count).toBe(28)
+        expect(pc.expectedSize).toBe(28)
+        expect(pc.isComplete).toBe(true)
+        expect(pc.completedChunks.map((c) => c.chunk_index)).toStrictEqual([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+        ])
     })
 })


### PR DESCRIPTION
## Problem

partition 50 is stuck

it has (apparently) 2 completed chunks still in the pending chunks before

this shouldn't be possible

```
"partition": 50,
  "chunkStates": {
    "01885920-984c-0000-3266-f95230c04fa9": {
      "chunk_count": 28,
      "chunk_indexes": [
        0,
        1,
        2,
        3,
        4,
        5,
        6,
        7,
        8,
        9,
        10,
        11,
        12,
        13,
        14,
        15,
        16,
        17,
        18,
        19,
        20,
        21,
        22,
        23,
        24,
        25,
        26,
        27
      ],
      "chunk_offsets_counts": 28,
      "first_chunk_timestamp": 1685122488406,
      "last_chunk_timestamp": 1685122490251
    },
    "01885920-9d1c-0000-8ada-7f2d691489ef": {
      "chunk_count": 29,
      "chunk_indexes": [
        0,
        1,
        2,
        3,
        4,
        5,
        6,
        7,
        8,
        9,
        10,
        11,
        12,
        13,
        14,
        15,
        16,
        17,
        18,
        19,
        20,
        21,
        22,
        23,
        24,
        25,
        26,
        27,
        28
      ],
      "chunk_offsets_counts": 29,
      "first_chunk_timestamp": 1685122489638,
      "last_chunk_timestamp": 1685122491365
    }
  }
```

my theory is these chunks aren't completing, so their offsets never make it to the offset manager, so, the partition can never commit the offset

## Changes

adds some very targeted logging to see what is different between reality, the code, and my assumptions 😓 

## How did you test this code?

🙈 
