### PR TITLE
ci: fix waiting for temporal to be up in backend tests

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -70,6 +70,9 @@ jobs:
                         # version changes
                         - docker-compose.dev.yml
                         - frontend/public/email/*
+                        # These scripts are used in the CI
+                        - bin/check_temporal_up
+                        - bin/check_kafka_clickhouse_up
 
     backend-code-quality:
         needs: changes

--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -2,9 +2,9 @@
 
 set -e
 
-# Wait for up to 120 seconds for Temporal to be ready
+# Wait for Temporal to be ready
 SECONDS=0
-TIMEOUT=120
+TIMEOUT=180
 
 # Check Temporal by just checking that the port is open
 while true; do

--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -6,11 +6,18 @@ set -e
 SECONDS=0
 TIMEOUT=120
 
-# Check Temporal
+# Check Temporal by just checking that the port is open
 while true; do
-    curl -s -o /dev/null -I 'http://localhost:7233/' && break || echo 'Checking Temporal status...' && sleep 1
-    if [ $SECONDS -gt $TIMEOUT ]; then
-        echo "Timeout waiting for Temporal to be ready"
+    if nc -z localhost 7233; then
+        echo "Temporal is up!"
+        exit 0
+    fi
+    
+    if [ $SECONDS -ge $TIMEOUT ]; then
+        echo "Timed out waiting for Temporal to be ready"
         exit 1
     fi
+    
+    echo "Waiting for Temporal to be ready"
+    sleep 1
 done


### PR DESCRIPTION
I think it got merged before because we weren't running the backend
tests on these script changes so I've also added them to the list of
paths to watch for changes.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
