### PR TITLE
chore: log every processed chunk :'(

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -389,34 +389,33 @@ export class SessionManager {
             // We want to add all the chunk offsets as well so that they are tracked correctly
             await this.processChunksToBuffer(pendingChunks)
             this.chunks.delete(message.chunk_id)
-            if (this.partition === 50) {
-                status.info('🧩', 'blob_ingester_session_manager completed chunked message', {
-                    chunk_id: message.chunk_id,
-                    partition: this.partition,
-                    team: this.teamId,
-                    session: this.sessionId,
-                    chunk_index: message.chunk_index,
-                    stillHasPendingChunks: !!this.chunks.get(message.chunk_id),
-                    offsetsThatWereJustAdded: pendingChunks.allChunkOffsets,
-                })
-            }
+
+            // TODO this should be removed as soon as possible
+            status.info('🧩', 'blob_ingester_session_manager completed chunked message', {
+                chunk_id: message.chunk_id,
+                partition: this.partition,
+                team: this.teamId,
+                session: this.sessionId,
+                chunk_index: message.chunk_index,
+                stillHasPendingChunks: !!this.chunks.get(message.chunk_id),
+                offsetsThatWereJustAdded: pendingChunks.allChunkOffsets,
+            })
         } else {
             // A very specific log line to help debug chunking issues
-            // partition 50 is stuck and at the point it is stuck it has two apparently complete chunks
+            // some partitions get stuck and at the point they are stuck apparently have complete chunks
             // still in the pendingChunks map
             // that should be impossible... but it is apparently happening
-            if (this.partition === 50) {
-                status.info('🧩', 'blob_ingester_session_manager received chunked message', {
-                    chunk_id: message.chunk_id,
-                    partition: this.partition,
-                    team: this.teamId,
-                    session: this.sessionId,
-                    chunk_index: message.chunk_index,
-                    pendingChunks: pendingChunks.logContext,
-                    pendingChunksIsComplete: pendingChunks.isComplete,
-                    offsetsPending: pendingChunks.allChunkOffsets,
-                })
-            }
+            // TODO: this should be removed as soon as possible
+            status.info('🧩', 'blob_ingester_session_manager received chunked message', {
+                chunk_id: message.chunk_id,
+                partition: this.partition,
+                team: this.teamId,
+                session: this.sessionId,
+                chunk_index: message.chunk_index,
+                pendingChunks: pendingChunks.logContext,
+                pendingChunksIsComplete: pendingChunks.isComplete,
+                offsetsPending: pendingChunks.allChunkOffsets,
+            })
         }
     }
 


### PR DESCRIPTION
## Problem

follow up to #15769 

after 3 days stuck, partition 50 unstuck itself while I was sorting out specific logging to investigate its behaviour

## Changes

log every chunk processed event so we can look at arbitrary stuck partitions until we have figured out why they get stuck

