### PR TITLE
refactor(insights): mark old insight container as legacy

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -13,7 +13,7 @@ import { AvailableFeature, ChartDisplayType, FilterType, FunnelStep, FunnelVizTy
 import './Experiment.scss'
 import '../insights/Insight.scss'
 import { experimentLogic, ExperimentLogicProps } from './experimentLogic'
-import { InsightContainer } from 'scenes/insights/InsightContainer'
+import { LegacyInsightContainer } from 'scenes/insights/LegacyInsightContainer'
 import { IconDelete, IconPlusMini } from 'lib/lemon-ui/icons'
 import { InfoCircleOutlined, CloseOutlined } from '@ant-design/icons'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
@@ -554,7 +554,7 @@ export function Experiment(): JSX.Element {
                                         <div className="card-secondary mb-4" data-attr="experiment-preview">
                                             Goal preview
                                         </div>
-                                        <InsightContainer
+                                        <LegacyInsightContainer
                                             disableHeader={experimentInsightType === InsightType.TRENDS}
                                             disableTable={true}
                                             disableCorrelationTable={true}
@@ -1077,7 +1077,7 @@ export function Experiment(): JSX.Element {
                                 }}
                             >
                                 <div className="mt-4">
-                                    <InsightContainer
+                                    <LegacyInsightContainer
                                         disableHeader={true}
                                         disableCorrelationTable={experimentInsightType === InsightType.FUNNELS}
                                         disableLastComputation={true}

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -557,7 +557,6 @@ export function Experiment(): JSX.Element {
                                         <LegacyInsightContainer
                                             disableHeader={experimentInsightType === InsightType.TRENDS}
                                             disableTable={true}
-                                            disableCorrelationTable={true}
                                         />
                                     </Col>
                                 </Row>
@@ -1077,11 +1076,7 @@ export function Experiment(): JSX.Element {
                                 }}
                             >
                                 <div className="mt-4">
-                                    <LegacyInsightContainer
-                                        disableHeader={true}
-                                        disableCorrelationTable={experimentInsightType === InsightType.FUNNELS}
-                                        disableLastComputation={true}
-                                    />
+                                    <LegacyInsightContainer disableHeader={true} disableLastComputation={true} />
                                 </div>
                             </BindLogic>
                         ) : (

--- a/frontend/src/scenes/experiments/MetricSelector.tsx
+++ b/frontend/src/scenes/experiments/MetricSelector.tsx
@@ -128,7 +128,7 @@ export function MetricSelector({
             )}
             <div className="mt-4">
                 <BindLogic logic={insightLogic} props={insightProps}>
-                    <LegacyInsightContainer disableHeader={true} disableTable={true} disableCorrelationTable={true} />
+                    <LegacyInsightContainer disableHeader={true} disableTable={true} />
                 </BindLogic>
             </div>
         </>

--- a/frontend/src/scenes/experiments/MetricSelector.tsx
+++ b/frontend/src/scenes/experiments/MetricSelector.tsx
@@ -5,7 +5,7 @@ import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { FilterType, InsightShortId, InsightType } from '~/types'
 import './Experiment.scss'
-import { InsightContainer } from 'scenes/insights/InsightContainer'
+import { LegacyInsightContainer } from 'scenes/insights/LegacyInsightContainer'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { LemonSelect } from '@posthog/lemon-ui'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
@@ -128,7 +128,7 @@ export function MetricSelector({
             )}
             <div className="mt-4">
                 <BindLogic logic={insightLogic} props={insightProps}>
-                    <InsightContainer disableHeader={true} disableTable={true} disableCorrelationTable={true} />
+                    <LegacyInsightContainer disableHeader={true} disableTable={true} disableCorrelationTable={true} />
                 </BindLogic>
             </div>
         </>

--- a/frontend/src/scenes/insights/LegacyInsightContainer.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightContainer.tsx
@@ -1,5 +1,5 @@
 import { Card, Col, Row } from 'antd'
-import { LegacyInsightDisplayConfig } from 'scenes/insights/InsightDisplayConfig'
+import { LegacyInsightDisplayConfig } from 'scenes/insights/LegacyInsightDisplayConfig'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { ComputationTimeWithRefresh } from 'scenes/insights/ComputationTimeWithRefresh'
 import { ChartDisplayType, ExporterFormat, FunnelVizType, InsightType, ItemMode } from '~/types'
@@ -173,6 +173,13 @@ export function LegacyInsightContainer({
         }
 
         return null
+    }
+
+    if (!isFunnelsFilter(filters) && !isTrendsFilter(filters)) {
+        // The legacy InsightContainer should only be used in Experiments,
+        // where we only have funnel and trend insights, allowing us already
+        // to gradually remove the other insight types here
+        throw new Error('Unsupported insight type')
     }
 
     return (

--- a/frontend/src/scenes/insights/LegacyInsightContainer.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightContainer.tsx
@@ -42,7 +42,7 @@ const VIEW_MAP = {
     [`${InsightType.PATHS}`]: <Paths />,
 }
 
-export function InsightContainer({
+export function LegacyInsightContainer({
     disableHeader,
     disableTable,
     disableCorrelationTable,

--- a/frontend/src/scenes/insights/LegacyInsightContainer.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightContainer.tsx
@@ -1,5 +1,5 @@
 import { Card, Col, Row } from 'antd'
-import { InsightDisplayConfig } from 'scenes/insights/InsightDisplayConfig'
+import { LegacyInsightDisplayConfig } from 'scenes/insights/InsightDisplayConfig'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { ComputationTimeWithRefresh } from 'scenes/insights/ComputationTimeWithRefresh'
 import { ChartDisplayType, ExporterFormat, FunnelVizType, InsightType, ItemMode } from '~/types'
@@ -190,7 +190,7 @@ export function LegacyInsightContainer({
             <Card
                 title={
                     disableHeader ? null : (
-                        <InsightDisplayConfig
+                        <LegacyInsightDisplayConfig
                             activeView={activeView as InsightType}
                             insightMode={insightMode || ItemMode.View}
                             filters={filters}

--- a/frontend/src/scenes/insights/LegacyInsightContainer.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightContainer.tsx
@@ -26,7 +26,6 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { FunnelStepsTable } from './views/Funnels/FunnelStepsTable'
 import { Animation } from 'lib/components/Animation/Animation'
 import { AnimationType } from 'lib/animations/animations'
-import { FunnelCorrelation } from './views/Funnels/FunnelCorrelation'
 import { FunnelInsight } from './views/Funnels/FunnelInsight'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -45,13 +44,11 @@ const VIEW_MAP = {
 export function LegacyInsightContainer({
     disableHeader,
     disableTable,
-    disableCorrelationTable,
     disableLastComputation,
     insightMode,
 }: {
     disableHeader?: boolean
     disableTable?: boolean
-    disableCorrelationTable?: boolean
     disableLastComputation?: boolean
     insightMode?: ItemMode
 }): JSX.Element {
@@ -268,7 +265,6 @@ export function LegacyInsightContainer({
                 </div>
             </Card>
             {renderTable()}
-            {!disableCorrelationTable && activeView === InsightType.FUNNELS && <FunnelCorrelation />}
         </>
     )
 }

--- a/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
@@ -90,7 +90,7 @@ function ConfigFilter(props: PropsWithChildren<ReactNode>): JSX.Element {
     return <span className="space-x-2 flex items-center text-sm">{props.children}</span>
 }
 
-export function InsightDisplayConfig({ filters, disableTable }: InsightDisplayConfigProps): JSX.Element {
+export function LegacyInsightDisplayConfig({ filters, disableTable }: InsightDisplayConfigProps): JSX.Element {
     if (!isFunnelsFilter(filters) && !isTrendsFilter(filters)) {
         // The legacy InsightContainer should only be used in Experiments,
         // where we only have funnel and trend insights, allowing us already

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeInsight.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeInsight.tsx
@@ -21,7 +21,6 @@ const Component = (props: NodeViewProps): JSX.Element => {
                 <div className="insights-container" data-attr="insight-view">
                     <LegacyInsightContainer
                         insightMode={ItemMode.Sharing}
-                        disableCorrelationTable
                         disableHeader
                         disableLastComputation
                         disableTable

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeInsight.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeInsight.tsx
@@ -1,7 +1,7 @@
 import { mergeAttributes, Node, NodeViewProps } from '@tiptap/core'
 import { ReactNodeViewRenderer } from '@tiptap/react'
 import { BindLogic, useValues } from 'kea'
-import { InsightContainer } from 'scenes/insights/InsightContainer'
+import { LegacyInsightContainer } from 'scenes/insights/LegacyInsightContainer'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightShortId, ItemMode } from '~/types'
 import { NodeWrapper } from 'scenes/notebooks/Nodes/NodeWrapper'
@@ -19,7 +19,7 @@ const Component = (props: NodeViewProps): JSX.Element => {
         <NodeWrapper nodeType={NotebookNodeType.Insight} title="Insight" href={href} heightEstimate="16rem" {...props}>
             <BindLogic logic={insightLogic} props={insightProps}>
                 <div className="insights-container" data-attr="insight-view">
-                    <InsightContainer
+                    <LegacyInsightContainer
                         insightMode={ItemMode.Sharing}
                         disableCorrelationTable
                         disableHeader


### PR DESCRIPTION
## Problem

Old code should be clearly marked as such

## Changes

This PR marks a couple of insight components where we have a newer replacement as legacy. It also throws an error when the component is used with a insight different from trends and funnel unexpectedly. 

Trends and funnels need to be supported until they are replaced in Experiments. I'm following up with PRs to remove the other insight types here and monitor for errors in Sentry.

## How did you test this code?

Visited various pages to look out for the error