### PR TITLE
feat: Add pausing/unpausing buttons to exports list

### DIFF
--- a/frontend/src/scenes/exports/ExportsList.tsx
+++ b/frontend/src/scenes/exports/ExportsList.tsx
@@ -1,9 +1,12 @@
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from '../urls'
 import { LemonButton } from '../../lib/lemon-ui/LemonButton'
-import { useCurrentTeamId, useExports } from './api'
+import { LemonTag } from '../../lib/lemon-ui/LemonTag/LemonTag'
+import { IconPlay, IconPause } from 'lib/lemon-ui/icons'
+import { useCurrentTeamId, useExports, useExportAction } from './api'
 import { LemonTable } from '../../lib/lemon-ui/LemonTable'
 import { Link } from 'lib/lemon-ui/Link'
+import clsx from 'clsx'
 
 export const scene: SceneExport = {
     component: Exports,
@@ -63,9 +66,68 @@ export function Exports(): JSX.Element {
                         },
                     },
                     {
+                        title: 'Status',
+                        key: 'status',
+                        render: function RenderStatus(_, export_) {
+                            return (
+                                <>
+                                    {export_.paused === true ? (
+                                        <LemonTag type="default" className="uppercase">
+                                            Paused
+                                        </LemonTag>
+                                    ) : (
+                                        <LemonTag type="primary" className="uppercase">
+                                            Running
+                                        </LemonTag>
+                                    )}
+                                </>
+                            )
+                        },
+                    },
+                    {
                         title: 'Frequency',
                         key: 'frequency',
                         dataIndex: 'interval',
+                    },
+                    {
+                        title: 'Actions',
+                        render: function Render(_, export_) {
+                            const {
+                                executeExportAction: pauseExport,
+                                loading: pausing,
+                                error: pauseError,
+                            } = useExportAction(currentTeamId, export_.id, 'pause')
+                            const {
+                                executeExportAction: resumeExport,
+                                loading: resuming,
+                                error: resumeError,
+                            } = useExportAction(currentTeamId, export_.id, 'unpause')
+
+                            return (
+                                <div className={clsx('flex flex-wrap')}>
+                                    <LemonButton
+                                        status="primary"
+                                        type="secondary"
+                                        onClick={() => {
+                                            export_.paused
+                                                ? resumeExport().then(() => {
+                                                      if (resumeError === null) {
+                                                          export_.paused = false
+                                                      }
+                                                  })
+                                                : pauseExport().then(() => {
+                                                      if (pauseError === null) {
+                                                          export_.paused = true
+                                                      }
+                                                  })
+                                        }}
+                                        icon={export_.paused ? <IconPlay /> : <IconPause />}
+                                        tooltip={export_.paused ? 'Resume this BatchExport' : 'Pause this BatchExport'}
+                                        loading={pausing || resuming}
+                                    />
+                                </div>
+                            )
+                        },
                     },
                 ]}
             />

--- a/frontend/src/scenes/exports/ExportsScene.stories.tsx
+++ b/frontend/src/scenes/exports/ExportsScene.stories.tsx
@@ -22,6 +22,7 @@ const createExportServiceHandlers = (): any => {
                     aws_secret_access_key: '',
                 },
             },
+            paused: false,
             interval: 'hour',
             status: 'RUNNING',
             created_at: '2021-09-01T00:00:00.000000Z',

--- a/frontend/src/scenes/exports/api.ts
+++ b/frontend/src/scenes/exports/api.ts
@@ -99,6 +99,7 @@ export type BatchExport = {
     status: 'RUNNING' | 'FAILED' | 'COMPLETED' | 'PAUSED'
     created_at: string
     last_updated_at: string
+    paused: boolean
 } & BatchExportData
 
 export type BatchExportsResponse = {
@@ -129,6 +130,37 @@ export const useCreateExport = (): {
     }, [])
 
     return { createExport, ...state }
+}
+
+export const useExportAction = (
+    teamId: number,
+    exportId: string,
+    action: string
+): {
+    executeExportAction: () => Promise<void>
+    loading: boolean
+    error: Error | null
+} => {
+    // Returns a callback to execute an action for the given team and export ID.
+    const [state, setState] = useState<{ loading: boolean; error: Error | null }>({ loading: false, error: null })
+
+    const executeExportAction = useCallback(() => {
+        setState({ loading: true, error: null })
+        return api
+            .createResponse(`/api/projects/${teamId}/batch_exports/${exportId}/${action}`, {})
+            .then((response) => {
+                if (response.ok) {
+                    setState({ loading: false, error: null })
+                } else {
+                    // TODO: parse the error response.
+                    const error = new Error(response.statusText)
+                    setState({ loading: false, error: error })
+                    throw error
+                }
+            })
+    }, [teamId, exportId, action])
+
+    return { executeExportAction, ...state }
 }
 
 export const useExport = (

--- a/frontend/src/scenes/exports/api.ts
+++ b/frontend/src/scenes/exports/api.ts
@@ -135,7 +135,7 @@ export const useCreateExport = (): {
 export const useExportAction = (
     teamId: number,
     exportId: string,
-    action: string
+    action: 'pause' | 'unpause'
 ): {
     executeExportAction: () => Promise<void>
     loading: boolean


### PR DESCRIPTION
## Problem

Users are very limited with what they can do in the Batch Exports UI. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

This adds support for pausing and unpausing batch exports. Also, we add a Status field to the table.

I made the Actions field a flex container to add a Delete button in a follow-up PR.

Here's a demo:

![Kooha-2023-06-14-16-19-52](https://github.com/PostHog/posthog/assets/18740659/f1c878d5-0263-453b-bff8-6112e626a875)

There's a couple of visual bugs you may spot in the demo:
* The size of the columns changes as the status value changes, maybe there is a way to fix this?
* The size of the play/unpause button also changes while loading (as the spinner takes up more space?). Would be nice if this also stayed constant.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
