### PR TITLE
feat: Added resizer for Notebooks

### DIFF
--- a/frontend/src/lib/components/Resizer/Resizer.scss
+++ b/frontend/src/lib/components/Resizer/Resizer.scss
@@ -1,5 +1,5 @@
 .Resizer {
-    --resizer-width: 16px;
+    --resizer-width: 8px;
     position: absolute;
     top: 0;
     bottom: 0;

--- a/frontend/src/lib/components/Resizer/Resizer.scss
+++ b/frontend/src/lib/components/Resizer/Resizer.scss
@@ -1,0 +1,55 @@
+.Resizer {
+    --resizer-width: 16px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: calc(var(--resizer-width) / 2 * -1);
+    width: var(--resizer-width);
+    cursor: col-resize;
+    user-select: none; // Fixes inadvertent selection of scene text when resizing
+    z-index: var(
+        --z-notifications-popover
+    ); // A bit above navbar for a nicer slider experience when the sidebar is closed
+
+    .Resizer[aria-hidden='true'] & {
+        cursor: e-resize;
+    }
+
+    .Resizer__handle {
+        position: absolute;
+        left: calc(var(--resizer-width) / 2);
+        top: 0px;
+        bottom: 0px;
+        width: 1px;
+
+        &::before,
+        &::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: var(--sidebar-slider-padding);
+            width: 1px;
+            box-sizing: content-box;
+        }
+
+        &::before {
+            transition: 100ms ease transform;
+            background: var(--border);
+        }
+        &::after {
+            transition: 100ms ease transform;
+            background: var(--text-3000);
+            opacity: 0;
+        }
+    }
+
+    &:hover .Resizer__handle::after,
+    &--resizing .Resizer__handle::after {
+        opacity: 0.25;
+    }
+    &--resizing .Resizer__handle::before,
+    &--resizing .Resizer__handle::after {
+        transform: scaleX(3);
+    }
+}

--- a/frontend/src/lib/components/Resizer/Resizer.scss
+++ b/frontend/src/lib/components/Resizer/Resizer.scss
@@ -28,7 +28,6 @@
             position: absolute;
             top: 0;
             bottom: 0;
-            left: var(--sidebar-slider-padding);
             width: 1px;
             box-sizing: content-box;
         }

--- a/frontend/src/lib/components/Resizer/Resizer.tsx
+++ b/frontend/src/lib/components/Resizer/Resizer.tsx
@@ -1,0 +1,24 @@
+import { useActions, useValues } from 'kea'
+import './Resizer.scss'
+import { ResizerLogicProps, resizerLogic } from './resizerLogic'
+import clsx from 'clsx'
+
+export function Resizer(props: ResizerLogicProps): JSX.Element {
+    const logic = resizerLogic(props)
+    const { isResizeInProgress } = useValues(logic)
+    const { beginResize } = useActions(logic)
+
+    console.log({ isResizeInProgress })
+    return (
+        <div
+            className={clsx('Resizer', isResizeInProgress && 'Resizer--resizing')}
+            onMouseDown={(e) => {
+                if (e.button === 0) {
+                    beginResize(e)
+                }
+            }}
+        >
+            <div className="Resizer__handle" />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/Resizer/Resizer.tsx
+++ b/frontend/src/lib/components/Resizer/Resizer.tsx
@@ -8,13 +8,12 @@ export function Resizer(props: ResizerLogicProps): JSX.Element {
     const { isResizeInProgress } = useValues(logic)
     const { beginResize } = useActions(logic)
 
-    console.log({ isResizeInProgress })
     return (
         <div
             className={clsx('Resizer', isResizeInProgress && 'Resizer--resizing')}
             onMouseDown={(e) => {
                 if (e.button === 0) {
-                    beginResize(e)
+                    beginResize(e.pageX)
                 }
             }}
         >

--- a/frontend/src/lib/components/Resizer/resizerLogic.ts
+++ b/frontend/src/lib/components/Resizer/resizerLogic.ts
@@ -11,7 +11,7 @@ export const resizerLogic = kea<resizerLogicType>([
     path(['components', 'resizer', 'resizerLogic']),
     props({} as ResizerLogicProps),
     actions({
-        beginResize: (event: MouseEvent) => ({ event }),
+        beginResize: (startX: number) => ({ startX }),
         endResize: true,
     }),
     reducers({
@@ -24,9 +24,8 @@ export const resizerLogic = kea<resizerLogicType>([
         ],
     }),
     listeners(({ cache }) => ({
-        beginResize: ({ event }) => {
-            cache.originX = event.pageX
-            // actions.setSidebarOverslide(values.isSidebarShown ? 0 : -MINIMUM_SIDEBAR_WIDTH_PX)
+        beginResize: ({ startX }) => {
+            cache.originX = startX
         },
     })),
     subscriptions(({ cache, actions, props }) => ({

--- a/frontend/src/lib/components/Resizer/resizerLogic.ts
+++ b/frontend/src/lib/components/Resizer/resizerLogic.ts
@@ -1,0 +1,53 @@
+import { actions, kea, listeners, path, props, reducers } from 'kea'
+import { subscriptions } from 'kea-subscriptions'
+
+import type { resizerLogicType } from './resizerLogicType'
+
+export type ResizerLogicProps = {
+    onResize: (event: { originX: number; desiredX: number; finished: boolean }) => void
+}
+
+export const resizerLogic = kea<resizerLogicType>([
+    path(['components', 'resizer', 'resizerLogic']),
+    props({} as ResizerLogicProps),
+    actions({
+        beginResize: (event: MouseEvent) => ({ event }),
+        endResize: true,
+    }),
+    reducers({
+        isResizeInProgress: [
+            false,
+            {
+                beginResize: () => true,
+                endResize: () => false,
+            },
+        ],
+    }),
+    listeners(({ cache }) => ({
+        beginResize: ({ event }) => {
+            cache.originX = event.pageX
+            // actions.setSidebarOverslide(values.isSidebarShown ? 0 : -MINIMUM_SIDEBAR_WIDTH_PX)
+        },
+    })),
+    subscriptions(({ cache, actions, props }) => ({
+        isResizeInProgress: (isResizeInProgress) => {
+            if (isResizeInProgress) {
+                cache.onMouseMove = (e: MouseEvent): void => {
+                    props.onResize({ originX: cache.originX, desiredX: e.pageX, finished: false })
+                }
+                cache.onMouseUp = (e: MouseEvent): void => {
+                    if (e.button === 0) {
+                        actions.endResize()
+                        props.onResize({ originX: cache.originX, desiredX: e.pageX, finished: true })
+                    }
+                }
+                document.addEventListener('mousemove', cache.onMouseMove)
+                document.addEventListener('mouseup', cache.onMouseUp)
+                return () => {}
+            } else {
+                document.removeEventListener('mousemove', cache.onMouseMove)
+                document.removeEventListener('mouseup', cache.onMouseUp)
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.scss
+++ b/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.scss
@@ -50,7 +50,7 @@
 
     &:hover {
         .DraggableToNotebook__indicator__text {
-            opacity: 0.5;
+            // opacity: 0.5;
         }
     }
 }

--- a/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.scss
+++ b/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.scss
@@ -47,12 +47,6 @@
             animation: notebook-indicator-appear-no-overflow 150ms ease-out;
         }
     }
-
-    &:hover {
-        .DraggableToNotebook__indicator__text {
-            // opacity: 0.5;
-        }
-    }
 }
 
 @keyframes notebook-indicator-appear-no-overflow {

--- a/frontend/src/scenes/notebooks/Notebook/NotebookSideBar.scss
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookSideBar.scss
@@ -1,17 +1,14 @@
 @import '../../../styles/mixins';
 
-$sidebar-width: 40rem;
-
 .NotebookSidebar {
     position: relative;
     height: 100%;
     min-height: calc(100vh - 3.5rem);
     display: flex;
-    width: $sidebar-width;
-    flex: 1;
+    max-width: 80%;
+    min-width: 600px;
 
     .NotebookSidebar__content {
-        width: $sidebar-width;
         height: 100%;
         transform: translateX(0);
         display: flex;
@@ -23,41 +20,10 @@ $sidebar-width: 40rem;
         box-shadow: var(--shadow--elevation);
     }
 
-    width: $sidebar-width;
-
-    // &--enter {
-    //     width: 0;
-    //     .NotebookSidebar__content {
-    //         transform: translateX(100%);
-    //     }
-    // }
-
-    // &--enter-active,
-    // &--enter-done {
-    //     width: $sidebar-width;
-    //     .NotebookSidebar__content {
-    //         transition: 200ms ease transform;
-    //         transform: translateX(0%);
-    //     }
-    // }
-
-    // &--exit {
-    //     width: $sidebar-width;
-    //     .NotebookSidebar__content {
-    //         transition: 200ms ease transform;
-    //         transform: translateX(0%);
-    //     }
-    // }
-
-    // &--exit-active {
-    //     width: 0;
-    //     .NotebookSidebar__content {
-    //         transform: translateX(100%);
-    //     }
-    // }
-
     &--full-screen {
         width: auto;
+        max-width: initial;
+        flex: 1;
 
         .NotebookSidebar__content {
             width: 100%;

--- a/frontend/src/scenes/notebooks/Notebook/NotebookSideBar.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookSideBar.tsx
@@ -6,7 +6,7 @@ import { notebookSidebarLogic } from 'scenes/notebooks/Notebook/notebookSidebarL
 import { LemonButton } from '@posthog/lemon-ui'
 import { IconFullScreen, IconChevronRight, IconLock, IconLockOpen } from 'lib/lemon-ui/icons'
 import { CSSTransition } from 'react-transition-group'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -14,12 +14,15 @@ import React from 'react'
 import { NotebookListMini } from './NotebookListMini'
 import { notebooksListLogic } from './notebooksListLogic'
 import { NotebookExpandButton, NotebookSyncInfo } from './NotebookMeta'
+import { Resizer } from 'lib/components/Resizer/Resizer'
 
 export function NotebookSideBar({ children }: { children: React.ReactElement<any> }): JSX.Element {
-    const { notebookSideBarShown, fullScreen, selectedNotebook } = useValues(notebookSidebarLogic)
-    const { setNotebookSideBarShown, setFullScreen, selectNotebook } = useActions(notebookSidebarLogic)
+    const { notebookSideBarShown, fullScreen, selectedNotebook, desiredWidth } = useValues(notebookSidebarLogic)
+    const { setNotebookSideBarShown, setFullScreen, selectNotebook, onResize, setElementRef } =
+        useActions(notebookSidebarLogic)
     const { createNotebook } = useActions(notebooksListLogic)
 
+    const ref = useRef<HTMLDivElement>(null)
     const [isEditable, setIsEditable] = useState(true)
 
     // NOTE: This doesn't work for some reason, possibly due to the way the editor is rendered
@@ -40,6 +43,12 @@ export function NotebookSideBar({ children }: { children: React.ReactElement<any
         style: fullScreen ? { display: 'none', visibility: 'hidden' } : {},
     })
 
+    useEffect(() => {
+        if (ref.current) {
+            setElementRef(ref)
+        }
+    }, [ref.current])
+
     return (
         <>
             {clonedChild}
@@ -51,7 +60,19 @@ export function NotebookSideBar({ children }: { children: React.ReactElement<any
                     unmountOnExit
                     classNames="NotebookSidebar-"
                 >
-                    <div className={clsx('NotebookSidebar', fullScreen && 'NotebookSidebar--full-screen')}>
+                    <div
+                        ref={ref}
+                        className={clsx('NotebookSidebar', fullScreen && 'NotebookSidebar--full-screen')}
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={
+                            !fullScreen
+                                ? {
+                                      width: desiredWidth,
+                                  }
+                                : {}
+                        }
+                    >
+                        <Resizer onResize={onResize} />
                         <div className="NotebookSidebar__content">
                             <header className="flex items-center justify-between gap-2 font-semibold shrink-0 p-1 border-b">
                                 <span className="flex items-center gap-1 text-primary-alt">


### PR DESCRIPTION
## Problem

Related to https://github.com/PostHog/posthog/issues/15680

The notebook sidebar wasn't resizable. This makes it resizable 

## Changes

* Adds a resizer component
* Handles the resizing of the notebook sidebar
* Didn't share the component with the other 3000 sidebar as that was a bit more involved 😅  @Twixes maybe it's easier with your eyes

![2023-05-30 18 13 48](https://github.com/PostHog/posthog/assets/2536520/c7e03ee2-1029-4e1c-8ec3-103b5efc0db8)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
