### PR TITLE
fix(toolbar): Don't create actions with hidden match group `tag_name`

### DIFF
--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -56,11 +56,9 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
 
 export function elementToActionStep(element: HTMLElement, dataAttributes: string[]): ActionStepType {
     const query = elementToQuery(element, dataAttributes)
-    const tagName = element.tagName.toLowerCase()
 
     return {
         event: '$autocapture',
-        tag_name: tagName,
         href: element.getAttribute('href') || '',
         name: element.getAttribute('name') || '',
         text: getSafeText(element) || '',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -368,6 +368,7 @@ export interface ActionStepType {
     name?: string
     properties?: AnyPropertyFilter[]
     selector?: string | null
+    /** @deprecated Only `selector` should be used now. */
     tag_name?: string
     text?: string | null
     /** @default StringMatching.Exact */


### PR DESCRIPTION
## Problem

I was just reviewing a [PR from Marius related to the webhooks](https://github.com/PostHog/posthog/pull/15707) feature, and was super surprised why my action is not being matched – turns out all my efforts in adjusting its definition were in vain, since its single match group had the legacy `tag_name` field due to being created from the Toolbar. The problem is that `tag_name` is not editable _anywhere_ in the UI – not in the Toolbar, nor in the app. This meant the match group could forever only match events related to `textarea`s and nothing else. I wouldn't even know if I didn't have DB access.

## Changes

Let's do the simple thing to avoid this confusion in the future: the Toolbar will no longer use `tag_name` when creating actions, and the field's been marked deprecated.
