### PR TITLE
feat: add autocapture opt out to team info in admin

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -19,10 +19,10 @@ from posthog.models import (
     OrganizationMembership,
     Person,
     Plugin,
+    PluginAttachment,
     PluginConfig,
     Team,
     User,
-    PluginAttachment,
 )
 
 admin.site.register(Person)
@@ -210,6 +210,7 @@ class OrganizationTeamInline(admin.TabularInline):
         "completed_snippet_onboarding",
         "ingested_event",
         "session_recording_opt_in",
+        "autocapture_opt_out",
         "signup_token",
         "is_demo",
         "access_control",


### PR DESCRIPTION
## Problem

A customer had questions about autocapture opt out setting and I realized it's not in the org admin for us to easily look at / change. It does exist on the TeamAdmin.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Added it to admin panel.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
