### PR TITLE
refactor(hogql): Groundwork for allowing placeholders in user SQL

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -57,7 +57,7 @@ class Type(AST):
 
 
 class Expr(AST):
-    type: Optional[Type]
+    type: Optional[Type] = None
 
 
 class Macro(Expr):

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -1,9 +1,17 @@
 # HogQL -> ClickHouse allowed transformations
-from typing import Optional, Dict, Tuple, Literal
+from datetime import date, datetime
+from typing import Optional, Dict, Tuple, Literal, TypeAlias
+from uuid import UUID
 
 from pydantic import BaseModel, Extra
 
-ConstantDataType = Literal["int", "float", "str", "bool", "array", "tuple", "date", "datetime", "uuid", "unknown"]
+ConstantDataType: TypeAlias = Literal[
+    "int", "float", "str", "bool", "array", "tuple", "date", "datetime", "uuid", "unknown"
+]
+ConstantSupportedPrimitive: TypeAlias = int | float | str | bool | date | datetime | UUID | None
+ConstantSupportedData: TypeAlias = (
+    ConstantSupportedPrimitive | list[ConstantSupportedPrimitive] | tuple[ConstantSupportedPrimitive, ...]
+)
 
 CLICKHOUSE_FUNCTIONS: Dict[str, Tuple[str, int | None, int | None]] = {
     # arithmetic

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -9,42 +9,32 @@ from posthog.hogql.errors import NotImplementedException, HogQLException, Syntax
 from posthog.hogql.grammar.HogQLLexer import HogQLLexer
 from posthog.hogql.grammar.HogQLParser import HogQLParser
 from posthog.hogql.parse_string import parse_string, parse_string_literal
-from posthog.hogql.placeholders import assert_no_placeholders, replace_placeholders
+from posthog.hogql.placeholders import replace_placeholders
 
 
-def parse_expr(expr: str, placeholders: Optional[Dict[str, ast.Expr]] = None, no_placeholders=False) -> ast.Expr:
+def parse_expr(expr: str, placeholders: Optional[Dict[str, ast.Expr]] = None) -> ast.Expr:
     parse_tree = get_parser(expr).expr()
     node = HogQLParseTreeConverter().visit(parse_tree)
     if placeholders:
         return replace_placeholders(node, placeholders)
-    elif no_placeholders:
-        assert_no_placeholders(node)
-
     return node
 
 
-def parse_order_expr(
-    order_expr: str, placeholders: Optional[Dict[str, ast.Expr]] = None, no_placeholders=False
-) -> ast.Expr:
+def parse_order_expr(order_expr: str, placeholders: Optional[Dict[str, ast.Expr]] = None) -> ast.Expr:
     parse_tree = get_parser(order_expr).orderExpr()
     node = HogQLParseTreeConverter().visit(parse_tree)
     if placeholders:
         return replace_placeholders(node, placeholders)
-    elif no_placeholders:
-        assert_no_placeholders(node)
-
     return node
 
 
 def parse_select(
-    statement: str, placeholders: Optional[Dict[str, ast.Expr]] = None, no_placeholders=False
+    statement: str, placeholders: Optional[Dict[str, ast.Expr]] = None
 ) -> ast.SelectQuery | ast.SelectUnionQuery:
     parse_tree = get_parser(statement).select()
     node = HogQLParseTreeConverter().visit(parse_tree)
     if placeholders:
         node = replace_placeholders(node, placeholders)
-    elif no_placeholders:
-        assert_no_placeholders(node)
     return node
 
 

--- a/posthog/hogql/placeholders.py
+++ b/posthog/hogql/placeholders.py
@@ -1,34 +1,28 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from posthog.hogql import ast
 from posthog.hogql.errors import HogQLException
 from posthog.hogql.visitor import CloningVisitor
 
 
-def replace_placeholders(node: ast.Expr, placeholders: Dict[str, ast.Expr]) -> ast.Expr:
+def replace_placeholders(node: ast.Expr, placeholders: Optional[Dict[str, ast.Expr]]) -> ast.Expr:
     return ReplacePlaceholders(placeholders).visit(node)
 
 
 class ReplacePlaceholders(CloningVisitor):
-    def __init__(self, placeholders: Dict[str, ast.Expr]):
+    def __init__(self, placeholders: Optional[Dict[str, ast.Expr]]):
         super().__init__()
         self.placeholders = placeholders
 
     def visit_placeholder(self, node):
+        if not self.placeholders:
+            raise HogQLException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
         if node.field in self.placeholders:
             new_node = self.placeholders[node.field]
             new_node.start = node.start
             new_node.end = node.end
             return new_node
         raise HogQLException(
-            f"Placeholder '{node.field}' not found in provided dict: {', '.join(list(self.placeholders))}"
+            f"Placeholder {{{node.field}}} is not available in this context. You can use the following: "
+            + ", ".join((f"{placeholder}" for placeholder in self.placeholders))
         )
-
-
-def assert_no_placeholders(node: ast.Expr):
-    AssertNoPlaceholders().visit(node)
-
-
-class AssertNoPlaceholders(CloningVisitor):
-    def visit_placeholder(self, node):
-        raise HogQLException(f"Placeholder '{node.field}' not allowed in this context")

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -485,7 +485,7 @@ class _Printer(Visitor):
             raise HogQLException(f"Unsupported function call '{node.name}(...)'")
 
     def visit_placeholder(self, node: ast.Placeholder):
-        raise HogQLException(f"Found a Placeholder {{{node.field}}} in the tree. Can't generate query!")
+        raise HogQLException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
 
     def visit_alias(self, node: ast.Alias):
         inside = self.visit(node.expr)

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -165,9 +165,7 @@ def property_to_expr(property: Union[BaseModel, PropertyGroup, Property, dict, l
             else:
                 exprs = [
                     property_to_expr(
-                        Property(type=property.type, key=property.key, operator=property.operator, value=v),
-                        team,
-                        filter=filter,
+                        Property(type=property.type, key=property.key, operator=property.operator, value=v), team
                     )
                     for v in value
                 ]

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -5,7 +5,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import HogQLSettings
 from posthog.hogql.hogql import HogQLContext
 from posthog.hogql.parser import parse_select
-from posthog.hogql.placeholders import assert_no_placeholders, replace_placeholders
+from posthog.hogql.placeholders import replace_placeholders
 from posthog.hogql.printer import prepare_ast_for_printing, print_ast, print_prepared_ast
 from posthog.hogql.visitor import clone_expr
 from posthog.models.team import Team
@@ -29,10 +29,7 @@ def execute_hogql_query(
     else:
         select_query = parse_select(str(query))
 
-    if placeholders:
-        select_query = replace_placeholders(select_query, placeholders)
-    else:
-        assert_no_placeholders(select_query)
+    select_query = replace_placeholders(select_query, placeholders)
 
     if select_query.limit is None:
         # One more "max" of MAX_SELECT_RETURNED_ROWS (100k) in applied in the query printer, overriding this if higher.

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -24,7 +24,7 @@ not_call = lambda x: ast.Call(name="not", args=[x])
 
 class TestProperty(BaseTest):
     def _property_to_expr(self, property: Union[PropertyGroup, Property, dict, list], team: Optional[Team] = None):
-        return clear_locations(property_to_expr(property, team=team))
+        return clear_locations(property_to_expr(property, team=team or self.team))
 
     def _selector_to_expr(self, selector: str):
         return clear_locations(selector_to_expr(selector))

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -343,6 +343,8 @@ def parse_prop_clauses(
             final.append(f"{property_operator} {filter_query}")
             params.update(filter_params)
         elif prop.type == "hogql":
+            if hogql_context is None:
+                raise ValueError("HogQL is not supported here")
             from posthog.hogql.hogql import translate_hogql
 
             filter_query = translate_hogql(prop.key, hogql_context)


### PR DESCRIPTION
## Problem

A user asked for dashboard time ranges to be supported in HogQL (ZEN-3438), so I digged a bit into this to understand HogQL more.

## Changes

Mainly improving error handling, but also added a concept of `hogql` variables, meaning user-facing placeholders. So now once we include the time range in the HogQL query definition, we can just add `date_from` and `date_to` to variables and users will be able to include `{date_from}`/`{date_to}`.