### PR TITLE
chore: send silent failures to sentry

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -91,6 +91,10 @@ export class EventPipelineRunner {
                 throw error
             }
             silentFailuresEventsPipeline.inc()
+            Sentry.captureException(error, {
+                tags: { location: 'runEventPipeline' },
+                extra: { originalEvent: this.originalEvent },
+            })
 
             return { lastStep: error.step, args: [], error: error.message }
         }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We have [silent failures](http://grafana-prod-us/d/snFrKu04z/tiina-test?orgId=1&from=now-7d&to=now&viewPanel=12), but don't know why - before we start blocking ingestion we should fix them, to do that we need to know what they are, so log the events to sentry for that. It's temporary until we merge https://github.com/PostHog/posthog/pull/15851

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
