### PR TITLE
fix: idle chunks are blocking

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -125,6 +125,9 @@ export function getDefaultConfig(): PluginsServerConfig {
             ? 1024 // NOTE: ~1MB in dev or test, so that even with gzipped content we still flush pretty frequently
             : 1024 * 50, // ~50MB after compression in prod
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
+        // a different threshold to SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS because we want
+        // more tolerance for idle chunks to avoid dropping chunks that will eventually be completed
+        SESSION_RECORDING_IDLE_CHUNKS_THRESHOLD_SECONDS: 60 * 120, // NOTE: 2 HOURS
     }
 }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -373,7 +373,8 @@ export class SessionRecordingBlobIngester {
                 void sessionManager
                     .flushIfSessionBufferIsOld(
                         referenceTime,
-                        this.serverConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS * 1000
+                        this.serverConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS * 1000,
+                        this.serverConfig.SESSION_RECORDING_IDLE_CHUNKS_THRESHOLD_SECONDS * 1000
                     )
                     .catch((err) => {
                         status.error(

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -192,6 +192,7 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number
     SESSION_RECORDING_REMOTE_FOLDER: string
+    SESSION_RECORDING_IDLE_CHUNKS_THRESHOLD_SECONDS: number
 }
 
 export interface Hub extends PluginsServerConfig {


### PR DESCRIPTION
## Problem

On a blocked partition we see logs like this

```
{
  "level": "warn",
  "logContext": {
    "sessionId": "1886c78e94f878-00fee8bd4ac269-7b515473-13c680-1886c78e958211",
    "partition": 32,
    "topic": "session_recording_events",
    "oldestKafkaTimestamp": null,
    "chunkStates": {
      "01886c8f-2def-0000-2479-590d8b55509f": {
        "chunk_count": 31,
        "chunk_indexes": [
          15,
          16,
          17,
          18,
          19,
          20,
          21,
          22,
          23,
          24,
          25,
          26,
          27,
          28,
          29,
          30
        ],
        "chunk_offsets_counts": 16,
        "first_chunk_timestamp": 1685448503568,
        "last_chunk_timestamp": 1685448504153
      }
    },
    "bufferCount": 0,
    "referenceTime": 1685567950113,
    "referenceTimeHumanReadable": "2023-05-31T21:19:10.113+00:00",
    "flushThresholdMillis": 600000
  },
  "msg": "[RECORDINGS-BLOB-INGESTION] 🚽 blob_ingester_session_manager buffer has no oldestKafkaTimestamp yet"
}

```

theory is the idle chunk test is incorrect and we've previously thrown away the starting chunks 😢 

the handle idle chunks check is after choosing not to flush on age because there's nothing to buffer, so we never clear this pending chunks

## Changes

* check idle chunk before the early return
* _for now_ still drop idle chunks but wait much longer

## How did you test this code?

developer tests
