### PR TITLE
feat(admin): add group type mapping inline admin

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -66,6 +66,8 @@ class GroupTypeMappingInline(admin.TabularInline):
     fields = ("group_type_index", "group_type", "name_singular", "name_plural")
     readonly_fields = fields
     classes = ("collapse",)
+    max_num = 5
+    min_num = 5
 
 
 @admin.register(Team)
@@ -299,32 +301,3 @@ class OrganizationAdmin(admin.ModelAdmin):
 
 class OrganizationBillingAdmin(admin.ModelAdmin):
     search_fields = ("name", "members__email")
-
-
-@admin.register(GroupTypeMapping)
-class GroupTypeMappingAdmin(admin.ModelAdmin):
-    list_display = (
-        "id",
-        "organization_link",
-        "team_link",
-        "group_type",
-        "group_type_index",
-        "name_singular",
-        "name_plural",
-    )
-    list_filter = ("group_type_index",)
-    search_fields = ("group_type", "team__name", "team__organization__name")
-
-    def organization_link(self, group_type_mapping: GroupTypeMapping):
-        return format_html(
-            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
-            group_type_mapping.team.organization.pk,
-            group_type_mapping.team.organization.name,
-        )
-
-    def team_link(self, group_type_mapping: GroupTypeMapping):
-        return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            group_type_mapping.team.pk,
-            group_type_mapping.team.name,
-        )

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -13,6 +13,7 @@ from posthog.models import (
     ActionStep,
     Element,
     FeatureFlag,
+    GroupTypeMapping,
     Insight,
     InstanceSetting,
     Organization,
@@ -289,3 +290,32 @@ class OrganizationAdmin(admin.ModelAdmin):
 
 class OrganizationBillingAdmin(admin.ModelAdmin):
     search_fields = ("name", "members__email")
+
+
+@admin.register(GroupTypeMapping)
+class GroupTypeMappingAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "organization_link",
+        "team_link",
+        "group_type",
+        "group_type_index",
+        "name_singular",
+        "name_plural",
+    )
+    list_filter = ("group_type_index",)
+    search_fields = ("group_type", "team__name", "team__organization__name")
+
+    def organization_link(self, group_type_mapping: GroupTypeMapping):
+        return format_html(
+            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
+            group_type_mapping.team.organization.pk,
+            group_type_mapping.team.organization.name,
+        )
+
+    def team_link(self, group_type_mapping: GroupTypeMapping):
+        return format_html(
+            '<a href="/admin/posthog/team/{}/change/">{}</a>',
+            group_type_mapping.team.pk,
+            group_type_mapping.team.name,
+        )

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -60,6 +60,14 @@ class PluginAdmin(admin.ModelAdmin):
     ordering = ("-created_at",)
 
 
+class GroupTypeMappingInline(admin.TabularInline):
+    extra = 0
+    model = GroupTypeMapping
+    fields = ("group_type_index", "group_type", "name_singular", "name_plural")
+    readonly_fields = fields
+    classes = ("collapse",)
+
+
 @admin.register(Team)
 class TeamAdmin(admin.ModelAdmin):
     list_display = ("id", "name", "organization_link", "organization_id")
@@ -74,6 +82,7 @@ class TeamAdmin(admin.ModelAdmin):
         "event_properties_numerical",
         "session_recording_retention_period_days",
     ]
+    inlines = [GroupTypeMappingInline]
 
     def organization_link(self, team: Team):
         return format_html(

--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -19,6 +19,3 @@ class GroupTypeMapping(models.Model):
     # Used to display in UI
     name_singular: models.CharField = models.CharField(max_length=400, null=True, blank=True)
     name_plural: models.CharField = models.CharField(max_length=400, null=True, blank=True)
-
-    def __str__(self) -> str:
-        return self.group_type

--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -19,3 +19,6 @@ class GroupTypeMapping(models.Model):
     # Used to display in UI
     name_singular: models.CharField = models.CharField(max_length=400, null=True, blank=True)
     name_plural: models.CharField = models.CharField(max_length=400, null=True, blank=True)
+
+    def __str__(self) -> str:
+        return self.group_type


### PR DESCRIPTION
## Problem

User would like us to delete groups for them and currently we have to do this with manual `DELETE ... FROM ...` statements, see http://runbooks/ingestion/groups#deleting-group-types.

## Changes

This PR adds an inline admin section for each team that allows deleting group type mappings.

<img width="2198" alt="Screenshot 2023-06-13 at 12 33 06" src="https://github.com/PostHog/posthog/assets/1851359/abb35aac-a672-41be-9900-99f03b84a940">

## How did you test this code?

Deleted a group type mapping and verified it doesn't show up if no new events with the group are ingested.