### PR TITLE
feat(hogql): null-tolerant concat

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -5,7 +5,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -21,7 +21,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -37,7 +37,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', ''), '%/%'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -53,7 +53,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -69,7 +69,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -85,7 +85,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), ilike(nullIf(nullIf(events.mat_path, ''), 'null'), '%/%'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -163,7 +163,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -179,7 +179,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals('a%sd', 'foo'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -195,7 +195,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals('a%sd', 'a%sd'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -211,7 +211,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -227,7 +227,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -243,7 +243,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals('a%sd', 'foo'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -259,7 +259,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals('a%sd', 'a%sd'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -275,7 +275,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -291,7 +291,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          'a%sd',
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
@@ -321,7 +321,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null'),
          'a%sd',
-         concat(events.event, ' ', nullIf(nullIf(events.mat_key, ''), 'null'))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
@@ -422,7 +422,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          events.event,
          events.distinct_id,
-         concat(events.event, ' ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -50,6 +50,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
+            self.maxDiff = None
             query = EventsQuery(select=["properties.key", "event", "distinct_id", "concat(event, ' ', properties.key)"])
             response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(
@@ -63,7 +64,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                         ["test_val2", "sign out", "2", "sign out test_val2"],
                         ["test_val3", "sign out", "2", "sign out test_val3"],
                     ],
-                    "types": ["Nullable(String)", "String", "String", "Nullable(String)"],
+                    "types": ["Nullable(String)", "String", "String", "String"],
                 },
             )
 

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -50,7 +50,6 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
-            self.maxDiff = None
             query = EventsQuery(select=["properties.key", "event", "distinct_id", "concat(event, ' ', properties.key)"])
             response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -470,8 +470,13 @@ class _Printer(Visitor):
                 ):
                     # must add precision if adding timezone in the next step
                     args.append("6")
+
                 if node.name in ADD_TIMEZONE_TO_FUNCTIONS:
                     args.append(self.visit(ast.Constant(value=self._get_timezone())))
+
+                if node.name == "concat":
+                    args = [f"ifNull(toString({arg}), '')" for arg in args]
+
                 return f"{clickhouse_name}({', '.join(args)})"
             else:
                 return f"{node.name}({', '.join(args)})"

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -448,25 +448,51 @@ class _Printer(Visitor):
 
         elif node.name in CLICKHOUSE_FUNCTIONS:
             clickhouse_name, min_args, max_args = CLICKHOUSE_FUNCTIONS[node.name]
-            args = [self.visit(arg) for arg in node.args]
 
-            if min_args is not None and len(args) < min_args:
+            if min_args is not None and len(node.args) < min_args:
                 if min_args == max_args:
-                    raise HogQLException(f"Function '{node.name}' expects {min_args} arguments. Passed {len(args)}.")
+                    raise HogQLException(
+                        f"Function '{node.name}' expects {min_args} arguments. Passed {len(node.args)}."
+                    )
                 raise HogQLException(
-                    f"Function '{node.name}' expects at least {min_args} arguments. Passed {len(args)}."
+                    f"Function '{node.name}' expects at least {min_args} arguments. Passed {len(node.args)}."
                 )
 
-            if max_args is not None and len(args) > max_args:
+            if max_args is not None and len(node.args) > max_args:
                 if min_args == max_args:
-                    raise HogQLException(f"Function '{node.name}' expects {max_args} arguments. Passed {len(args)}.")
+                    raise HogQLException(
+                        f"Function '{node.name}' expects {max_args} arguments. Passed {len(node.args)}."
+                    )
                 raise HogQLException(
-                    f"Function '{node.name}' expects at most least {max_args} arguments. Passed {len(args)}."
+                    f"Function '{node.name}' expects at most least {max_args} arguments. Passed {len(node.args)}."
                 )
 
             if self.dialect == "clickhouse":
-                if (clickhouse_name == "now64" and len(args) == 0) or (
-                    clickhouse_name == "parseDateTime64BestEffortOrNull" and len(args) == 1
+                if node.name == "concat":
+                    args: List[str] = []
+                    for arg in node.args:
+                        if isinstance(arg, ast.Constant):
+                            if arg.value is None:
+                                args.append("''")
+                            elif isinstance(arg.value, str):
+                                args.append(self.visit(arg))
+                            else:
+                                args.append(f"toString({self.visit(arg)})")
+                        elif isinstance(arg, ast.Call) and arg.name == "toString":
+                            if len(arg.args) == 1 and isinstance(arg.args[0], ast.Constant):
+                                if arg.args[0].value is None:
+                                    args.append("''")
+                                else:
+                                    args.append(self.visit(arg))
+                            else:
+                                args.append(f"ifNull({self.visit(arg)}, '')")
+                        else:
+                            args.append(f"ifNull(toString({self.visit(arg)}), '')")
+                else:
+                    args = [self.visit(arg) for arg in node.args]
+
+                if (clickhouse_name == "now64" and len(node.args) == 0) or (
+                    clickhouse_name == "parseDateTime64BestEffortOrNull" and len(node.args) == 1
                 ):
                     # must add precision if adding timezone in the next step
                     args.append("6")
@@ -474,12 +500,9 @@ class _Printer(Visitor):
                 if node.name in ADD_TIMEZONE_TO_FUNCTIONS:
                     args.append(self.visit(ast.Constant(value=self._get_timezone())))
 
-                if node.name == "concat":
-                    args = [f"ifNull(toString({arg}), '')" for arg in args]
-
                 return f"{clickhouse_name}({', '.join(args)})"
             else:
-                return f"{node.name}({', '.join(args)})"
+                return f"{node.name}({', '.join([self.visit(arg) for arg in node.args])})"
         else:
             all_function_names = list(CLICKHOUSE_FUNCTIONS.keys()) + list(HOGQL_AGGREGATIONS.keys())
             close_matches = get_close_matches(node.name, all_function_names, 1)

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -613,12 +613,12 @@ class TestPrinter(BaseTest):
 
     def test_nullish_concat(self):
         self.assertEqual(
-            self._expr("concat(null, 'a', 3)"),
-            f"concat(ifNull(toString(NULL), ''), ifNull(toString(%(hogql_val_0)s), ''), ifNull(toString(3), ''))",
+            self._expr("concat(null, 'a', 3, toString(4), toString(NULL))"),
+            f"concat('', %(hogql_val_0)s, toString(3), toString(4), '')",
         )
 
     def test_concat_pipes(self):
         self.assertEqual(
-            self._expr("'a' || 'b' || 3"),
-            f"concat(ifNull(toString(%(hogql_val_0)s), ''), ifNull(toString(%(hogql_val_1)s), ''), ifNull(toString(3), ''))",
+            self._expr("'a' || 'b' || 3 || timestamp"),
+            f"concat(%(hogql_val_0)s, %(hogql_val_1)s, toString(3), ifNull(toString(toTimeZone(events.timestamp, %(hogql_val_2)s)), ''))",
         )

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -610,3 +610,15 @@ class TestPrinter(BaseTest):
             ),
             f"SELECT events.distinct_id, min(toTimeZone(events.timestamp, %(hogql_val_0)s)) OVER win1 AS timestamp FROM events WHERE equals(events.team_id, {self.team.pk}) WINDOW win1 AS (PARTITION BY events.distinct_id ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) LIMIT 10000",
         )
+
+    def test_nullish_concat(self):
+        self.assertEqual(
+            self._expr("concat(null, 'a', 3)"),
+            f"concat(ifNull(toString(NULL), ''), ifNull(toString(%(hogql_val_0)s), ''), ifNull(toString(3), ''))",
+        )
+
+    def test_concat_pipes(self):
+        self.assertEqual(
+            self._expr("'a' || 'b' || 3"),
+            f"concat(ifNull(toString(%(hogql_val_0)s), ''), ifNull(toString(%(hogql_val_1)s), ''), ifNull(toString(3), ''))",
+        )

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -362,7 +362,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT concat(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', ''), ' : ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')) AS value,
+    (SELECT concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', '')), ''), ' : ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')), '')) AS value,
             sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
      FROM events e
      INNER JOIN
@@ -394,7 +394,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT concat(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', ''), ' : ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')) AS value,
+    (SELECT concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', '')), ''), ' : ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')), '')) AS value,
             avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as count
      FROM events e
      INNER JOIN
@@ -454,7 +454,7 @@
                        day_start
               UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
                                toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
-                               concat(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', ''), ' : ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')) as breakdown_value
+                               concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', '')), ''), ' : ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')), '')) as breakdown_value
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
@@ -474,7 +474,7 @@
                 AND event = 'session start'
                 AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-                AND concat(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', ''), ' : ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')) in (['some_val : London', 'some_val : Paris'])
+                AND concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', '')), ''), ' : ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')), '')) in (['some_val : London', 'some_val : Paris'])
               GROUP BY day_start,
                        breakdown_value))
         GROUP BY day_start,
@@ -510,7 +510,7 @@
                        day_start
               UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) as total,
                                toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
-                               concat(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', ''), ' : ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')) as breakdown_value
+                               concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', '')), ''), ' : ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')), '')) as breakdown_value
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
@@ -530,7 +530,7 @@
                 AND event = 'session start'
                 AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-                AND concat(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', ''), ' : ', replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')) in (['some_val : London', 'some_val : Paris'])
+                AND concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, '$some_prop'), ''), 'null'), '^"|"$', '')), ''), ' : ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'location'), ''), 'null'), '^"|"$', '')), '')) in (['some_val : London', 'some_val : Paris'])
               GROUP BY day_start,
                        breakdown_value))
         GROUP BY day_start,

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -263,66 +263,63 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging
-  'SELECT 1'
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
   '
   
   SET LOCAL statement_timeout = 2
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
+  '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.2
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
   '
-  
-  SET LOCAL statement_timeout = 2
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
-  '
   WITH target_person_ids AS
     (SELECT team_id,
             person_id
@@ -365,13 +362,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -379,6 +376,20 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
+  '
+  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
+         "posthog_featureflaghashkeyoverride"."hash_key",
+         "posthog_featureflaghashkeyoverride"."person_id"
+  FROM "posthog_featureflaghashkeyoverride"
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
+                                                              2,
+                                                              3,
+                                                              4,
+                                                              5 /* ... */)
+         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.7

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -263,62 +263,65 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging
-  '
-  
-  SET LOCAL statement_timeout = 2
-  '
+  'SELECT 1'
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.1
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.2
   '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
+  '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.3
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
   '
   WITH target_person_ids AS
     (SELECT team_id,
@@ -362,13 +365,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.4
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -376,20 +379,6 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.6
-  '
-  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
-         "posthog_featureflaghashkeyoverride"."hash_key",
-         "posthog_featureflaghashkeyoverride"."person_id"
-  FROM "posthog_featureflaghashkeyoverride"
-  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
-                                                              2,
-                                                              3,
-                                                              4,
-                                                              5 /* ... */)
-         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_error_race_conditions_on_person_merging.7


### PR DESCRIPTION
## Problem

1. `concat`-ing any `null` value makes everything null
2. `concat`-ing any numbers or booleans makes everything crash

We likely want to store `null` properties as `null`s, but concat messes this up.

## Changes

Makes `concat` null-tolerant (sounds the opposite of what it is). Now the following:

```sql
concat(null, 'a', 3, toString(4), toString(NULL))
```

gets automatically converted to

```sql
concat('', 'a', toString(3), toString(4), '')
```

Also adds the piped concat operator:

```sql
properties.$screen_width || 'x' || properties.$screen_height
```

Actual property access inside a ClickHouse SQL string while inside a concat looks kind of dorky, but should be accurate. We can definitely simplify this further if we need to.

```
-- hogql
concat(properties.$screen_width, 'x', properties.$screen_height)

-- clickhouse
concat(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$screen_width', ''), 'null'), '^\"|\"$', '')), ''), 'x', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$screen_height'), ''), 'null'), '^\"|\"$', '')), ''))
```

## Questions

Do we want this? I'd consider it a big UX improvement. Otherwise I need to put the `ifNull`-s everywhere myself, as I can never be too sure every property is always set.

We can alternatively make properties always take default values, but that has its own issues and is not concluded yet. This fix seems like a happy middle ground bandage.

## Alternatives

Alternatively we can implement a new type of non-ANSI compliant string operator, e.g. `f'{NULL}-haha-{properties.bla}'`, but I'd keep the operators standard and be flexible with the types instead.

## How did you test this code?

Added tests