### PR TITLE
feat(hogql): errors for large full select queries

### DIFF
--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -2,13 +2,13 @@ import { useActions, useValues } from 'kea'
 import { HogQLQuery } from '~/queries/schema'
 import { useEffect, useRef, useState } from 'react'
 import { hogQLQueryEditorLogic } from './hogQLQueryEditorLogic'
-import MonacoEditor from '@monaco-editor/react'
+import MonacoEditor, { Monaco } from '@monaco-editor/react'
 import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
-import { IDisposable } from 'monaco-editor'
+import { IDisposable, editor as importedEditor } from 'monaco-editor'
 
 export interface HogQLQueryEditorProps {
     query: HogQLQuery
@@ -18,7 +18,9 @@ export interface HogQLQueryEditorProps {
 let uniqueNode = 0
 export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
     const [key] = useState(() => uniqueNode++)
-    const hogQLQueryEditorLogicProps = { query: props.query, setQuery: props.setQuery, key }
+    const [monaco, setMonaco] = useState(null as Monaco | null)
+    const [editor, setEditor] = useState(null as importedEditor.IStandaloneCodeEditor | null)
+    const hogQLQueryEditorLogicProps = { query: props.query, setQuery: props.setQuery, key, editor, monaco }
     const { queryInput } = useValues(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
     const { setQueryInput, saveQuery } = useActions(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
 
@@ -63,6 +65,8 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                                             run: () => saveQuery(),
                                         })
                                     )
+                                    setMonaco(monaco)
+                                    setEditor(editor)
                                 }}
                                 options={{
                                     minimap: {

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -23,7 +23,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
     )
     const [monaco, editor] = monacoAndEditor ?? []
     const hogQLQueryEditorLogicProps = { query: props.query, setQuery: props.setQuery, key, editor, monaco }
-    const { queryInput } = useValues(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
+    const { queryInput, hasErrors, error } = useValues(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
     const { setQueryInput, saveQuery } = useActions(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
 
     // Using useRef, not useState, as we don't want to reload the component when this changes.
@@ -84,7 +84,13 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                     onClick={saveQuery}
                     type="primary"
                     status={'muted-alt'}
-                    disabledReason={!props.setQuery ? 'No permission to update' : undefined}
+                    disabledReason={
+                        !props.setQuery
+                            ? 'No permission to update'
+                            : hasErrors
+                            ? error ?? 'Query has errors'
+                            : undefined
+                    }
                     fullWidth
                     center
                 >

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -18,8 +18,10 @@ export interface HogQLQueryEditorProps {
 let uniqueNode = 0
 export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
     const [key] = useState(() => uniqueNode++)
-    const [monaco, setMonaco] = useState(null as Monaco | null)
-    const [editor, setEditor] = useState(null as importedEditor.IStandaloneCodeEditor | null)
+    const [monacoAndEditor, setMonacoAndEditor] = useState(
+        null as [Monaco, importedEditor.IStandaloneCodeEditor] | null
+    )
+    const [monaco, editor] = monacoAndEditor ?? []
     const hogQLQueryEditorLogicProps = { query: props.query, setQuery: props.setQuery, key, editor, monaco }
     const { queryInput } = useValues(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
     const { setQueryInput, saveQuery } = useActions(hogQLQueryEditorLogic(hogQLQueryEditorLogicProps))
@@ -65,8 +67,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                                             run: () => saveQuery(),
                                         })
                                     )
-                                    setMonaco(monaco)
-                                    setEditor(editor)
+                                    setMonacoAndEditor([monaco, editor])
                                 }}
                                 options={{
                                     minimap: {

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -44,7 +44,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
             </div>
             <div
                 data-attr="hogql-query-editor"
-                className={'flex flex-col p-2 bg-border space-y-2 resize-y overflow-auto h-80 w-full'}
+                className={'flex flex-col p-2 bg-border space-y-2 resize-y h-80 w-full'}
             >
                 <div className="flex-1">
                     <AutoSizer disableWidth>

--- a/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.ts
+++ b/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.ts
@@ -1,12 +1,17 @@
 import { actions, kea, key, listeners, path, props, propsChanged, reducers } from 'kea'
-import { HogQLQuery } from '~/queries/schema'
+import { HogQLMetadata, HogQLQuery, NodeKind } from '~/queries/schema'
 
 import type { hogQLQueryEditorLogicType } from './hogQLQueryEditorLogicType'
+import { editor as importedEditor, MarkerSeverity } from 'monaco-editor'
+import { query } from '~/queries/query'
+import { Monaco } from '@monaco-editor/react'
 
 export interface HogQLQueryEditorLogicProps {
     key: number
     query: HogQLQuery
     setQuery?: (query: HogQLQuery) => void
+    monaco?: Monaco | null
+    editor?: importedEditor.IStandaloneCodeEditor | null
 }
 
 export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
@@ -30,6 +35,39 @@ export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
             const query = values.queryInput
             actions.setQueryInput(query)
             props.setQuery?.({ ...props.query, query })
+        },
+        setQueryInput: async (_, breakpoint) => {
+            if (!props.editor || !props.monaco) {
+                return
+            }
+            const model = props.editor?.getModel()
+            if (!model) {
+                return
+            }
+            await breakpoint(300)
+            const { queryInput } = values
+            const response = await query<HogQLMetadata>({
+                kind: NodeKind.HogQLMetadata,
+                select: queryInput,
+            })
+            breakpoint()
+            if (!response?.isValid) {
+                const start = model.getPositionAt(response?.errorStart ?? 0)
+                const end = model.getPositionAt(response?.errorEnd ?? queryInput.length)
+                const markers: importedEditor.IMarkerData[] = [
+                    {
+                        startLineNumber: start.lineNumber,
+                        startColumn: start.column,
+                        endLineNumber: end.lineNumber,
+                        endColumn: end.column,
+                        message: response?.error ?? 'Unknown error',
+                        severity: MarkerSeverity.Error,
+                    },
+                ]
+                props.monaco.editor.setModelMarkers(model, 'hogql', markers)
+            } else {
+                props.monaco.editor.setModelMarkers(model, 'hogql', [])
+            }
         },
     })),
 ])

--- a/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.ts
+++ b/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.ts
@@ -2,16 +2,19 @@ import { actions, kea, key, listeners, path, props, propsChanged, reducers, sele
 import { HogQLMetadata, HogQLQuery, NodeKind } from '~/queries/schema'
 
 import type { hogQLQueryEditorLogicType } from './hogQLQueryEditorLogicType'
-import { editor as importedEditor, MarkerSeverity } from 'monaco-editor'
+import { editor, MarkerSeverity } from 'monaco-editor'
 import { query } from '~/queries/query'
 import { Monaco } from '@monaco-editor/react'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ModelMarker extends editor.IMarkerData {}
 
 export interface HogQLQueryEditorLogicProps {
     key: number
     query: HogQLQuery
     setQuery?: (query: HogQLQuery) => void
     monaco?: Monaco | null
-    editor?: importedEditor.IStandaloneCodeEditor | null
+    editor?: editor.IStandaloneCodeEditor | null
 }
 
 export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
@@ -26,11 +29,11 @@ export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
     actions({
         saveQuery: true,
         setQueryInput: (queryInput: string) => ({ queryInput }),
-        setModelMarkers: (markers: importedEditor.IMarkerData[]) => ({ markers }),
+        setModelMarkers: (markers: ModelMarker[]) => ({ markers }),
     }),
     reducers(({ props }) => ({
         queryInput: [props.query.query, { setQueryInput: (_, { queryInput }) => queryInput }],
-        modelMarkers: [[] as importedEditor.IMarkerData[], { setModelMarkers: (_, { markers }) => markers }],
+        modelMarkers: [[] as ModelMarker[], { setModelMarkers: (_, { markers }) => markers }],
     })),
     selectors({
         hasErrors: [(s) => [s.modelMarkers], (modelMarkers) => !!modelMarkers?.length],
@@ -66,7 +69,7 @@ export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
             if (!response?.isValid) {
                 const start = model.getPositionAt(response?.errorStart ?? 0)
                 const end = model.getPositionAt(response?.errorEnd ?? queryInput.length)
-                const markers: importedEditor.IMarkerData[] = [
+                const markers: ModelMarker[] = [
                     {
                         startLineNumber: start.lineNumber,
                         startColumn: start.column,

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -129,6 +129,7 @@ export const commonConfig = {
         'process.env.NODE_ENV': isDev ? '"development"' : '"production"',
     },
     loader: {
+        '.ttf': 'file',
         '.png': 'file',
         '.svg': 'file',
         '.woff': 'file',

--- a/posthog/hogql/errors.py
+++ b/posthog/hogql/errors.py
@@ -16,16 +16,7 @@ class HogQLException(Exception):
 class SyntaxException(HogQLException):
     """Invalid HogQL syntax."""
 
-    line: int
-    column: int
-
-    def __init__(self, message: str, *, line: int, column: int):
-        super().__init__(message)
-        self.line = line
-        self.column = column
-
-    def __str__(self):
-        return f"Syntax error at line {self.line}, column {self.column}: {super().__str__()}"
+    pass
 
 
 class QueryException(HogQLException):

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -19,7 +19,9 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
                 "isValid": False,
                 "inputExpr": "select 1",
                 "inputSelect": None,
-                "error": "Syntax error at line 1, column 7: extraneous input '1' expecting <EOF>",
+                "error": "extraneous input '1' expecting <EOF>",
+                "errorStart": 7,
+                "errorEnd": 8,
             },
         )
 
@@ -55,9 +57,9 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
                 "isValid": False,
                 "inputExpr": None,
                 "inputSelect": "timestamp",
-                "error": "Syntax error at line 1, column 0: mismatched input 'timestamp' expecting {SELECT, WITH, '('}",
-                "errorStart": None,
-                "errorEnd": None,
+                "error": "mismatched input 'timestamp' expecting {SELECT, WITH, '('}",
+                "errorStart": 0,
+                "errorEnd": 9,
             },
         )
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -263,14 +263,12 @@ class TestPrinter(BaseTest):
         self._assert_expr_error("person", "Can't select a table when a column is expected: person")
 
     def test_expr_syntax_errors(self):
-        self._assert_expr_error("(", "Syntax error at line 1, column 1: no viable alternative at input '('")
-        self._assert_expr_error("())", "Syntax error at line 1, column 1: no viable alternative at input '()'")
-        self._assert_expr_error(
-            "select query from events", "Syntax error at line 1, column 13: mismatched input 'from' expecting <EOF>"
-        )
+        self._assert_expr_error("(", "no viable alternative at input '('")
+        self._assert_expr_error("())", "no viable alternative at input '()'")
+        self._assert_expr_error("select query from events", "mismatched input 'from' expecting <EOF>")
         self._assert_expr_error("this makes little sense", "Unable to resolve field: this")
-        self._assert_expr_error("1;2", "Syntax error at line 1, column 1: mismatched input ';' expecting <EOF>")
-        self._assert_expr_error("b.a(bla)", "Syntax error at line 1, column 3: mismatched input '(' expecting '.'")
+        self._assert_expr_error("1;2", "mismatched input ';' expecting <EOF>")
+        self._assert_expr_error("b.a(bla)", "mismatched input '(' expecting '.'")
 
     def test_logic(self):
         self.assertEqual(


### PR DESCRIPTION
## Problem

The full HogQL insight editor does not show errors as well as the inline filter editors.

## Changes

Support passing error information from `HogQLMetadata` now.

![2023-06-08 14 46 10](https://github.com/PostHog/posthog/assets/53387/bba6452d-d6cc-4184-aa36-4cea927a6676)

Also cleaned up the location information with antlr syntax errors.

## How did you test this code?

See the gif