### PR TITLE
feat(usage-report): Add decide usage report

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -272,7 +272,7 @@ jobs:
               # Also skip for persons-on-events runs, as we want to ignore snapshots diverging there
               if: ${{ github.repository == 'PostHog/posthog' && needs.changes.outputs.backend == 'true' && !matrix.person-on-events }}
               with:
-                  add: '["ee", "posthog/clickhouse/test/__snapshots__", "posthog/api/test/__snapshots__", "posthog/test/__snapshots__", "posthog/queries/", "posthog/migrations"]'
+                  add: '["ee", "posthog/clickhouse/test/__snapshots__", "posthog/api/test/__snapshots__", "posthog/test/__snapshots__", "posthog/queries/", "posthog/migrations", "posthog/tasks"]'
                   message: 'Update query snapshots'
                   pull: --rebase --autostash # Make sure we're up to date with other segments' updates
                   default_author: github_actions

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -210,10 +210,10 @@ def get_decide(request: HttpRequest):
             # `test_decide_doesnt_error_out_when_database_is_down`
             # which ensures that decide doesn't error out when the database is down
 
-            if feature_flags and settings.ENABLE_DECIDE_BILLING_ANALYTICS:
+            if feature_flags:
                 # Billing analytics for decide requests with feature flags
 
-                # Sampling to relax the load on redis
+                # Sample no. of decide requests with feature flags
                 if settings.DECIDE_BILLING_SAMPLING_RATE and random() < settings.DECIDE_BILLING_SAMPLING_RATE:
                     count = int(1 / settings.DECIDE_BILLING_SAMPLING_RATE)
                     increment_request_count(team.pk, count)

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -122,13 +122,24 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -139,7 +150,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -150,7 +161,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -161,7 +172,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -189,7 +200,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -209,22 +220,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -122,24 +122,13 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -150,7 +139,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -161,7 +150,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -172,7 +161,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -200,7 +189,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -220,6 +209,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -1820,7 +1820,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user
         )
         self.client.logout()
-        with self.settings(ENABLE_DECIDE_BILLING_ANALYTICS=False, DECIDE_BILLING_SAMPLING_RATE=1):
+        with self.settings(DECIDE_BILLING_SAMPLING_RATE=0):
             response = self._post_decide(api_version=3)
             self.assertEqual(response.status_code, 200)
 
@@ -1828,9 +1828,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             # check that no increments made it to redis
             self.assertEqual(client.hgetall(f"posthog:decide_requests:{self.team.pk}"), {})
 
-        with self.settings(ENABLE_DECIDE_BILLING_ANALYTICS="true", DECIDE_BILLING_SAMPLING_RATE=1), freeze_time(
-            "2022-05-07 12:23:07"
-        ):
+        with self.settings(DECIDE_BILLING_SAMPLING_RATE=1), freeze_time("2022-05-07 12:23:07"):
             response = self._post_decide(api_version=3)
             self.assertEqual(response.status_code, 200)
 
@@ -1846,9 +1844,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user
         )
         self.client.logout()
-        with self.settings(ENABLE_DECIDE_BILLING_ANALYTICS="true", DECIDE_BILLING_SAMPLING_RATE=0.5), freeze_time(
-            "2022-05-07 12:23:07"
-        ):
+        with self.settings(DECIDE_BILLING_SAMPLING_RATE=0.5), freeze_time("2022-05-07 12:23:07"):
             for _ in range(5):
                 # given the seed, 4 out of 5 are sampled
                 response = self._post_decide(api_version=3)
@@ -1865,9 +1861,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user
         )
         self.client.logout()
-        with self.settings(ENABLE_DECIDE_BILLING_ANALYTICS="true", DECIDE_BILLING_SAMPLING_RATE=0.02), freeze_time(
-            "2022-05-07 12:23:07"
-        ):
+        with self.settings(DECIDE_BILLING_SAMPLING_RATE=0.02), freeze_time("2022-05-07 12:23:07"):
             for _ in range(5):
                 # given the seed, 1 out of 5 are sampled
                 response = self._post_decide(api_version=3)
@@ -1884,9 +1878,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user
         )
         self.client.logout()
-        with self.settings(ENABLE_DECIDE_BILLING_ANALYTICS="true", DECIDE_BILLING_SAMPLING_RATE=0), freeze_time(
-            "2022-05-07 12:23:07"
-        ):
+        with self.settings(DECIDE_BILLING_SAMPLING_RATE=0), freeze_time("2022-05-07 12:23:07"):
             for _ in range(5):
                 # 0 out of 5 are sampled
                 response = self._post_decide(api_version=3)

--- a/posthog/models/feature_flag/flag_analytics.py
+++ b/posthog/models/feature_flag/flag_analytics.py
@@ -33,11 +33,15 @@ def capture_team_decide_usage(ph_client: "Posthog", team_id: int, team_uuid: str
             key_name = get_team_request_key(team_id)
             existing_values = client.hgetall(key_name)
             time_buckets = existing_values.keys()
+            min_time = time.time()
+            max_time = 0
             # The latest bucket is still being filled, so we don't want to delete it nor count it.
             # It will be counted in a later iteration, when it's not being filled anymore.
             if time_buckets and len(time_buckets) > 1:
                 # redis returns encoded bytes, so we need to convert them into unix epoch for sorting
                 for time_bucket in sorted(time_buckets, key=lambda bucket: int(bucket))[:-1]:
+                    min_time = min(min_time, int(time_bucket) * CACHE_BUCKET_SIZE)
+                    max_time = max(max_time, int(time_bucket) * CACHE_BUCKET_SIZE)
                     total_request_count += int(existing_values[time_bucket])
                     client.hdel(key_name, time_bucket)
 
@@ -45,7 +49,13 @@ def capture_team_decide_usage(ph_client: "Posthog", team_id: int, team_uuid: str
                 ph_client.capture(
                     team_id,
                     "decide usage",
-                    {"count": total_request_count, "team_id": team_id, "team_uuid": team_uuid},
+                    {
+                        "count": total_request_count,
+                        "team_id": team_id,
+                        "team_uuid": team_uuid,
+                        "min_time": min_time,
+                        "max_time": max_time,
+                    },
                 )
 
     except redis.exceptions.LockError:

--- a/posthog/models/feature_flag/flag_analytics.py
+++ b/posthog/models/feature_flag/flag_analytics.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 from posthog.redis import redis, get_client
 import time
 from sentry_sdk import capture_exception
+from django.conf import settings
 
 if TYPE_CHECKING:
     from posthoganalytics import Posthog
@@ -45,7 +46,7 @@ def capture_team_decide_usage(ph_client: "Posthog", team_id: int, team_uuid: str
                     total_request_count += int(existing_values[time_bucket])
                     client.hdel(key_name, time_bucket)
 
-            if total_request_count > 0:
+            if total_request_count > 0 and settings.DECIDE_BILLING_ANALYTICS_TOKEN:
                 ph_client.capture(
                     team_id,
                     "decide usage",
@@ -55,6 +56,7 @@ def capture_team_decide_usage(ph_client: "Posthog", team_id: int, team_uuid: str
                         "team_uuid": team_uuid,
                         "min_time": min_time,
                         "max_time": max_time,
+                        "token": settings.DECIDE_BILLING_ANALYTICS_TOKEN,
                     },
                 )
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -29,6 +29,7 @@ DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type
 # Decide billing analytics
 
 DECIDE_BILLING_SAMPLING_RATE = get_from_env("DECIDE_BILLING_SAMPLING_RATE", 0.1, type_cast=float)
+DECIDE_BILLING_ANALYTICS_TOKEN = get_from_env("DECIDE_BILLING_ANALYTICS_TOKEN", None, type_cast=str, optional=True)
 
 # Application definition
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -28,7 +28,6 @@ DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type
 
 # Decide billing analytics
 
-ENABLE_DECIDE_BILLING_ANALYTICS = get_from_env("ENABLE_DECIDE_BILLING_ANALYTICS", False, type_cast=str_to_bool)
 DECIDE_BILLING_SAMPLING_RATE = get_from_env("DECIDE_BILLING_SAMPLING_RATE", 0.1, type_cast=float)
 
 # Application definition

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -1,0 +1,298 @@
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests
+  '
+  
+  SELECT team_id,
+         count(1) as count
+  FROM events
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.1
+  '
+  
+  SELECT team_id,
+         count(1) as count
+  FROM events
+  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.10
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.11
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.12
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.13
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.14
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.15
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.16
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.17
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.18
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.19
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.2
+  '
+  
+  SELECT team_id,
+         count(1) as count
+  FROM events
+  WHERE timestamp between '2022-01-01 00:00:00' AND '2022-01-10 23:59:59'
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.3
+  '
+  
+  SELECT team_id,
+         count(1) as count
+  FROM events
+  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND ($group_0 != ''
+         OR $group_1 != ''
+         OR $group_2 != ''
+         OR $group_3 != ''
+         OR $group_4 != '')
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.4
+  '
+  
+  SELECT team_id,
+         count(distinct session_id) as count
+  FROM session_recording_events
+  WHERE first_event_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND session_id NOT IN
+      (SELECT DISTINCT session_id
+       FROM session_recording_events
+       WHERE toDate(first_event_timestamp) = toDate('2022-01-10 00:00:00') - INTERVAL 1 DAY
+       GROUP BY session_id)
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.5
+  '
+  
+  SELECT team_id,
+         count(distinct session_id) as count
+  FROM session_recording_events
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.6
+  '
+  
+  SELECT distinct_id as team,
+         sum(JSONExtractInt(properties, 'count')) as sum
+  FROM events
+  WHERE team_id = 2
+    AND event='decide usage'
+    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
+  GROUP BY team
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.7
+  '
+  
+  SELECT distinct_id as team,
+         sum(JSONExtractInt(properties, 'count')) as sum
+  FROM events
+  WHERE team_id = 2
+    AND event='decide usage'
+    AND timestamp between '2022-01-01 00:00:00' AND '2022-01-10 23:59:59'
+    AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
+  GROUP BY team
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.8
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '
+---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.9
+  '
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '
+---

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -31,6 +31,7 @@ from posthog.test.base import (
     _create_event,
     _create_person,
     flush_persons_and_events,
+    snapshot_clickhouse_queries,
 )
 from posthog.utils import get_machine_id
 
@@ -297,6 +298,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "dashboard_tagged_count": 0,
                     "ff_count": 2,
                     "ff_active_count": 1,
+                    "decide_requests_in_month": 0,
+                    "decide_requests_in_period": 0,
                     "hogql_app_bytes_read": 0,
                     "hogql_app_rows_read": 0,
                     "hogql_app_duration_ms": 0,
@@ -330,6 +333,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 2,
                             "ff_active_count": 1,
+                            "decide_requests_in_month": 0,
+                            "decide_requests_in_period": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -357,6 +362,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 0,
                             "ff_active_count": 0,
+                            "decide_requests_in_month": 0,
+                            "decide_requests_in_period": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -405,6 +412,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "dashboard_tagged_count": 0,
                     "ff_count": 0,
                     "ff_active_count": 0,
+                    "decide_requests_in_month": 0,
+                    "decide_requests_in_period": 0,
                     "hogql_app_bytes_read": 0,
                     "hogql_app_rows_read": 0,
                     "hogql_app_duration_ms": 0,
@@ -438,6 +447,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 0,
                             "ff_active_count": 0,
+                            "decide_requests_in_month": 0,
+                            "decide_requests_in_period": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -541,6 +552,127 @@ class HogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTables
         # Nothing was read via the API
         assert report["hogql_api_rows_read"] == 0
         assert report["event_explorer_api_rows_read"] == 0
+
+
+@freeze_time("2022-01-10T00:01:00Z")
+class TestFeatureFlagsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin):
+    def setUp(self) -> None:
+        Team.objects.all().delete()
+        return super().setUp()
+
+    def _setup_teams(self) -> None:
+        self.analytics_org = Organization.objects.create(name="PostHog")
+        self.org_1 = Organization.objects.create(name="Org 1")
+        self.org_2 = Organization.objects.create(name="Org 2")
+
+        self.analytics_team = Team.objects.create(pk=2, organization=self.analytics_org, name="Analytics")
+
+        self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
+        self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
+        self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
+
+    @snapshot_clickhouse_queries
+    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.send_report_to_billing_service")
+    def test_usage_report_decide_requests(self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock) -> None:
+
+        self._setup_teams()
+        for i in range(10):
+            _create_event(
+                distinct_id="3",
+                event="decide usage",
+                properties={"count": 10, "token": "correct"},
+                timestamp=now() - relativedelta(hours=i),
+                team=self.analytics_team,
+            )
+
+        for i in range(5):
+            _create_event(
+                distinct_id="4",
+                event="decide usage",
+                properties={"count": 1, "token": "correct"},
+                timestamp=now() - relativedelta(hours=i),
+                team=self.analytics_team,
+            )
+            _create_event(
+                distinct_id="4",
+                event="decide usage",
+                properties={"count": 100, "token": "wrong"},
+                timestamp=now() - relativedelta(hours=i),
+                team=self.analytics_team,
+            )
+
+        for i in range(7):
+            _create_event(
+                distinct_id="5",
+                event="decide usage",
+                properties={"count": 100},
+                timestamp=now() - relativedelta(hours=i),
+                team=self.analytics_team,
+            )
+
+        # some out of range events
+        _create_event(
+            distinct_id="3",
+            event="decide usage",
+            properties={"count": 20000, "token": "correct"},
+            timestamp=now() - relativedelta(days=20),
+            team=self.analytics_team,
+        )
+        flush_persons_and_events()
+
+        with self.settings(DECIDE_BILLING_ANALYTICS_TOKEN="correct"):
+            all_reports = send_all_org_usage_reports(dry_run=False, at=str(now() + relativedelta(days=1)))
+
+        assert len(all_reports) == 4
+
+        all_reports = sorted(all_reports, key=lambda x: x["organization_name"])
+
+        assert [all_reports["organization_name"] for all_reports in all_reports] == [
+            "Org 1",
+            "Org 2",
+            "PostHog",
+            "Test",
+        ]
+
+        org_1_report = all_reports[0]
+        org_2_report = all_reports[1]
+        analytics_report = all_reports[2]
+
+        assert org_1_report["organization_name"] == "Org 1"
+        assert org_1_report["decide_requests_in_period"] == 11
+        assert org_1_report["decide_requests_in_month"] == 105
+        assert org_1_report["teams"]["3"]["decide_requests_in_period"] == 10
+        assert org_1_report["teams"]["3"]["decide_requests_in_month"] == 100
+        assert org_1_report["teams"]["4"]["decide_requests_in_period"] == 1
+        assert org_1_report["teams"]["4"]["decide_requests_in_month"] == 5
+
+        # because of wrong token, Org 2 has no decide counts.
+        assert org_2_report["organization_name"] == "Org 2"
+        assert org_2_report["decide_requests_in_period"] == 0
+        assert org_2_report["decide_requests_in_month"] == 0
+        assert org_2_report["teams"]["5"]["decide_requests_in_period"] == 0
+        assert org_2_report["teams"]["5"]["decide_requests_in_month"] == 0
+
+        # billing service calls are made only for org1, which has decide requests, and analytics org - which has decide usage events.
+        calls = [
+            call(
+                org_1_report["organization_id"],
+                ANY,
+            ),
+            call(
+                analytics_report["organization_id"],
+                ANY,
+            ),
+        ]
+        assert billing_task_mock.delay.call_count == 2
+        billing_task_mock.delay.assert_has_calls(
+            calls,
+            any_order=True,
+        )
+
+        # capture usage report calls are made for all orgs
+        assert posthog_capture_mock.return_value.capture.call_count == 4
 
 
 class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -298,8 +298,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "dashboard_tagged_count": 0,
                     "ff_count": 2,
                     "ff_active_count": 1,
-                    "decide_requests_in_month": 0,
-                    "decide_requests_in_period": 0,
+                    "decide_requests_count_in_month": 0,
+                    "decide_requests_count_in_period": 0,
                     "hogql_app_bytes_read": 0,
                     "hogql_app_rows_read": 0,
                     "hogql_app_duration_ms": 0,
@@ -333,8 +333,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 2,
                             "ff_active_count": 1,
-                            "decide_requests_in_month": 0,
-                            "decide_requests_in_period": 0,
+                            "decide_requests_count_in_month": 0,
+                            "decide_requests_count_in_period": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -362,8 +362,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 0,
                             "ff_active_count": 0,
-                            "decide_requests_in_month": 0,
-                            "decide_requests_in_period": 0,
+                            "decide_requests_count_in_month": 0,
+                            "decide_requests_count_in_period": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -412,8 +412,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "dashboard_tagged_count": 0,
                     "ff_count": 0,
                     "ff_active_count": 0,
-                    "decide_requests_in_month": 0,
-                    "decide_requests_in_period": 0,
+                    "decide_requests_count_in_month": 0,
+                    "decide_requests_count_in_period": 0,
                     "hogql_app_bytes_read": 0,
                     "hogql_app_rows_read": 0,
                     "hogql_app_duration_ms": 0,
@@ -447,8 +447,8 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 0,
                             "ff_active_count": 0,
-                            "decide_requests_in_month": 0,
-                            "decide_requests_in_period": 0,
+                            "decide_requests_count_in_month": 0,
+                            "decide_requests_count_in_period": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -640,19 +640,19 @@ class TestFeatureFlagsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
         analytics_report = all_reports[2]
 
         assert org_1_report["organization_name"] == "Org 1"
-        assert org_1_report["decide_requests_in_period"] == 11
-        assert org_1_report["decide_requests_in_month"] == 105
-        assert org_1_report["teams"]["3"]["decide_requests_in_period"] == 10
-        assert org_1_report["teams"]["3"]["decide_requests_in_month"] == 100
-        assert org_1_report["teams"]["4"]["decide_requests_in_period"] == 1
-        assert org_1_report["teams"]["4"]["decide_requests_in_month"] == 5
+        assert org_1_report["decide_requests_count_in_period"] == 11
+        assert org_1_report["decide_requests_count_in_month"] == 105
+        assert org_1_report["teams"]["3"]["decide_requests_count_in_period"] == 10
+        assert org_1_report["teams"]["3"]["decide_requests_count_in_month"] == 100
+        assert org_1_report["teams"]["4"]["decide_requests_count_in_period"] == 1
+        assert org_1_report["teams"]["4"]["decide_requests_count_in_month"] == 5
 
         # because of wrong token, Org 2 has no decide counts.
         assert org_2_report["organization_name"] == "Org 2"
-        assert org_2_report["decide_requests_in_period"] == 0
-        assert org_2_report["decide_requests_in_month"] == 0
-        assert org_2_report["teams"]["5"]["decide_requests_in_period"] == 0
-        assert org_2_report["teams"]["5"]["decide_requests_in_month"] == 0
+        assert org_2_report["decide_requests_count_in_period"] == 0
+        assert org_2_report["decide_requests_count_in_month"] == 0
+        assert org_2_report["teams"]["5"]["decide_requests_count_in_period"] == 0
+        assert org_2_report["teams"]["5"]["decide_requests_count_in_month"] == 0
 
         # billing service calls are made only for org1, which has decide requests, and analytics org - which has decide usage events.
         calls = [

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -37,7 +37,7 @@ from posthog.models.plugin import PluginConfig
 from posthog.models.team.team import Team
 from posthog.models.utils import namedtuplefetchall
 from posthog.settings import INSTANCE_TAG, CLICKHOUSE_CLUSTER
-from posthog.utils import get_helm_info_env, get_instance_realm, get_machine_id, get_previous_day
+from posthog.utils import get_helm_info_env, get_instance_realm, get_machine_id, get_previous_day, get_instance_region
 from posthog.version import VERSION
 
 logger = structlog.get_logger(__name__)
@@ -69,6 +69,8 @@ class UsageReportCounters:
     # Feature flags
     ff_count: int
     ff_active_count: int
+    decide_requests_in_period: int
+    decide_requests_in_month: int
     # HogQL
     hogql_app_bytes_read: int
     hogql_app_rows_read: int
@@ -430,12 +432,31 @@ def get_teams_with_hogql_metric(
     return result
 
 
+def get_teams_with_decide_requests_count_in_period(begin: datetime, end: datetime) -> List[Tuple[int, int]]:
+    # depending on the region, events are stored in different teams
+    team_to_query = 1 if get_instance_region() == "EU" else 2
+    validity_token = settings.DECIDE_BILLING_ANALYTICS_TOKEN
+
+    result = sync_execute(
+        """
+        SELECT distinct_id as team, sum(JSONExtractInt(properties, 'count')) as sum
+        FROM events
+        WHERE team_id = %(team_to_query)s AND event='decide usage' AND timestamp between %(begin)s AND %(end)s
+        AND has([%(validity_token)s], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
+        GROUP BY team
+    """,
+        {"begin": begin, "end": end, "team_to_query": team_to_query, "validity_token": validity_token},
+    )
+
+    return result
+
+
 def find_count_for_team_in_rows(team_id: int, rows: list) -> int:
     for row in rows:
         if "team_id" in row:
             if row["team_id"] == team_id:
                 return row["total"]
-        elif row[0] == team_id:
+        elif str(row[0]) == str(team_id):
             return row[1]
     return 0
 
@@ -458,7 +479,9 @@ def capture_report(
 
 # extend this with future usage based products
 def has_non_zero_usage(report: FullUsageReport) -> bool:
-    return report.event_count_in_period > 0 or report.recording_count_in_period > 0
+    return (
+        report.event_count_in_period > 0 or report.recording_count_in_period > 0 or report.decide_requests_in_period > 0
+    )
 
 
 @app.task(ignore_result=True, retries=3)
@@ -489,6 +512,10 @@ def send_all_org_usage_reports(
         # teams_with_event_count_by_name=get_teams_with_event_count_by_name(period_start, period_end),
         teams_with_recording_count_in_period=get_teams_with_recording_count_in_period(period_start, period_end),
         teams_with_recording_count_total=get_teams_with_recording_count_total(),
+        teams_with_decide_requests_in_period=get_teams_with_decide_requests_count_in_period(period_start, period_end),
+        teams_with_decide_requests_in_month=get_teams_with_decide_requests_count_in_period(
+            period_start.replace(day=1), period_end
+        ),
         teams_with_group_types_total=list(
             GroupTypeMapping.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
         ),
@@ -626,6 +653,12 @@ def send_all_org_usage_reports(
             ),
             recording_count_total=find_count_for_team_in_rows(team.id, all_data["teams_with_recording_count_total"]),
             group_types_total=find_count_for_team_in_rows(team.id, all_data["teams_with_group_types_total"]),
+            decide_requests_in_period=find_count_for_team_in_rows(
+                team.id, all_data["teams_with_decide_requests_in_period"]
+            ),
+            decide_requests_in_month=find_count_for_team_in_rows(
+                team.id, all_data["teams_with_decide_requests_in_month"]
+            ),
             dashboard_count=find_count_for_team_in_rows(team.id, all_data["teams_with_dashboard_count"]),
             dashboard_template_count=find_count_for_team_in_rows(
                 team.id, all_data["teams_with_dashboard_template_count"]

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -69,8 +69,8 @@ class UsageReportCounters:
     # Feature flags
     ff_count: int
     ff_active_count: int
-    decide_requests_in_period: int
-    decide_requests_in_month: int
+    decide_requests_count_in_period: int
+    decide_requests_count_in_month: int
     # HogQL
     hogql_app_bytes_read: int
     hogql_app_rows_read: int
@@ -480,7 +480,9 @@ def capture_report(
 # extend this with future usage based products
 def has_non_zero_usage(report: FullUsageReport) -> bool:
     return (
-        report.event_count_in_period > 0 or report.recording_count_in_period > 0 or report.decide_requests_in_period > 0
+        report.event_count_in_period > 0
+        or report.recording_count_in_period > 0
+        or report.decide_requests_count_in_period > 0
     )
 
 
@@ -512,8 +514,10 @@ def send_all_org_usage_reports(
         # teams_with_event_count_by_name=get_teams_with_event_count_by_name(period_start, period_end),
         teams_with_recording_count_in_period=get_teams_with_recording_count_in_period(period_start, period_end),
         teams_with_recording_count_total=get_teams_with_recording_count_total(),
-        teams_with_decide_requests_in_period=get_teams_with_decide_requests_count_in_period(period_start, period_end),
-        teams_with_decide_requests_in_month=get_teams_with_decide_requests_count_in_period(
+        teams_with_decide_requests_count_in_period=get_teams_with_decide_requests_count_in_period(
+            period_start, period_end
+        ),
+        teams_with_decide_requests_count_in_month=get_teams_with_decide_requests_count_in_period(
             period_start.replace(day=1), period_end
         ),
         teams_with_group_types_total=list(
@@ -653,11 +657,11 @@ def send_all_org_usage_reports(
             ),
             recording_count_total=find_count_for_team_in_rows(team.id, all_data["teams_with_recording_count_total"]),
             group_types_total=find_count_for_team_in_rows(team.id, all_data["teams_with_group_types_total"]),
-            decide_requests_in_period=find_count_for_team_in_rows(
-                team.id, all_data["teams_with_decide_requests_in_period"]
+            decide_requests_count_in_period=find_count_for_team_in_rows(
+                team.id, all_data["teams_with_decide_requests_count_in_period"]
             ),
-            decide_requests_in_month=find_count_for_team_in_rows(
-                team.id, all_data["teams_with_decide_requests_in_month"]
+            decide_requests_count_in_month=find_count_for_team_in_rows(
+                team.id, all_data["teams_with_decide_requests_count_in_month"]
             ),
             dashboard_count=find_count_for_team_in_rows(team.id, all_data["teams_with_dashboard_count"]),
             dashboard_template_count=find_count_for_team_in_rows(

--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -93,14 +93,30 @@ class TestFeatureFlagAnalytics(BaseTest):
             capture_team_decide_usage(mock_capture, team_id, team_uuid)
             capture_team_decide_usage(mock_capture, team_id, team_uuid)
             mock_capture.capture.assert_called_once_with(
-                team_id, "decide usage", {"count": 15, "team_id": team_id, "team_uuid": team_uuid}
+                team_id,
+                "decide usage",
+                {
+                    "count": 15,
+                    "team_id": team_id,
+                    "team_uuid": team_uuid,
+                    "max_time": 1651926190,
+                    "min_time": 1651926180,
+                },
             )
 
             mock_capture.reset_mock()
             capture_team_decide_usage(mock_capture, other_team_id, other_team_uuid)
             capture_team_decide_usage(mock_capture, other_team_id, other_team_uuid)
             mock_capture.capture.assert_called_once_with(
-                other_team_id, "decide usage", {"count": 10, "team_id": other_team_id, "team_uuid": other_team_uuid}
+                other_team_id,
+                "decide usage",
+                {
+                    "count": 10,
+                    "team_id": other_team_id,
+                    "team_uuid": other_team_uuid,
+                    "max_time": 1651926190,
+                    "min_time": 1651926180,
+                },
             )
 
     @pytest.mark.skip(
@@ -160,10 +176,26 @@ class TestFeatureFlagAnalytics(BaseTest):
                 assert future.exception() is None
 
             mock_capture.capture.assert_any_call(
-                team_id, "decide usage", {"count": 15, "team_id": team_id, "team_uuid": team_uuid}
+                team_id,
+                "decide usage",
+                {
+                    "count": 15,
+                    "team_id": team_id,
+                    "team_uuid": team_uuid,
+                    "max_time": 1651926190,
+                    "min_time": 1651926180,
+                },
             )
             mock_capture.capture.assert_any_call(
-                other_team_id, "decide usage", {"count": 10, "team_id": other_team_id, "team_uuid": other_team_uuid}
+                other_team_id,
+                "decide usage",
+                {
+                    "count": 10,
+                    "team_id": other_team_id,
+                    "team_uuid": other_team_uuid,
+                    "max_time": 1651926190,
+                    "min_time": 1651926180,
+                },
             )
             assert mock_capture.capture.call_count == 2
 
@@ -214,7 +246,15 @@ class TestFeatureFlagAnalytics(BaseTest):
                 assert future.exception() is None
 
             mock_capture.capture.assert_any_call(
-                team_id, "decide usage", {"count": 15, "team_id": team_id, "team_uuid": team_uuid}
+                team_id,
+                "decide usage",
+                {
+                    "count": 15,
+                    "team_id": team_id,
+                    "team_uuid": team_uuid,
+                    "max_time": 1651926190,
+                    "min_time": 1651926180,
+                },
             )
             assert mock_capture.capture.call_count == 1
 


### PR DESCRIPTION
## Problem

We want decide request analytics data in the usage report. This adds it.

A few considerations:

1. Data for all teams is sent to team 1 on EU, and team 2 on US.
2. We want to defend against a random bad actor sending us events to increase/decrease their usage. So, we only count 'valid' usage: where validity is controlled by a token we set (so only data coming from our own posthog prod instance, not even dev, is valid for usage counting)


In a follow up, I'll add the same for local evaluation requests.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
