### PR TITLE
refactor(insights): remove data exploration feature flag

### DIFF
--- a/frontend/src/scenes/funnels/funnelCorrelationLogic.ts
+++ b/frontend/src/scenes/funnels/funnelCorrelationLogic.ts
@@ -17,7 +17,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { funnelDataLogic } from './funnelDataLogic'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
-import { insightLogic } from 'scenes/insights/insightLogic'
 import { appendToCorrelationConfig } from './funnelUtils'
 
 export const funnelCorrelationLogic = kea<funnelCorrelationLogicType>([
@@ -26,8 +25,6 @@ export const funnelCorrelationLogic = kea<funnelCorrelationLogicType>([
     path((key) => ['scenes', 'funnels', 'funnelCorrelationLogic', key]),
     connect((props: InsightLogicProps) => ({
         values: [
-            insightLogic(props),
-            ['isUsingDataExploration'],
             funnelLogic(props),
             ['filters'],
             funnelDataLogic(props),
@@ -140,14 +137,7 @@ export const funnelCorrelationLogic = kea<funnelCorrelationLogicType>([
         },
     }),
     selectors({
-        // apiParams for data exploration and legacy mode
         apiParams: [
-            (s) => [s.isUsingDataExploration, s.dataExplorationApiParams, s.legacyApiParams],
-            (isUsingDataExploration, dataExplorationApiParams, legacyApiParams) => {
-                return isUsingDataExploration ? dataExplorationApiParams : legacyApiParams
-            },
-        ],
-        dataExplorationApiParams: [
             (s) => [s.querySource],
             (querySource) => {
                 const cleanedParams: Partial<FunnelsFilterType> = querySource
@@ -156,22 +146,7 @@ export const funnelCorrelationLogic = kea<funnelCorrelationLogicType>([
                 return cleanedParams
             },
         ],
-        legacyApiParams: [
-            (s) => [s.filters],
-            (filters) => {
-                const cleanedParams: Partial<FunnelsFilterType> = cleanFilters(filters)
-                return cleanedParams
-            },
-        ],
-        // aggregationGroupTypeIndex for data exploration and legacy mode
-        aggregationGroupTypeIndex: [
-            (s) => [s.isUsingDataExploration, s.querySource, s.filters],
-            (isUsingDataExploration, querySource, filters) => {
-                return isUsingDataExploration
-                    ? querySource?.aggregation_group_type_index
-                    : filters?.aggregation_group_type_index
-            },
-        ],
+        aggregationGroupTypeIndex: [(s) => [s.querySource], (querySource) => querySource?.aggregation_group_type_index],
 
         // event correlation
         correlationValues: [

--- a/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
@@ -28,7 +28,7 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
             insightVizDataLogic(props.insightProps),
             ['querySource'],
             insightLogic(props.insightProps),
-            ['filters', 'isUsingDataExploration'],
+            ['filters'],
             featureFlagLogic,
             ['featureFlags'],
         ],
@@ -94,21 +94,7 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
         },
     })),
     subscriptions(({ values, actions }) => ({
-        filters: (filters) => {
-            if (values.isUsingDataExploration) {
-                return
-            }
-
-            const newSamplingPercentage = filters.sampling_factor ? filters.sampling_factor * 100 : null
-            if (newSamplingPercentage !== values.samplingPercentage) {
-                actions.setSamplingPercentage(newSamplingPercentage)
-            }
-        },
         querySource: (querySource) => {
-            if (!values.isUsingDataExploration) {
-                return
-            }
-
             const newSamplingPercentage = querySource?.samplingFactor ? querySource.samplingFactor * 100 : null
             if (newSamplingPercentage !== values.samplingPercentage) {
                 actions.setSamplingPercentage(newSamplingPercentage)

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -63,7 +63,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         insightSaving,
         hasDashboardItemId,
         exporterResourceParams,
-        isUsingDataExploration,
         isUsingDashboardQueries,
     } = useValues(logic)
     const { setInsightMetadata, saveAs } = useActions(logic)
@@ -320,7 +319,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 insightChanged={insightChanged || queryChanged}
                             />
                         )}
-                        {isUsingDataExploration && isInsightVizNode(query) ? (
+                        {isInsightVizNode(query) ? (
                             <LemonButton
                                 tooltip={
                                     showQueryEditor ? (

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -630,14 +630,12 @@ export const insightLogic = kea<insightLogicType>([
                 insight.effective_privilege_level >= DashboardPrivilegeLevel.CanEdit,
         ],
         insightChanged: [
-            (s) => [s.insight, s.savedInsight, s.filters, s.isUsingDataExploration],
-            (insight, savedInsight, filters, isUsingDataExploration): boolean => {
+            (s) => [s.insight, s.savedInsight],
+            (insight, savedInsight): boolean => {
                 return (
                     (insight.name || '') !== (savedInsight.name || '') ||
                     (insight.description || '') !== (savedInsight.description || '') ||
-                    !objectsEqual(insight.tags || [], savedInsight.tags || []) ||
-                    (!isUsingDataExploration &&
-                        !objectsEqual(cleanFilters(savedInsight.filters || {}), cleanFilters(filters || {})))
+                    !objectsEqual(insight.tags || [], savedInsight.tags || [])
                 )
             },
         ],
@@ -777,12 +775,6 @@ export const insightLogic = kea<insightLogicType>([
                 )
             },
         ],
-        isUsingDataExploration: [
-            () => [],
-            (): boolean => {
-                return true
-            },
-        ],
         isUsingDashboardQueries: [
             (s) => [s.featureFlags],
             (featureFlags: FeatureFlagsSet): boolean => {
@@ -833,7 +825,7 @@ export const insightLogic = kea<insightLogicType>([
 
             // (Re)load results when filters have changed or if there's no result yet
             if (backendFilterChanged || !values.insight?.result) {
-                if ((!values.isUsingDataExploration || props.disableDataExploration) && !values.insight?.query) {
+                if (props.disableDataExploration && !values.insight?.query) {
                     actions.loadResults()
                 }
             }

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -95,10 +95,6 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                 },
             ],
         ],
-        isUsingDataExploration: [
-            (s) => [s.insightLogicRef],
-            (insightLogicRef) => !!insightLogicRef?.logic.values.isUsingDataExploration,
-        ],
     })),
     sharedListeners(({ actions, values }) => ({
         reloadInsightLogic: () => {
@@ -206,8 +202,6 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     )
 
                     eventUsageLogic.actions.reportInsightCreated(filters?.insight || InsightType.TRENDS)
-                } else if (filters && !values.isUsingDataExploration) {
-                    values.insightLogicRef?.logic.actions.setFilters(cleanFilters(filters || {}))
                 }
             }
 

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { ActionsPie, ActionsLineGraph, ActionsHorizontalBar } from './viz'
 import { trendsLogic } from './trendsLogic'
 import { ChartDisplayType, InsightType, ItemMode } from '~/types'
-import { InsightsTable, InsightsTableDataExploration } from 'scenes/insights/views/InsightsTable/InsightsTable'
+import { InsightsTableDataExploration } from 'scenes/insights/views/InsightsTable/InsightsTable'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { WorldMap } from 'scenes/insights/views/WorldMap'
@@ -16,7 +16,7 @@ interface Props {
 
 export function TrendInsight({ view }: Props): JSX.Element {
     const { insightMode } = useValues(insightSceneLogic)
-    const { insightProps, isUsingDataExploration } = useValues(insightLogic)
+    const { insightProps } = useValues(insightLogic)
     const { filters: _filters, loadMoreBreakdownUrl, breakdownValuesLoading } = useValues(trendsLogic(insightProps))
     const { loadMoreBreakdownValues } = useActions(trendsLogic(insightProps))
     const display = isTrendsFilter(_filters) || isStickinessFilter(_filters) ? _filters.display : null
@@ -35,7 +35,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
             return <BoldNumber />
         }
         if (display === ChartDisplayType.ActionsTable) {
-            const ActionsTable = isUsingDataExploration ? InsightsTableDataExploration : InsightsTable
+            const ActionsTable = InsightsTableDataExploration
             return (
                 <ActionsTable
                     embedded


### PR DESCRIPTION
## Problem

Feature flags need to be cleaned up

## Changes

This PR removes the feature flag selector `isUsingDataExploration` from the `insightLogic` along with related cleanup

## How did you test this code?

Opened a new and a saved insight