### PR TITLE
fix(insights): fix refresh

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -67,14 +67,18 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         isUsingDashboardQueries,
         getInsightRefreshButtonDisabledReason,
     } = useValues(logic)
-    const { setInsightMetadata, saveAs, loadResults } = useActions(logic)
+    const { setInsightMetadata, saveAs } = useActions(logic)
 
     // savedInsightsLogic
     const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
 
     // insightDataLogic
     const { query, queryChanged, showQueryEditor } = useValues(insightDataLogic(insightProps))
-    const { saveInsight: saveQueryBasedInsight, toggleQueryEditorPanel } = useActions(insightDataLogic(insightProps))
+    const {
+        saveInsight: saveQueryBasedInsight,
+        toggleQueryEditorPanel,
+        loadData,
+    } = useActions(insightDataLogic(insightProps))
 
     // other logics
     useMountedLogic(insightCommandLogic(insightProps))
@@ -150,7 +154,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         <>
                                             <LemonButton
                                                 status="stealth"
-                                                onClick={() => loadResults(true)}
+                                                onClick={() => loadData(true)}
                                                 fullWidth
                                                 data-attr="refresh-insight-from-insight-view"
                                                 disabledReason={insightRefreshButtonDisabledReason}
@@ -169,7 +173,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         <>
                                             <LemonButton
                                                 status="stealth"
-                                                onClick={() => loadResults(true)}
+                                                onClick={() => loadData(true)}
                                                 fullWidth
                                                 data-attr="refresh-insight-from-insight-view"
                                                 disabledReason={insightRefreshButtonDisabledReason}

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -65,7 +65,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         exporterResourceParams,
         isUsingDataExploration,
         isUsingDashboardQueries,
-        getInsightRefreshButtonDisabledReason,
     } = useValues(logic)
     const { setInsightMetadata, saveAs } = useActions(logic)
 
@@ -73,7 +72,9 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
 
     // insightDataLogic
-    const { query, queryChanged, showQueryEditor } = useValues(insightDataLogic(insightProps))
+    const { query, queryChanged, showQueryEditor, getInsightRefreshButtonDisabledReason } = useValues(
+        insightDataLogic(insightProps)
+    )
     const {
         saveInsight: saveQueryBasedInsight,
         toggleQueryEditorPanel,

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -46,6 +46,9 @@ export const insightDataLogic = kea<insightDataLogicType>([
         actions: [
             insightLogic,
             ['setInsight', 'loadInsightSuccess', 'loadResultsSuccess', 'saveInsight as insightLogicSaveInsight'],
+            // TODO: need to pass empty query here, as otherwise dataNodeLogic will throw
+            dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
+            ['loadData'],
         ],
         logic: [insightDataTimingLogic(props)],
     })),

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -39,7 +39,11 @@ export const insightDataLogic = kea<insightDataLogicType>([
             ['filters', 'insight', 'isUsingDashboardQueries', 'savedInsight'],
             // TODO: need to pass empty query here, as otherwise dataNodeLogic will throw
             dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
-            ['dataLoading as insightDataLoading', 'responseErrorObject as insightDataError'],
+            [
+                'dataLoading as insightDataLoading',
+                'responseErrorObject as insightDataError',
+                'getInsightRefreshButtonDisabledReason',
+            ],
             filterTestAccountsDefaultsLogic,
             ['filterTestAccountsDefault'],
         ],

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -53,7 +53,6 @@ import { toLocalFilters } from './filters/ActionFilter/entityFilterLogic'
 import { loaders } from 'kea-loaders'
 import { legacyInsightQuery, queryExportContext } from '~/queries/query'
 import { tagsModel } from '~/models/tagsModel'
-import { dayjs } from 'lib/dayjs'
 import { isInsightVizNode } from '~/queries/utils'
 import { userLogic } from 'scenes/userLogic'
 import { globalInsightLogic } from './globalInsightLogic'
@@ -803,29 +802,6 @@ export const insightLogic = kea<insightLogicType>([
             (s) => [s.featureFlags],
             (featureFlags: FeatureFlagsSet): boolean => {
                 return !!featureFlags[FEATURE_FLAGS.HOGQL]
-            },
-        ],
-        getInsightRefreshButtonDisabledReason: [
-            (s) => [s.nextAllowedRefresh, s.lastRefresh],
-            (nextAllowedRefresh: string | null, lastRefresh: string | null) => (): string => {
-                const now = dayjs()
-                let disabledReason = ''
-                if (!!nextAllowedRefresh && now.isBefore(dayjs(nextAllowedRefresh))) {
-                    // If this is a saved insight, the result will contain nextAllowedRefresh and we use that to disable the button
-                    disabledReason = `You can refresh this insight again ${dayjs(nextAllowedRefresh).from(now)}`
-                } else if (
-                    !!lastRefresh &&
-                    now.subtract(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES - 0.5, 'minutes').isBefore(lastRefresh)
-                ) {
-                    // Unsaved insights don't get cached and get refreshed on every page load, but we avoid allowing users to click
-                    // 'refresh' more than once every UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES. This can be bypassed by simply
-                    // refreshing the page though, as there's no cache layer on the backend
-                    disabledReason = `You can refresh this insight again ${dayjs(lastRefresh)
-                        .add(UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES, 'minutes')
-                        .from(now)}`
-                }
-
-                return disabledReason
             },
         ],
     }),


### PR DESCRIPTION
## Problem

> There's definitely something up with refreshes
>
> Other than being hidden, I've also randomly run into an issue when it didn't refresh properly, but failed to document it at the time. Seems like a recent-ish change :thinking_face:

https://posthog.slack.com/archives/C0368RPHLQH/p1685554528519849?thread_ts=1685548461.217599&cid=C0368RPHLQH

## Changes

This PR replaces the refresh based on the old `loadResults` action with the new `loadData` action of `dataNodeLogic` and uses it's `getInsightRefreshButtonDisabledReason` selector.

## How did you test this code?

Verified I can refresh an insight and that it then disables the refresh button