### PR TITLE
feat(lemon-ui): add htmlFor support to LemonLabel

### DIFF
--- a/frontend/src/lib/forms/Field.tsx
+++ b/frontend/src/lib/forms/Field.tsx
@@ -21,6 +21,8 @@ export type PureFieldProps = {
     onClick?: () => void
     /** Flex the field as a row rather than columns */
     inline?: boolean
+    /** The id of the input this field is for */
+    htmlFor?: string
 }
 
 /** A "Pure" field - used when you want the Field styles without the Kea form functionality */
@@ -29,6 +31,7 @@ export const PureField = ({
     info,
     error,
     help,
+    htmlFor,
     showOptional,
     onExplanationClick,
     className,
@@ -49,6 +52,7 @@ export const PureField = ({
                     className={clsx({
                         'cursor-pointer': !!onClick,
                     })}
+                    htmlFor={htmlFor}
                 >
                     {label}
                 </LemonLabel>

--- a/frontend/src/lib/lemon-ui/LemonLabel/LemonLabel.tsx
+++ b/frontend/src/lib/lemon-ui/LemonLabel/LemonLabel.tsx
@@ -10,6 +10,7 @@ export interface LemonLabelProps
     infoLink?: LinkProps['to']
     showOptional?: boolean
     onExplanationClick?: () => void
+    htmlFor?: string
 }
 
 export function LemonLabel({
@@ -19,10 +20,11 @@ export function LemonLabel({
     showOptional,
     onExplanationClick,
     infoLink,
+    htmlFor,
     ...props
 }: LemonLabelProps): JSX.Element {
     return (
-        <label className={clsx('LemonLabel', className)} {...props}>
+        <label className={clsx('LemonLabel', className)} htmlFor={htmlFor} {...props}>
             {children}
 
             {showOptional ? <span className="LemonLabel__extra">(optional)</span> : null}


### PR DESCRIPTION
So that people with reduced visibility can navigate forms more easily,
we allow the association of form label with the input element that
should be selected for the specified data.

I'm not sure if this is the best way to go about this tbh, I haven't done much
a11y work before but thought it would be nice to start adding this #learning

It also might be useful in making tests that look for specific elements.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
