### PR TITLE
chore(early-access-feature): remove scene and use table

### DIFF
--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -7,7 +7,6 @@ import { earlyAccessFeatureLogic } from './earlyAccessFeatureLogic'
 import { Form } from 'kea-forms'
 import { EarlyAccessFeatureStage, EarlyAccessFeatureType, PropertyFilterType, PropertyOperator } from '~/types'
 import { urls } from 'scenes/urls'
-import { PersonsScene } from 'scenes/persons/Persons'
 import { IconClose, IconFlag, IconHelpOutline } from 'lib/lemon-ui/icons'
 import { router } from 'kea-router'
 import { useState } from 'react'
@@ -20,6 +19,8 @@ import { PersonsLogicProps, personsLogic } from 'scenes/persons/personsLogic'
 import clsx from 'clsx'
 import { InstructionsModal } from './InstructionsModal'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { PersonsTable } from 'scenes/persons/PersonsTable'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 
 export const scene: SceneExport = {
     component: EarlyAccessFeature,
@@ -294,37 +295,54 @@ function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element {
         ],
     }
     const logic = personsLogic(personsLogicProps)
-    const { persons } = useValues(logic)
+    const { persons, personsLoading, listFilters } = useValues(logic)
+    const { loadPersons, setListFilters } = useActions(logic)
     const { featureFlag } = useValues(featureFlagLogic({ id: earlyAccessFeature.feature_flag.id || 'link' }))
 
     return (
         <BindLogic logic={personsLogic} props={personsLogicProps}>
             <h3 className="text-xl font-semibold">Opted-In Users</h3>
-            <PersonsScene
-                showSearch={persons.results.length > 0}
-                showFilters={persons.results.length > 0}
-                extraSceneActions={
-                    persons.results.length > 0
-                        ? [
-                              <LemonButton
-                                  key="help-button"
-                                  onClick={toggleImplementOptInInstructionsModal}
-                                  sideIcon={<IconHelpOutline />}
-                              >
-                                  Implement public opt-in
-                              </LemonButton>,
-                          ]
-                        : []
-                }
-                compact={true}
-                showExportAction={false}
-                emptyState={
-                    <div>
-                        No manual opt-ins. Manually opted-in people will appear here. Start by{' '}
-                        <a onClick={toggleImplementOptInInstructionsModal}>implementing public opt-in</a>
+
+            <div className="space-y-2">
+                {persons.results.length > 0 && (
+                    <div className="flex flex-row justify-between">
+                        <PropertyFilters
+                            pageKey="persons-list-page"
+                            propertyFilters={listFilters.properties}
+                            onChange={(properties) => {
+                                setListFilters({ properties })
+                                loadPersons()
+                            }}
+                            endpoint="person"
+                            taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties]}
+                            showConditionBadge
+                        />
+                        <LemonButton
+                            key="help-button"
+                            onClick={toggleImplementOptInInstructionsModal}
+                            sideIcon={<IconHelpOutline />}
+                        >
+                            Implement public opt-in
+                        </LemonButton>
                     </div>
-                }
-            />
+                )}
+                <PersonsTable
+                    people={persons.results}
+                    loading={personsLoading}
+                    hasPrevious={!!persons.previous}
+                    hasNext={!!persons.next}
+                    loadPrevious={() => loadPersons(persons.previous)}
+                    loadNext={() => loadPersons(persons.next)}
+                    compact={true}
+                    extraColumns={[]}
+                    emptyState={
+                        <div>
+                            No manual opt-ins. Manually opted-in people will appear here. Start by{' '}
+                            <a onClick={toggleImplementOptInInstructionsModal}>implementing public opt-in</a>
+                        </div>
+                    }
+                />
+            </div>
             <InstructionsModal
                 featureFlag={featureFlag}
                 visible={implementOptInInstructionsModal}

--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -48,8 +48,6 @@ export function PersonsScene({
     const { loadPersons, setListFilters } = useActions(personsLogic)
     const { persons, listFilters, personsLoading, exporterProps, apiDocsURL } = useValues(personsLogic)
 
-    console.log(persons.results.length, personsLoading, Object.keys(listFilters).length, listFilters)
-
     return persons.results.length > 0 || personsLoading || Object.keys(listFilters).length > 1 || listFilters.search ? (
         <div className="persons-list">
             <div className="space-y-2">


### PR DESCRIPTION
## Problem

- persons scene has a new empty state that isn't relevant to early access feature
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- use table not scene

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
