### PR TITLE
feat: Remove team fetch from prepare event step

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -69,6 +69,7 @@ export const capture = async ({
     topic = ['$performance_event', '$snapshot'].includes(event)
         ? 'session_recording_events'
         : 'events_plugin_ingestion',
+    ip = '',
 }: {
     teamId: number | null
     distinctId: string
@@ -82,6 +83,7 @@ export const capture = async ({
     topic?: string
     $set?: object
     $set_once?: object
+    ip?: string
 }) => {
     // WARNING: this capture method is meant to simulate the ingestion of events
     // from the capture endpoint, but there is no guarantee that is is 100%
@@ -92,7 +94,7 @@ export const capture = async ({
             JSON.stringify({
                 token,
                 distinct_id: distinctId,
-                ip: '',
+                ip: ip,
                 site_url: '',
                 team_id: teamId,
                 now: now,
@@ -333,7 +335,8 @@ export const createTeam = async (
     organizationId: string,
     slack_incoming_webhook?: string,
     token?: string,
-    sessionRecordingOptIn = true
+    sessionRecordingOptIn = true,
+    anonymize_ips = false
 ) => {
     const team = await insertRow(postgres, 'posthog_team', {
         organization_id: organizationId,
@@ -346,7 +349,7 @@ export const createTeam = async (
         event_properties_numerical: [],
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
-        anonymize_ips: false,
+        anonymize_ips: anonymize_ips,
         completed_snippet_onboarding: true,
         ingested_event: true,
         uuid: new UUIDT().toString(),

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -168,7 +168,7 @@ test.concurrent(`event ingestion: ip kept if not anonymize`, async () => {
             expect.objectContaining({
                 event: 'random',
                 properties: expect.objectContaining({
-                    ip: '123.12.12.23',
+                    $ip: '123.12.12.23',
                 }),
                 distinctId: distinctId,
                 uuid: firstUuid,
@@ -197,7 +197,7 @@ test.concurrent(`event ingestion: anonymize ip respected`, async () => {
             expect.objectContaining({
                 event: 'random',
                 properties: expect.not.objectContaining({
-                    ip: '123.12.12.23',
+                    $ip: '123.12.12.23',
                 }),
                 distinctId: distinctId,
                 uuid: firstUuid,

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -167,7 +167,9 @@ test.concurrent(`event ingestion: ip kept if not anonymize`, async () => {
         expect(event).toEqual(
             expect.objectContaining({
                 event: 'random',
-                ip: '123.12.12.23',
+                properties: expect.objectContaining({
+                    ip: '123.12.12.23',
+                }),
                 distinctId: distinctId,
                 uuid: firstUuid,
                 teamId: teamId,
@@ -194,7 +196,9 @@ test.concurrent(`event ingestion: anonymize ip respected`, async () => {
         expect(event).toEqual(
             expect.objectContaining({
                 event: 'random',
-                ip: null,
+                properties: expect.not.objectContaining({
+                    ip: '123.12.12.23',
+                }),
                 distinctId: distinctId,
                 uuid: firstUuid,
                 teamId: teamId,

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -150,16 +150,17 @@ test.concurrent(`event ingestion: handles $groupidentify with no properties`, as
 })
 
 test.concurrent(`event ingestion: ip kept if not anonymize`, async () => {
-    const teamId = await createTeam(organizationId)
+    const teamId = await createTeam(organizationId, '', 'test_team_token', false, false)
     const distinctId = new UUIDT().toString()
     const firstUuid = new UUIDT().toString()
 
     await capture({
-        teamId,
+        teamId: null, // making sure we go through normal ingestion flow
         distinctId,
         uuid: firstUuid,
         event: 'random',
         ip: '123.12.12.23',
+        token: 'test_team_token',
     })
 
     await waitForExpect(async () => {
@@ -179,16 +180,17 @@ test.concurrent(`event ingestion: ip kept if not anonymize`, async () => {
 })
 
 test.concurrent(`event ingestion: anonymize ip respected`, async () => {
-    const teamId = await createTeam(organizationId, '', '', false, true)
+    const teamId = await createTeam(organizationId, '', 'test_team_token', false, true)
     const distinctId = new UUIDT().toString()
     const firstUuid = new UUIDT().toString()
 
     await capture({
-        teamId,
+        teamId: null, // making sure we go through normal ingestion flow
         distinctId,
         uuid: firstUuid,
         event: 'random',
         ip: '123.12.12.23',
+        token: 'test_team_token',
     })
 
     await waitForExpect(async () => {

--- a/plugin-server/functional_tests/ingestion.test.ts
+++ b/plugin-server/functional_tests/ingestion.test.ts
@@ -170,9 +170,9 @@ test.concurrent(`event ingestion: ip kept if not anonymize`, async () => {
                 properties: expect.objectContaining({
                     $ip: '123.12.12.23',
                 }),
-                distinctId: distinctId,
+                distinct_id: distinctId,
                 uuid: firstUuid,
-                teamId: teamId,
+                team_id: teamId,
             })
         )
     })
@@ -199,9 +199,9 @@ test.concurrent(`event ingestion: anonymize ip respected`, async () => {
                 properties: expect.not.objectContaining({
                     $ip: '123.12.12.23',
                 }),
-                distinctId: distinctId,
+                distinct_id: distinctId,
                 uuid: firstUuid,
-                teamId: teamId,
+                team_id: teamId,
             })
         )
     })

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -37,14 +37,8 @@ export async function populateTeamDataStep(
     })
 
     // If a team_id is present (event captured from an app), trust it and return the event as is.
+    // Furthermore we assume that the sender knows not provide or anonymize ips if needed.
     if (event.team_id) {
-        // Because of ip anonymization even if we have teamId already we need to fetch the team
-        const team = await runner.hub.teamManager.fetchTeam(event.team_id)
-        event = {
-            ...event,
-            // default to anonymizing if we can't fetch the team
-            ip: team ? (team.anonymize_ips ? null : event.ip) : null,
-        }
         return event as PluginEvent
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -38,6 +38,13 @@ export async function populateTeamDataStep(
 
     // If a team_id is present (event captured from an app), trust it and return the event as is.
     if (event.team_id) {
+        // Because of ip anonymization even if we have teamId already we need to fetch the team
+        const team = await runner.hub.teamManager.fetchTeam(event.team_id)
+        event = {
+            ...event,
+            // default to anonymizing if we can't fetch the team
+            ip: team ? (team.anonymize_ips ? null : event.ip) : null,
+        }
         return event as PluginEvent
     }
 

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -800,22 +800,6 @@ test('capture new person', async () => {
     )
 })
 
-test('capture bad team', async () => {
-    await expect(
-        eventsProcessor.processEvent(
-            'asdfasdfasdf',
-            '',
-            {
-                event: '$pageview',
-                properties: { distinct_id: 'asdfasdfasdf', token: team.api_token },
-            } as any as PluginEvent,
-            1337,
-            now,
-            new UUIDT().toString()
-        )
-    ).rejects.toThrowError("No team found with ID 1337. Can't ingest event.")
-})
-
 test('capture no element', async () => {
     await createPerson(hub, team, ['asdfasdfasdf'])
 

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -117,7 +117,7 @@ async function processEvent(
     ip: string | null,
     _siteUrl: string,
     data: Partial<PluginEvent>,
-    teamId: number,
+    teamId: number | null,
     timestamp: DateTime,
     eventUuid: string
 ): Promise<void> {
@@ -779,7 +779,6 @@ test('capture new person', async () => {
                 property_type: 'String',
                 property_type_format: null,
                 query_usage_30_day: null,
-                team_id: 2,
                 type: 2,
                 group_type_index: null,
                 volume_30_day: null,
@@ -889,9 +888,10 @@ test('anonymized ip capture', async () => {
         '',
         {
             event: '$pageview',
-            properties: { distinct_id: 'asdfasdfasdf', token: team.api_token },
+            properties: { distinct_id: 'asdfasdfasdf' },
+            token: team.api_token,
         } as any as PluginEvent,
-        team.id,
+        null,
         now,
         new UUIDT().toString()
     )

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -779,6 +779,7 @@ test('capture new person', async () => {
                 property_type: 'String',
                 property_type_format: null,
                 query_usage_30_day: null,
+                team_id: 2,
                 type: 2,
                 group_type_index: null,
                 volume_30_day: null,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We're fetching the team, which can result in a postgres fetch, which is unneccessary as we already know everything we need from earlier https://github.com/PostHog/posthog/blob/504a3edab85cd5b7768ca29b66269dff254faad1/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts#L75 

While in theory the caching should do all the work here in practice it didn't on dev as we saw some failures and we don't need it regardless.

Notice that if the team_id is supplied events come from plugin-server and the interface provided doesn't allow adding ip, https://github.com/PostHog/posthog/pull/14365/files#r1126276444 so we're safe to ignore that.

Added a functional test also to make sure ip anonymising works as needed

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
