### PR TITLE
feat(webhooks): Allow getting event/action/person link directly

### DIFF
--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -46,9 +46,9 @@ describe('hooks', () => {
         test('Slack', () => {
             const [userDetails, userDetailsMarkdown] = getPersonDetails(
                 event,
-                team,
                 'http://localhost:8000',
-                WebhookType.Slack
+                WebhookType.Slack,
+                team
             )
 
             expect(userDetails).toBe('test@posthog.com')
@@ -58,9 +58,9 @@ describe('hooks', () => {
         test('Teams', () => {
             const [userDetails, userDetailsMarkdown] = getPersonDetails(
                 event,
-                team,
                 'http://localhost:8000',
-                WebhookType.Teams
+                WebhookType.Teams,
+                team
             )
 
             expect(userDetails).toBe('test@posthog.com')


### PR DESCRIPTION
## Problem

It was possible to get the link to an event/action/person in the form of that thing's formatted name, but the link wasn't available as a direct message token. See ZEN-3387

## Changes

Now you can use "[event.link]", "[action.link]", and "[person.link]".
