### PR TITLE
fix: GIT SHA label for posthog cloud

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -74,6 +74,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v3
 
+            - name: Update git SHA
+              run: echo "GIT_SHA = '${GITHUB_SHA}'" > posthog/gitsha.py
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
Currently https://app.posthog.com/instance/status shows `undefined` as git sha, but that would be quick and convenient way to check the version of the release especially for app developers who aren't always on k9s. We do this for the other build just above.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
