### PR TITLE
fix(insights): yesterday ends with yesterday

### DIFF
--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
@@ -56,7 +56,7 @@ describe('dateFilterLogic', () => {
             key: 'test',
             onChange,
             dateFrom: '-1dStart',
-            dateTo: 'dStart',
+            dateTo: '-1dEnd',
             dateOptions: dateMapping,
             isDateFormatted: false,
         }

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
@@ -63,7 +63,7 @@ describe('dateFilterLogic', () => {
         const withDateFrom = dateFilterLogic(props)
         withDateFrom.mount()
 
-        await expectLogic(withDateFrom).toMatchValues({ dateFrom: '-1dStart', dateTo: 'dStart', label: 'Yesterday' })
+        await expectLogic(withDateFrom).toMatchValues({ dateFrom: '-1dStart', dateTo: '-1dEnd', label: 'Yesterday' })
         expect(onChange).not.toHaveBeenCalled()
     })
 

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -319,7 +319,7 @@ describe('dateFilterToText()', () => {
                 'February 29 - March 2, 2012'
             )
             expect(dateFilterToText('-1d', null, 'default', dateMapping, true)).toEqual('March 1 - March 2, 2012')
-            expect(dateFilterToText('-1dStart', 'dStart', 'default', dateMapping, true)).toEqual('March 1, 2012')
+            expect(dateFilterToText('-1dStart', '-1dEnd', 'default', dateMapping, true)).toEqual('March 1, 2012')
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default', dateMapping, true)).toEqual(
                 'March 1 - March 31, 2012'
             )

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -288,7 +288,7 @@ describe('dateFilterToText()', () => {
             expect(dateFilterToText('-24h', null, 'default')).toEqual('Last 24 hours')
             expect(dateFilterToText('-48h', undefined, 'default')).toEqual('Last 48 hours')
             expect(dateFilterToText('-1d', null, 'default')).toEqual('Last 1 day')
-            expect(dateFilterToText('-1dStart', 'dStart', 'default')).toEqual('Yesterday')
+            expect(dateFilterToText('-1dStart', '-1dEnd', 'default')).toEqual('Yesterday')
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default')).toEqual('Previous month')
         })
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -810,7 +810,7 @@ export const dateMapping: DateMappingOption[] = [
     },
     {
         key: 'Yesterday',
-        values: ['-1dStart', 'dStart'],
+        values: ['-1dStart', '-1dEnd'],
         getFormattedDate: (date: dayjs.Dayjs): string => date.subtract(1, 'd').format(DATE_FORMAT),
         defaultInterval: 'hour',
     },


### PR DESCRIPTION
## Problem

The date option "Yesterday" used to select from `-1dStart` to `dStart`. Which today translates to `2023-05-30 00:00:00` to `2023-05-31 00:00:00`.

<img width="1167" alt="image" src="https://github.com/PostHog/posthog/assets/53387/b405a162-db32-4038-8db2-8d81986dc21a">

If a chart used the "hourly" view, this was fine, except for the one empty hour on the line:

<img width="1173" alt="image" src="https://github.com/PostHog/posthog/assets/53387/c4e26b19-c601-4160-b8ff-8d425c653c49">

but the "monthly" view and the "total" views selected two days instead of just one.

<img width="1151" alt="image" src="https://github.com/PostHog/posthog/assets/53387/d10afa65-f292-4790-bb72-2fed0c575e71">
<img width="1165" alt="image" src="https://github.com/PostHog/posthog/assets/53387/c23f1c34-6cab-4073-8099-dfc21efc54dd">

## Changes

Changes the range to `-1dStart` to `-1dEnd`, making everything look fine:

<img width="1169" alt="image" src="https://github.com/PostHog/posthog/assets/53387/8b0c1e04-ab90-45bb-b9dd-928f7cd4e72e">
<img width="1160" alt="image" src="https://github.com/PostHog/posthog/assets/53387/0449f00f-025f-4672-8713-0522465b5d90">
<img width="1152" alt="image" src="https://github.com/PostHog/posthog/assets/53387/caf9232e-a929-492d-8f28-429c5d743615">

... even the hourly trends:

<img width="1163" alt="image" src="https://github.com/PostHog/posthog/assets/53387/babab535-3cf0-4493-a060-0a4a85a55ebb">


## How did you test this code?

Visually in the UI, and updated some tests, hoping CI says they're fine.