### PR TITLE
fix(hogql): empty properties array in filter

### DIFF
--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -101,6 +101,10 @@ class TestProperty(BaseTest):
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "not_regex"}),
             self._parse_expr("not(match(properties.a, '.*'))"),
         )
+        self.assertEqual(
+            self._property_to_expr({"type": "event", "key": "a", "value": [], "operator": "exact"}),
+            self._parse_expr("true"),
+        )
 
     def test_property_to_expr_boolean(self):
         PropertyDefinition.objects.create(
@@ -195,6 +199,16 @@ class TestProperty(BaseTest):
         )
 
     def test_property_groups(self):
+        self.assertEqual(
+            self._property_to_expr(
+                PropertyGroup(
+                    type=PropertyOperatorType.AND,
+                    values=[],
+                )
+            ),
+            self._parse_expr("true"),
+        )
+
         self.assertEqual(
             self._property_to_expr(
                 PropertyGroup(


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/4229855681/?project=1899813&referrer=slack

Selecting a property with an empty list used to make the event explorer crash.

## Changes

Fixes this bug.
<img width="1457" alt="image" src="https://github.com/PostHog/posthog/assets/53387/03d3eb70-60f0-4baf-8e6a-bc3de349e57f">


## How did you test this code?

Added two tests