### PR TITLE
chore(early-access-management): add cancel button to early access management

### DIFF
--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -8,7 +8,7 @@ import { Form } from 'kea-forms'
 import { EarlyAccessFeatureStage, EarlyAccessFeatureType, PropertyFilterType, PropertyOperator } from '~/types'
 import { urls } from 'scenes/urls'
 import { PersonsScene } from 'scenes/persons/Persons'
-import { IconFlag, IconHelpOutline } from 'lib/lemon-ui/icons'
+import { IconClose, IconFlag, IconHelpOutline } from 'lib/lemon-ui/icons'
 import { router } from 'kea-router'
 import { useState } from 'react'
 import { Popover } from 'lib/lemon-ui/Popover'
@@ -19,7 +19,7 @@ import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { PersonsLogicProps, personsLogic } from 'scenes/persons/personsLogic'
 import clsx from 'clsx'
 import { InstructionsModal } from './InstructionsModal'
-import { Col, Popconfirm } from 'antd'
+import { Col, Popconfirm, Row } from 'antd'
 
 export const scene: SceneExport = {
     component: EarlyAccessFeature,
@@ -140,9 +140,19 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                             info={<>A feature flag will be generated from feature name if not provided</>}
                         >
                             {({ value, onChange }) => (
-                                <div>
+                                <Row>
                                     <FlagSelector value={value} onChange={onChange} />
-                                </div>
+                                    {value && (
+                                        <LemonButton
+                                            className="ml-2"
+                                            icon={<IconClose />}
+                                            size="small"
+                                            status="stealth"
+                                            onClick={() => onChange(undefined)}
+                                            aria-label="close"
+                                        />
+                                    )}
+                                </Row>
                             )}
                         </Field>
                     )}

--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -19,7 +19,7 @@ import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { PersonsLogicProps, personsLogic } from 'scenes/persons/personsLogic'
 import clsx from 'clsx'
 import { InstructionsModal } from './InstructionsModal'
-import { Col, Popconfirm, Row } from 'antd'
+import { Col, Popconfirm } from 'antd'
 
 export const scene: SceneExport = {
     component: EarlyAccessFeature,
@@ -140,7 +140,7 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                             info={<>A feature flag will be generated from feature name if not provided</>}
                         >
                             {({ value, onChange }) => (
-                                <Row>
+                                <div className="flex">
                                     <FlagSelector value={value} onChange={onChange} />
                                     {value && (
                                         <LemonButton
@@ -152,7 +152,7 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                                             aria-label="close"
                                         />
                                     )}
-                                </Row>
+                                </div>
                             )}
                         </Field>
                     )}


### PR DESCRIPTION
## Problem

- if you select a flag to connect during creation for early access management, you can't remove it to apply default flow

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add cancel button
<img width="372" alt="Screenshot 2023-05-31 at 9 38 52 AM" src="https://github.com/PostHog/posthog/assets/13127476/ad4e8d3a-59b2-4b00-bbfa-8088c31710d5">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
