### PR TITLE
feat: remove lz64 support for posthog-js

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -67,7 +67,8 @@ def get_decide(request: HttpRequest):
         "config": {"enable_collect_everything": True},
         "toolbarParams": {},
         "isAuthenticated": False,
-        "supportedCompression": ["gzip", "gzip-js", "lz64"],
+        # gzip and gzip-js are aliases for the same compression algorithm
+        "supportedCompression": ["gzip", "gzip-js"],
     }
 
     response["featureFlags"] = []

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -116,7 +116,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             response["sessionRecording"],
             {"endpoint": "/s/", "recorderVersion": "v1", "consoleLogRecordingEnabled": False},
         )
-        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
+        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js"])
 
     def test_user_session_recording_version(self, *args):
         # :TRICKY: Test for regression around caching
@@ -175,7 +175,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             response["sessionRecording"],
             {"endpoint": "/s/", "recorderVersion": "v1", "consoleLogRecordingEnabled": False},
         )
-        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
+        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js"])
 
         # Make sure the domain matches exactly
         response = self._post_decide(origin="https://random.example.com.evilsite.com").json()
@@ -1564,7 +1564,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             response["sessionRecording"],
             {"endpoint": "/s/", "recorderVersion": "v1", "consoleLogRecordingEnabled": True},
         )
-        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
+        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js"])
         self.assertEqual(response["siteApps"], [])
         self.assertEqual(response["capturePerformance"], True)
         self.assertEqual(response["featureFlags"], {})
@@ -1577,7 +1577,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
                 response["sessionRecording"],
                 {"endpoint": "/s/", "recorderVersion": "v1", "consoleLogRecordingEnabled": True},
             )
-            self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
+            self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js"])
             self.assertEqual(response["siteApps"], [])
             self.assertEqual(response["capturePerformance"], True)
             self.assertEqual(response["featureFlags"], {})
@@ -1955,7 +1955,7 @@ class TestDatabaseCheckForDecide(BaseTest, QueryMatchingTest):
                 response["sessionRecording"],
                 {"endpoint": "/s/", "recorderVersion": "v1", "consoleLogRecordingEnabled": True},
             )
-            self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
+            self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js"])
             self.assertEqual(response["siteApps"], [])
             self.assertEqual(response["capturePerformance"], True)
             self.assertEqual(response["featureFlags"], {"no-props": True})


### PR DESCRIPTION
## Problem

needs https://github.com/PostHog/posthog-js/pull/654 first

## Changes

We're removing lz64 support from posthog-js to reduce bundle size, so we can stop advertising it from decide.
And we can prompt ourselves in sentry if we ever see someone try to use it

## How did you test this code?

developer tests