### PR TITLE
refactor(data-exploration): remove dead code from summarizeInsight function

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -237,7 +237,6 @@ function InsightMeta({
         aggregationLabel,
         cohortsById,
         mathDefinitions,
-        isUsingDataExploration: true,
         isUsingDashboardQueries: !!featureFlags[FEATURE_FLAGS.HOGQL],
     })
 

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -119,7 +119,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         name="name"
                         value={insight.name || ''}
                         placeholder={summarizeInsight(query, filters, {
-                            isUsingDataExploration,
                             aggregationLabel,
                             cohortsById,
                             mathDefinitions,

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -607,24 +607,9 @@ export const insightLogic = kea<insightLogicType>([
                 !!props.dashboardItemId && props.dashboardItemId !== 'new' && !props.dashboardItemId.startsWith('new-'),
         ],
         derivedName: [
-            (s) => [
-                s.insight,
-                s.aggregationLabel,
-                s.cohortsById,
-                s.mathDefinitions,
-                s.isUsingDataExploration,
-                s.isUsingDashboardQueries,
-            ],
-            (
-                insight,
-                aggregationLabel,
-                cohortsById,
-                mathDefinitions,
-                isUsingDataExploration,
-                isUsingDashboardQueries
-            ) =>
+            (s) => [s.insight, s.aggregationLabel, s.cohortsById, s.mathDefinitions, s.isUsingDashboardQueries],
+            (insight, aggregationLabel, cohortsById, mathDefinitions, isUsingDashboardQueries) =>
                 summarizeInsight(insight.query, insight.filters || {}, {
-                    isUsingDataExploration,
                     aggregationLabel,
                     cohortsById,
                     mathDefinitions,

--- a/frontend/src/scenes/insights/summarizeInsight.test.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.test.ts
@@ -69,13 +69,11 @@ const summaryContext: SummaryContext = {
     aggregationLabel,
     cohortsById: cohortIdsMapped,
     mathDefinitions,
-    isUsingDataExploration: false,
     isUsingDashboardQueries: false,
 }
 
 const flagsOnSummaryContext: SummaryContext = {
     ...summaryContext,
-    isUsingDataExploration: true,
     isUsingDashboardQueries: true,
 }
 

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -329,7 +329,6 @@ function summariseQuery(query: Node): string {
 }
 
 export interface SummaryContext {
-    isUsingDataExploration: boolean
     isUsingDashboardQueries: boolean
     aggregationLabel: groupsModelType['values']['aggregationLabel']
     cohortsById: cohortsModelType['values']['cohortsById']
@@ -342,8 +341,7 @@ export function summarizeInsight(
     context: SummaryContext
 ): string {
     const hasFilters = Object.keys(filters || {}).length > 0
-
-    return context.isUsingDataExploration && isInsightVizNode(query)
+    return isInsightVizNode(query)
         ? summarizeInsightQuery(query.source, context)
         : context.isUsingDashboardQueries && !!query && !isInsightVizNode(query)
         ? summariseQuery(query)

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -334,7 +334,6 @@ function SavedInsightsGrid(): JSX.Element {
 
 export function SavedInsights(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    const isUsingDataExploration = true
     const isUsingDashboardQueries = !!featureFlags[FEATURE_FLAGS.HOGQL]
 
     const { loadInsights, updateFavoritedInsight, renameInsight, duplicateInsight, setSavedInsightsFilters } =
@@ -372,7 +371,6 @@ export function SavedInsights(): JSX.Element {
                                 {name || (
                                     <i>
                                         {summarizeInsight(insight.query, insight.filters, {
-                                            isUsingDataExploration,
                                             aggregationLabel,
                                             cohortsById,
                                             mathDefinitions,


### PR DESCRIPTION
## Problem

The "view source" feature aka data exploration is rolled out to 100% of users, but we still have dead code lying around. See https://github.com/PostHog/meta/issues/84 for an overview of outstanding tasks.

## Changes

This PR removes the flag from the `summarizeInsight` function.

## How did you test this code?

Checked that summaries are still built