### PR TITLE
fix(api): Actually use pagination `default_limit`

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -125,10 +125,10 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
         relevantAnnotations: [
             (s) => [s.annotations, s.dateRange, (_, props) => props.insightNumericId],
             (annotations, dateRange, insightNumericId) => {
-                // This assumes that there are no more than AnnotationsViewSet.default_limit (500) annotations
-                // in the project. Right now this is true on Cloud, though some projects are getting close (400+).
-                // If we see the scale increasing, we might need to fetch annotations on a per-insight basis here.
-                // That would greatly increase the number of requests to the annotations endpoint though.
+                // This assumes that there are no more annotations in the project than AnnotationsViewSet
+                // pagination class's default_limit of 100. As of June 2023, this is not true on Cloud US,
+                // where 3 projects exceed this limit. To accomodate those, we should always make a request for the
+                // date range of the graph, and not rely on the annotations in the store.
                 return (
                     dateRange
                         ? annotations.filter(

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from django.db.models import Q, QuerySet
-from rest_framework import serializers, status, viewsets
+from rest_framework import serializers, status, viewsets, pagination
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
@@ -37,7 +37,7 @@ class ActivityLogSerializer(serializers.ModelSerializer):
 class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
     queryset = ActivityLog.objects.all()
     serializer_class = ActivityLogSerializer
-    default_limit = 500
+    pagination_class = pagination.LimitOffsetPagination(default_limit=500)
 
     def filter_queryset_by_parents_lookups(self, queryset) -> QuerySet:
         team = self.team

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -34,10 +34,14 @@ class ActivityLogSerializer(serializers.ModelSerializer):
             return bookmark_date < obj.created_at.replace(microsecond=obj.created_at.microsecond // 1000 * 1000)
 
 
+class ActivityLogPagination(pagination.LimitOffsetPagination):
+    default_limit = 500
+
+
 class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
     queryset = ActivityLog.objects.all()
     serializer_class = ActivityLogSerializer
-    pagination_class = pagination.LimitOffsetPagination(default_limit=500)
+    pagination_class = ActivityLogPagination
 
     def filter_queryset_by_parents_lookups(self, queryset) -> QuerySet:
         team = self.team

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from django.db.models import Q, QuerySet
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from rest_framework import filters, serializers, viewsets
+from rest_framework import filters, serializers, viewsets, pagination
 from rest_framework.permissions import IsAuthenticated
 
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
@@ -64,7 +64,7 @@ class AnnotationsViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
     serializer_class = AnnotationSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
     filter_backends = [filters.SearchFilter]
-    default_limit = 500
+    pagination_class = pagination.LimitOffsetPagination(default_limit=1000)
     search_fields = ["content"]
 
     def get_queryset(self) -> QuerySet:

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -55,6 +55,10 @@ class AnnotationSerializer(serializers.ModelSerializer):
         return annotation
 
 
+class AnnotationsLimitOffsetPagination(pagination.LimitOffsetPagination):
+    default_limit = 1000
+
+
 class AnnotationsViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     """
     Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/user-guides/annotations) for more information on annotations.
@@ -64,7 +68,7 @@ class AnnotationsViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
     serializer_class = AnnotationSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
     filter_backends = [filters.SearchFilter]
-    pagination_class = pagination.LimitOffsetPagination(default_limit=1000)
+    pagination_class = AnnotationsLimitOffsetPagination
     search_fields = ["content"]
 
     def get_queryset(self) -> QuerySet:

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -251,7 +251,7 @@
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted")
   ORDER BY "posthog_annotation"."date_marker" DESC
-  LIMIT 100 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15
@@ -563,6 +563,6 @@
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted")
   ORDER BY "posthog_annotation"."date_marker" DESC
-  LIMIT 100 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---


### PR DESCRIPTION
## Problem

When adding annotations to the 3000 sidebar, I realized there is a hairy issue: we have multiples more annotations in the production project than we send in a single page. More than that, the page size value we have set does not have an effect, so those pages are even smaller than intended.

## Changes

Fixed `default_limit` on the activity log and annotations endpoints, which is in reality an attribute of the pagination class and not of the viewset class. Also increased it for annotations, so that no annotations are hidden in almost all cases (the cases where this isn't quite true [can be seen here](http://metabase-prod-us/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgYW5ub3RhdGlvbl9jb3VudCwgcG9zdGhvZ190ZWFtLm5hbWUgQVMgdGVhbV9uYW1lLCB0ZWFtX2lkLCBwb3N0aG9nX29yZ2FuaXphdGlvbi5uYW1lIEFTIG9yZ19uYW1lIEZST00gKFxuICAgIFNFTEVDVCBjb3VudCgqKSBBUyBhbm5vdGF0aW9uX2NvdW50LCB0ZWFtX2lkIEZST00gcG9zdGhvZ19hbm5vdGF0aW9uIEdST1VQIEJZIHRlYW1faWQgT1JERVIgQlkgYW5ub3RhdGlvbl9jb3VudCBERVNDXG4pIGFubm90YXRpb25zXG5KT0lOIHBvc3Rob2dfdGVhbSBPTiBhbm5vdGF0aW9ucy50ZWFtX2lkID0gcG9zdGhvZ190ZWFtLmlkXG5KT0lOIHBvc3Rob2dfb3JnYW5pemF0aW9uIE9OIHBvc3Rob2dfdGVhbS5vcmdhbml6YXRpb25faWQgPSBwb3N0aG9nX29yZ2FuaXphdGlvbi5pZCIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjM0fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)).
