### PR TITLE
ci: fix temporal port number 8088 -> 7233

### DIFF
--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -8,7 +8,7 @@ TIMEOUT=120
 
 # Check Temporal
 while true; do
-    curl -s -o /dev/null -I 'http://localhost:8088/' && break || echo 'Checking Temporal status...' && sleep 1
+    curl -s -o /dev/null -I 'http://localhost:7233/' && break || echo 'Checking Temporal status...' && sleep 1
     if [ $SECONDS -gt $TIMEOUT ]; then
         echo "Timeout waiting for Temporal to be ready"
         exit 1


### PR DESCRIPTION
I'm not sure what happened there, but for some reason it was fine with
8088 but I think the right one if 7233.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
