### PR TITLE
fix(insights): ignore cached result when refreshing

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -75,7 +75,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 setResponse: (response) => response,
                 clearResponse: () => null,
                 loadData: async ({ refresh, queryId }, breakpoint) => {
-                    if (props.cachedResults) {
+                    if (props.cachedResults && !refresh) {
                         return props.cachedResults
                     }
 


### PR DESCRIPTION
## Problem

Refreshing an insight still doesn't work in all cases - concretely the dataNodeLogic would return a cached result early even when loading with `refresh=true`

## Changes

This PR does not return a cached result when loadData gets passed `refresh: true`

## How did you test this code?

Tried that an insight with cached results can be refreshed