### PR TITLE
feat: things that will break in batch exports if we update mypy

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -10,7 +10,6 @@ from posthog.models import (
     BatchExport,
     BatchExportDestination,
     BatchExportRun,
-    Team,
     User,
 )
 from posthog.batch_exports.service import (
@@ -45,8 +44,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data: dict) -> BatchExportDestination:
         """Create a BatchExportDestination."""
-        team = Team.objects.get(id=self.context["team_id"])
-        export_destination = BatchExportDestination.objects.create(team=team, **validated_data)
+        export_destination = BatchExportDestination.objects.create(**validated_data)
         return export_destination
 
     def to_representation(self, instance: BatchExportDestination) -> dict:

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -3,6 +3,9 @@ from asgiref.sync import sync_to_async
 from uuid import UUID
 
 from dataclasses import dataclass, asdict
+
+from rest_framework.exceptions import ValidationError
+
 from posthog import settings
 from posthog.batch_exports.models import BatchExport, BatchExportDestination, BatchExportRun
 from posthog.temporal.client import sync_connect
@@ -135,6 +138,9 @@ def backfill_export(batch_export_id: str, start_at: dt.datetime | None = None, e
         end_at: Up to when to backfill. If this is not defined, then we will backfill up to this
             BatchExportSchedule's created_at.
     """
+    if start_at is None or end_at is None:
+        raise ValidationError("start_at and end_at must be defined for backfilling")
+
     batch_export = BatchExport.objects.get(id=batch_export_id)
     backfill_run = BatchExportRun.objects.create(
         batch_export=batch_export,


### PR DESCRIPTION
## Problem

I am a masochist and as a result am trying to update mypy

That's going slowly but newer versions of mypy will want these changes

## Changes

* does not pass team to create a batch export destination
* rejects optional start_at or end_at in the API for them

## How did you test this code?

🙈 
see https://github.com/PostHog/posthog/pull/15987