### PR TITLE
fix: limit session replay listing by storage ttl

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -325,16 +325,20 @@ def list_recordings(
         # Only go to clickhouse if we still have remaining specified IDs or we are not specifying IDs
 
         # TODO: once person on events is deployed, we can remove the check for hogql properties https://github.com/PostHog/posthog/pull/14458#discussion_r1135780372
-        session_recording_list_instance: Type[SessionRecordingList] = (
-            SessionRecordingListFromReplaySummary
-            if can_use_v3
-            else SessionRecordingListV2
-            if can_use_v2
-            else SessionRecordingList
-        )
-        (ch_session_recordings, more_recordings_available) = session_recording_list_instance(
-            filter=filter, team=team
-        ).run()
+        if can_use_v3:
+            # check separately here to help mypy see that SessionRecordingListFromReplaySummary
+            # is its own thing even though it is still stuck with inheritance until we can collapse
+            # the number of listing mechanisms
+            (ch_session_recordings, more_recordings_available) = SessionRecordingListFromReplaySummary(
+                filter=filter, team=team
+            ).run()
+        else:
+            session_recording_list_instance: Type[SessionRecordingList] = (
+                SessionRecordingListV2 if can_use_v2 else SessionRecordingList
+            )
+            (ch_session_recordings, more_recordings_available) = session_recording_list_instance(
+                filter=filter, team=team
+            ).run()
         recordings_from_clickhouse = SessionRecording.get_or_build_from_clickhouse(team, ch_session_recordings)
         recordings = recordings + recordings_from_clickhouse
 

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -1,8 +1,10 @@
 import dataclasses
+import datetime
 from typing import Any, Dict, List, Tuple, Union, Literal
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters.mixins.utils import cached_property
+from posthog.models.instance_setting import get_instance_setting
 from posthog.queries.session_recordings.session_recording_list import SessionRecordingList
 
 
@@ -22,6 +24,15 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
     # because it doesn't return MatchingEvents any person/event selection templating is redundant here
 
     SESSION_RECORDINGS_DEFAULT_LIMIT = 50
+
+    def __init__(
+        self,
+        **kwargs,
+    ):
+        super().__init__(
+            **kwargs,
+        )
+        self.ttl_days = (get_instance_setting("RECORDINGS_TTL_WEEKS") or 3) * 7
 
     _persons_lookup_cte = """
     distinct_ids_for_person as (
@@ -52,6 +63,9 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
        sum(active_milliseconds)/1000 as active_seconds
     FROM session_replay_events
     PREWHERE team_id = %(team_id)s
+        -- regardless of what other filters are applied
+        -- limit by storage TTL
+        AND min_first_timestamp >= %(clamped_to_storage_ttl)s
          -- we can filter on the pre-aggregated timestamp columns
         -- because any not-the-lowest min value is _more_ greater than the min value
         -- and any not-the-highest max value is _less_ lower than the max value
@@ -180,7 +194,13 @@ class SessionRecordingListFromReplaySummary(SessionRecordingList):
 
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
         offset = self._filter.offset or 0
-        base_params = {"team_id": self._team_id, "limit": self.limit + 1, "offset": offset}
+
+        base_params = {
+            "team_id": self._team_id,
+            "limit": self.limit + 1,
+            "offset": offset,
+            "clamped_to_storage_ttl": (datetime.datetime.now() - datetime.timedelta(days=self.ttl_days)),
+        }
 
         recording_person_query, recording_person_query_params = self._get_recording_person_query()
 

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -24,6 +24,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2022-12-14 00:00:00'
   AND min_first_timestamp >= '2022-12-28 00:00:00'
   AND max_last_timestamp <= '2023-01-04 00:00:00'
   AND session_id in
@@ -62,6 +63,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2022-12-14 00:00:00'
   AND min_first_timestamp >= '2022-12-28 00:00:00'
   AND max_last_timestamp <= '2023-01-04 00:00:00'
   AND session_id in
@@ -101,6 +103,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2022-12-14 00:00:00'
   AND min_first_timestamp >= '2022-12-28 00:00:00'
   AND max_last_timestamp <= '2023-01-04 00:00:00'
   AND session_id in
@@ -150,6 +153,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-22 00:00:00'
   AND max_last_timestamp <= '2021-01-04 23:59:59'
   AND session_id in
@@ -189,6 +193,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-31 20:00:00'
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
   AND session_id in
@@ -225,6 +230,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-31 20:00:00'
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
   AND session_id in
@@ -261,6 +267,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-31 20:00:00'
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
   AND session_id in
@@ -296,6 +303,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-31 20:00:00'
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
   AND session_id in
@@ -332,6 +340,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-31 20:00:00'
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
   AND session_id in
@@ -368,6 +377,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-31 20:00:00'
   AND min_first_timestamp >= '2021-01-14 00:00:00'
   AND max_last_timestamp <= '2021-01-21 20:00:00'
   AND session_id in
@@ -396,6 +406,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -421,6 +432,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -447,6 +459,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -473,6 +486,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -498,6 +512,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -523,6 +538,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -548,6 +564,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2021-01-01 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -573,8 +590,87 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-30 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
+  WHERE 1=1
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_date_from_filter_cannot_search_before_ttl
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         sum(active_milliseconds)/1000 as active_seconds
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 12:46:00'
+  AND min_first_timestamp >= '2020-12-12 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 12:46:00'
+  WHERE 1=1
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_date_from_filter_cannot_search_before_ttl.1
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         sum(active_milliseconds)/1000 as active_seconds
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 12:46:00'
+  AND min_first_timestamp >= '2020-12-11 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 12:46:00'
+  WHERE 1=1
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_date_from_filter_cannot_search_before_ttl.2
+  '
+  
+  SELECT session_id,
+         any(team_id),
+         any(distinct_id),
+         min(min_first_timestamp) as start_time,
+         max(max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(first_url) as first_url,
+         sum(click_count),
+         sum(keypress_count),
+         sum(mouse_activity_count),
+         sum(active_milliseconds)/1000 as active_seconds
+  FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 12:46:00'
+  AND min_first_timestamp >= '2020-12-10 00:00:00'
+  AND max_last_timestamp <= '2021-01-01 12:46:00'
   WHERE 1=1
   GROUP BY session_id
   HAVING 1=1
@@ -598,6 +694,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2020-12-28 23:59:59'
   WHERE 1=1
@@ -623,6 +720,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2020-12-29 23:59:59'
   WHERE 1=1
@@ -648,6 +746,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -674,6 +773,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -708,6 +808,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -744,6 +845,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -780,6 +882,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -817,6 +920,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -883,6 +987,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2021-07-31 20:00:00'
   AND min_first_timestamp >= '2021-08-14 00:00:00'
   AND max_last_timestamp <= '2021-08-21 20:00:00'
   WHERE 1=1
@@ -919,6 +1024,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -955,6 +1061,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -1000,6 +1107,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1
@@ -1037,6 +1145,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -1074,6 +1183,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -1111,6 +1221,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -1148,6 +1259,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -1184,6 +1296,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -1220,6 +1333,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   AND session_id in
@@ -1260,6 +1374,7 @@
          sum(mouse_activity_count),
          sum(active_milliseconds)/1000 as active_seconds
   FROM session_replay_events PREWHERE team_id = 2
+  AND min_first_timestamp >= '2020-12-11 13:46:23'
   AND min_first_timestamp >= '2020-12-25 00:00:00'
   AND max_last_timestamp <= '2021-01-01 13:46:23'
   WHERE 1=1

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -262,66 +262,63 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging
-  'SELECT 1'
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
   '
   
   SET LOCAL statement_timeout = 2
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
+  '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.2
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
   '
-  
-  SET LOCAL statement_timeout = 2
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
-  '
   WITH target_person_ids AS
     (SELECT team_id,
             person_id
@@ -364,13 +361,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -378,6 +375,20 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
+  '
+  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
+         "posthog_featureflaghashkeyoverride"."hash_key",
+         "posthog_featureflaghashkeyoverride"."person_id"
+  FROM "posthog_featureflaghashkeyoverride"
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
+                                                              2,
+                                                              3,
+                                                              4,
+                                                              5 /* ... */)
+         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.7

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -262,62 +262,65 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging
-  '
-  
-  SET LOCAL statement_timeout = 2
-  '
+  'SELECT 1'
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.2
   '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
+  '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
   '
   WITH target_person_ids AS
     (SELECT team_id,
@@ -361,13 +364,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -375,20 +378,6 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
-  '
-  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
-         "posthog_featureflaghashkeyoverride"."hash_key",
-         "posthog_featureflaghashkeyoverride"."person_id"
-  FROM "posthog_featureflaghashkeyoverride"
-  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
-                                                              2,
-                                                              3,
-                                                              4,
-                                                              5 /* ... */)
-         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.7


### PR DESCRIPTION
## Problem

Session replay summaries have been being aggregated for more than 21 days. If you search for more than 21 days we can now list recordings where there is no longer any data and we show an error message when you try to play one :homer-doh.gif:

## Changes

Limits the session replay listing to the configured storage TTL

## How did you test this code?

dev tests