### PR TITLE
perf: Cache `Team` persons-on-events querying flag

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -13,7 +13,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -31,10 +30,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -78,7 +76,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -96,10 +93,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -136,7 +132,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_1"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -154,10 +149,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_1"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_1")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -198,7 +192,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -216,10 +209,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -263,7 +255,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -281,10 +272,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -321,7 +311,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_1"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -339,10 +328,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_1"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_1")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -850,7 +838,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -868,10 +855,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -911,7 +897,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id)
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -929,10 +914,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND notEmpty(e.person_id) ) SELECT DISTINCT breakdown_values,
-                                                      intervals_from_base,
-                                                      actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -172,7 +172,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         # Filter by distinct ID
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(9):
             response = self.client.get("/api/person/?distinct_id=distinct_id")  # must be exact matches
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 1)
@@ -667,7 +667,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         create_person(team_id=self.team.pk, version=0)
 
         returned_ids = []
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(9):
             response = self.client.get("/api/person/?limit=10").json()
         self.assertEqual(len(response["results"]), 9)
         returned_ids += [x["distinct_ids"][0] for x in response["results"]]

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -206,7 +206,7 @@ class Team(UUIDClassicModel):
     def person_on_events_querying_enabled(self) -> bool:
         return self.person_on_events_mode != PersonOnEventsMode.DISABLED
 
-    @property
+    @cached_property
     def _person_on_events_querying_enabled(self) -> bool:
         if settings.PERSON_ON_EVENTS_OVERRIDE is not None:
             return settings.PERSON_ON_EVENTS_OVERRIDE

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -1376,6 +1376,25 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')))) )
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', ''))))) person ON person.id = pdi.person_id
         LEFT JOIN
           (SELECT group_key,
                   argMax(group_properties, _timestamp) AS group_properties_0
@@ -1387,9 +1406,7 @@
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
-          AND ((has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
-               AND (has(['value'], replaceRegexpAll(JSONExtractRaw(e.person_properties, 'key'), '^"|"$', ''))))
-          AND notEmpty(e.person_id)
+          AND ((has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))))
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)


### PR DESCRIPTION
## Problem

Noticed we do a lot more `InstanceSetting` queries to get the `PERSON_ON_EVENTS_ENABLED` value than needed.

## Changes

The `Team._person_on_events_querying_enabled` property can easily be cached in-memory for the object.
