### PR TITLE
feat(insights): allow using a standalone query component for insight viz

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -45,6 +45,12 @@ export function InsightViz({ query, setQuery, context }: InsightVizProps): JSX.E
         setQuery?.({ ...query, source })
     }
 
+    const showIfFull = !!query.full
+    const disableHeader = query.showHeader ? !query.showHeader : !showIfFull
+    const disableTable = query.showTable ? !query.showTable : !showIfFull
+    const disableCorrelationTable = query.showCorrelationTable ? !query.showCorrelationTable : !showIfFull
+    const disableLastComputation = query.showLastComputation ? !query.showLastComputation : !showIfFull
+
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
             <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
@@ -60,7 +66,14 @@ export function InsightViz({ query, setQuery, context }: InsightVizProps): JSX.E
                     />
 
                     <div className="insights-container" data-attr="insight-view">
-                        <InsightContainer insightMode={insightMode} context={context} />
+                        <InsightContainer
+                            insightMode={insightMode}
+                            context={context}
+                            disableHeader={disableHeader}
+                            disableTable={disableTable}
+                            disableCorrelationTable={disableCorrelationTable}
+                            disableLastComputation={disableLastComputation}
+                        />
                     </div>
                 </div>
             </BindLogic>

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -13,6 +13,7 @@ import { EditorFilters } from './EditorFilters'
 import { InsightLogicProps, ItemMode } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { getCachedResults } from './utils'
+import { useState } from 'react'
 
 /** The key for the dataNodeLogic mounted by an InsightViz for insight of insightProps */
 export const insightVizDataNodeKey = (insightProps: InsightLogicProps): string => {
@@ -25,8 +26,11 @@ type InsightVizProps = {
     context?: QueryContext
 }
 
+let uniqueNode = 0
+
 export function InsightViz({ query, setQuery, context }: InsightVizProps): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+    const [key] = useState(() => `InsightViz.${uniqueNode++}`)
+    const insightProps: InsightLogicProps = context?.insightProps || { dashboardItemId: `new-AdHoc.${key}` }
     const dataNodeLogicProps: DataNodeLogicProps = {
         query: query.source,
         key: insightVizDataNodeKey(insightProps),
@@ -42,18 +46,24 @@ export function InsightViz({ query, setQuery, context }: InsightVizProps): JSX.E
     }
 
     return (
-        <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-            <div
-                className={clsx('insight-wrapper', {
-                    'insight-wrapper--singlecolumn': isFunnels,
-                })}
-            >
-                <EditorFilters query={query.source} setQuery={setQuerySource} showing={insightMode === ItemMode.Edit} />
+        <BindLogic logic={insightLogic} props={insightProps}>
+            <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                <div
+                    className={clsx('insight-wrapper', {
+                        'insight-wrapper--singlecolumn': isFunnels,
+                    })}
+                >
+                    <EditorFilters
+                        query={query.source}
+                        setQuery={setQuerySource}
+                        showing={insightMode === ItemMode.Edit}
+                    />
 
-                <div className="insights-container" data-attr="insight-view">
-                    <InsightContainer insightMode={insightMode} context={context} />
+                    <div className="insights-container" data-attr="insight-view">
+                        <InsightContainer insightMode={insightMode} context={context} />
+                    </div>
                 </div>
-            </div>
+            </BindLogic>
         </BindLogic>
     )
 }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1225,9 +1225,25 @@
         "InsightVizNode": {
             "additionalProperties": false,
             "properties": {
+                "full": {
+                    "description": "Show with most visual options enabled. Used in insight scene.",
+                    "type": "boolean"
+                },
                 "kind": {
                     "const": "InsightVizNode",
                     "type": "string"
+                },
+                "showCorrelationTable": {
+                    "type": "boolean"
+                },
+                "showHeader": {
+                    "type": "boolean"
+                },
+                "showLastComputation": {
+                    "type": "boolean"
+                },
+                "showTable": {
+                    "type": "boolean"
                 },
                 "source": {
                     "$ref": "#/definitions/InsightQueryNode"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -308,7 +308,12 @@ export interface InsightVizNode extends Node {
     kind: NodeKind.InsightVizNode
     source: InsightQueryNode
 
-    // showViz, showTable, etc.
+    /** Show with most visual options enabled. Used in insight scene. */
+    full?: boolean
+    showHeader?: boolean
+    showTable?: boolean
+    showCorrelationTable?: boolean
+    showLastComputation?: boolean
 }
 
 /** Base class for insight query nodes. Should not be used directly. */

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -19,6 +19,7 @@ import {
     LifecycleFilterType,
     LifecycleToggle,
     HogQLMathType,
+    InsightLogicProps,
 } from '~/types'
 
 /**
@@ -527,6 +528,7 @@ export interface QueryContext {
     showQueryEditor?: boolean
     /* Adds help and examples to the query editor component */
     showQueryHelp?: boolean
+    insightProps?: InsightLogicProps
     emptyStateHeading?: string
     emptyStateDetail?: string
 }

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -10,7 +10,7 @@ import { InsightsNav } from './InsightNav/InsightsNav'
 import { InsightSkeleton } from 'scenes/insights/InsightSkeleton'
 import { Query } from '~/queries/Query/Query'
 import { InsightPageHeader } from 'scenes/insights/InsightPageHeader'
-import { containsHogQLQuery } from '~/queries/utils'
+import { containsHogQLQuery, isInsightVizNode } from '~/queries/utils'
 
 export interface InsightSceneProps {
     insightId: InsightShortId | 'new'
@@ -69,7 +69,7 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element {
                 {insightMode === ItemMode.Edit && <InsightsNav />}
 
                 <Query
-                    query={{ ...query, full: true }}
+                    query={isInsightVizNode(query) ? { ...query, full: true } : query}
                     setQuery={insightMode === ItemMode.Edit ? setQuery : undefined}
                     readOnly={insightMode !== ItemMode.Edit}
                     context={{

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -69,7 +69,7 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element {
                 {insightMode === ItemMode.Edit && <InsightsNav />}
 
                 <Query
-                    query={query}
+                    query={{ ...query, full: true }}
                     setQuery={insightMode === ItemMode.Edit ? setQuery : undefined}
                     readOnly={insightMode !== ItemMode.Edit}
                     context={{

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -76,6 +76,7 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element {
                         showOpenEditorButton: false,
                         showQueryEditor: actuallyShowQueryEditor,
                         showQueryHelp: insightMode === ItemMode.Edit && !containsHogQLQuery(query),
+                        insightProps,
                     }}
                 />
             </div>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1120,7 +1120,12 @@ class InsightVizNode(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    full: Optional[bool] = Field(None, description="Show with most visual options enabled. Used in insight scene.")
     kind: str = Field("InsightVizNode", const=True)
+    showCorrelationTable: Optional[bool] = None
+    showHeader: Optional[bool] = None
+    showLastComputation: Optional[bool] = None
+    showTable: Optional[bool] = None
     source: Union[TrendsQuery, FunnelsQuery, RetentionQuery, PathsQuery, StickinessQuery, LifecycleQuery]
 
 


### PR DESCRIPTION
## Problem

The `<Query />` component for an `InsightVizNode` crashes when it's not wrapped in a bound `insightLogic`.

## Changes

This PR makes a bound `insightLogic` optional and takes `insightProps` as context on an `InsightVizNode`. Additionally the `InsightVizNode` can be configured to hide the header, table, etc.

## How did you test this code?

Use the logger in initKea to see that the correct insightNode is used for existing insights