### PR TITLE
chore: Default async migrations to be off

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -123,6 +123,8 @@ services:
         restart: 'no'
         deploy:
             replicas: 0
+        environment:
+            SKIP_ASYNC_MIGRATIONS_SETUP: 0
 
     # Temporal containers
     elasticsearch:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -105,6 +105,7 @@ services:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
+            SKIP_ASYNC_MIGRATIONS_SETUP: 0
 
     # Temporal containers
     temporal:

--- a/posthog/settings/async_migrations.py
+++ b/posthog/settings/async_migrations.py
@@ -1,12 +1,8 @@
-from posthog.settings.base_variables import E2E_TESTING, TEST
-from posthog.settings.overrides import cmd
-from posthog.settings.service_requirements import SKIP_SERVICE_VERSION_REQUIREMENTS
 from posthog.settings.utils import get_from_env, str_to_bool
 
-_default_skip_async_migrations_setup = TEST or E2E_TESTING or SKIP_SERVICE_VERSION_REQUIREMENTS or cmd != "runserver"
-SKIP_ASYNC_MIGRATIONS_SETUP = get_from_env(
-    "SKIP_ASYNC_MIGRATIONS_SETUP", _default_skip_async_migrations_setup, type_cast=str_to_bool
-)
+# To help reduce PG load during deploys we're setting this to True by default.
+# We don't currently have any async migrations that need to be added/ran.
+SKIP_ASYNC_MIGRATIONS_SETUP = get_from_env("SKIP_ASYNC_MIGRATIONS_SETUP", True, type_cast=str_to_bool)
 
 ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS = get_from_env(
     "ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS", 2 * 60 * 60, type_cast=int


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We don't currently have any async migrations and future ones might be done via temporal 🤷‍♀️ 
Making sure we always avoid doing this by default rather than making sure we don't mess up envs in the chart is safer for our clouds not to relay on Postgres during startup.

We're seeing warnings about the envs currently during deploys - showing an example of how we might mess up on that side.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
