### PR TITLE
chore: allow plugins to be made non-global but continue to work

### DIFF
--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -32,7 +32,6 @@ function pluginConfigsInForceQuery(specificField?: keyof PluginConfig): string {
        LEFT JOIN posthog_plugin ON posthog_plugin.id = posthog_pluginconfig.plugin_id
        WHERE (
            posthog_pluginconfig.enabled='t' AND posthog_organization.plugins_access_level > 0
-           AND (posthog_plugin.organization_id = posthog_organization.id OR posthog_plugin.is_global)
        )`
 }
 


### PR DESCRIPTION
We want to be able to make plugins non-global, but we don't want to
break existing plugins. This commit adds a test to ensure that plugins
continue to work when they are made non-global.

Previously they would have been disabled by the `is_global` check.

TODO: what will be the impact of making this change.

See https://github.com/PostHog/product-internal/issues/488 for context.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
