### PR TITLE
feat: filter recordings by inactive duration

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/DurationFilter.test.ts
+++ b/frontend/src/scenes/session-recordings/filters/DurationFilter.test.ts
@@ -23,6 +23,15 @@ describe('DurationFilter', () => {
             [PropertyOperator.GreaterThan, 3600, 'active_seconds', '> 1 active hour'],
             [PropertyOperator.GreaterThan, 3601, 'active_seconds', '> 3601 active seconds'],
             [PropertyOperator.GreaterThan, 3660, 'active_seconds', '> 61 active minutes'],
+            [PropertyOperator.GreaterThan, 0, 'inactive_seconds', '> 0 inactive seconds'],
+            [PropertyOperator.GreaterThan, 1, 'inactive_seconds', '> 1 inactive second'],
+            [PropertyOperator.GreaterThan, 60, 'inactive_seconds', '> 1 inactive minute'],
+            [PropertyOperator.GreaterThan, 61, 'inactive_seconds', '> 61 inactive seconds'],
+            [PropertyOperator.GreaterThan, 120, 'inactive_seconds', '> 2 inactive minutes'],
+            [PropertyOperator.GreaterThan, 121, 'inactive_seconds', '> 121 inactive seconds'],
+            [PropertyOperator.GreaterThan, 3600, 'inactive_seconds', '> 1 inactive hour'],
+            [PropertyOperator.GreaterThan, 3601, 'inactive_seconds', '> 3601 inactive seconds'],
+            [PropertyOperator.GreaterThan, 3660, 'inactive_seconds', '> 61 inactive minutes'],
             [PropertyOperator.LessThan, 0, 'active_seconds', '< 0 active seconds'],
         ])('converts the value correctly for total duration', async (operator, value, durationType, expectation) => {
             const filter: RecordingDurationFilter = {

--- a/frontend/src/scenes/session-recordings/filters/DurationFilter.tsx
+++ b/frontend/src/scenes/session-recordings/filters/DurationFilter.tsx
@@ -15,13 +15,19 @@ interface Props {
     usesListingV3?: boolean
 }
 
+const durationTypeMapping: Record<DurationTypeFilter, string> = {
+    duration: '',
+    active_seconds: 'active ',
+    inactive_seconds: 'inactive ',
+}
+
 export const humanFriendlyDurationFilter = (
     recordingDurationFilter: RecordingDurationFilter,
     durationTypeFilter: DurationTypeFilter
 ): string => {
     const operator = recordingDurationFilter.operator === PropertyOperator.GreaterThan ? '>' : '<'
     const duration = convertSecondsToDuration(recordingDurationFilter.value || 0)
-    const durationDescription = durationTypeFilter === 'active_seconds' ? 'active ' : ''
+    const durationDescription = durationTypeMapping[durationTypeFilter]
     const unit = duration.timeValue === 1 ? duration.unit.slice(0, -1) : duration.unit
     return `${operator} ${duration.timeValue || 0} ${durationDescription}${unit}`
 }

--- a/frontend/src/scenes/session-recordings/filters/DurationTypeSelect.tsx
+++ b/frontend/src/scenes/session-recordings/filters/DurationTypeSelect.tsx
@@ -20,6 +20,10 @@ export function DurationTypeSelect({ onChange, value }: DurationTypeFilterProps)
                     label: 'active duration',
                     value: 'active_seconds',
                 },
+                {
+                    label: 'inactive duration',
+                    value: 'inactive_seconds',
+                },
             ]}
             size="small"
             value={value || 'duration'}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -679,7 +679,7 @@ export interface RecordingDurationFilter extends BasePropertyFilter {
     operator: PropertyOperator
 }
 
-export type DurationTypeFilter = 'duration' | 'active_seconds'
+export type DurationTypeFilter = 'duration' | 'active_seconds' | 'inactive_seconds'
 
 export interface RecordingFilters {
     date_from?: string | null

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -137,7 +137,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
             list_recordings(filter, request, context=self.get_serializer_context(), v2=use_v2_list, v3=use_v3_list)
         )
 
-    # Returns meta data about the recording
+    # Returns metadata about the recording
     def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         recording = self.get_object()
 

--- a/posthog/api/test/test_annotation.py
+++ b/posthog/api/test/test_annotation.py
@@ -40,7 +40,7 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
             content=now().isoformat(),
         )
 
-        with self.assertNumQueries(6), snapshot_postgres_queries_context(self):
+        with self.assertNumQueries(FuzzyInt(6, 7)), snapshot_postgres_queries_context(self):
             response = self.client.get(f"/api/projects/{self.team.id}/annotations/").json()
             self.assertEqual(len(response["results"]), 1)
 
@@ -52,7 +52,7 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
             content=now().isoformat(),
         )
 
-        with self.assertNumQueries(6), snapshot_postgres_queries_context(self):
+        with self.assertNumQueries(FuzzyInt(6, 7)), snapshot_postgres_queries_context(self):
             response = self.client.get(f"/api/projects/{self.team.id}/annotations/").json()
             self.assertEqual(len(response["results"]), 2)
 

--- a/posthog/api/test/test_annotation.py
+++ b/posthog/api/test/test_annotation.py
@@ -6,7 +6,7 @@ from django.utils.timezone import now
 from rest_framework import status
 
 from posthog.models import Annotation, Organization, Team, User
-from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries_context
+from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries_context, FuzzyInt
 
 
 class TestAnnotation(APIBaseTest, QueryMatchingTest):
@@ -28,7 +28,7 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
         """
         see https://sentry.io/organizations/posthog/issues/3706110236/events/db0167ece56649f59b013cbe9de7ba7a/?project=1899813
         """
-        with self.assertNumQueries(6), snapshot_postgres_queries_context(self):
+        with self.assertNumQueries(FuzzyInt(6, 7)), snapshot_postgres_queries_context(self):
             response = self.client.get(f"/api/projects/{self.team.id}/annotations/").json()
             self.assertEqual(len(response["results"]), 0)
 

--- a/posthog/models/filters/mixins/session_recordings.py
+++ b/posthog/models/filters/mixins/session_recordings.py
@@ -15,9 +15,9 @@ class PersonUUIDMixin(BaseParamMixin):
 
 class SessionRecordingsMixin(BaseParamMixin):
     @cached_property
-    def duration_type_filter(self) -> Literal["duration", "active_seconds"]:
+    def duration_type_filter(self) -> Literal["duration", "active_seconds", "inactive_seconds"]:
         user_value = self._data.get("duration_type_filter", None)
-        if user_value in ["duration", "active_seconds"]:
+        if user_value in ["duration", "active_seconds", "inactive_seconds"]:
             return user_value
         else:
             return "duration"

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -49,7 +49,8 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
        sum(click_count),
        sum(keypress_count),
        sum(mouse_activity_count),
-       sum(active_milliseconds)/1000 as active_seconds
+       sum(active_milliseconds)/1000 as active_seconds,
+       duration-active_seconds as inactive_seconds
     FROM session_replay_events
     PREWHERE team_id = %(team_id)s
          -- we can filter on the pre-aggregated timestamp columns
@@ -147,6 +148,7 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
             "keypress_count",
             "mouse_activity_count",
             "active_seconds",
+            "inactive_seconds",
         ]
 
         return [
@@ -161,7 +163,7 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
         return self._filter.limit or self.SESSION_RECORDINGS_DEFAULT_LIMIT
 
     def duration_clause(
-        self, duration_filter_type: Literal["duration", "active_seconds"]
+        self, duration_filter_type: Literal["duration", "active_seconds", "inactive_seconds"]
     ) -> Tuple[str, Dict[str, Any]]:
         duration_clause = ""
         duration_params = {}

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -22,7 +22,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2022-12-28 00:00:00'
   AND max_last_timestamp <= '2023-01-04 00:00:00'
@@ -60,7 +61,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2022-12-28 00:00:00'
   AND max_last_timestamp <= '2023-01-04 00:00:00'
@@ -99,7 +101,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2022-12-28 00:00:00'
   AND max_last_timestamp <= '2023-01-04 00:00:00'
@@ -148,7 +151,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-22 00:00:00'
   AND max_last_timestamp <= '2021-01-04 23:59:59'
@@ -187,7 +191,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
@@ -223,7 +228,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
@@ -259,7 +265,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
@@ -294,7 +301,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
@@ -330,7 +338,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
@@ -366,7 +375,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
@@ -394,7 +404,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -419,7 +430,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -445,7 +457,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -453,6 +466,33 @@
   GROUP BY session_id
   HAVING 1=1
   AND active_seconds > 60
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_basic_query_active_sessions.2
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-25 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 13:46:23'
+  WHERE 1=1
+  GROUP BY session_id
+  HAVING 1=1
+  AND inactive_seconds > 60
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0
@@ -471,7 +511,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -496,7 +537,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -521,7 +563,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -546,7 +589,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-01-01 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -571,7 +615,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-30 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -596,7 +641,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2020-12-28 23:59:59'
@@ -621,7 +667,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2020-12-29 23:59:59'
@@ -646,7 +693,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -672,7 +720,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -706,7 +755,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -742,7 +792,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -778,7 +829,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -815,7 +867,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -881,7 +934,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2021-08-14 00:00:00'
   AND max_last_timestamp <= '2021-08-21 20:00:00'
@@ -917,7 +971,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -953,7 +1008,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -998,7 +1054,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -1035,7 +1092,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -1072,7 +1130,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -1109,7 +1168,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -1146,7 +1206,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -1182,7 +1243,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -1218,7 +1280,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
@@ -1258,7 +1321,8 @@
          sum(click_count),
          sum(keypress_count),
          sum(mouse_activity_count),
-         sum(active_milliseconds)/1000 as active_seconds
+         sum(active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds
   FROM session_replay_events PREWHERE team_id = 2
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'

--- a/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list_from_session_replay.py
@@ -130,6 +130,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
                 "mouse_activity_count": 2,
                 "duration": 1980,
                 "active_seconds": 792.0,
+                "inactive_seconds": 1188.0,
                 "start_time": self.base_time + relativedelta(seconds=20),
                 "end_time": self.base_time + relativedelta(seconds=2000),
                 "first_url": None,
@@ -143,6 +144,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
                 "mouse_activity_count": 4,
                 "duration": 50,
                 "active_seconds": 25.0,
+                "inactive_seconds": 25.0,
                 "start_time": self.base_time,
                 "end_time": self.base_time + relativedelta(seconds=50),
                 "first_url": "https://example.io/home",
@@ -160,6 +162,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
 
         session_id_total_is_61 = f"test_basic_query_active_sessions-total-{str(uuid4())}"
         session_id_active_is_61 = f"test_basic_query_active_sessions-active-{str(uuid4())}"
+        session_id_inactive_is_61 = f"test_basic_query_active_sessions-inactive-{str(uuid4())}"
 
         produce_replay_summary(
             session_id=session_id_total_is_61,
@@ -189,6 +192,20 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             active_milliseconds=61000,
         )
 
+        produce_replay_summary(
+            session_id=session_id_inactive_is_61,
+            team_id=self.team.pk,
+            # can CH handle a timestamp with no T
+            first_timestamp=(self.base_time),
+            last_timestamp=(self.base_time + relativedelta(seconds=61)),
+            distinct_id=user,
+            first_url="https://a-different-url.com",
+            click_count=0,
+            keypress_count=0,
+            mouse_activity_count=0,
+            active_milliseconds=0,
+        )
+
         filter = SessionRecordingsFilter(
             team=self.team,
             data={
@@ -199,8 +216,12 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
         session_recording_list_instance = SessionRecordingListFromReplaySummary(filter=filter, team=self.team)
         (session_recordings, more_recordings_available) = session_recording_list_instance.run()
 
-        assert [(s["session_id"], s["duration"], s["active_seconds"]) for s in session_recordings] == [
-            (session_id_total_is_61, 61, 59.0)
+        assert sorted(
+            [(s["session_id"], s["duration"], s["active_seconds"]) for s in session_recordings],
+            key=lambda x: x[0],
+        ) == [
+            (session_id_inactive_is_61, 61, 0.0),
+            (session_id_total_is_61, 61, 59.0),
         ]
 
         filter = SessionRecordingsFilter(
@@ -215,6 +236,20 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
 
         assert [(s["session_id"], s["duration"], s["active_seconds"]) for s in session_recordings] == [
             (session_id_active_is_61, 59, 61.0)
+        ]
+
+        filter = SessionRecordingsFilter(
+            team=self.team,
+            data={
+                "duration_type_filter": "inactive_seconds",
+                "session_recording_duration": '{"type":"recording","key":"duration","value":60,"operator":"gt"}',
+            },
+        )
+        session_recording_list_instance = SessionRecordingListFromReplaySummary(filter=filter, team=self.team)
+        (session_recordings, more_recordings_available) = session_recording_list_instance.run()
+
+        assert [(s["session_id"], s["duration"], s["inactive_seconds"]) for s in session_recordings] == [
+            (session_id_inactive_is_61, 61, 61.0)
         ]
 
     @snapshot_clickhouse_queries
@@ -281,6 +316,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
                 "mouse_activity_count": 2,
                 "duration": 1980,
                 "active_seconds": 792.0,
+                "inactive_seconds": 1188.0,
                 "start_time": self.base_time + relativedelta(seconds=20),
                 "end_time": self.base_time + relativedelta(seconds=2000),
                 "first_url": None,
@@ -303,6 +339,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
                 "mouse_activity_count": 4,
                 "duration": 50,
                 "active_seconds": 25.0,
+                "inactive_seconds": 25.0,
                 "start_time": self.base_time,
                 "end_time": self.base_time + relativedelta(seconds=50),
                 "first_url": "https://example.io/home",


### PR DESCRIPTION
## Problem

When demoing filtering recordings by active duration, I wondered: why not inactive sessions?

## Changes

Allows filtering by inactive duration instead of active duration

<img width="813" alt="Screenshot 2023-06-05 at 18 03 57" src="https://github.com/PostHog/posthog/assets/984817/c4c9a985-449c-4b3e-a59b-cc7d8226339a">

## How did you test this code?

👀 locally 
developer tests
