### PR TITLE
chore(hogql): Expose the `UNKNOWN_FUNCTION` error too

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -119,7 +119,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: Dict[int, ErrorCodeMeta] = {
     43: ErrorCodeMeta("ILLEGAL_TYPE_OF_ARGUMENT", user_safe=True),
     44: ErrorCodeMeta("ILLEGAL_COLUMN"),
     45: ErrorCodeMeta("ILLEGAL_NUMBER_OF_RESULT_COLUMNS"),
-    46: ErrorCodeMeta("UNKNOWN_FUNCTION"),
+    46: ErrorCodeMeta("UNKNOWN_FUNCTION", user_safe=True),
     47: ErrorCodeMeta("UNKNOWN_IDENTIFIER"),
     48: ErrorCodeMeta("NOT_IMPLEMENTED"),
     49: ErrorCodeMeta("LOGICAL_ERROR"),


### PR DESCRIPTION
## Changes

#15959 exposed a few ClickHouse errors to users in HogQL, `UNKNOWN_FUNCTION` is worth adding there too. Prompted by this user report: ZEN-3441

An example of a query where this pops up:

```SQL
SELECT min(timestamp) AS min_timestamp
FROM events
GROUP BY min_timestamp
```

The error is:
> Unknown function min. There is an aggregate function with the same name, but ordinary function is expected here. Maybe you meant: ['bin','in'].

Effectively this means "you can't group by an expression with an aggregate function!", which would be clearer, but the CH error already suggests the problem much better than a server error.