### PR TITLE
ci: Always cancel previous runs, except for snapshot updates

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -29,11 +29,6 @@ env:
     OBJECT_STORAGE_ACCESS_KEY_ID: 'object_storage_root_user'
     OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
 
-concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-    # Allow query snapshot updates to finish, so that we don't need to wait for the whole stack to start all over again
-    cancel-in-progress: false
-
 jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
@@ -84,6 +79,13 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            # If this run wasn't initiated by the bot (meaning: snapshot update) and we've determined
+            # there are backend changes, cancel previous runs
+            - uses: n1hility/cancel-previous-runs@v3
+              if: github.actor != 'posthog-bot' && needs.changes.outputs.backend == 'true'
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 1

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -7,11 +7,6 @@ on:
             - '.storybook/**'
             - 'package.json'
 
-concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-    # Allow UI snapshot updates to finish, so that we don't need to wait for Storybook to build all over again
-    cancel-in-progress: false
-
 jobs:
     storybook-chromatic:
         name: Publish to Chromatic
@@ -96,6 +91,12 @@ jobs:
             firefox-2-total: ${{ steps.diff.outputs.firefox-2-total }}
             firefox-2-commitHash: ${{ steps.commit-hash.outputs.firefox-2-commitHash }}
         steps:
+            # If this run wasn't initiated by the bot (meaning: snapshot update), cancel previous runs
+            - uses: n1hility/cancel-previous-runs@v3
+              if: github.actor != 'posthog-bot'
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 1


### PR DESCRIPTION
## Problem

@frankh flagged with me that while #15757 improved the experience of snapshot updates (by allowing all the updates to play out in one CI run), it also contributes to some wasted GH Actions minutes (as we also allow the old CI runs to play out if there are no snapshot updates involved).

## Changes

Now we do things conditionally: if the commit is a snapshot update, we allow the previous run(s) to continue – otherwise happy to cancel.