### PR TITLE
fix(pnpm): use latest pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "engines": {
         "node": ">=18 <19"
     },
-    "packageManager": "pnpm@8.3.1",
+    "packageManager": "pnpm@8.6.0",
     "scripts": {
         "copy-scripts": "mkdir -p frontend/dist/ && ./bin/copy-posthog-js",
         "test": "pnpm test:unit && pnpm test:visual-regression",


### PR DESCRIPTION
## Problem

Seems https://github.com/PostHog/posthog/pull/15823 has broken the build by upgrading the lockfile version to v6.1

## Changes

This PR upgrades pnpm to the latest version, compatible with lockfile version 6.1

## How did you test this code?

This PR