### PR TITLE
fix(hogql): events url snip, hogql object/array react display

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -56,7 +56,13 @@ export function renderColumn(
                 return <TZLabel time={value} showSeconds />
             }
         }
-        return <Property value={value} />
+        if (typeof value === 'object') {
+            if (Array.isArray(value)) {
+                return <ReactJson src={value} name={key} collapsed={value.length > 10 ? 0 : 1} />
+            }
+            return <ReactJson src={value} name={key} collapsed={Object.keys(value).length > 10 ? 0 : 1} />
+        }
+        return <span>{String(value)}</span>
     } else if (key === 'event' && isEventsQuery(query.source)) {
         const resultRow = record as any[]
         const eventRecord = query.source.select.includes('*') ? resultRow[query.source.select.indexOf('*')] : null
@@ -77,6 +83,7 @@ export function renderColumn(
     } else if (key === 'timestamp' || key === 'created_at' || key === 'session_start' || key === 'session_end') {
         return <TZLabel time={value} showSeconds />
     } else if (!Array.isArray(record) && key.startsWith('properties.')) {
+        // TODO: remove after removing the old events table
         const propertyKey = trimQuotes(key.substring(11))
         if (setQuery && (isEventsQuery(query.source) || isPersonsNode(query.source)) && query.showPropertyFilter) {
             const newProperty: AnyPropertyFilter = {
@@ -121,7 +128,8 @@ export function renderColumn(
             )
         }
         return <Property value={record.properties[propertyKey]} />
-    } else if (key.startsWith('person.properties.')) {
+    } else if (!Array.isArray(record) && key.startsWith('person.properties.')) {
+        // TODO: remove after removing the old events table
         const eventRecord = record as EventType
         const propertyKey = trimQuotes(key.substring(18))
         if (setQuery && isEventsQuery(query.source)) {


### PR DESCRIPTION
## Problem

1. HogQL insights eat the "http://" part of any URL
2. Actual arrays/objects returned from ClickHouse don't render well (properties JSON arrays/objects work)

<img width="1862" alt="image" src="https://github.com/PostHog/posthog/assets/53387/e0655905-c4a4-4227-8c35-643d12419e29">

## Changes

<img width="1855" alt="image" src="https://github.com/PostHog/posthog/assets/53387/b796481e-50a8-4ea7-987c-98e9ca955628">

## How did you test this code?

See screenshot.