### PR TITLE
chore: split tests onto their own dedicated GitHub runners

### DIFF
--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -15,7 +15,7 @@ env:
 jobs:
     django:
         name: Run Django tests and save test durations
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-backend
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -38,7 +38,7 @@ jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-backend
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run backend checks
@@ -81,7 +81,7 @@ jobs:
         timeout-minutes: 10
 
         name: Python code quality checks
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-backend
 
         steps:
             - uses: actions/checkout@v3
@@ -167,7 +167,7 @@ jobs:
         timeout-minutes: 5
 
         name: Validate Django migrations
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-backend
 
         steps:
             - uses: actions/checkout@v3
@@ -231,7 +231,7 @@ jobs:
         timeout-minutes: 30
 
         name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-backend
 
         strategy:
             fail-fast: false
@@ -311,7 +311,7 @@ jobs:
         if: github.repository == 'PostHog/posthog' && needs.changes.outputs.backend == 'true'
 
         name: Django tests – Cloud
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-backend
         steps:
             - name: Fetch posthog-cloud
               run: |
@@ -410,7 +410,7 @@ jobs:
         name: Async migrations tests
         needs: changes
         if: needs.changes.outputs.backend == 'true'
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-backend
         steps:
             - name: 'Checkout repo'
               uses: actions/checkout@v3

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     changes:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-e2e
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run E2E checks
@@ -50,7 +50,7 @@ jobs:
     cypress_prep:
         needs: changes
         name: Cypress preparation
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-e2e
         timeout-minutes: 30
         outputs:
             specs: ${{ steps.set-specs.outputs.specs }}
@@ -75,7 +75,7 @@ jobs:
 
     cypress:
         name: Cypress E2E tests (${{ strategy.job-index }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-e2e
         timeout-minutes: 30
         needs: [cypress_prep, changes]
         permissions:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
     frontend-code-quality:
         name: Code quality checks
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest-frontend
         steps:
             - uses: actions/checkout@v3
 
@@ -58,7 +58,7 @@ jobs:
               run: pnpm schema:build:json && git diff --exit-code
 
     jest:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest-frontend
         name: Jest test (${{ matrix.chunk }})
 
         strategy:

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
     code-quality:
         name: Code quality
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest-pluginserver
         defaults:
             run:
                 working-directory: 'plugin-server'
@@ -74,7 +74,7 @@ jobs:
 
     tests:
         name: Tests (${{matrix.shard}})
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest-pluginserver
 
         strategy:
             fail-fast: false
@@ -159,7 +159,7 @@ jobs:
 
     functional-tests:
         name: Functional tests (POE_EMBRACE_JOIN_FOR_TEAMS=${{matrix.POE_EMBRACE_JOIN_FOR_TEAMS}})
-        runs-on: ubuntu-latest-8-cores
+        runs-on: ubuntu-latest-pluginserver
 
         strategy:
             fail-fast: false
@@ -263,7 +263,7 @@ jobs:
         # comparable results, but rather to give a rough idea of how
         # ingestion performance changes over time.
 
-        runs-on: ubuntu-latest-8-cores
+        runs-on: ubuntu-latest-pluginserver
 
         env:
             DEBUG: 'true'

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -49,7 +49,7 @@ jobs:
 
     visual-regression:
         name: Visual regression tests
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest-frontend
         timeout-minutes: 30
         container:
             image: mcr.microsoft.com/playwright:v1.29.2
@@ -191,7 +191,7 @@ jobs:
 
     visual-regression-summary:
         name: Summarize visual regression tests
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest-frontend
         timeout-minutes: 5
         needs: visual-regression
         if: always() # Run even if visual-regression fails for one (or more) of the browsers

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     storybook-deployment:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-frontend
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Check out PostHog/posthog repo


### PR DESCRIPTION
## Problem

Tests are getting backed up - let's see how much faster having tunable dedicated runners for each class of test would make this.

Once we land this the default pool should be more available for smaller tedious tasks like triggering the `depot` builds and doing basic linting and style checks.

## Changes

Added runners for each class of test on GitHub.
Point each test suite to the tag of the runner setup on github.

![image](https://github.com/PostHog/posthog/assets/391319/9f1e84ec-4c84-42d8-9b03-af4dd84cb6a0)

**If we land this we should remove these runners:**
- [`ubuntu-latest-16-cores`](https://github.com/organizations/PostHog/settings/actions/github-hosted-runners/3?viewing_from_runner_group=false)
- [`ubuntu-latest-8-cores`](https://github.com/organizations/PostHog/settings/actions/github-hosted-runners/2?viewing_from_runner_group=false)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

This PR should be the test

It's working! Now let's see if it actually speeds things up:
<img width="1046" alt="image" src="https://github.com/PostHog/posthog/assets/391319/d4f0f5cb-1b79-4197-b5b8-0e80a226fe56">


