### PR TITLE
fix: only track timestamps of completed chunks

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -128,11 +128,6 @@ export class SessionManager {
             return
         }
 
-        this.buffer.oldestKafkaTimestamp = Math.min(
-            this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
-            message.metadata.timestamp
-        )
-
         // TODO: Check that the offset is higher than the lastProcessed
         // If not - ignore it
         // If it is - update lastProcessed and process it
@@ -345,6 +340,11 @@ export class SessionManager {
      */
     private async addToBuffer(message: IncomingRecordingMessage): Promise<void> {
         try {
+            this.buffer.oldestKafkaTimestamp = Math.min(
+                this.buffer.oldestKafkaTimestamp ?? message.metadata.timestamp,
+                message.metadata.timestamp
+            )
+
             const messageData = convertToPersistedMessage(message)
             this.setEventsRangeFrom(message)
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -66,17 +66,19 @@ describe('session-manager', () => {
 
     it('adds a message', async () => {
         const payload = JSON.stringify([{ simple: 'data' }])
+        const timestamp = DateTime.now().toMillis() - 10000
         const event = createIncomingRecordingMessage({
             data: compressToString(payload),
+            metadata: {
+                timestamp: timestamp,
+            } as any,
         })
 
-        const messageTimestamp = DateTime.now().toMillis() - 10000
-        event.metadata.timestamp = messageTimestamp
         await sessionManager.add(event)
 
         expect(sessionManager.buffer).toEqual({
             count: 1,
-            oldestKafkaTimestamp: messageTimestamp,
+            oldestKafkaTimestamp: timestamp,
             file: expect.any(String),
             id: expect.any(String),
             size: 61, // The size of the event payload - this may change when test data changes
@@ -91,19 +93,76 @@ describe('session-manager', () => {
         expect(writeFileSync).toHaveBeenCalledWith(sessionManager.buffer.file, '', 'utf-8')
     })
 
-    it('does not flush if it has received a message recently', async () => {
+    it('chunks do not affect oldest message timestamp', async () => {
         const payload = JSON.stringify([{ simple: 'data' }])
         const event = createIncomingRecordingMessage({
             data: compressToString(payload),
+            chunk_count: 2,
+            metadata: {
+                timestamp: DateTime.now().toMillis() - 10000,
+            } as any,
         })
 
+        await sessionManager.add(event)
+
+        expect(sessionManager.buffer).toHaveProperty('oldestKafkaTimestamp', null)
+    })
+
+    it('chunks affect oldest message timestamp once completed', async () => {
+        const payload = JSON.stringify([{ simple: 'data' }])
+
+        await sessionManager.add(
+            createIncomingRecordingMessage({
+                data: compressToString(payload),
+                chunk_count: 2,
+                metadata: {
+                    timestamp: 5000, // this is the oldest message timestamp
+                } as any,
+            })
+        )
+
+        await sessionManager.add(
+            createIncomingRecordingMessage({
+                data: compressToString(payload),
+                chunk_count: 1,
+                metadata: {
+                    timestamp: 7000, // this is the effective oldest message timestamp because the chunk wasn't applied
+                } as any,
+            })
+        )
+
+        expect(sessionManager.buffer).toHaveProperty('oldestKafkaTimestamp', 7000)
+
+        await sessionManager.add(
+            createIncomingRecordingMessage({
+                data: compressToString(payload),
+                chunk_count: 2,
+                chunk_index: 1,
+                metadata: {
+                    timestamp: 9000,
+                } as any,
+            })
+        )
+
+        expect(sessionManager.buffer).toHaveProperty('oldestKafkaTimestamp', 5000)
+    })
+
+    it('does not flush if it has received a message recently', async () => {
         const flushThreshold = 2500 // any value here...
         const now = DateTime.now()
-        event.metadata.timestamp = now
-            .minus({
-                milliseconds: flushThreshold - 10, // less than the threshold
-            })
-            .toMillis()
+
+        const payload = JSON.stringify([{ simple: 'data' }])
+        const event = createIncomingRecordingMessage({
+            data: compressToString(payload),
+            metadata: {
+                timestamp: now
+                    .minus({
+                        milliseconds: flushThreshold - 10, // less than the threshold
+                    })
+                    .toMillis(),
+            } as any,
+        })
+
         await sessionManager.add(event)
 
         await sessionManager.flushIfSessionBufferIsOld(now.toMillis(), flushThreshold)
@@ -113,6 +172,7 @@ describe('session-manager', () => {
     })
 
     it('does flush if it has not received a message recently', async () => {
+        const flushThreshold = 2500 // any value here...
         const firstTimestamp = 1679568043305
         const lastTimestamp = 1679568043305 + 4000
 
@@ -126,6 +186,9 @@ describe('session-manager', () => {
                     data: { href: 'http://localhost:3001/', width: 2560, height: 1304 },
                 },
             ],
+            metadata: {
+                timestamp: DateTime.now().minus({ milliseconds: flushThreshold }).toMillis(),
+            } as any,
         })
         const eventTwo = createIncomingRecordingMessage({
             data: compressToString(payload),
@@ -136,12 +199,12 @@ describe('session-manager', () => {
                     data: { href: 'http://localhost:3001/', width: 2560, height: 1304 },
                 },
             ],
+            metadata: {
+                timestamp: DateTime.now().minus({ milliseconds: flushThreshold }).toMillis(),
+            } as any,
         })
 
-        const flushThreshold = 2500 // any value here...
-        eventOne.metadata.timestamp = DateTime.now().minus({ milliseconds: flushThreshold }).toMillis()
         await sessionManager.add(eventOne)
-        eventTwo.metadata.timestamp = DateTime.now().minus({ milliseconds: flushThreshold }).toMillis()
         await sessionManager.add(eventTwo)
 
         await sessionManager.flushIfSessionBufferIsOld(DateTime.now().toMillis(), flushThreshold)
@@ -161,16 +224,18 @@ describe('session-manager', () => {
     })
 
     it('does not flush a short session even when lagging if within threshold', async () => {
-        const payload = JSON.stringify([{ simple: 'data' }])
-        const event = createIncomingRecordingMessage({
-            data: compressToString(payload),
-        })
-
         // a timestamp that means the message is older than threshold and all-things-being-equal should flush
         // uses timestamps offset from now to show this logic still works even if the consumer is running behind
         const aDayInMilliseconds = 24 * 60 * 60 * 1000
         const now = DateTime.now()
-        event.metadata.timestamp = now.minus({ milliseconds: aDayInMilliseconds - 3500 }).toMillis()
+
+        const payload = JSON.stringify([{ simple: 'data' }])
+        const event = createIncomingRecordingMessage({
+            data: compressToString(payload),
+            metadata: {
+                timestamp: now.minus({ milliseconds: aDayInMilliseconds - 3500 }).toMillis(),
+            } as any,
+        })
 
         await sessionManager.add(event)
 
@@ -443,81 +508,81 @@ describe('session-manager', () => {
         }
     )
 
-    // it.each([
-    //     [
-    //         'incomplete, we do not add to the buffer',
-    //         [
-    //             { chunk_count: 2, chunk_index: 1, metadata: { timestamp: 1000 } } as IncomingRecordingMessage,
-    //             { chunk_count: 2, chunk_index: 1, metadata: { timestamp: 1000 } } as IncomingRecordingMessage,
-    //         ],
-    //         0,
-    //         [],
-    //     ],
-    //     [
-    //         'exactly complete, we add to the buffer',
-    //         [
-    //             {
-    //                 chunk_count: 2,
-    //                 chunk_index: 0,
-    //                 data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
-    //                 metadata: { timestamp: 1000, offset: 1 },
-    //             } as IncomingRecordingMessage,
-    //             {
-    //                 chunk_count: 2,
-    //                 chunk_index: 1,
-    //                 data: 'GFIBfKsgDiFIZGhBIiVGGoZYhkAOTL8NSYAAAA=',
-    //                 metadata: { timestamp: 1000, offset: 2 },
-    //             } as IncomingRecordingMessage,
-    //         ],
-    //         1,
-    //         [2, 1],
-    //     ],
-    //     [
-    //         'over complete, we add only necessary data to the buffer, but all offsets',
-    //         [
-    //             // receives first event 3 times
-    //             {
-    //                 chunk_count: 2,
-    //                 chunk_index: 0,
-    //                 data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
-    //                 metadata: { timestamp: 1000, offset: 1 },
-    //             } as IncomingRecordingMessage,
-    //             {
-    //                 chunk_count: 2,
-    //                 chunk_index: 0,
-    //                 data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
-    //                 metadata: { timestamp: 1000, offset: 2 },
-    //             } as IncomingRecordingMessage,
-    //             {
-    //                 chunk_count: 2,
-    //                 chunk_index: 0,
-    //                 data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
-    //                 metadata: { timestamp: 1000, offset: 3 },
-    //             } as IncomingRecordingMessage,
-    //             {
-    //                 chunk_count: 2,
-    //                 chunk_index: 1,
-    //                 data: 'GFIBfKsgDiFIZGhBIiVGGoZYhkAOTL8NSYAAAA=',
-    //                 metadata: { timestamp: 1000, offset: 4 },
-    //             } as IncomingRecordingMessage,
-    //         ],
-    //         1,
-    //         [4, 2, 3, 1],
-    //     ],
-    // ])(
-    //     'correctly handles adding to and completing chunks - %s',
-    //     (
-    //         _description: string,
-    //         chunks: IncomingRecordingMessage[],
-    //         expectedBufferCount: number,
-    //         expectedBufferOffsets: number[]
-    //     ) => {
-    //         chunks.forEach(async (chunk) => {
-    //             await sessionManager.add(chunk)
-    //         })
+    it.each([
+        [
+            'incomplete, we do not add to the buffer',
+            [
+                { chunk_count: 2, chunk_index: 1, metadata: { timestamp: 1000 } } as IncomingRecordingMessage,
+                { chunk_count: 2, chunk_index: 1, metadata: { timestamp: 1000 } } as IncomingRecordingMessage,
+            ],
+            0,
+            [],
+        ],
+        [
+            'exactly complete, we add to the buffer',
+            [
+                {
+                    chunk_count: 2,
+                    chunk_index: 0,
+                    data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
+                    metadata: { timestamp: 1000, offset: 1 },
+                } as IncomingRecordingMessage,
+                {
+                    chunk_count: 2,
+                    chunk_index: 1,
+                    data: 'GFIBfKsgDiFIZGhBIiVGGoZYhkAOTL8NSYAAAA=',
+                    metadata: { timestamp: 1000, offset: 2 },
+                } as IncomingRecordingMessage,
+            ],
+            1,
+            [1, 2, 1], // we allow duplicates because the offset manager can cope with them
+        ],
+        [
+            'over complete, we add only necessary data to the buffer, but all offsets',
+            [
+                // receives first event 3 times
+                {
+                    chunk_count: 2,
+                    chunk_index: 0,
+                    data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
+                    metadata: { timestamp: 1000, offset: 1 },
+                } as IncomingRecordingMessage,
+                {
+                    chunk_count: 2,
+                    chunk_index: 0,
+                    data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
+                    metadata: { timestamp: 1000, offset: 2 },
+                } as IncomingRecordingMessage,
+                {
+                    chunk_count: 2,
+                    chunk_index: 0,
+                    data: 'H4sIAAAAAAAAE4tmqGZQYihmyGTIZShgy',
+                    metadata: { timestamp: 1000, offset: 3 },
+                } as IncomingRecordingMessage,
+                {
+                    chunk_count: 2,
+                    chunk_index: 1,
+                    data: 'GFIBfKsgDiFIZGhBIiVGGoZYhkAOTL8NSYAAAA=',
+                    metadata: { timestamp: 1000, offset: 4 },
+                } as IncomingRecordingMessage,
+            ],
+            1,
+            [1, 2, 3, 4, 1],
+        ],
+    ])(
+        'correctly handles adding to and completing chunks - %s',
+        (
+            _description: string,
+            chunks: IncomingRecordingMessage[],
+            expectedBufferCount: number,
+            expectedBufferOffsets: number[]
+        ) => {
+            chunks.forEach(async (chunk) => {
+                await sessionManager.add(chunk)
+            })
 
-    //         expect(sessionManager.buffer.count).toEqual(expectedBufferCount)
-    //         expect(sessionManager.buffer.offsets).toEqual(expectedBufferOffsets)
-    //     }
-    // )
+            expect(sessionManager.buffer.count).toEqual(expectedBufferCount)
+            expect(sessionManager.buffer.offsets).toEqual(expectedBufferOffsets)
+        }
+    )
 })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
@@ -6,13 +6,6 @@ import jsonFullSnapshot from './data/snapshot-full.json'
 
 export function createIncomingRecordingMessage(data: Partial<IncomingRecordingMessage> = {}): IncomingRecordingMessage {
     return {
-        metadata: {
-            topic: 'session_recording_events',
-            partition: 1,
-            offset: 1,
-            timestamp: 1,
-        },
-
         team_id: 1,
         distinct_id: 'distinct_id',
         session_id: 'session_id_1',
@@ -33,6 +26,13 @@ export function createIncomingRecordingMessage(data: Partial<IncomingRecordingMe
             },
         ],
         ...data,
+        metadata: {
+            topic: 'session_recording_events',
+            partition: 1,
+            offset: 1,
+            timestamp: 1,
+            ...data.metadata,
+        },
     }
 }
 


### PR DESCRIPTION
## Problem

we're throwing an error if we enter flush but there is nothing in the buffer

we're adding timestamps to oldestMessageTimestamp field whether they are from complete or incomplete chunks

So if the oldest message is from an incomplete chunk, and that is before the flush on idle threshold. and that session has no messages in the buffer we throw. That's unnecessary

### log message that shows this state

```
{
  "sessionId": "1886b8cfe5233b7-04ffad7953e214-1c525634-1fa400-1886b8cfe5310a2",
  "partition": 38,
  "topic": "session_recording_events",
  "oldestKafkaTimestamp": 1685436925949,
  "oldestKafkaTimestampHumanReadable": "2023-05-30T08:55:25.949+00:00",
  "chunkStates": {
    "01886bde-87f4-0000-9a6b-d77f758dfddd": {
      "chunk_count": 2,
      "chunk_indexes": [
        0
      ],
      "chunk_offsets_counts": 1,
      "first_chunk_timestamp": 1685436925949,
      "last_chunk_timestamp": 1685436925949
    }
  },
  "bufferCount": 0,
  "referenceTime": 1685440577854,
  "referenceTimeHumanReadable": "2023-05-30T09:56:17.854+00:00",
  "flushThresholdMillis": 600000,
  "bufferAge": 3651905,
  "msg": "[RECORDINGS-BLOB-INGESTION] 🚽 blob_ingester_session_manager flushing buffer due to age"
}
```

## Changes

* uncomment some tests that were commented out during earlier testing
* only track timestamps on a session buffer when we add messages to it

## How did you test this code?

* developer tests
