### PR TITLE
chore(exports): use LemonTable for exports list

### DIFF
--- a/frontend/src/scenes/exports/ExportsList.tsx
+++ b/frontend/src/scenes/exports/ExportsList.tsx
@@ -1,8 +1,9 @@
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from '../urls'
-import { Link } from '../../lib/lemon-ui/Link'
-import { useCurrentTeamId, useExports } from './api'
 import { LemonButton } from '../../lib/lemon-ui/LemonButton'
+import { useCurrentTeamId, useExports } from './api'
+import { LemonTable } from '../../lib/lemon-ui/LemonTable'
+import { Link } from 'lib/lemon-ui/Link'
 
 export const scene: SceneExport = {
     component: Exports,
@@ -44,29 +45,30 @@ export function Exports(): JSX.Element {
     return (
         <>
             <h1>Exports</h1>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Type</th>
-                        <th>Frequency</th>
-                        <th>Status</th>
-                        <th>Last run</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {exports.map((export_) => (
-                        <tr key={export_.id}>
-                            <td>
-                                <Link to={urls.viewExport(export_.id)}>{export_.name}</Link>
-                            </td>
-                            <td>{export_.destination.type}</td>
-                            <td>{export_.interval}</td>
-                            <td>{export_.status}</td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
+            <LemonTable
+                dataSource={exports}
+                columns={[
+                    {
+                        title: 'Name',
+                        key: 'name',
+                        render: function RenderName(_, export_) {
+                            return <Link to={urls.viewExport(export_.id)}>{export_.name}</Link>
+                        },
+                    },
+                    {
+                        title: 'Type',
+                        key: 'type',
+                        render: function RenderType(_, export_) {
+                            return <>{export_.destination.type}</>
+                        },
+                    },
+                    {
+                        title: 'Frequency',
+                        key: 'frequency',
+                        dataIndex: 'interval',
+                    },
+                ]}
+            />
             <LemonButton to={urls.createExport()}>Create export</LemonButton>
             {/* If we are loading, we overlay a spinner */}
             {loading && <div>Loading...</div>}

--- a/frontend/src/scenes/exports/api.ts
+++ b/frontend/src/scenes/exports/api.ts
@@ -83,7 +83,7 @@ type SnowflakeDestination = {
     }
 }
 
-type Destination = S3Destination | SnowflakeDestination
+export type Destination = S3Destination | SnowflakeDestination
 
 export type BatchExportData = {
     // User provided data for the export. This is the data that the user


### PR DESCRIPTION
I had made it an Html table element before, but that's not well styled
as it is so changing to LemonTable to use it's styling.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
