### PR TITLE
chore(early-access-feature): filter for beta only

### DIFF
--- a/posthog/api/early_access_feature.py
+++ b/posthog/api/early_access_feature.py
@@ -222,9 +222,9 @@ def early_access_features(request: Request):
         )
 
     early_access_features = MinimalEarlyAccessFeatureSerializer(
-        EarlyAccessFeature.objects.filter(team_id=team.id)
-        .exclude(stage=EarlyAccessFeature.Stage.GENERAL_AVAILABILITY)
-        .select_related("feature_flag"),
+        EarlyAccessFeature.objects.filter(team_id=team.id, stage=EarlyAccessFeature.Stage.BETA).select_related(
+            "feature_flag"
+        ),
         many=True,
     ).data
 

--- a/posthog/api/test/__snapshots__/test_early_access_feature.ambr
+++ b/posthog/api/test/__snapshots__/test_early_access_feature.ambr
@@ -183,7 +183,7 @@
          "posthog_featureflag"."usage_dashboard_id"
   FROM "posthog_earlyaccessfeature"
   LEFT OUTER JOIN "posthog_featureflag" ON ("posthog_earlyaccessfeature"."feature_flag_id" = "posthog_featureflag"."id")
-  WHERE ("posthog_earlyaccessfeature"."team_id" = 2
-         AND NOT ("posthog_earlyaccessfeature"."stage" = 'general-availability')) /*controller='posthog.api.early_access_feature.early_access_features',route='%5Eapi/early_access_features/%3F%28%3F%3A%5B%3F%23%5D.%2A%29%3F%24'*/
+  WHERE ("posthog_earlyaccessfeature"."stage" = 'beta'
+         AND "posthog_earlyaccessfeature"."team_id" = 2) /*controller='posthog.api.early_access_feature.early_access_features',route='%5Eapi/early_access_features/%3F%28%3F%3A%5B%3F%23%5D.%2A%29%3F%24'*/
   '
 ---

--- a/posthog/api/test/test_early_access_feature.py
+++ b/posthog/api/test/test_early_access_feature.py
@@ -453,7 +453,7 @@ class TestPreviewList(BaseTest, QueryMatchingTest):
             stage="beta",
             feature_flag=feature_flag,
         )
-        feature2 = EarlyAccessFeature.objects.create(
+        EarlyAccessFeature.objects.create(
             team=self.team,
             name="Sprocket",
             description="A fancy new sprocket.",
@@ -478,15 +478,7 @@ class TestPreviewList(BaseTest, QueryMatchingTest):
                         "stage": "beta",
                         "documentationUrl": "",
                         "flagKey": "sprocket",
-                    },
-                    {
-                        "id": str(feature2.id),
-                        "name": "Sprocket",
-                        "description": "A fancy new sprocket.",
-                        "stage": "alpha",
-                        "documentationUrl": "",
-                        "flagKey": "sprocket2",
-                    },
+                    }
                 ],
             )
 


### PR DESCRIPTION
## Problem

- after https://github.com/PostHog/posthog/pull/15820 we need to filter for beta specifically so drafts don't show up

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- only show beta

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
