### PR TITLE
fix(funnels): fix aggregation select component

### DIFF
--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -3,21 +3,11 @@ import { groupsModel } from '~/models/groupsModel'
 import { LemonSelect, LemonSelectSection } from '@posthog/lemon-ui'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { GroupIntroductionFooter } from 'scenes/groups/GroupsIntroduction'
-import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { InsightLogicProps } from '~/types'
-import { insightLogic } from '../insightLogic'
 import { isFunnelsQuery, isInsightQueryNode } from '~/queries/utils'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { FunnelsQuery } from '~/queries/schema'
-import { isFunnelsFilter } from 'scenes/insights/sharedUtils'
 import { HogQLEditor } from 'lib/components/HogQLEditor/HogQLEditor'
-
-type AggregationSelectProps = {
-    insightProps: InsightLogicProps
-    className?: string
-    hogqlAvailable?: boolean
-    value?: string
-}
 
 function getHogQLValue(groupIndex?: number, aggregationQuery?: string): string {
     if (groupIndex !== undefined) {
@@ -39,7 +29,16 @@ function hogQLToFilterValue(value?: string): { groupIndex?: number; aggregationQ
     }
 }
 
-export function AggregationSelectDataExploration({
+const UNIQUE_USERS = 'person_id'
+
+type AggregationSelectProps = {
+    insightProps: InsightLogicProps
+    className?: string
+    hogqlAvailable?: boolean
+    value?: string
+}
+
+export function AggregationSelect({
     insightProps,
     className,
     hogqlAvailable,
@@ -55,74 +54,17 @@ export function AggregationSelectDataExploration({
         querySource.aggregation_group_type_index,
         isFunnelsQuery(querySource) ? querySource.funnelsFilter?.funnel_aggregate_by_hogql : undefined
     )
-
-    return (
-        <AggregationSelectComponent
-            className={className}
-            hogqlAvailable={hogqlAvailable}
-            value={value}
-            onChange={(value) => {
-                const { aggregationQuery, groupIndex } = hogQLToFilterValue(value)
-                if (isFunnelsQuery(querySource)) {
-                    updateQuerySource({
-                        aggregation_group_type_index: groupIndex,
-                        funnelsFilter: { ...querySource.funnelsFilter, funnel_aggregate_by_hogql: aggregationQuery },
-                    } as FunnelsQuery)
-                } else {
-                    updateQuerySource({ aggregation_group_type_index: groupIndex } as FunnelsQuery)
-                }
-            }}
-        />
-    )
-}
-
-export function AggregationSelect({ insightProps, className, hogqlAvailable }: AggregationSelectProps): JSX.Element {
-    const { filters } = useValues(insightLogic(insightProps))
-    const { setFilters } = useActions(funnelLogic(insightProps))
-
-    const value = getHogQLValue(
-        filters.aggregation_group_type_index,
-        isFunnelsFilter(filters) ? filters.funnel_aggregate_by_hogql : undefined
-    )
-
-    return (
-        <AggregationSelectComponent
-            className={className}
-            value={value}
-            hogqlAvailable={hogqlAvailable}
-            onChange={(value) => {
-                const { aggregationQuery, groupIndex } = hogQLToFilterValue(value)
-                if (isFunnelsFilter(filters)) {
-                    setFilters({
-                        ...filters,
-                        aggregation_group_type_index: groupIndex,
-                        funnel_aggregate_by_hogql: aggregationQuery,
-                    })
-                } else {
-                    setFilters({
-                        ...filters,
-                        aggregation_group_type_index: groupIndex,
-                    })
-                }
-            }}
-        />
-    )
-}
-
-const UNIQUE_USERS = 'person_id'
-interface AggregationSelectComponentProps {
-    className?: string
-    hogqlAvailable?: boolean
-    value?: string
-    onChange: (value: string | undefined) => void
-}
-
-function AggregationSelectComponent({
-    className,
-    hogqlAvailable,
-    onChange,
-    value,
-}: AggregationSelectComponentProps): JSX.Element {
+    const onChange = (value: string): void => {
+        const { aggregationQuery, groupIndex } = hogQLToFilterValue(value)
+        if (isFunnelsQuery(querySource)) {
+            updateQuerySource({
+                aggregation_group_type_index: groupIndex,
+                funnelsFilter: { ...querySource.funnelsFilter, funnel_aggregate_by_hogql: aggregationQuery },
+            } as FunnelsQuery)
+        } else {
+            updateQuerySource({ aggregation_group_type_index: groupIndex } as FunnelsQuery)
+        }
+    }
     const { groupTypes, aggregationLabel } = useValues(groupsModel)
     const { needsUpgradeForGroups, canStartUsingGroups } = useValues(groupsAccessLogic)
 
@@ -168,6 +110,7 @@ function AggregationSelectComponent({
                 label: <span className="font-mono">{value}</span>,
                 labelInMenu: function CustomHogQLOptionWrapped({ onSelect }) {
                     return (
+                        // eslint-disable-next-line react/forbid-dom-props
                         <div className="w-120" style={{ maxWidth: 'max(60vw, 20rem)' }}>
                             <HogQLEditor
                                 onChange={onSelect}


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C045L1VEG87/p1686151129553679

## Changes

This PR:
- actually uses the data exploration variant of the `<AggregationSelect />` component for retention and funnel insights
- removes the legacy variant of the component

## How did you test this code?

Verified that the changes are applied to the insight and query