### PR TITLE
chore: make duration type selector trackable

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/DurationTypeSelect.tsx
+++ b/frontend/src/scenes/session-recordings/filters/DurationTypeSelect.tsx
@@ -9,6 +9,7 @@ interface DurationTypeFilterProps {
 export function DurationTypeSelect({ onChange, value }: DurationTypeFilterProps): JSX.Element {
     return (
         <LemonSelect
+            data-attr="duration-type-selector"
             onChange={(v) => onChange((v || 'all') as DurationTypeFilter)}
             options={[
                 {


### PR DESCRIPTION
You can't track the duration type selector with autocapture because it is in a popover not its apparent parent

so, add a data-attr