### PR TITLE
fix: update logic status when selecting recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
@@ -8,7 +8,8 @@ import { sessionRecordingDataLogic } from '../player/sessionRecordingDataLogic'
 
 describe('sessionRecordingsListLogic', () => {
     let logic: ReturnType<typeof sessionRecordingsListLogic.build>
-    const listOfSessionRecordings = [{ id: 'abc', viewed: false, recording_duration: 10 }]
+    const aRecording = { id: 'abc', viewed: false, recording_duration: 10 }
+    const listOfSessionRecordings = [aRecording]
 
     beforeEach(() => {
         useMocks({
@@ -292,45 +293,40 @@ describe('sessionRecordingsListLogic', () => {
         })
 
         describe('sessionRecording.viewed', () => {
-            it('changes when setSelectedRecordingId is called', () => {
-                expectLogic(logic, () => {
-                    logic.actions.getSessionRecordingsSuccess({
-                        results: [
+            it('changes when setSelectedRecordingId is called', async () => {
+                await expectLogic(logic)
+                    .toFinishAllListeners()
+                    .toMatchValues({
+                        sessionRecordingsResponse: {
+                            results: [{ ...aRecording }],
+                        },
+                        sessionRecordings: [
                             {
-                                id: 'abc',
-                                viewed: false,
-                                recording_duration: 1,
-                                start_time: '',
-                                end_time: '',
+                                ...aRecording,
                             },
                         ],
-                        has_next: false,
                     })
-                }).toMatchValues({
-                    sessionRecordings: [
-                        {
-                            id: 'abc',
-                            viewed: false,
-                            recording_duration: 1,
-                            start_time: '',
-                            end_time: '',
-                        },
-                    ],
-                })
 
-                expectLogic(logic, () => {
+                await expectLogic(logic, () => {
                     logic.actions.setSelectedRecordingId('abc')
-                }).toMatchValues({
-                    sessionRecordings: [
-                        {
-                            id: 'abc',
-                            viewed: true,
-                            recording_duration: 1,
-                            start_time: '',
-                            end_time: '',
-                        },
-                    ],
                 })
+                    .toFinishAllListeners()
+                    .toMatchValues({
+                        sessionRecordingsResponse: {
+                            results: [
+                                {
+                                    ...aRecording,
+                                    viewed: true,
+                                },
+                            ],
+                        },
+                        sessionRecordings: [
+                            {
+                                ...aRecording,
+                                viewed: true,
+                            },
+                        ],
+                    })
             })
 
             it('is set by setFilters and loads filtered results', async () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -232,6 +232,24 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                         results: mergedResults,
                     }
                 },
+                setSelectedRecordingId: async ({ id }) => {
+                    const existing = [...(values.sessionRecordingsResponse?.results ?? [])]
+
+                    const updatedResults = existing.map((recording) => {
+                        if (recording.id === id) {
+                            return {
+                                ...recording,
+                                viewed: true,
+                            }
+                        }
+                        return recording
+                    })
+
+                    return {
+                        has_next: values.sessionRecordingsResponse.has_next,
+                        results: updatedResults,
+                    }
+                },
             },
         ],
         pinnedRecordingsResponse: [


### PR DESCRIPTION
## Problem

When the recordings list marked a recording as viewed it did not update all of the state in the list logic. So, when loading more recordings in the infinite scroller the viewed status would appear to reset.

## Changes

Update the rest of the state

## How did you test this code?

Seeing it work locally