### PR TITLE
chore: convert noisy log to prom counter

### DIFF
--- a/posthog/caching/tolerant_zlib_compressor.py
+++ b/posthog/caching/tolerant_zlib_compressor.py
@@ -9,13 +9,13 @@ from prometheus_client import Counter
 
 logger = structlog.get_logger(__name__)
 
-decompression_failed_counter = Counter(
-    "posthog_redis_decompression_failed_total",
+COULD_NOT_DECOMPRESS_VALUE_COUNTER = Counter(
+    "posthog_redis_could_not_decompress_value_counter",
     """
     Number of times decompression from redis failed while the setting was on.
     This is probably a sign that either there are still uncompressed values in redis
     or a value that was too small to compress and so doesn't need decompressing
-    and so, seeing postive values here isn't necessarily an error.
+    and so, seeing positive values here isn't necessarily an error.
     """,
 )
 
@@ -42,7 +42,7 @@ class TolerantZlibCompressor(BaseCompressor):
             return zlib.decompress(value)
         except zlib.error:
             if settings.USE_REDIS_COMPRESSION:
-                decompression_failed_counter.inc()
+                COULD_NOT_DECOMPRESS_VALUE_COUNTER.inc()
             # if the decompression fails, behave like the IdentityCompressor
             # this way if the compressor is turned off we can still read values
             return value

--- a/posthog/caching/tolerant_zlib_compressor.py
+++ b/posthog/caching/tolerant_zlib_compressor.py
@@ -5,8 +5,19 @@ from django_redis.compressors.base import BaseCompressor
 from django.conf import settings
 
 import structlog
+from prometheus_client import Counter
 
 logger = structlog.get_logger(__name__)
+
+decompression_failed_counter = Counter(
+    "posthog_redis_decompression_failed_total",
+    """
+    Number of times decompression from redis failed while the setting was on.
+    This is probably a sign that either there are still uncompressed values in redis
+    or a value that was too small to compress and so doesn't need decompressing
+    and so, seeing postive values here isn't necessarily an error.
+    """,
+)
 
 
 class TolerantZlibCompressor(BaseCompressor):
@@ -30,6 +41,8 @@ class TolerantZlibCompressor(BaseCompressor):
         try:
             return zlib.decompress(value)
         except zlib.error:
+            if settings.USE_REDIS_COMPRESSION:
+                decompression_failed_counter.inc()
             # if the decompression fails, behave like the IdentityCompressor
-            logger.warning("tolerant_zlib_compressor - failed to decompress value from redis, returning original value")
+            # this way if the compressor is turned off we can still read values
             return value


### PR DESCRIPTION
## Problem

Added logging here when writing the tolerant reading zlib compressor for redis, without thinking about when it would fire.

If the setting is off it warns on every cache get, which both doesn't make sense and is wasteful

## Changes

We don't care about every instance so convert it to a counter that only increments if the compression setting is on, but compression of the value in redis failed.

## How did you test this code?

🙈 