### PR TITLE
fix: Use tailscale oauth secret instead of authkey

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -36,10 +36,13 @@ jobs:
                   role-duration-seconds: 3600
 
             - name: connect to tailscale
-              uses: tailscale/github-action@ce41a99162202a647a4b24c30c558a567b926709
+              uses: tailscale/github-action@8b804aa882ac3429b804a2a22f9803a2101a0db9
+              env:
+                  TS_EXPERIMENT_OAUTH_AUTHKEY: true
               with:
-                  authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-                  hostname: github-posthog-${{ github.action }}-${{ github.job }}
+                  version: 1.42.0
+                  authkey: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+                  args: --advertise-tags tag:github-runner
 
             - name: start deployment
               uses: bobheadxi/deployments@v1.4.0


### PR DESCRIPTION

## Problem
Authkeys expire every 90 days, use an oauth secret instead which don't expire


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
deployed the PR deploy which is the only place tailscale is used 