### PR TITLE
feat(surveys): setup help

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -4,11 +4,21 @@ import { useActions, useValues } from 'kea'
 import { Form, Group } from 'kea-forms'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
-import { LemonButton, LemonDivider, LemonInput, LemonSelect, LemonTextArea, Link } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonCheckbox,
+    LemonCollapse,
+    LemonDivider,
+    LemonInput,
+    LemonModal,
+    LemonSelect,
+    LemonTextArea,
+    Link,
+} from '@posthog/lemon-ui'
 import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { Field, PureField } from 'lib/forms/Field'
-import { FilterLogicalOperator, SurveyQuestion, SurveyType } from '~/types'
+import { FilterLogicalOperator, Survey, SurveyQuestion, SurveyType } from '~/types'
 import { FlagSelector } from 'scenes/early-access-features/EarlyAccessFeature'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { IconCancel, IconDelete, IconErrorOutline, IconPlus, IconPlusMini, IconSubArrowRight } from 'lib/lemon-ui/icons'
@@ -25,6 +35,9 @@ import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/uti
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { cohortsModel } from '~/models/cohortsModel'
 import { TZLabel } from 'lib/components/TZLabel'
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 
 export const scene: SceneExport = {
     component: Survey,
@@ -33,6 +46,11 @@ export const scene: SceneExport = {
         id: id,
     }),
 }
+
+const OPT_IN_SNIPPET = `posthog.init('YOUR_PROJECT_API_KEY', {
+    api_host: 'YOUR API HOST',
+    opt_in_site_apps: true // <--- Add this line
+})`
 
 export function Survey({ id }: { id?: string } = {}): JSX.Element {
     const { isEditingSurvey } = useValues(surveyLogic)
@@ -238,13 +256,16 @@ export function SurveyForm({ id }: { id: string }): JSX.Element {
 }
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
-    const { survey, dataTableQuery, surveyLoading } = useValues(surveyLogic)
+    const { survey, dataTableQuery, surveyLoading, surveyPlugin, installingPlugin } = useValues(surveyLogic)
     // TODO: survey results logic
     // const { surveyImpressionsCount, surveyStartedCount, surveyCompletedCount } = useValues(surveyResultsLogic)
-    const { editingSurvey, updateSurvey, launchSurvey, stopSurvey, archiveSurvey } = useActions(surveyLogic)
+    const { editingSurvey, updateSurvey, launchSurvey, stopSurvey, archiveSurvey, installSurveyPlugin } =
+        useActions(surveyLogic)
     const { deleteSurvey } = useActions(surveysLogic)
     const { cohortsById } = useValues(cohortsModel)
-
+    const { editPlugin } = useActions(pluginsLogic)
+    const [setupModalIsOpen, setSetupModalIsOpen] = useState(false)
+    console.log('surv plugin', surveyPlugin)
     const [tabKey, setTabKey] = useState(survey.start_date ? 'results' : 'overview')
     useEffect(() => {
         if (survey.start_date) {
@@ -285,7 +306,16 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                 />
                                 <LemonDivider vertical />
                                 {!survey.start_date ? (
-                                    <LemonButton type="primary" onClick={() => launchSurvey()}>
+                                    <LemonButton
+                                        type="primary"
+                                        onClick={() => {
+                                            if (!surveyPlugin && !survey.conditions?.is_headless) {
+                                                setSetupModalIsOpen(true)
+                                            } else {
+                                                launchSurvey()
+                                            }
+                                        }}
+                                    >
                                         Launch
                                     </LemonButton>
                                 ) : survey.end_date && !survey.archived ? (
@@ -323,140 +353,211 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                         tabs={[
                             {
                                 content: (
-                                    <div className="flex flex-col w-fit">
-                                        <span className="card-secondary mt-4">Type</span>
-                                        <span>{capitalizeFirstLetter(SurveyType.Popover)}</span>
-                                        <span className="card-secondary mt-4">Questions</span>
-                                        {survey.questions.map((q, idx) => (
-                                            <span key={idx}>{q.question}</span>
-                                        ))}
-                                        <span className="card-secondary mt-4">Linked feature flag</span>
-                                        {survey.linked_flag ? (
-                                            <Link to={urls.featureFlag(survey.linked_flag.id)}>
-                                                {survey.linked_flag.key}
-                                            </Link>
-                                        ) : (
-                                            <span>None</span>
-                                        )}
-                                        <div className="flex flex-row gap-8">
-                                            {survey.start_date && (
-                                                <div className="flex flex-col">
-                                                    <span className="card-secondary mt-4">Start date</span>
-                                                    <TZLabel time={survey.start_date} />
-                                                </div>
+                                    <div className="flex flex-row">
+                                        <div className="flex flex-col w-full">
+                                            <span className="card-secondary mt-4">Type</span>
+                                            <span>{capitalizeFirstLetter(SurveyType.Popover)}</span>
+                                            <span className="card-secondary mt-4">Questions</span>
+                                            {survey.questions.map((q, idx) => (
+                                                <span key={idx}>{q.question}</span>
+                                            ))}
+                                            <span className="card-secondary mt-4">Linked feature flag</span>
+                                            {survey.linked_flag ? (
+                                                <Link to={urls.featureFlag(survey.linked_flag.id)}>
+                                                    {survey.linked_flag.key}
+                                                </Link>
+                                            ) : (
+                                                <span>None</span>
                                             )}
-                                            {survey.end_date && (
-                                                <div className="flex flex-col">
-                                                    <span className="card-secondary mt-4">End date</span>
-                                                    <TZLabel time={survey.end_date} />
+                                            <div className="flex flex-row gap-8">
+                                                {survey.start_date && (
+                                                    <div className="flex flex-col">
+                                                        <span className="card-secondary mt-4">Start date</span>
+                                                        <TZLabel time={survey.start_date} />
+                                                    </div>
+                                                )}
+                                                {survey.end_date && (
+                                                    <div className="flex flex-col">
+                                                        <span className="card-secondary mt-4">End date</span>
+                                                        <TZLabel time={survey.end_date} />
+                                                    </div>
+                                                )}
+                                            </div>
+                                            {(survey.conditions || survey.targeting_flag) && (
+                                                <div className="flex flex-col mt-6">
+                                                    <span className="font-medium text-lg">Targeting</span>
+                                                    {survey.conditions?.url && (
+                                                        <>
+                                                            <span className="card-secondary mt-4 mb-1 underline">
+                                                                Url
+                                                            </span>
+                                                            <span>{survey.conditions.url}</span>
+                                                            {(survey.conditions?.selector || survey.targeting_flag) && (
+                                                                <LogicalRowDivider
+                                                                    logicalOperator={FilterLogicalOperator.And}
+                                                                />
+                                                            )}
+                                                        </>
+                                                    )}
+                                                    {survey.conditions?.selector && (
+                                                        <>
+                                                            <span className="card-secondary mt-4">Selector</span>
+                                                            <span>{survey.conditions.selector}</span>
+                                                        </>
+                                                    )}
+                                                    {survey.targeting_flag && (
+                                                        <>
+                                                            <span className="card-secondary mt-4 pb-1 underline">
+                                                                Release conditions
+                                                            </span>
+                                                            {survey.targeting_flag.filters.groups.map(
+                                                                (group, index) => (
+                                                                    <>
+                                                                        {index > 0 && (
+                                                                            <div className="text-primary-alt font-semibold text-xs ml-2 py-1">
+                                                                                OR
+                                                                            </div>
+                                                                        )}
+                                                                        {group.properties.map((property, idx) => (
+                                                                            <>
+                                                                                <div
+                                                                                    className="feature-flag-property-display"
+                                                                                    key={idx}
+                                                                                >
+                                                                                    {idx === 0 ? (
+                                                                                        <LemonButton
+                                                                                            icon={
+                                                                                                <IconSubArrowRight className="arrow-right" />
+                                                                                            }
+                                                                                            status="muted"
+                                                                                            size="small"
+                                                                                        />
+                                                                                    ) : (
+                                                                                        <LemonButton
+                                                                                            icon={
+                                                                                                <span className="text-sm">
+                                                                                                    &
+                                                                                                </span>
+                                                                                            }
+                                                                                            status="muted"
+                                                                                            size="small"
+                                                                                        />
+                                                                                    )}
+                                                                                    <span className="simple-tag tag-light-blue text-primary-alt">
+                                                                                        {property.type === 'cohort'
+                                                                                            ? 'Cohort'
+                                                                                            : property.key}{' '}
+                                                                                    </span>
+                                                                                    {isPropertyFilterWithOperator(
+                                                                                        property
+                                                                                    ) ? (
+                                                                                        <span>
+                                                                                            {allOperatorsToHumanName(
+                                                                                                property.operator
+                                                                                            )}{' '}
+                                                                                        </span>
+                                                                                    ) : null}
+
+                                                                                    {property.type === 'cohort' ? (
+                                                                                        <a
+                                                                                            href={urls.cohort(
+                                                                                                property.value
+                                                                                            )}
+                                                                                            target="_blank"
+                                                                                            rel="noopener"
+                                                                                            className="simple-tag tag-light-blue text-primary-alt display-value"
+                                                                                        >
+                                                                                            {(property.value &&
+                                                                                                cohortsById[
+                                                                                                    property.value
+                                                                                                ]?.name) ||
+                                                                                                `ID ${property.value}`}
+                                                                                        </a>
+                                                                                    ) : (
+                                                                                        [
+                                                                                            ...(Array.isArray(
+                                                                                                property.value
+                                                                                            )
+                                                                                                ? property.value
+                                                                                                : [property.value]),
+                                                                                        ].map((val, idx) => (
+                                                                                            <span
+                                                                                                key={idx}
+                                                                                                className="simple-tag tag-light-blue text-primary-alt display-value"
+                                                                                            >
+                                                                                                {val}
+                                                                                            </span>
+                                                                                        ))
+                                                                                    )}
+                                                                                </div>
+                                                                            </>
+                                                                        ))}
+                                                                    </>
+                                                                )
+                                                            )}
+                                                        </>
+                                                    )}
                                                 </div>
                                             )}
                                         </div>
-                                        {(survey.conditions || survey.targeting_flag) && (
-                                            <div className="flex flex-col mt-6">
-                                                <span className="font-medium text-lg">Targeting</span>
-                                                {survey.conditions?.url && (
-                                                    <>
-                                                        <span className="card-secondary mt-4 mb-1 underline">Url</span>
-                                                        <span>{survey.conditions.url}</span>
-                                                        {(survey.conditions?.selector || survey.targeting_flag) && (
-                                                            <LogicalRowDivider
-                                                                logicalOperator={FilterLogicalOperator.And}
-                                                            />
-                                                        )}
-                                                    </>
-                                                )}
-                                                {survey.conditions?.selector && (
-                                                    <>
-                                                        <span className="card-secondary mt-4">Selector</span>
-                                                        <span>{survey.conditions.selector}</span>
-                                                    </>
-                                                )}
-                                                {survey.targeting_flag && (
-                                                    <>
-                                                        <span className="card-secondary mt-4 pb-1 underline">
-                                                            Release conditions
-                                                        </span>
-                                                        {survey.targeting_flag.filters.groups.map((group, index) => (
-                                                            <>
-                                                                {index > 0 && (
-                                                                    <div className="text-primary-alt font-semibold text-xs ml-2 py-1">
-                                                                        OR
+                                        <div className="w-full">
+                                            <LemonCollapse
+                                                className="w-full"
+                                                panels={[
+                                                    {
+                                                        key: '1',
+                                                        header: 'Survey setup help',
+                                                        content: (
+                                                            <div>
+                                                                <div className="flex flex-col">
+                                                                    <span className="font-medium mb-2">
+                                                                        Option 1: Enable the surveys app (recommended)
+                                                                    </span>
+                                                                    <div className="flex gap-2 items-start">
+                                                                        <LemonCheckbox /> Add the following option to
+                                                                        your PostHog instance:
                                                                     </div>
-                                                                )}
-                                                                {group.properties.map((property, idx) => (
-                                                                    <>
-                                                                        <div
-                                                                            className="feature-flag-property-display"
-                                                                            key={idx}
+                                                                    <CodeSnippet language={Language.JavaScript} wrap>
+                                                                        {OPT_IN_SNIPPET}
+                                                                    </CodeSnippet>
+                                                                    <div className="flex gap-1 items-center">
+                                                                        <LemonCheckbox checked={!!surveyPlugin} />{' '}
+                                                                        {surveyPlugin ? (
+                                                                            <span>Install survey app</span>
+                                                                        ) : (
+                                                                            <LemonButton onClick={installSurveyPlugin}>
+                                                                                Install the survey app
+                                                                            </LemonButton>
+                                                                        )}{' '}
+                                                                        {installingPlugin && <Spinner />}
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1">
+                                                                        <LemonCheckbox />{' '}
+                                                                        <LemonButton
+                                                                            onClick={() =>
+                                                                                surveyPlugin?.id &&
+                                                                                editPlugin(surveyPlugin.id)
+                                                                            }
                                                                         >
-                                                                            {idx === 0 ? (
-                                                                                <LemonButton
-                                                                                    icon={
-                                                                                        <IconSubArrowRight className="arrow-right" />
-                                                                                    }
-                                                                                    status="muted"
-                                                                                    size="small"
-                                                                                />
-                                                                            ) : (
-                                                                                <LemonButton
-                                                                                    icon={
-                                                                                        <span className="text-sm">
-                                                                                            &
-                                                                                        </span>
-                                                                                    }
-                                                                                    status="muted"
-                                                                                    size="small"
-                                                                                />
-                                                                            )}
-                                                                            <span className="simple-tag tag-light-blue text-primary-alt">
-                                                                                {property.type === 'cohort'
-                                                                                    ? 'Cohort'
-                                                                                    : property.key}{' '}
-                                                                            </span>
-                                                                            {isPropertyFilterWithOperator(property) ? (
-                                                                                <span>
-                                                                                    {allOperatorsToHumanName(
-                                                                                        property.operator
-                                                                                    )}{' '}
-                                                                                </span>
-                                                                            ) : null}
-
-                                                                            {property.type === 'cohort' ? (
-                                                                                <a
-                                                                                    href={urls.cohort(property.value)}
-                                                                                    target="_blank"
-                                                                                    rel="noopener"
-                                                                                    className="simple-tag tag-light-blue text-primary-alt display-value"
-                                                                                >
-                                                                                    {(property.value &&
-                                                                                        cohortsById[property.value]
-                                                                                            ?.name) ||
-                                                                                        `ID ${property.value}`}
-                                                                                </a>
-                                                                            ) : (
-                                                                                [
-                                                                                    ...(Array.isArray(property.value)
-                                                                                        ? property.value
-                                                                                        : [property.value]),
-                                                                                ].map((val, idx) => (
-                                                                                    <span
-                                                                                        key={idx}
-                                                                                        className="simple-tag tag-light-blue text-primary-alt display-value"
-                                                                                    >
-                                                                                        {val}
-                                                                                    </span>
-                                                                                ))
-                                                                            )}
-                                                                        </div>
-                                                                    </>
-                                                                ))}
-                                                            </>
-                                                        ))}
-                                                    </>
-                                                )}
-                                            </div>
-                                        )}
+                                                                            Enable and save the surveys app
+                                                                        </LemonButton>
+                                                                    </div>
+                                                                </div>
+                                                                <div className="flex flex-col mt-3">
+                                                                    <span className="font-medium">
+                                                                        Option 2: Create your own custom survey UI with
+                                                                        our headless API
+                                                                    </span>
+                                                                    <Link to="/docs/features/surveys">
+                                                                        See documentation
+                                                                    </Link>
+                                                                </div>
+                                                            </div>
+                                                        ),
+                                                    },
+                                                ]}
+                                            />
+                                        </div>
                                     </div>
                                 ),
                                 key: 'overview',
@@ -491,6 +592,49 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                     />
                 </>
             )}
+            <SurveyLaunchSetupModal
+                isOpen={setupModalIsOpen}
+                closeModal={() => setSetupModalIsOpen(false)}
+                launchSurvey={() => {
+                    installSurveyPlugin()
+                    launchSurvey()
+                    setSetupModalIsOpen(false)
+                }}
+            />
         </div>
+    )
+}
+
+interface SurveyLaunchSetupModalProps {
+    isOpen: boolean
+    closeModal: () => void
+    launchSurvey: () => void
+}
+
+function SurveyLaunchSetupModal({ isOpen, closeModal, launchSurvey }: SurveyLaunchSetupModalProps): JSX.Element {
+    return (
+        <LemonModal
+            isOpen={isOpen}
+            onClose={closeModal}
+            width={600}
+            title="Launch setup instructions"
+            description="To launch this survey, you'll need to make sure you've enabled site apps in your PostHog instance by adding this option:"
+            footer={
+                <div className="flex gap-4">
+                    <LemonButton type="primary" onClick={launchSurvey}>
+                        Launch
+                    </LemonButton>
+                    <LemonButton type="secondary" onClick={closeModal}>
+                        Cancel
+                    </LemonButton>
+                </div>
+            }
+        >
+            <CodeSnippet language={Language.JavaScript} wrap>
+                {OPT_IN_SNIPPET}
+            </CodeSnippet>
+            Launching this survey will install the surveys app for your project. You can then enable the app and save it
+            to complete the setup.
+        </LemonModal>
     )
 }

--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -265,7 +265,7 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
     const { editPlugin } = useActions(pluginsLogic)
     const [setupModalIsOpen, setSetupModalIsOpen] = useState(false)
-    console.log('surv plugin', surveyPlugin)
+
     const [tabKey, setTabKey] = useState(survey.start_date ? 'results' : 'overview')
     useEffect(() => {
         if (survey.start_date) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2005,7 +2005,7 @@ export interface Survey {
     linked_flag: FeatureFlagBasicType | null
     targeting_flag: FeatureFlagBasicType | null
     targeting_flag_filters: Pick<FeatureFlagFilters, 'groups'> | undefined
-    conditions: { url: string; selector: string } | null
+    conditions: { url: string; selector: string; is_headless?: boolean } | null
     appearance: SurveyAppearance
     questions: SurveyQuestion[]
     created_at: string


### PR DESCRIPTION
## Problem

setup can be confusing

## Changes
- Add setup help information box at all times that'll install the plugin for you and remind you to enable it

<img width="683" alt="Screen Shot 2023-06-13 at 5 06 38 PM" src="https://github.com/PostHog/posthog/assets/25164963/7fce03d2-ecfd-41e2-a2d4-397da342c4ec">

- When launching a survey that is not headless API enabled, and if the survey app is not installed, a modal will pop up to do so for you

<img width="1117" alt="Screen Shot 2023-06-13 at 5 06 52 PM" src="https://github.com/PostHog/posthog/assets/25164963/dbb7db99-07e6-4638-95a0-bf2ca7e9ec0a">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
