### PR TITLE
chore: Remove updateIsIdentified class function

### DIFF
--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1459,7 +1459,7 @@ test('identify set', async () => {
     const [person] = await hub.db.fetchPersons()
     expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
     expect(person.properties).toEqual({ a_prop: 'test-1', c_prop: 'test-1' })
-    expect(person.is_identified).toEqual(false)
+    expect(person.is_identified).toEqual(true)
 
     await processEvent(
         'distinct_id1',
@@ -1510,7 +1510,7 @@ test('identify set_once', async () => {
     const [person] = await hub.db.fetchPersons()
     expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
     expect(person.properties).toEqual({ a_prop: 'test-1', c_prop: 'test-1' })
-    expect(person.is_identified).toEqual(false)
+    expect(person.is_identified).toEqual(true)
 
     await processEvent(
         'distinct_id1',
@@ -1531,7 +1531,7 @@ test('identify set_once', async () => {
     expect((await hub.db.fetchEvents()).length).toBe(2)
     const [person2] = await hub.db.fetchPersons()
     expect(person2.properties).toEqual({ a_prop: 'test-1', b_prop: 'test-2b', c_prop: 'test-1' })
-    expect(person2.is_identified).toEqual(false)
+    expect(person2.is_identified).toEqual(true)
 })
 
 test('identify with illegal (generic) id', async () => {
@@ -1713,7 +1713,7 @@ test('identify with the same distinct_id as anon_distinct_id', async () => {
 
     const [person] = await hub.db.fetchPersons()
     expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['anonymous_id'])
-    expect(person.is_identified).toEqual(false)
+    expect(person.is_identified).toEqual(true)
 })
 
 test('distinct with multiple anonymous_ids which were already created', async () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The code with that class method was complex to follow.
Also when we marked use as is_identified was complex to understand. Now it's simple - regardless if we merge or not if you pass a distinct_id to `$identify`, `$create_alias` or `$merge_dangerously` that distinct_id user will be marked as is_identified (alias and anon_id won't if merge won't happen)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
