### PR TITLE
chore(msw): allow specifying an MSW handler for a mock

### DIFF
--- a/frontend/src/mocks/utils.ts
+++ b/frontend/src/mocks/utils.ts
@@ -17,11 +17,16 @@ export const mocksToHandlers = (mocks: Mocks): ReturnType<(typeof rest)['get']>[
             response.push(
                 (rest[method] as (typeof rest)['get'])(pathWithoutTrailingSlash, async (req, res, ctx) => {
                     if (typeof handler === 'function') {
-                        const responseArray = await handler(req, res, ctx)
-                        if (responseArray.length === 2 && typeof responseArray[0] === 'number') {
-                            return res(ctx.status(responseArray[0]), ctx.json(responseArray[1] ?? null))
+                        const response = await handler(req, res, ctx)
+                        if (Array.isArray(response)) {
+                            const responseArray = response
+                            if (responseArray.length === 2 && typeof responseArray[0] === 'number') {
+                                return res(ctx.status(responseArray[0]), ctx.json(responseArray[1] ?? null))
+                            }
+                            return res(...responseArray)
+                        } else {
+                            return response
                         }
-                        return res(...responseArray)
                     } else {
                         return res(ctx.json(handler ?? null))
                     }


### PR DESCRIPTION
We've got a couple of abstractions over the MSW handler, but I want to
be able to, e.g. add delays into handlers to better simulate real world
scenarios (e.g. loading spinners).

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
