### PR TITLE
fix: Do not hardcode s3 export region

### DIFF
--- a/frontend/src/scenes/exports/CreateExport.tsx
+++ b/frontend/src/scenes/exports/CreateExport.tsx
@@ -62,6 +62,7 @@ export function CreateS3Export(): JSX.Element {
     const accessKeyIdRef = useRef<HTMLInputElement>(null)
     const secretAccessKeyRef = useRef<HTMLInputElement>(null)
     const intervalRef = useRef<'hour' | 'day' | null>(null)
+    const [regionState, setRegionState] = useState<{ value: string | null }>({ value: null })
 
     const { createExport, loading, error } = useCreateExport()
 
@@ -73,8 +74,10 @@ export function CreateS3Export(): JSX.Element {
             !regionRef.current ||
             !accessKeyIdRef.current ||
             !secretAccessKeyRef.current ||
-            !intervalRef.current
+            !intervalRef.current ||
+            !regionState.value
         ) {
+            // TODO: This should just fail and report back to the user.
             console.warn('Missing ref')
         }
 
@@ -82,10 +85,10 @@ export function CreateS3Export(): JSX.Element {
         const name = nameRef.current?.value ?? ''
         const bucket = bucketRef.current?.value ?? ''
         const prefix = prefixRef.current?.value ?? ''
-        const region = regionRef.current ?? ''
         const accessKeyId = accessKeyIdRef.current?.value ?? ''
         const secretAccessKey = secretAccessKeyRef.current?.value ?? ''
         const interval = intervalRef.current ?? ''
+        const region = regionState.value ?? ''
 
         const exportData = {
             name,
@@ -150,6 +153,9 @@ export function CreateS3Export(): JSX.Element {
                         { value: 'me-south-1', label: 'Middle East (Bahrain)' },
                         { value: 'sa-east-1', label: 'South America (São Paulo)' },
                     ]}
+                    onChange={(region) => {
+                        setRegionState({ value: region })
+                    }}
                 />
             </PureField>
 


### PR DESCRIPTION
## Problem

Current batch export frontend is hardcoding the region to `us-east-1`, but our clients may have buckets in many other regions, like EU regions.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use a callback in the field to update a state holding the region value. Not sure if this is the best way to achieve this.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
