### PR TITLE
chore(plugin-server): patch bug in pg library

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -130,5 +130,10 @@
         "prettier": "^2.8.8",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4"
+    },
+    "pnpm": {
+        "patchedDependencies": {
+            "pg@8.10.0": "patches/pg@8.10.0.patch"
+        }
     }
 }

--- a/plugin-server/patches/pg@8.10.0.patch
+++ b/plugin-server/patches/pg@8.10.0.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/connection.js b/lib/connection.js
+index 9e24391b6bdcfd8677a6d0dd51481c1231990159..058109c8c0f04980f45402cdb2e3a6ca5a981ee9 100644
+--- a/lib/connection.js
++++ b/lib/connection.js
+@@ -83,19 +83,18 @@ class Connection extends EventEmitter {
+       const options = {
+         socket: self.stream,
+       }
+-
+-      if (self.ssl !== true) {
+-        Object.assign(options, self.ssl)
+-
+-        if ('key' in self.ssl) {
+-          options.key = self.ssl.key
+-        }
+-      }
+-
+-      if (net.isIP(host) === 0) {
+-        options.servername = host
+-      }
+       try {
++        if (self.ssl !== true) {
++          Object.assign(options, self.ssl)
++  
++          if ('key' in self.ssl) {
++            options.key = self.ssl.key
++          }
++        }
++  
++        if (net.isIP(host) === 0) {
++          options.servername = host
++        }
+         self.stream = tls.connect(options)
+       } catch (err) {
+         return self.emit('error', err)

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: '6.0'
 
+patchedDependencies:
+  pg@8.10.0:
+    hash: ju7a73s3qkmrf666u3aacfrooi
+    path: patches/pg@8.10.0.patch
+
 dependencies:
   '@aws-sdk/client-s3':
     specifier: ^3.315.0
@@ -114,7 +119,7 @@ dependencies:
     version: 2.1.1
   pg:
     specifier: ^8.6.0
-    version: 8.10.0
+    version: 8.10.0(patch_hash=ju7a73s3qkmrf666u3aacfrooi)
   pino:
     specifier: ^8.6.0
     version: 8.11.0
@@ -6980,7 +6985,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 7.1.0
       json5: 2.2.3
-      pg: 8.10.0
+      pg: 8.10.0(patch_hash=ju7a73s3qkmrf666u3aacfrooi)
       tslib: 2.5.0
       yargs: 16.2.0
     transitivePeerDependencies:
@@ -9382,7 +9387,7 @@ packages:
     peerDependencies:
       pg: '>=8.0'
     dependencies:
-      pg: 8.10.0
+      pg: 8.10.0(patch_hash=ju7a73s3qkmrf666u3aacfrooi)
     dev: false
 
   /pg-protocol@1.6.0:
@@ -9398,7 +9403,7 @@ packages:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  /pg@8.10.0:
+  /pg@8.10.0(patch_hash=ju7a73s3qkmrf666u3aacfrooi):
     resolution: {integrity: sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -9415,6 +9420,7 @@ packages:
       pg-types: 2.2.0
       pgpass: 1.0.5
     dev: false
+    patched: true
 
   /pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -43,6 +43,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Compile and install Node.js dependencies.
 COPY ./plugin-server/package.json ./plugin-server/pnpm-lock.yaml ./plugin-server/tsconfig.json ./
+COPY ./plugin-server/patches/ ./patches/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "make" \


### PR DESCRIPTION
## Problem

Addresses what's triggering https://github.com/PostHog/posthog/issues/15942 for the Postgres App: `EventEmitter`s have a special error handling, and an exception thrown there bubbles through `try` / `catch` blocks.

In our case, setting `?ssl=off` triggers an unhandled exception when connecting to the server. This is an invalid value, but the library does not reject it when parsing it's input.

## Changes

- Patch our `pg` dependency to extend the existing `try` / `catch` to cover what's currently breaking.

We'll revert once https://github.com/brianc/node-postgres/pull/3004 is accepted upstream and we can upgrade to a release shipping the fix.

## How did you test this code?

#### Without the patch

> [15:09:26.166] ERROR (91510): [MAIN] 🤮 uncaughtException!
>    stack: "TypeError: Cannot read properties of undefined (reading 'length')\n    at process.Job.cancel (/Users/xavier/git/posthog/plugin-server/node_modules/.pnpm/node-schedule@2.1.1/node_modules/node-schedule/lib/Job.js:92:49)\n    at process.emit (node:events:525:35)\n    at process.emit (node:domain:489:12)\n    at Signal.callbackTrampoline (node:internal/async_hooks:130:17)"
>    error: {}
> [15:09:26.166] INFO (91510): [MAIN] 🛑 Stopped Graphile worker...


#### With the patch

> [15:15:03.175] INFO (92646): [MAIN] ⚡ Reloading plugins!
> [15:15:03.177] WARN (92646): [MAIN] ⚠️ Failed to load plugin PostgreSQL Export Plugin ID 8 (organization ID 0188961f-ec93-0000-e55e-2d00231a51de). SetupPluginError: setupPlugin failed with Error: Unable to connect to PostgreSQL instance and create table with error: Cannot use 'in' operator to search for 'key' in off for plugin PostgreSQL Export Plugin ID 8 (organization ID 0188961f-ec93-0000-e55e-2d00231a51de). Disabled the app!