### PR TITLE
feat: Person merge restrictions info to UI

### DIFF
--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -87,6 +87,21 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
                 <span className="text-muted">First seen:</span>{' '}
                 {person.created_at ? <TZLabel time={person.created_at} /> : 'unknown'}
             </div>
+            <div>
+                <span className="text-muted">Merge restrictions:</span> {person.is_identified ? 'applied' : 'none'}
+                <Link to={'https://posthog.com/docs/data/identify'}>
+                    <Tooltip
+                        title={
+                            <>
+                                Can<strong>{person.is_identified ? ' not' : ''}</strong> be used as `$anon_distinct_id`
+                                or `alias_id`, click for more info.
+                            </>
+                        }
+                    >
+                        <IconInfo className="ml-1 text-base shrink-0" />
+                    </Tooltip>
+                </Link>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -89,7 +89,9 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
             </div>
             <div>
                 <span className="text-muted">Merge restrictions:</span> {person.is_identified ? 'applied' : 'none'}
-                <Link to={'https://posthog.com/docs/data/identify'}>
+                <Link
+                    to={'https://posthog.com/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user'}
+                >
                     <Tooltip
                         title={
                             <>

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -93,7 +93,7 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
                     <Tooltip
                         title={
                             <>
-                                Can<strong>{person.is_identified ? ' not' : ''}</strong> be used as `$anon_distinct_id`
+                                {person.is_identified ? <strong>Cannot</strong> : 'Can'} be used as `$anon_distinct_id`
                                 or `alias_id`, click for more info.
                             </>
                         }

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -93,8 +93,8 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
                     <Tooltip
                         title={
                             <>
-                                {person.is_identified ? <strong>Cannot</strong> : 'Can'} be used as `$anon_distinct_id`
-                                or `alias_id`, click for more info.
+                                {person.is_identified ? <strong>Cannot</strong> : 'Can'} be used as `alias_id` - click
+                                for more info.
                             </>
                         }
                     >


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This is confusing and not clear to users. Showing the is_identified state in the UI would help with support requests a bit.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
<img width="512" alt="Screenshot 2023-06-13 at 17 21 46" src="https://github.com/PostHog/posthog/assets/890921/f4c68a28-93a4-4267-9792-99edd3e90ff3">
<img width="552" alt="Screenshot 2023-06-13 at 17 21 30" src="https://github.com/PostHog/posthog/assets/890921/ac31cd02-70a3-49be-9516-1e4e26e07ab1">


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
