### PR TITLE
ci: wait for temporal to be up before running backend tests

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -85,10 +85,7 @@ runs:
 
         - name: Wait for Temporal
           shell: bash
-          run: |
-              while true; do
-                curl -s -o /dev/null -I 'http://localhost:8088/' && break || echo 'Checking Temporal status...' && sleep 1
-              done
+          run: bin/check_temporal_up
 
         - name: Determine if --snapshot-update should be on
           # Skip on forks (due to GITHUB_TOKEN being read-only in PRs coming from them) except for persons-on-events

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -83,6 +83,13 @@ runs:
           shell: bash
           run: bin/check_kafka_clickhouse_up
 
+        - name: Wait for Temporal
+          shell: bash
+          run: |
+              while true; do
+                curl -s -o /dev/null -I 'http://localhost:8088/' && break || echo 'Checking Temporal status...' && sleep 1
+              done
+
         - name: Determine if --snapshot-update should be on
           # Skip on forks (due to GITHUB_TOKEN being read-only in PRs coming from them) except for persons-on-events
           # runs, as we want to ignore snapshots diverging there

--- a/bin/check_kafka_clickhouse_up
+++ b/bin/check_kafka_clickhouse_up
@@ -11,8 +11,3 @@ done
 while true; do
 curl -s -o /dev/null -I 'http://localhost:8123/' && break || echo 'Checking ClickHouse status...' && sleep 1
 done
-
-# Check Temporal
-while true; do
-curl -s -o /dev/null -I 'http://localhost:8088/' && break || echo 'Checking Temporal status...' && sleep 1
-done

--- a/bin/check_kafka_clickhouse_up
+++ b/bin/check_kafka_clickhouse_up
@@ -11,3 +11,8 @@ done
 while true; do
 curl -s -o /dev/null -I 'http://localhost:8123/' && break || echo 'Checking ClickHouse status...' && sleep 1
 done
+
+# Check Temporal
+while true; do
+curl -s -o /dev/null -I 'http://localhost:8088/' && break || echo 'Checking Temporal status...' && sleep 1
+done

--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Wait for up to 120 seconds for Temporal to be ready
+SECONDS=0
+TIMEOUT=120
+
+# Check Temporal
+while true; do
+    curl -s -o /dev/null -I 'http://localhost:8088/' && break || echo 'Checking Temporal status...' && sleep 1
+    if [ $SECONDS -gt $TIMEOUT ]; then
+        echo "Timeout waiting for Temporal to be ready"
+        exit 1
+    fi
+done


### PR DESCRIPTION
If we don't wait, then there are some tests that fail because temporal
isn't up yet(?). These tests ideally shouldn't be using the real temporal
server, but rather the test server that is spun up when e.g. using
`temporalio.testing.WorkflowEnvironment` although for the sake of
getting tests to not be flaky, this is a good enough solution for now.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
