### PR TITLE
perf(ingestion): don't block for each event's kafka produce

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -27,12 +27,19 @@ type IngestionSplitBatch = {
     toOverflow: KafkaMessage[]
 }
 
+// Subset of EventPipelineResult to make sure we don't access what's exported for the tests
+type IngestResult = {
+    // Promises that the batch handler should await on before committing offsets,
+    // contains the Kafka producer ACKs, to avoid blocking after every message.
+    promises?: Array<Promise<void>>
+}
+
 export async function eachBatchParallelIngestion(
     { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
     queue: IngestionConsumer,
     overflowMode: IngestionOverflowMode
 ): Promise<void> {
-    async function eachMessage(event: PipelineEvent, queue: IngestionConsumer): Promise<EventPipelineResult> {
+    async function eachMessage(event: PipelineEvent, queue: IngestionConsumer): Promise<IngestResult> {
         return ingestEvent(queue.pluginsServer, queue.workerMethods, event)
     }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -26,6 +26,7 @@ import { UUID } from './utils/utils'
 import { ActionManager } from './worker/ingestion/action-manager'
 import { ActionMatcher } from './worker/ingestion/action-matcher'
 import { AppMetrics } from './worker/ingestion/app-metrics'
+import { EventPipelineResult } from './worker/ingestion/event-pipeline/runner'
 import { HookCommander } from './worker/ingestion/hooks'
 import { OrganizationManager } from './worker/ingestion/organization-manager'
 import { PersonManager } from './worker/ingestion/person-manager'
@@ -434,7 +435,7 @@ export interface PluginTask {
 
 export type WorkerMethods = {
     runAsyncHandlersEventPipeline: (event: PostIngestionEvent) => Promise<void>
-    runEventPipeline: (event: PipelineEvent) => Promise<void>
+    runEventPipeline: (event: PipelineEvent) => Promise<EventPipelineResult>
 }
 
 export type VMMethods = {

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -25,7 +25,7 @@ export class KafkaProducerWrapper {
         this.waitForAck = waitForAck
     }
 
-    async queueMessage(kafkaMessage: ProducerRecord, waitForAck?: boolean) {
+    async queueMessage(kafkaMessage: ProducerRecord, waitForAck?: boolean): Promise<void> {
         try {
             return await Promise.all(
                 kafkaMessage.messages.map((message) =>
@@ -47,7 +47,9 @@ export class KafkaProducerWrapper {
                         waitForAck: waitForAck === undefined ? this.waitForAck : waitForAck,
                     })
                 )
-            )
+            ).then((_) => {
+                return // Swallow the returned offsets, and return a void for easier typing
+            })
         } catch (error) {
             status.error('⚠️', 'kafka_produce_error', { error: error, topic: kafkaMessage.topic })
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/createEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/createEventStep.ts
@@ -5,6 +5,6 @@ export async function createEventStep(
     runner: EventPipelineRunner,
     event: PreIngestionEvent,
     person: Person
-): Promise<RawClickHouseEvent> {
+): Promise<[RawClickHouseEvent, Promise<void>]> {
     return await runner.hub.eventsProcessor.createEvent(event, person)
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -5,6 +5,7 @@ import { runInSpan } from '../../../sentry'
 import { Hub, PipelineEvent, PostIngestionEvent } from '../../../types'
 import { DependencyUnavailableError } from '../../../utils/db/error'
 import { timeoutGuard } from '../../../utils/db/utils'
+import { stringToBoolean } from '../../../utils/env-utils'
 import { status } from '../../../utils/status'
 import { generateEventDeadLetterQueueMessage } from '../utils'
 import { createEventStep } from './createEventStep'
@@ -42,11 +43,15 @@ export class EventPipelineRunner {
 
     // See https://docs.google.com/document/d/12Q1KcJ41TicIwySCfNJV5ZPKXWVtxT7pzpB3r9ivz_0
     poEEmbraceJoin: boolean
+    private delayAcks: boolean
 
     constructor(hub: Hub, originalEvent: PipelineEvent | ProcessedPluginEvent, poEEmbraceJoin = false) {
         this.hub = hub
         this.originalEvent = originalEvent
         this.poEEmbraceJoin = poEEmbraceJoin
+
+        // TODO: remove after successful rollout
+        this.delayAcks = stringToBoolean(process.env.INGESTION_DELAY_WRITE_ACKS)
     }
 
     async runEventPipeline(event: PipelineEvent): Promise<EventPipelineResult> {
@@ -102,7 +107,12 @@ export class EventPipelineRunner {
             [this, preparedEvent, person],
             event.team_id
         )
-        return this.registerLastStep('createEventStep', event.team_id, [rawClickhouseEvent, person], [eventAck])
+        if (this.delayAcks) {
+            return this.registerLastStep('createEventStep', event.team_id, [rawClickhouseEvent, person], [eventAck])
+        } else {
+            await eventAck
+            return this.registerLastStep('createEventStep', event.team_id, [rawClickhouseEvent, person])
+        }
     }
 
     async runAsyncHandlersEventPipeline(event: PostIngestionEvent): Promise<EventPipelineResult> {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -14,10 +14,13 @@ import { prepareEventStep } from './prepareEventStep'
 import { processPersonsStep } from './processPersonsStep'
 import { runAsyncHandlersStep } from './runAsyncHandlersStep'
 
-// Only used in tests
-// TODO: update to test for side-effects of running the pipeline rather than
-// this return type.
 export type EventPipelineResult = {
+    // Promises that the batch handler should await on before committing offsets,
+    // contains the Kafka producer ACKs, to avoid blocking after every message.
+    promises?: Array<Promise<void>>
+    // Only used in tests
+    // TODO: update to test for side-effects of running the pipeline rather than
+    // this return type.
     lastStep: string
     args: any[]
     error?: string

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -163,7 +163,10 @@ export class EventsProcessor {
         return res
     }
 
-    async createEvent(preIngestionEvent: PreIngestionEvent, person: Person): Promise<RawClickHouseEvent> {
+    async createEvent(
+        preIngestionEvent: PreIngestionEvent,
+        person: Person
+    ): Promise<[RawClickHouseEvent, Promise<void>]> {
         const {
             eventUuid: uuid,
             event,
@@ -202,7 +205,7 @@ export class EventsProcessor {
             ...groupsColumns,
         }
 
-        await this.kafkaProducer.queueMessage({
+        const ack = this.kafkaProducer.queueMessage({
             topic: this.pluginsServer.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
             messages: [
                 {
@@ -211,7 +214,8 @@ export class EventsProcessor {
                 },
             ],
         })
-        return rawEvent
+
+        return [rawEvent, ack]
     }
 
     private async upsertGroup(teamId: number, properties: Properties, timestamp: DateTime): Promise<void> {

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -64,7 +64,7 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
             },
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),
-                runEventPipeline: jest.fn(),
+                runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }
     })

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -67,7 +67,7 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
             },
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),
-                runEventPipeline: jest.fn(),
+                runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }
     })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -101,7 +101,7 @@ describe('EventPipelineRunner', () => {
             { person, personUpdateProperties: {}, get: () => Promise.resolve(person) } as any,
         ])
         jest.mocked(prepareEventStep).mockResolvedValue(preIngestionEvent)
-        jest.mocked(createEventStep).mockResolvedValue(null)
+        jest.mocked(createEventStep).mockResolvedValue([null, Promise.resolve()])
         jest.mocked(runAsyncHandlersStep).mockResolvedValue(null)
     })
 
@@ -120,7 +120,8 @@ describe('EventPipelineRunner', () => {
         })
 
         it('emits metrics for every step', async () => {
-            await runner.runEventPipeline(pipelineEvent)
+            const result = await runner.runEventPipeline(pipelineEvent)
+            expect(result.error).toBeUndefined()
 
             expect(hub.statsd.timing).toHaveBeenCalledTimes(5)
             expect(hub.statsd.increment).toHaveBeenCalledTimes(8)


### PR DESCRIPTION
## Problem

Ingestion currently await Kafka write ACKs sequentially, only starting to process a new event if the existing one has been committed to Kafka. This creates a lot of blocking awaits, reducing the workload's throughput.

## Changes

- Add an array of promises to the `EventPipelineResult` type, for promises that need to be `await`ed before the batch is considered successful but don't preclude us from processing another event
- `createEventStep` bubbles up its kafka produce promise into `EventPipelineResult`
- `eachBatchParallelIngestion` collects these promises, to await them all before committing offsets
- Add more tracing spans around `eachBatchParallelIngestion` to account for all steps of the processing

Note: queuing up the message into the kafka producer's buffer (the `producer.produce` call) is a blocking operation, and can block/fail if we produce messages faster than the brokers can accept it. It's OK to block here, to have some backpressure in our consumer loop when Kafka is struggling. The async part we `await` on is checking for the delivery confirmation, after the Kafka brokers have ACKed the write.


Added a `INGESTION_DELAY_WRITE_ACKS` envvar for a safer rollout. Unit and functional tests [were green](https://github.com/PostHog/posthog/actions/runs/5143990781) before that commit (with the delay enabled).


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
