### PR TITLE
refactor(hogql): Rename "macros" to the standard "CTEs"

### DIFF
--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -103,7 +103,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
 
     def visitSelectStmt(self, ctx: HogQLParser.SelectStmtContext):
         select_query = ast.SelectQuery(
-            macros=self.visit(ctx.withClause()) if ctx.withClause() else None,
+            ctes=self.visit(ctx.withClause()) if ctx.withClause() else None,
             select=self.visit(ctx.columnExprList()) if ctx.columnExprList() else [],
             distinct=True if ctx.DISTINCT() else None,
             select_from=self.visit(ctx.fromClause()) if ctx.fromClause() else None,
@@ -634,21 +634,21 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         )
 
     def visitWithExprList(self, ctx: HogQLParser.WithExprListContext):
-        macros: Dict[str, ast.Macro] = {}
+        ctes: Dict[str, ast.CTE] = {}
         for expr in ctx.withExpr():
-            macro = self.visit(expr)
-            macros[macro.name] = macro
-        return macros
+            cte = self.visit(expr)
+            ctes[cte.name] = cte
+        return ctes
 
     def visitWithExprSubquery(self, ctx: HogQLParser.WithExprSubqueryContext):
         subquery = self.visit(ctx.selectUnionStmt())
         name = self.visit(ctx.identifier())
-        return ast.Macro(name=name, expr=subquery, macro_format="subquery")
+        return ast.CTE(name=name, expr=subquery, cte_type="subquery")
 
     def visitWithExprColumn(self, ctx: HogQLParser.WithExprColumnContext):
         expr = self.visit(ctx.columnExpr())
         name = self.visit(ctx.identifier())
-        return ast.Macro(name=name, expr=expr, macro_format="column")
+        return ast.CTE(name=name, expr=expr, cte_type="column")
 
     def visitColumnIdentifier(self, ctx: HogQLParser.ColumnIdentifierContext):
         if ctx.PLACEHOLDER():

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -664,31 +664,31 @@ class TestResolver(BaseTest):
         ]
         self.assertEqual(node.select, expected)
 
-    def test_macros_loop(self):
+    def test_ctes_loop(self):
         with self.assertRaises(ResolverException) as e:
-            self._print_hogql("with macro as (select * from macro) select * from macro")
-        self.assertIn("Too many macro expansions (50+). Probably a macro loop.", str(e.exception))
+            self._print_hogql("with cte as (select * from cte) select * from cte")
+        self.assertIn("Too many CTE expansions (50+). Probably a CTE loop.", str(e.exception))
 
-    def test_macros_basic_column(self):
-        expr = self._print_hogql("with 1 as macro select macro from events")
+    def test_ctes_basic_column(self):
+        expr = self._print_hogql("with 1 as cte select cte from events")
         expected = self._print_hogql("select 1 from events")
         self.assertEqual(
             expr,
             expected,
         )
 
-    def test_macros_recursive_column(self):
+    def test_ctes_recursive_column(self):
         self.assertEqual(
-            self._print_hogql("with 1 as macro, macro as soap select soap from events"),
+            self._print_hogql("with 1 as cte, cte as soap select soap from events"),
             self._print_hogql("select 1 from events"),
         )
 
-    def test_macros_field_access(self):
+    def test_ctes_field_access(self):
         with self.assertRaises(ResolverException) as e:
-            self._print_hogql("with properties as macro select macro.$browser from events")
-        self.assertIn("Cannot access fields on macro macro yet.", str(e.exception))
+            self._print_hogql("with properties as cte select cte.$browser from events")
+        self.assertIn("Cannot access fields on CTE cte yet.", str(e.exception))
 
-    def test_macros_subqueries(self):
+    def test_ctes_subqueries(self):
         self.assertEqual(
             self._print_hogql("with my_table as (select * from events) select * from my_table"),
             self._print_hogql("select * from (select * from events) my_table"),
@@ -704,7 +704,7 @@ class TestResolver(BaseTest):
             self._print_hogql("select timestamp from (select * from events) my_table"),
         )
 
-    def test_macros_subquery_deep(self):
+    def test_ctes_subquery_deep(self):
         self.assertEqual(
             self._print_hogql(
                 "with my_table as (select * from events), "
@@ -716,7 +716,7 @@ class TestResolver(BaseTest):
             ),
         )
 
-    def test_macros_subquery_recursion(self):
+    def test_ctes_subquery_recursion(self):
         self.assertEqual(
             self._print_hogql(
                 "with users as (select event, timestamp as tt from events ), final as ( select tt from users ) select * from final"

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -33,7 +33,7 @@ class TraversingVisitor(Visitor):
     def visit_expr(self, node: ast.Expr):
         raise HogQLException("Can not visit generic Expr node")
 
-    def visit_macro(self, node: ast.Macro):
+    def visit_cte(self, node: ast.CTE):
         pass
 
     def visit_alias(self, node: ast.Alias):
@@ -239,14 +239,14 @@ class CloningVisitor(Visitor):
     def visit_expr(self, node: ast.Expr):
         raise HogQLException("Can not visit generic Expr node")
 
-    def visit_macro(self, node: ast.Macro):
-        return ast.Macro(
+    def visit_cte(self, node: ast.CTE):
+        return ast.CTE(
             start=None if self.clear_locations else node.start,
             end=None if self.clear_locations else node.end,
             type=None if self.clear_types else node.type,
             name=node.name,
             expr=self.visit(node.expr),
-            macro_format=node.macro_format,
+            cte_type=node.cte_type,
         )
 
     def visit_alias(self, node: ast.Alias):
@@ -426,9 +426,7 @@ class CloningVisitor(Visitor):
             start=None if self.clear_locations else node.start,
             end=None if self.clear_locations else node.end,
             type=None if self.clear_types else node.type,
-            macros={key: self.visit(expr) for key, expr in node.macros.items()}
-            if node.macros
-            else None,  # to not traverse
+            ctes={key: self.visit(expr) for key, expr in node.ctes.items()} if node.ctes else None,  # to not traverse
             select_from=self.visit(node.select_from),  # keep "select_from" before "select" to resolve tables first
             select=[self.visit(expr) for expr in node.select] if node.select else None,
             where=self.visit(node.where),


### PR DESCRIPTION
## Problem

It's confusing how we call the standard SQL feature of common table expressions "macros". They're just CTEs. If there is a wider strategy to this, then I'm happy to adjust my thinking, but currently it seems to me like we don't have "macros".

## Changes

Renames the "Macro" expr to "CTE".

## How did you test this code?

There are tests for this.