### PR TITLE
fix: prefer seen properties before preferring anything else

### DIFF
--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -233,7 +233,7 @@ class QueryContext:
               {self.excluded_properties_filter}
              {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
              {self.event_name_filter}
-            ORDER BY {verified_ordering} is_seen_on_filtered_events DESC, posthog_propertydefinition.query_usage_30_day DESC NULLS LAST, posthog_propertydefinition.name ASC
+            ORDER BY is_seen_on_filtered_events DESC, {verified_ordering} posthog_propertydefinition.query_usage_30_day DESC NULLS LAST, posthog_propertydefinition.name ASC
             LIMIT {self.limit} OFFSET {self.offset}
             """
 


### PR DESCRIPTION
## Problem

<img width="604" alt="Screenshot 2023-06-09 at 12 14 52" src="https://github.com/PostHog/posthog/assets/984817/06391923-d634-40f8-ab7e-6598b9375a42">

Maybe introduced with https://github.com/PostHog/posthog/pull/15937

Properties that have been seen with events are listed after properties that have not. That does not spark joy

## Changes

Always sort by "seen" first. 

So sorting order is

* was seen
* verified (when available)
* query usage
* name

## How did you test this code?

added a developer test
