### PR TITLE
fix(tests): make assertNumQueries fuzzy

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -8,7 +8,7 @@ from posthog.constants import ExperimentSignificanceCode
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.experiment import Experiment
 from posthog.models.feature_flag import FeatureFlag, get_feature_flags_for_team_in_cache
-from posthog.test.base import ClickhouseTestMixin, snapshot_clickhouse_queries
+from posthog.test.base import ClickhouseTestMixin, snapshot_clickhouse_queries, FuzzyInt
 from posthog.test.test_journeys import journeys_for
 
 
@@ -54,7 +54,7 @@ class TestExperimentCRUD(APILicensedTest):
             format="json",
         ).json()
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(FuzzyInt(9, 10)):
             response = self.client.get(f"/api/projects/{self.team.id}/experiments")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -71,7 +71,7 @@ class TestExperimentCRUD(APILicensedTest):
                 format="json",
             ).json()
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(FuzzyInt(9, 10)):
             response = self.client.get(f"/api/projects/{self.team.id}/experiments")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -40,6 +40,7 @@ from posthog.test.base import (
     flush_persons_and_events,
     snapshot_clickhouse_queries,
     snapshot_postgres_queries,
+    FuzzyInt,
 )
 from posthog.test.db_context_capturing import capture_db_queries
 from posthog.test.test_journeys import journeys_for
@@ -360,7 +361,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         # adding more insights doesn't change the query count
         self.assertEqual(
-            [11, 11, 11, 11, 11],
+            [FuzzyInt(11, 12), FuzzyInt(11, 12), FuzzyInt(11, 12), FuzzyInt(11, 12), FuzzyInt(11, 12)],
             query_counts,
             f"received query counts\n\n{query_counts}",
         )

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -68,11 +68,12 @@ def _setup_test_data(klass):
 
 
 class FuzzyInt(int):
-"""
-Some query count assertions vary depending on the order of tests in the run because values are cached and so their related query doesn't always run.
+    """
+    Some query count assertions vary depending on the order of tests in the run because values are cached and so their related query doesn't always run.
 
-For the purposes of testing query counts we don't care about that variation
-"""
+    For the purposes of testing query counts we don't care about that variation
+    """
+
     lowest: int
     highest: int
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -67,6 +67,20 @@ def _setup_test_data(klass):
         klass.organization_membership = klass.user.organization_memberships.get()
 
 
+class FuzzyInt(int):
+    def __new__(cls, lowest, highest):
+        obj = super(FuzzyInt, cls).__new__(cls, highest)
+        obj.lowest = lowest
+        obj.highest = highest
+        return obj
+
+    def __eq__(self, other):
+        return other >= self.lowest and other <= self.highest
+
+    def __repr__(self):
+        return "[%d..%d]" % (self.lowest, self.highest)
+
+
 class ErrorResponsesMixin:
 
     ERROR_INVALID_CREDENTIALS = {

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -68,6 +68,9 @@ def _setup_test_data(klass):
 
 
 class FuzzyInt(int):
+    lowest: int
+    highest: int
+
     def __new__(cls, lowest, highest):
         obj = super(FuzzyInt, cls).__new__(cls, highest)
         obj.lowest = lowest
@@ -75,7 +78,7 @@ class FuzzyInt(int):
         return obj
 
     def __eq__(self, other):
-        return other >= self.lowest and other <= self.highest
+        return self.lowest <= other <= self.highest
 
     def __repr__(self):
         return "[%d..%d]" % (self.lowest, self.highest)

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -68,6 +68,11 @@ def _setup_test_data(klass):
 
 
 class FuzzyInt(int):
+"""
+Some query count assertions vary depending on the order of tests in the run because values are cached and so their related query doesn't always run.
+
+For the purposes of testing query counts we don't care about that variation
+"""
     lowest: int
     highest: int
 


### PR DESCRIPTION
## Problem

Counting queries in tests is flakey.

We've all seen this:

```
FAILED ee/clickhouse/views/test/test_clickhouse_experiments.py::TestExperimentCRUD::test_getting_experiments_is_not_nplus1

>       with self.assertNumQueries(9):
E   AssertionError: 10 != 9 : 10 queries executed, 9 expected
```

or

```
FAILED posthog/api/test/test_insight.py::TestInsight::test_listing_insights_does_not_nplus1
E       First differing element 1:
E       11
E       12
```
(happened when running tests for this PR)

## Changes

Makes 9 equal 10

## How did you test this code?

Tests passed for once.

## Additional context

There are a few other tests that could use this treatment