### PR TITLE
feat(webhooks): Support person display name preferences and nested properties

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -63,7 +63,7 @@ export const privilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
 
 // Persons
 export const PERSON_DISTINCT_ID_MAX_SIZE = 3
-// Sync with api/person.py
+// Sync with .../api/person.py and .../ingestion/hooks.ts
 export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     'email',
     'Email',

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -39,8 +39,9 @@ export function asDisplay(person: PersonPropType | null | undefined, maxLength?:
         return 'Unknown'
     }
     const team = teamLogic.findMounted()?.values?.currentTeam
-    const personDisplayNameProperties = team?.person_display_name_properties ?? PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
 
+    // Sync the logic below with the plugin server `getPersonDetails`
+    const personDisplayNameProperties = team?.person_display_name_properties ?? PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
     const customPropertyKey = personDisplayNameProperties.find((x) => person.properties?.[x])
     const propertyIdentifier = customPropertyKey ? person.properties?.[customPropertyKey] : undefined
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -514,7 +514,7 @@ export interface Team {
     name: string
     anonymize_ips: boolean
     api_token: string
-    slack_incoming_webhook: string
+    slack_incoming_webhook: string | null
     session_recording_opt_in: boolean
     ingested_event: boolean
     person_display_name_properties: string[] | null

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -517,6 +517,7 @@ export interface Team {
     slack_incoming_webhook: string
     session_recording_opt_in: boolean
     ingested_event: boolean
+    person_display_name_properties: string[] | null
 }
 
 /** Properties shared by RawEventMessage and EventMessage. */

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import { Properties } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import { randomBytes } from 'crypto'
 import Redis, { RedisOptions } from 'ioredis'
@@ -580,4 +581,19 @@ export function stalenessCheck(hub: Hub | undefined, stalenessSeconds: number): 
         lastActivity: hub?.lastActivity ? new Date(hub.lastActivity).toISOString() : null,
         lastActivityType: hub?.lastActivityType,
     }
+}
+
+/** Get a value from a properties object by its path. This allows accessing nested properties. */
+export function getPropertyValueByPath(properties: Properties, [firstKey, ...nestedKeys]: string[]): any {
+    if (firstKey === undefined) {
+        throw new Error('No path to property was provided')
+    }
+    let value = properties[firstKey]
+    for (const key of nestedKeys) {
+        if (value === undefined) {
+            return undefined
+        }
+        value = value[key]
+    }
+    return value
 }

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -6,7 +6,7 @@ import { Action, Hook, PostIngestionEvent, Team } from '../../types'
 import { DB } from '../../utils/db/db'
 import fetch from '../../utils/fetch'
 import { status } from '../../utils/status'
-import { stringify } from '../../utils/utils'
+import { getPropertyValueByPath, stringify } from '../../utils/utils'
 import { OrganizationManager } from './organization-manager'
 import { SiteUrlManager } from './site-url-manager'
 import { TeamManager } from './team-manager'
@@ -157,8 +157,9 @@ export function getValueOfToken(
         if (tokenParts.length === 1) {
             ;[text, markdown] = getPersonDetails(event, team, siteUrl, webhookType)
         } else if (tokenParts[1] === 'properties' && tokenParts.length > 2) {
-            const propertyName = tokenParts[2]
-            const property = event.person_properties?.[propertyName]
+            const property = event.person_properties
+                ? getPropertyValueByPath(event.person_properties, tokenParts.slice(2))
+                : undefined
             markdown = text = webhookEscape(property, webhookType)
         }
     } else if (tokenParts[0] === 'action') {
@@ -178,8 +179,9 @@ export function getValueOfToken(
         } else if (tokenParts[1] === 'distinct_id') {
             markdown = text = webhookEscape(event.distinctId, webhookType)
         } else if (tokenParts[1] === 'properties' && tokenParts.length > 2) {
-            const propertyName = tokenParts[2]
-            const property = event.properties?.[propertyName]
+            const property = event.properties
+                ? getPropertyValueByPath(event.properties, tokenParts.slice(2))
+                : undefined
             markdown = text = webhookEscape(property, webhookType)
         }
     } else {

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -2,7 +2,7 @@ import { captureException } from '@sentry/node'
 import { StatsD } from 'hot-shots'
 import { format } from 'util'
 
-import { Action, Hook, PostIngestionEvent } from '../../types'
+import { Action, Hook, PostIngestionEvent, Team } from '../../types'
 import { DB } from '../../utils/db/db'
 import fetch from '../../utils/fetch'
 import { status } from '../../utils/status'
@@ -74,13 +74,34 @@ export function toWebhookLink(text: string | null, url: string, webhookType: Web
     }
 }
 
-export function getUserDetails(event: PostIngestionEvent, siteUrl: string, webhookType: WebhookType): [string, string] {
-    const userName =
-        event.person_properties?.email ||
-        event.person_properties?.name ||
-        event.person_properties?.username ||
-        event.distinctId
-    return toWebhookLink(userName, `${siteUrl}/person/${encodeURIComponent(event.distinctId)}`, webhookType)
+// Sync with .../api/person.py and .../lib/constants.tsx
+export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
+    'email',
+    'Email',
+    'name',
+    'Name',
+    'username',
+    'Username',
+    'UserName',
+]
+
+export function getPersonDetails(
+    event: PostIngestionEvent,
+    team: Team,
+    siteUrl: string,
+    webhookType: WebhookType
+): [string, string] {
+    // Sync the logic below with the frontend `asDisplay`
+    const personDisplayNameProperties = team.person_display_name_properties ?? PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
+    const customPropertyKey = personDisplayNameProperties.find((x) => event.person_properties?.[x])
+    const propertyIdentifier = customPropertyKey ? event.person_properties[customPropertyKey] : undefined
+
+    const customIdentifier: string =
+        typeof propertyIdentifier !== 'string' ? JSON.stringify(propertyIdentifier) : propertyIdentifier
+
+    const display: string | undefined = (customIdentifier || event.distinctId)?.trim()
+
+    return toWebhookLink(display, `${siteUrl}/person/${encodeURIComponent(event.distinctId)}`, webhookType)
 }
 
 export function getActionDetails(action: Action, siteUrl: string, webhookType: WebhookType): [string, string] {
@@ -114,6 +135,7 @@ export function getTokens(messageFormat: string): [string[], string] {
 export function getValueOfToken(
     action: Action,
     event: PostIngestionEvent,
+    team: Team,
     siteUrl: string,
     webhookType: WebhookType,
     tokenParts: string[]
@@ -125,7 +147,7 @@ export function getValueOfToken(
         // [user.name] and [user.foo] are DEPRECATED as they had odd mechanics
         // [person] OR [event.properties.bar] should be used instead
         if (tokenParts[1] === 'name') {
-            ;[text, markdown] = getUserDetails(event, siteUrl, webhookType)
+            ;[text, markdown] = getPersonDetails(event, team, siteUrl, webhookType)
         } else {
             const propertyName = `$${tokenParts[1]}`
             const property = event.properties?.[propertyName]
@@ -133,7 +155,7 @@ export function getValueOfToken(
         }
     } else if (tokenParts[0] === 'person') {
         if (tokenParts.length === 1) {
-            ;[text, markdown] = getUserDetails(event, siteUrl, webhookType)
+            ;[text, markdown] = getPersonDetails(event, team, siteUrl, webhookType)
         } else if (tokenParts[1] === 'properties' && tokenParts.length > 2) {
             const propertyName = tokenParts[2]
             const property = event.person_properties?.[propertyName]
@@ -169,6 +191,7 @@ export function getValueOfToken(
 export function getFormattedMessage(
     action: Action,
     event: PostIngestionEvent,
+    team: Team,
     siteUrl: string,
     webhookType: WebhookType
 ): [string, string] {
@@ -184,7 +207,7 @@ export function getFormattedMessage(
         for (const token of tokens) {
             const tokenParts = token.match(/\$\w+|\$\$\w+|\w+/g) || []
 
-            const [value, markdownValue] = getValueOfToken(action, event, siteUrl, webhookType, tokenParts)
+            const [value, markdownValue] = getValueOfToken(action, event, team, siteUrl, webhookType, tokenParts)
             values.push(value)
             markdownValues.push(markdownValue)
         }
@@ -242,7 +265,7 @@ export class HookCommander {
         if (webhookUrl) {
             const webhookRequests = actionMatches
                 .filter((action) => action.post_to_slack)
-                .map((action) => this.postWebhook(webhookUrl, action, event))
+                .map((action) => this.postWebhook(webhookUrl, action, event, team))
             await Promise.all(webhookRequests).catch((error) =>
                 captureException(error, { tags: { team_id: event.teamId } })
             )
@@ -264,10 +287,15 @@ export class HookCommander {
         }
     }
 
-    private async postWebhook(webhookUrl: string, action: Action, event: PostIngestionEvent): Promise<void> {
+    private async postWebhook(
+        webhookUrl: string,
+        action: Action,
+        event: PostIngestionEvent,
+        team: Team
+    ): Promise<void> {
         const webhookType = determineWebhookType(webhookUrl)
         const siteUrl = await this.siteUrlManager.getSiteUrl()
-        const [messageText, messageMarkdown] = getFormattedMessage(action, event, siteUrl || '', webhookType)
+        const [messageText, messageMarkdown] = getFormattedMessage(action, event, team, siteUrl || '', webhookType)
         let message: Record<string, any>
         if (webhookType === WebhookType.Slack) {
             message = {

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -158,7 +158,8 @@ export async function fetchTeam(client: Client | Pool, teamId: Team['id']): Prom
                 api_token,
                 slack_incoming_webhook,
                 session_recording_opt_in,
-                ingested_event
+                ingested_event,
+                person_display_name_properties
             FROM posthog_team
             WHERE id = $1
             `,

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -1120,7 +1120,8 @@ describe('DB', () => {
                 session_recording_opt_in: true,
                 slack_incoming_webhook: null,
                 uuid: expect.any(String),
-            })
+                person_display_name_properties: [],
+            } as Team)
         })
 
         it('returns null if the team does not exist', async () => {

--- a/plugin-server/tests/utils.test.ts
+++ b/plugin-server/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
     clickHouseTimestampToDateTime,
     cloneObject,
     escapeClickHouseString,
+    getPropertyValueByPath,
     groupBy,
     sanitizeSqlIdentifier,
     stringify,
@@ -277,5 +278,26 @@ describe('utils', () => {
                 DateTime.fromISO('2020-02-23T02:15:00.000Z').toUTC()
             )
         })
+    })
+})
+
+describe('getPropertyValueByPath', () => {
+    it('returns primitive value when present', () => {
+        expect(getPropertyValueByPath({ a: { b: 1 } }, ['a', 'b'])).toEqual(1)
+    })
+    it('returns object value when present', () => {
+        expect(getPropertyValueByPath({ a: { b: 1 } }, ['a'])).toEqual({ b: 1 })
+    })
+    it('returns undefined when not present', () => {
+        expect(getPropertyValueByPath({ a: { b: 1 } }, ['a', 'c'])).toEqual(undefined)
+    })
+    it('returns undefined when trying to access a property of a primitive', () => {
+        expect(getPropertyValueByPath({ a: { b: 1 } }, ['a', 'b', 'c', 'd'])).toEqual(undefined)
+    })
+    it('returns value from array', () => {
+        expect(getPropertyValueByPath({ a: { b: [1, 2, 3] } }, ['a', 'b', '1'])).toEqual(2)
+    })
+    it('requires at least one path key', () => {
+        expect(() => getPropertyValueByPath({ a: { b: 'foo' } }, [])).toThrowError('No path to property was provided')
     })
 })

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -64,6 +64,7 @@ from posthog.tasks.split_person import split_person
 from posthog.utils import convert_property_value, format_query_params_absolute_url, is_anonymous_id, relative_date_parse
 
 DEFAULT_PAGE_LIMIT = 100
+# Sync with .../lib/constants.tsx and .../ingestion/hooks.ts
 PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     "email",
     "Email",

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -262,66 +262,63 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging
-  'SELECT 1'
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
   '
   
   SET LOCAL statement_timeout = 2
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
+  '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.2
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
   '
-  
-  SET LOCAL statement_timeout = 2
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
-  '
   WITH target_person_ids AS
     (SELECT team_id,
             person_id
@@ -364,13 +361,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -378,6 +375,20 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
+  '
+  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
+         "posthog_featureflaghashkeyoverride"."hash_key",
+         "posthog_featureflaghashkeyoverride"."person_id"
+  FROM "posthog_featureflaghashkeyoverride"
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
+                                                              2,
+                                                              3,
+                                                              4,
+                                                              5 /* ... */)
+         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.7

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -262,62 +262,65 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging
-  '
-  
-  SET LOCAL statement_timeout = 2
-  '
+  'SELECT 1'
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.2
   '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
+  '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
   '
   WITH target_person_ids AS
     (SELECT team_id,
@@ -361,13 +364,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -375,20 +378,6 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
-  '
-  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
-         "posthog_featureflaghashkeyoverride"."hash_key",
-         "posthog_featureflaghashkeyoverride"."person_id"
-  FROM "posthog_featureflaghashkeyoverride"
-  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
-                                                              2,
-                                                              3,
-                                                              4,
-                                                              5 /* ... */)
-         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.7


### PR DESCRIPTION
## Problem

We allow setting custom person display name preferences in project settings, but webhooks didn't support this, which was confusing. This was reported by a user: ZEN-3383
Additionally, now that we're adding support for nested properties in HogQL, we should support them in webhooks too intuitively.

## Changes

We now use `Team.person_display_name_properties` in the plugin server, just like we've been doing on the frontend. And nested properties are supported.

## How did you test this code?

Added plugin server tests.