### PR TITLE
chore: always check idle chunks

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -172,6 +172,7 @@ export class SessionManager {
             oldestKafkaTimestamp: this.buffer.oldestKafkaTimestamp,
             referenceTime: referenceNow,
             flushThresholdMillis,
+            bufferCount: this.buffer.count,
         }
 
         if (this.buffer.oldestKafkaTimestamp === null) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -165,42 +165,47 @@ export class SessionManager {
             return
         }
 
+        const logContext: Record<string, any> = {
+            sessionId: this.sessionId,
+            partition: this.partition,
+            chunkSize: this.chunks.size,
+            oldestKafkaTimestamp: this.buffer.oldestKafkaTimestamp,
+            referenceTime: referenceNow,
+            flushThresholdMillis,
+        }
+
         if (this.buffer.oldestKafkaTimestamp === null) {
             // We have no messages yet, so we can't flush
             if (this.buffer.count > 0) {
                 throw new Error('Session buffer has messages but oldest timestamp is null. A paradox!')
             }
+            status.warn('🚽', `blob_ingester_session_manager buffer has no oldestKafkaTimestamp yet`, { logContext })
             return
         }
 
         const bufferAge = referenceNow - this.buffer.oldestKafkaTimestamp
+        logContext['bufferAge'] = bufferAge
+
+        this.chunks = this.handleIdleChunks(this.chunks, referenceNow, flushThresholdMillis, logContext)
+
+        if (this.chunks.size !== 0) {
+            const chunkStates: Record<string, any> = {}
+            for (const [key, chunk] of this.chunks.entries()) {
+                chunkStates[key] = chunk.logContext
+            }
+            logContext['chunkStates'] = chunkStates
+        }
 
         if (bufferAge >= flushThresholdMillis) {
-            const logContext: Record<string, any> = {
-                bufferAge,
-                sessionId: this.sessionId,
-                partition: this.partition,
-                chunkSize: this.chunks.size,
-                oldestKafkaTimestamp: this.buffer.oldestKafkaTimestamp,
-                referenceTime: referenceNow,
-                flushThresholdMillis,
-            }
-
-            this.chunks = this.handleIdleChunks(this.chunks, referenceNow, flushThresholdMillis, logContext)
-
-            if (this.chunks.size !== 0) {
-                const chunkStates: Record<string, any> = {}
-                for (const [key, chunk] of this.chunks.entries()) {
-                    chunkStates[key] = chunk.logContext
-                }
-                logContext['chunkStates'] = chunkStates
-            }
-
             status.info('🚽', `blob_ingester_session_manager flushing buffer due to age`, {
                 ...logContext,
             })
             // return the promise and let the caller decide whether to await
             return this.flush('buffer_age')
+        } else {
+            status.info('🚽', `blob_ingester_session_manager not flushing buffer due to age`, {
+                ...logContext,
+            })
         }
     }
 


### PR DESCRIPTION
## Problem

follow up to https://github.com/PostHog/posthog/pull/15772

we see

```
{
  "chunk_id": "01886094-3ce5-0000-1db8-5771a01f7cde",
  "partition": 6,
  "session": "blah",
  "chunk_index": 6,
  "pendingChunks": {
    "chunk_count": 7,
    "chunk_indexes": [
      1,
      2,
      3,
      4,
      5,
      6
    ],
    "chunk_offsets_counts": 6,
    "first_chunk_timestamp": 1685247507760,
    "last_chunk_timestamp": 1685247507820
  },
  "pendingChunksIsComplete": false,
  "offsetsPending": [
    286929446,
    286929450,
    286929452,
    286929455,
    286929460,
    286929461
  ],
  "msg": "[RECORDINGS-BLOB-INGESTION] 🧩 blob_ingester_session_manager received chunked message"
}
```

and later we see

```bash
{
  "partition": 6,
  "blockingSession": "blah",
  "lowestInflightOffset": 286929446,
  "lowestOffsetToRemove": 286929453,
  "msg": "[RECORDINGS-BLOB-INGESTION] 💾 offset_manager - no offset to commit"
}
```

so offset `286929446` is blocking and is from a pending chunk that is missing index 0

## Changes

we should expect that the pending chunk becomes idle and stops blocking, but this session appears not to be flushing on age

so, log more in the age flushing code to find out why

