### PR TITLE
fix: Do not set endpoint-url for S3 exports

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -1,16 +1,16 @@
 import datetime as dt
 import json
+import tempfile
 from dataclasses import dataclass
 from string import Template
-import tempfile
 from typing import TYPE_CHECKING, List
 
-from django.conf import settings
 import boto3
+from django.conf import settings
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
-from posthog.batch_exports.service import S3BatchExportInputs
 
+from posthog.batch_exports.service import S3BatchExportInputs
 from posthog.temporal.workflows.base import (
     CreateBatchExportRunInputs,
     PostHogWorkflow,
@@ -117,7 +117,6 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
             region_name=inputs.region,
             aws_access_key_id=inputs.aws_access_key_id,
             aws_secret_access_key=inputs.aws_secret_access_key,
-            endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
         )
         multipart_response = s3_client.create_multipart_upload(Bucket=inputs.bucket_name, Key=key)
         upload_id = multipart_response["UploadId"]


### PR DESCRIPTION
## Problem

See: https://github.com/PostHog/posthog/pull/16013. Just wanna see what tests fail if we instead delete the `endpoint_url` param.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Deleted `endpoint_url` from the `boto3.client` call. One test is failing.

To make it pass, we do indeed need mocking unfortunately. However, I tried to keep the mocking fairly restricted: only mocking the `boto3.client` function, and only by adding the `endpoint_url` keyword param. All other params are taken as passed by the workflow.

Finally, there is also some automatic import statement sorting.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
