### PR TITLE
fix(insights): add series values to filter conversion

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -179,6 +179,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             formula: filters.formula,
             shown_as: filters.shown_as,
             display: filters.display,
+            show_values_on_series: filters.show_values_on_series,
         })
     }
 
@@ -255,6 +256,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
             stickiness_days: filters.stickiness_days,
             shown_as: filters.shown_as,
+            show_values_on_series: filters.show_values_on_series,
         })
     }
 
@@ -263,6 +265,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
         query.lifecycleFilter = objectCleanWithEmpty({
             shown_as: filters.shown_as,
             toggledLifecycles: filters.toggledLifecycles,
+            show_values_on_series: filters.show_values_on_series,
         })
     }
 


### PR DESCRIPTION
## Problem

The `show_values_on_series` filter was missing from the `filtersToQueryNode` conversion.

See https://posthoghelp.zendesk.com/agent/tickets/3273 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/6165) for a related customer issue.

## Changes

Adds it there

## How did you test this code?

Verified that insights with set `show_values_on_series` load correctly