### PR TITLE
fix(batch-exports): only specify endpoint when running locally

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -1,4 +1,6 @@
 import os
+from posthog.settings.base_variables import TEST
+
 
 TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default")
 TEMPORAL_TASK_QUEUE = os.getenv("TEMPORAL_TASK_QUEUE", "no-sandbox-python-django")
@@ -10,5 +12,7 @@ TEMPORAL_CLIENT_KEY = os.getenv("TEMPORAL_CLIENT_KEY", None)
 TEMPORAL_WORKFLOW_MAX_ATTEMPTS = os.getenv("TEMPORAL_WORKFLOW_MAX_ATTEMPTS", "3")
 
 
+# When testing locally we want to use the minio instance rather than AWS S3
+BATCH_EXPORT_S3_ENDPOINT_URL = os.getenv("BATCH_EXPORT_S3_ENDPOINT_URL", "http://localhost:19000" if TEST else None)
 BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024 * 50  # 50MB
 BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024 * 100  # 100MB

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -77,7 +77,7 @@ def setup_module(module):
 
     s3_client = boto3.client(
         "s3",
-        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+        endpoint_url=settings.BATCH_EXPORT_S3_ENDPOINT_URL,
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
     )
@@ -92,7 +92,7 @@ def teardown_module(module):
     """
     s3_client = boto3.client(
         "s3",
-        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+        endpoint_url=settings.BATCH_EXPORT_S3_ENDPOINT_URL,
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
     )
@@ -173,7 +173,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(activity_environment):
     # Check that the data was written to S3.
     s3_client = boto3.client(
         "s3",
-        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+        endpoint_url=settings.BATCH_EXPORT_S3_ENDPOINT_URL,
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
     )

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -112,18 +112,12 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
 
         # Create a multipart upload to S3
         key = f"{inputs.prefix}/{inputs.data_interval_start}-{inputs.data_interval_end}.jsonl"
-        # When running locally, we need to use the local minio's endpoint.
-        # However, in production we need to use the AWS endpoint. In this case
-        # we let Boto3 figure out the endpoint based on the region.
-        endpoint_url = (
-            settings.OBJECT_STORAGE_ENDPOINT if "http://localhost:19000" == settings.OBJECT_STORAGE_ENDPOINT else None
-        )
         s3_client = boto3.client(
             "s3",
             region_name=inputs.region,
             aws_access_key_id=inputs.aws_access_key_id,
             aws_secret_access_key=inputs.aws_secret_access_key,
-            endpoint_url=endpoint_url,
+            endpoint_url=settings.BATCH_EXPORT_S3_ENDPOINT_URL,
         )
         multipart_response = s3_client.create_multipart_upload(Bucket=inputs.bucket_name, Key=key)
         upload_id = multipart_response["UploadId"]

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -112,12 +112,18 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
 
         # Create a multipart upload to S3
         key = f"{inputs.prefix}/{inputs.data_interval_start}-{inputs.data_interval_end}.jsonl"
+        # When running locally, we need to use the local minio's endpoint.
+        # However, in production we need to use the AWS endpoint. In this case
+        # we let Boto3 figure out the endpoint based on the region.
+        endpoint_url = (
+            settings.OBJECT_STORAGE_ENDPOINT if "http://localhost:19000" == settings.OBJECT_STORAGE_ENDPOINT else None
+        )
         s3_client = boto3.client(
             "s3",
             region_name=inputs.region,
             aws_access_key_id=inputs.aws_access_key_id,
             aws_secret_access_key=inputs.aws_secret_access_key,
-            endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+            endpoint_url=endpoint_url,
         )
         multipart_response = s3_client.create_multipart_upload(Bucket=inputs.bucket_name, Key=key)
         upload_id = multipart_response["UploadId"]


### PR DESCRIPTION
If we use the `OBJECT_STORAGE_ENDPOINT` environment variable when
running in production, we end up with endpoints that include the region
in the URL. Instead we let boto3 decide which url to use in these cases.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
