### PR TITLE
chore(cd): merge image CD steps, push posthog image to ECR

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -1,11 +1,8 @@
 #
 # Build and push PostHog and PostHog Cloud container images
 #
-# - posthog_build: build and push the PostHog container image to DockerHub
-#
-# - posthog_cloud_build: build the PostHog Cloud container image using
-#   as base image the container image from the previous step. The image is
-#   then pushed to AWS ECR.
+# - build and push the PostHog container image to DockerHub and AWS ECR
+# - build the PostHog Cloud container image (based on the PostHog image), push it to ECR
 #
 name: Container Images CD
 
@@ -48,47 +45,6 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-            - name: Build and push container images
-              id: build
-              uses: depot/build-push-action@v1
-              with:
-                  project: x19jffd9zf # posthog
-                  buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
-                  cache-from: type=gha # always pull the layers from GHA
-                  cache-to: type=gha,mode=max # always push the layers to GHA
-                  push: true
-                  tags: posthog/posthog:latest
-                  platforms: linux/amd64,linux/arm64
-
-    posthog_cloud_build:
-        name: Build and push PostHog Cloud
-        if: github.repository == 'PostHog/posthog'
-        runs-on: ubuntu-latest
-        permissions:
-            id-token: write # allow issuing OIDC tokens for this workflow run
-            contents: read # allow at least reading the repo contents, add other permissions if necessary
-            packages: read # allow pull from ghcr.io
-        needs: [posthog_build]
-
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v2
-
-            - name: Set up Depot CLI
-              uses: depot/setup-action@v1
-
-            - name: Checkout PostHog Cloud code
-              run: |
-                  mkdir cloud/
-                  cd cloud/
-                  curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
-
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
@@ -100,8 +56,26 @@ jobs:
               id: aws-ecr
               uses: aws-actions/amazon-ecr-login@v1
 
-            - name: Build container images
+            - name: Build and push container images
               id: build
+              uses: depot/build-push-action@v1
+              with:
+                  project: x19jffd9zf # posthog
+                  buildx-fallback: true # fallback to using 'docker buildx build' if 'depot build' is unable to acquire a builder connection
+                  cache-from: type=gha # always pull the layers from GHA
+                  cache-to: type=gha,mode=max # always push the layers to GHA
+                  push: true
+                  tags: posthog/posthog:latest,${{ steps.aws-ecr.outputs.registry }}/posthog:latest
+                  platforms: linux/amd64,linux/arm64
+
+            - name: Checkout PostHog Cloud code
+              run: |
+                  mkdir cloud/
+                  cd cloud/
+                  curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
+
+            - name: Build cloud images
+              id: build-cloud
               uses: depot/build-push-action@v1
               with:
                   project: 1stsk4xt19 # posthog-cloud


### PR DESCRIPTION
## Problem

We will soon move away from the `posthog-cloud` image, and just run the vanilla `posthog` image on Cloud, For that to happen, we need to push that image to our ECR too.

## Changes

- Push the vanilla `posthog` image to our ECR, alongside Docker Hub
- Merge the `posthog_cloud_build` step into the `posthog_build` step to avoid waiting for a runner twice (that wait is getting pretty long on peak hours).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
