### PR TITLE
chore: run cypress if front end dependencies might have changed

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -36,6 +36,8 @@ jobs:
                         - requirements-dev.txt
                         - mypy.ini
                         - pytest.ini
+                        - package.json
+                        - pnpm-lock.yaml
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-e2e.yml
                         # We use docker compose for tests, make sure we rerun on


### PR DESCRIPTION
## Problem

We skip the Cypress tests for plugin server changes.

It was also skipping when automerging posthog-js version updates

## Changes

does not skip if FE dependencies might have changed
