### PR TITLE
feat: add test for generic signup page benefits

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -150,6 +150,7 @@ export const FEATURE_FLAGS = {
     SESSION_RECORDING_SUMMARY_LISTING: 'session-recording-summary-listing', // owner: #team-monitoring
     SURVEYS: 'surveys', // owner: @liyiy
     NEW_EMPTY_STATES: 'new-empty-states', // owner: @raquelmsmith
+    GENERIC_SIGNUP_BENEFITS: 'generic-signup-benefits', // owner: @raquelmsmith
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/scenes/authentication/signup/SignupContainer.tsx
+++ b/frontend/src/scenes/authentication/signup/SignupContainer.tsx
@@ -8,7 +8,8 @@ import { Region } from '~/types'
 import { router } from 'kea-router'
 import { Link } from 'lib/lemon-ui/Link'
 import { IconCheckCircleOutline } from 'lib/lemon-ui/icons'
-import { CLOUD_HOSTNAMES } from 'lib/constants'
+import { CLOUD_HOSTNAMES, FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export const scene: SceneExport = {
     component: SignupContainer,
@@ -49,6 +50,9 @@ export function SignupContainer(): JSX.Element | null {
 
 export function SignupLeftContainer(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const showGenericSignupBenefits: boolean = featureFlags[FEATURE_FLAGS.GENERIC_SIGNUP_BENEFITS] === 'test'
 
     const getRegionUrl = (region: string): string => {
         const { pathname, search, hash } = router.values.currentLocation
@@ -58,21 +62,37 @@ export function SignupLeftContainer(): JSX.Element {
     const productBenefits: {
         benefit: string
         description: string
-    }[] = [
-        {
-            benefit: 'Free for 1M events every month',
-            description: 'Product analytics, feature flags, experiments, and more.',
-        },
-        {
-            benefit: 'Start collecting events immediately',
-            description: 'Integrate with developer-friendly APIs or use our easy autocapture script.',
-        },
-        {
-            benefit: 'Join industry leaders that run on PostHog',
-            description:
-                'ClickHouse, Airbus, Hasura, Y Combinator, and thousands more trust PostHog as their Product OS.',
-        },
-    ]
+    }[] = showGenericSignupBenefits
+        ? [
+              {
+                  benefit: 'Get loads of free usage every month - even on paid plans',
+                  description: '1M free events, 15K free session recordings, and more. Every month. Forever.',
+              },
+              {
+                  benefit: 'Everything you need to understand your users, all in one place',
+                  description: 'Analytics. Session replay. Feature flags. A/B testing. CDP. The list goes on.',
+              },
+              {
+                  benefit: 'Join industry leaders that run on PostHog',
+                  description:
+                      'ClickHouse, Airbus, Hasura, Y Combinator, and thousands more trust PostHog as their Product OS.',
+              },
+          ]
+        : [
+              {
+                  benefit: 'Free for 1M events every month',
+                  description: 'Product analytics, feature flags, experiments, and more.',
+              },
+              {
+                  benefit: 'Start collecting events immediately',
+                  description: 'Integrate with developer-friendly APIs or use our easy autocapture script.',
+              },
+              {
+                  benefit: 'Join industry leaders that run on PostHog',
+                  description:
+                      'ClickHouse, Airbus, Hasura, Y Combinator, and thousands more trust PostHog as their Product OS.',
+              },
+          ]
 
     return (
         <>
@@ -83,7 +103,7 @@ export function SignupLeftContainer(): JSX.Element {
                             <IconCheckCircleOutline className="mt-2 w-4 h-4 text-primary" />
                         </div>
                         <div>
-                            <h3 className="mb-0 font-bold">{benefit.benefit}</h3>
+                            <h3 className="mb-1 font-bold leading-6">{benefit.benefit}</h3>
                             <p className="m-0 text-sm">{benefit.description}</p>
                         </div>
                     </div>


### PR DESCRIPTION
## Problem

The language on the signup page was very focused on product analytics. We're hypothesizing that this is why the signup conversion for people who are interested in other products (eg session replay) is lower. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a test for some more generic language not focused on any single product.

| Before | After |
|--------|--------|
| ![image](https://github.com/PostHog/posthog/assets/18598166/68ce5cf8-52c4-4b2e-9229-8c45ec8e86cb) | ![image](https://github.com/PostHog/posthog/assets/18598166/4c25eb13-6537-4fbd-84b6-652341941f59) |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
