### PR TITLE
fix(event-explorer): fix old saved columns

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -186,7 +186,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                     <div className="flex-1">
                         <LemonButton
                             type="secondary"
-                            onClick={() => setColumns(defaultDataTableColumns(NodeKind.EventsNode))}
+                            onClick={() => setColumns(defaultDataTableColumns(NodeKind.EventsQuery))}
                         >
                             Reset to defaults
                         </LemonButton>

--- a/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
+++ b/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
@@ -1,6 +1,7 @@
 import { TeamType } from '~/types'
 import { EventsQuery, NodeKind } from '~/queries/schema'
 import { getDefaultEventsSceneQuery } from 'scenes/events/defaults'
+import { escapePropertyAsHogQlIdentifier } from '~/queries/utils'
 
 /** Indicates HogQL usage if team.live_events_columns = [HOGQL_COLUMNS_KEY, ...] */
 export const HOGQL_COLUMNS_KEY = '--v2:hogql'
@@ -23,7 +24,7 @@ export function cleanLiveEventsColumns(columns: string[]): string[] {
             if (column === 'source') {
                 return 'properties.$lib'
             }
-            return `properties.${column}`
+            return `properties.${escapePropertyAsHogQlIdentifier(String(column))}`
         }),
         'timestamp',
     ]

--- a/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
+++ b/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
@@ -11,18 +11,20 @@ export function cleanLiveEventsColumns(columns: string[]): string[] {
         return columns.slice(1)
     }
     // legacy columns
-    return columns.map((column) => {
-        if (column === 'event' || column === 'person') {
-            return column
-        }
-        if (column === 'url') {
-            return 'coalesce(properties.$current_url, properties.$screen_name) -- Url / Screen'
-        }
-        if (column === 'source') {
-            return 'properties.$lib'
-        }
-        return `properties.${column}`
-    })
+    return columns
+        .map((column) => {
+            if (column === 'event' || column === 'person') {
+                return column
+            }
+            if (column === 'url') {
+                return 'coalesce(properties.$current_url, properties.$screen_name) -- Url / Screen'
+            }
+            if (column === 'source') {
+                return 'properties.$lib'
+            }
+            return `properties.${column}`
+        })
+        .concat(['timestamp'])
 }
 
 export function getDefaultEventsQueryForTeam(team: Partial<TeamType>): EventsQuery | null {

--- a/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
+++ b/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
@@ -11,8 +11,9 @@ export function cleanLiveEventsColumns(columns: string[]): string[] {
         return columns.slice(1)
     }
     // legacy columns
-    return columns
-        .map((column) => {
+    return [
+        '*',
+        ...columns.map((column) => {
             if (column === 'event' || column === 'person') {
                 return column
             }
@@ -23,8 +24,9 @@ export function cleanLiveEventsColumns(columns: string[]): string[] {
                 return 'properties.$lib'
             }
             return `properties.${column}`
-        })
-        .concat(['timestamp'])
+        }),
+        'timestamp',
+    ]
 }
 
 export function getDefaultEventsQueryForTeam(team: Partial<TeamType>): EventsQuery | null {

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -33,7 +33,9 @@ def escape_param_clickhouse(value: str) -> str:
 # Copied from clickhouse_driver.util.escape, adapted from single quotes to backquotes. Added a $.
 def escape_hogql_identifier(identifier: str) -> str:
     # HogQL allows dollars in the identifier.
-    if re.match(r"^[A-Za-z_$][A-Za-z0-9_$]*$", identifier):  # Same regex as the frontend propertyKeyToHogQlIdentifier
+    if re.match(
+        r"^[A-Za-z_$][A-Za-z0-9_$]*$", identifier
+    ):  # Same regex as the frontend escapePropertyAsHogQlIdentifier
         return identifier
     return "`%s`" % "".join(backquote_escape_chars_map.get(c, c) for c in identifier)
 


### PR DESCRIPTION
## Changes

Fixes issue where migrating from old "live events" saved team defaults to the "event explorer" saved team defaults loses the timestamp column. It was a fixed column last time, not part of the mutable list.

Fixed some tiny bugs too.

https://posthog.slack.com/archives/C02E3BKC78F/p1686087530390269

## How did you test this code?

Enabled/disabled the flag and noticed that both the "*" and "timestamp" columns showed up.