### PR TITLE
feat: Make persons sync script handle large teams

### DIFF
--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -244,7 +244,10 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         # verify we don't change anything
         self.everything_test_run(False)
 
-    def everything_test_run(self, live_run):
+    def test_live_run_everything_batch_2(self):
+        self.everything_test_run(True, 2)
+
+    def everything_test_run(self, live_run, batch: int = 100):
         # 2 persons who shouldn't be changed
         person_not_changed_1 = Person.objects.create(
             team_id=self.team.pk, properties={"abcdef": 1111}, version=0, uuid=uuid4()
@@ -371,6 +374,9 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             "person_override": True,
             "group": True,
             "deletes": True,
+            "batch_size_pg": batch,
+            "batch_size_ch": batch,
+            "log_every_nth": batch,
         }
         run(options, sync=True)
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We can't use the sync script anymore for large teams and it's only going to get worse. Allow batching and ability to customize it and logging frequency too.

## Changes

Didn't handle deletes nor groups (as they annoyingly don't have version) as that isn't necessary for PoE data verification.

Also it was time to refactor the code - didn't want to rewrite the same thing 3x again, this seemed like the simplest way according to my 🧠 , you might disagree about that 😅  open to suggestions.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unittests, which didn't change
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
