### PR TITLE
feat(hogql): add session_replay_events table

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -538,6 +538,7 @@ HOGQL_AGGREGATIONS = {
     "argMinIf": 3,
     "argMax": 2,
     "argMaxIf": 3,
+    "argMinMerge": 1,
     "avgWeighted": 2,
     "avgWeightedIf": 3,
     # "topK": 1,

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -21,6 +21,7 @@ from posthog.hogql.database.schema.person_distinct_ids import PersonDistinctIdTa
 from posthog.hogql.database.schema.persons import PersonsTable, RawPersonsTable
 from posthog.hogql.database.schema.person_overrides import PersonOverridesTable, RawPersonOverridesTable
 from posthog.hogql.database.schema.session_recording_events import SessionRecordingEvents
+from posthog.hogql.database.schema.session_replay_events import RawSessionReplayEventsTable, SessionReplayEventsTable
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
 from posthog.hogql.errors import HogQLException
 from posthog.utils import PersonOnEventsMode
@@ -38,9 +39,11 @@ class Database(BaseModel):
     person_overrides: PersonOverridesTable = PersonOverridesTable()
 
     session_recording_events: SessionRecordingEvents = SessionRecordingEvents()
+    session_replay_events: SessionReplayEventsTable = SessionReplayEventsTable()
     cohort_people: CohortPeople = CohortPeople()
     static_cohort_people: StaticCohortPeople = StaticCohortPeople()
 
+    raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdTable = RawPersonDistinctIdTable()
     raw_persons: RawPersonsTable = RawPersonsTable()
     raw_groups: RawGroupsTable = RawGroupsTable()

--- a/posthog/hogql/database/schema/session_replay_events.py
+++ b/posthog/hogql/database/schema/session_replay_events.py
@@ -1,0 +1,111 @@
+from typing import Dict, List
+
+from posthog.hogql.database.models import (
+    Table,
+    StringDatabaseField,
+    DateTimeDatabaseField,
+    IntegerDatabaseField,
+    LazyJoin,
+    FieldTraverser,
+    DatabaseField,
+    LazyTable,
+)
+from posthog.hogql.database.schema.person_distinct_ids import PersonDistinctIdTable, join_with_person_distinct_ids_table
+
+
+class RawSessionReplayEventsTable(Table):
+    session_id: StringDatabaseField = StringDatabaseField(name="session_id")
+    team_id: IntegerDatabaseField = IntegerDatabaseField(name="team_id")
+    distinct_id: StringDatabaseField = StringDatabaseField(name="distinct_id")
+
+    min_first_timestamp: DateTimeDatabaseField = DateTimeDatabaseField(name="min_first_timestamp")
+    max_last_timestamp: DateTimeDatabaseField = DateTimeDatabaseField(name="max_last_timestamp")
+    first_url: DatabaseField = DatabaseField(name="first_url")
+
+    click_count: IntegerDatabaseField = IntegerDatabaseField(name="click_count")
+    keypress_count: IntegerDatabaseField = IntegerDatabaseField(name="keypress_count")
+    mouse_activity_count: IntegerDatabaseField = IntegerDatabaseField(name="mouse_activity_count")
+    active_milliseconds: IntegerDatabaseField = IntegerDatabaseField(name="active_milliseconds")
+    console_log_count: IntegerDatabaseField = IntegerDatabaseField(name="console_log_count")
+    console_warn_count: IntegerDatabaseField = IntegerDatabaseField(name="console_warn_count")
+    console_error_count: IntegerDatabaseField = IntegerDatabaseField(name="console_error_count")
+
+    pdi: LazyJoin = LazyJoin(
+        from_field="distinct_id",
+        join_table=PersonDistinctIdTable(),
+        join_function=join_with_person_distinct_ids_table,
+    )
+
+    person: FieldTraverser = FieldTraverser(chain=["pdi", "person"])
+    person_id: FieldTraverser = FieldTraverser(chain=["pdi", "person_id"])
+
+    def avoid_asterisk_fields(self) -> List[str]:
+        return ["first_url"]
+
+    def clickhouse_table(self):
+        return "session_replay_events"
+
+    def hogql_table(self):
+        return "raw_session_replay_events"
+
+
+def select_from_session_replay_events_table(requested_fields: Dict[str, List[str]]):
+    from posthog.hogql import ast
+
+    table_name = "raw_session_replay_events"
+
+    aggregate_fields = {
+        "start_time": ast.Call(name="min", args=[ast.Field(chain=[table_name, "min_first_timestamp"])]),
+        "end_time": ast.Call(name="max", args=[ast.Field(chain=[table_name, "max_last_timestamp"])]),
+        "first_url": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "first_url"])]),
+        "click_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "click_count"])]),
+        "keypress_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "keypress_count"])]),
+        "mouse_activity_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "mouse_activity_count"])]),
+        "active_milliseconds": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "active_milliseconds"])]),
+        "console_log_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "console_log_count"])]),
+        "console_warn_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "console_warn_count"])]),
+        "console_error_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "console_error_count"])]),
+    }
+
+    select_fields: List[ast.Expr] = []
+    group_by_fields: List[ast.Expr] = []
+
+    for name, chain in requested_fields.items():
+        if name in aggregate_fields:
+            select_fields.append(ast.Alias(alias=name, expr=aggregate_fields[name]))
+        else:
+            select_fields.append(ast.Alias(alias=name, expr=ast.Field(chain=[table_name] + chain)))
+            group_by_fields.append(ast.Field(chain=[table_name] + chain))
+
+    return ast.SelectQuery(
+        select=select_fields,
+        select_from=ast.JoinExpr(table=ast.Field(chain=[table_name])),
+        group_by=group_by_fields,
+    )
+
+
+class SessionReplayEventsTable(LazyTable):
+    session_id: StringDatabaseField = StringDatabaseField(name="session_id")
+    team_id: IntegerDatabaseField = IntegerDatabaseField(name="team_id")
+    distinct_id: StringDatabaseField = StringDatabaseField(name="distinct_id")
+
+    start_time: DateTimeDatabaseField = DateTimeDatabaseField(name="start_time")
+    end_time: DateTimeDatabaseField = DateTimeDatabaseField(name="end_time")
+    first_url: StringDatabaseField = StringDatabaseField(name="first_url")
+
+    click_count: IntegerDatabaseField = IntegerDatabaseField(name="click_count")
+    keypress_count: IntegerDatabaseField = IntegerDatabaseField(name="keypress_count")
+    mouse_activity_count: IntegerDatabaseField = IntegerDatabaseField(name="mouse_activity_count")
+    active_milliseconds: IntegerDatabaseField = IntegerDatabaseField(name="active_milliseconds")
+    console_log_count: IntegerDatabaseField = IntegerDatabaseField(name="console_log_count")
+    console_warn_count: IntegerDatabaseField = IntegerDatabaseField(name="console_warn_count")
+    console_error_count: IntegerDatabaseField = IntegerDatabaseField(name="console_error_count")
+
+    def lazy_select(self, requested_fields: Dict[str, List[str]]):
+        return select_from_session_replay_events_table(requested_fields)
+
+    def clickhouse_table(self):
+        return "session_replay_events"
+
+    def hogql_table(self):
+        return "session_replay_events"

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -285,6 +285,56 @@
               ]
           }
       ],
+      "session_replay_events": [
+          {
+              "key": "session_id",
+              "type": "string"
+          },
+          {
+              "key": "distinct_id",
+              "type": "string"
+          },
+          {
+              "key": "start_time",
+              "type": "datetime"
+          },
+          {
+              "key": "end_time",
+              "type": "datetime"
+          },
+          {
+              "key": "first_url",
+              "type": "string"
+          },
+          {
+              "key": "click_count",
+              "type": "integer"
+          },
+          {
+              "key": "keypress_count",
+              "type": "integer"
+          },
+          {
+              "key": "mouse_activity_count",
+              "type": "integer"
+          },
+          {
+              "key": "active_milliseconds",
+              "type": "integer"
+          },
+          {
+              "key": "console_log_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_warn_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_error_count",
+              "type": "integer"
+          }
+      ],
       "cohort_people": [
           {
               "key": "person_id",
@@ -313,6 +363,73 @@
               "key": "person",
               "type": "lazy_table",
               "table": "persons"
+          }
+      ],
+      "raw_session_replay_events": [
+          {
+              "key": "session_id",
+              "type": "string"
+          },
+          {
+              "key": "distinct_id",
+              "type": "string"
+          },
+          {
+              "key": "min_first_timestamp",
+              "type": "datetime"
+          },
+          {
+              "key": "max_last_timestamp",
+              "type": "datetime"
+          },
+          {
+              "key": "click_count",
+              "type": "integer"
+          },
+          {
+              "key": "keypress_count",
+              "type": "integer"
+          },
+          {
+              "key": "mouse_activity_count",
+              "type": "integer"
+          },
+          {
+              "key": "active_milliseconds",
+              "type": "integer"
+          },
+          {
+              "key": "console_log_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_warn_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_error_count",
+              "type": "integer"
+          },
+          {
+              "key": "pdi",
+              "type": "lazy_table",
+              "table": "person_distinct_ids"
+          },
+          {
+              "key": "person",
+              "type": "field_traverser",
+              "chain": [
+                  "pdi",
+                  "person"
+              ]
+          },
+          {
+              "key": "person_id",
+              "type": "field_traverser",
+              "chain": [
+                  "pdi",
+                  "person_id"
+              ]
           }
       ],
       "raw_person_distinct_ids": [
@@ -715,6 +832,56 @@
               ]
           }
       ],
+      "session_replay_events": [
+          {
+              "key": "session_id",
+              "type": "string"
+          },
+          {
+              "key": "distinct_id",
+              "type": "string"
+          },
+          {
+              "key": "start_time",
+              "type": "datetime"
+          },
+          {
+              "key": "end_time",
+              "type": "datetime"
+          },
+          {
+              "key": "first_url",
+              "type": "string"
+          },
+          {
+              "key": "click_count",
+              "type": "integer"
+          },
+          {
+              "key": "keypress_count",
+              "type": "integer"
+          },
+          {
+              "key": "mouse_activity_count",
+              "type": "integer"
+          },
+          {
+              "key": "active_milliseconds",
+              "type": "integer"
+          },
+          {
+              "key": "console_log_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_warn_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_error_count",
+              "type": "integer"
+          }
+      ],
       "cohort_people": [
           {
               "key": "person_id",
@@ -743,6 +910,73 @@
               "key": "person",
               "type": "lazy_table",
               "table": "persons"
+          }
+      ],
+      "raw_session_replay_events": [
+          {
+              "key": "session_id",
+              "type": "string"
+          },
+          {
+              "key": "distinct_id",
+              "type": "string"
+          },
+          {
+              "key": "min_first_timestamp",
+              "type": "datetime"
+          },
+          {
+              "key": "max_last_timestamp",
+              "type": "datetime"
+          },
+          {
+              "key": "click_count",
+              "type": "integer"
+          },
+          {
+              "key": "keypress_count",
+              "type": "integer"
+          },
+          {
+              "key": "mouse_activity_count",
+              "type": "integer"
+          },
+          {
+              "key": "active_milliseconds",
+              "type": "integer"
+          },
+          {
+              "key": "console_log_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_warn_count",
+              "type": "integer"
+          },
+          {
+              "key": "console_error_count",
+              "type": "integer"
+          },
+          {
+              "key": "pdi",
+              "type": "lazy_table",
+              "table": "person_distinct_ids"
+          },
+          {
+              "key": "person",
+              "type": "field_traverser",
+              "chain": [
+                  "pdi",
+                  "person"
+              ]
+          },
+          {
+              "key": "person_id",
+              "type": "field_traverser",
+              "chain": [
+                  "pdi",
+                  "person_id"
+              ]
           }
       ],
       "raw_person_distinct_ids": [

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -274,11 +274,15 @@ class _Printer(Visitor):
             join_strings.append(self.visit(node.table))
             join_strings.append(f"AS {self._print_identifier(node.alias)}")
 
-        elif isinstance(node.type, ast.LazyTableType) and self.dialect == "hogql":
-            join_strings.append(self._print_identifier(node.type.table.hogql_table()))
-
+        elif isinstance(node.type, ast.LazyTableType):
+            if self.dialect == "hogql":
+                join_strings.append(self._print_identifier(node.type.table.hogql_table()))
+            else:
+                raise HogQLException(f"Unexpected LazyTableType for: {node.type.table.hogql_table()}")
         else:
-            raise HogQLException("Only selecting from a table or a subquery is supported")
+            raise HogQLException(
+                f"Only selecting from a table or a subquery is supported. Unexpected type: {node.type.__class__.__name__}"
+            )
 
         if node.table_final:
             join_strings.append("FINAL")

--- a/posthog/hogql/transforms/lazy_tables.py
+++ b/posthog/hogql/transforms/lazy_tables.py
@@ -47,7 +47,7 @@ class LazyTableResolver(TraversingVisitor):
         elif isinstance(type, ast.VirtualTableType):
             return f"{self._get_long_table_name(select, type.table_type)}__{type.field}"
         else:
-            raise HogQLException("Should not be reachable")
+            raise HogQLException(f"Unknown table type in LazyTableResolver: {type.__class__.__name__}")
 
     def visit_property_type(self, node: ast.PropertyType):
         if node.joined_subquery is not None:
@@ -97,6 +97,23 @@ class LazyTableResolver(TraversingVisitor):
         ]
         sorted_properties: List[ast.PropertyType | ast.FieldType] = matched_properties + matched_fields
 
+        # Look for tables without requested fields to support cases like `select count() from table`
+        join = node.select_from
+        while join:
+            if isinstance(join.table.type, ast.LazyTableType):
+                fields = []
+                for field_or_property in field_collector:
+                    if isinstance(field_or_property, ast.FieldType):
+                        if field_or_property.table_type == join.table.type:
+                            fields.append(field_or_property)
+                    elif isinstance(field_or_property, ast.PropertyType):
+                        if field_or_property.field_type.table_type == join.table.type:
+                            fields.append(field_or_property)
+                if len(fields) == 0:
+                    table_name = join.alias or self._get_long_table_name(select_type, join.table.type)
+                    tables_to_add[table_name] = TableToAdd(fields_accessed={}, lazy_table=join.table.type.table)
+            join = join.next_join
+
         for field_or_property in sorted_properties:
             if isinstance(field_or_property, ast.FieldType):
                 property = None
@@ -105,7 +122,7 @@ class LazyTableResolver(TraversingVisitor):
                 property = field_or_property
                 field = property.field_type
             else:
-                raise Exception("Should not be reachable")
+                raise HogQLException("Should not be reachable")
             table_type = field.table_type
 
             # Traverse the lazy tables until we reach a real table, collecting them in a list.
@@ -220,7 +237,7 @@ class LazyTableResolver(TraversingVisitor):
             elif isinstance(field_or_property, ast.PropertyType):
                 table_type = field_or_property.field_type.table_type
             else:
-                raise Exception("Should not be reachable")
+                raise HogQLException("Should not be reachable")
 
             table_name = self._get_long_table_name(select_type, table_type)
             table_type = select_type.tables[table_name]

--- a/posthog/hogql/transforms/test/test_lazy_tables.py
+++ b/posthog/hogql/transforms/test/test_lazy_tables.py
@@ -154,6 +154,14 @@ class TestLazyJoins(BaseTest):
         )
         self.assertEqual(printed, expected)
 
+    def test_select_count_from_lazy_table(self):
+        printed = self._print_select("select count() from persons")
+        expected = (
+            f"SELECT count() FROM (SELECT person.id AS id FROM person WHERE equals(person.team_id, {self.team.pk}) "
+            f"GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS persons LIMIT 10000"
+        )
+        self.assertEqual(printed, expected)
+
     def _print_select(self, select: str):
         expr = parse_select(select)
         return print_ast(expr, HogQLContext(team_id=self.team.pk, enable_select_queries=True), "clickhouse")


### PR DESCRIPTION
## Problem

The `session_replay_events` table is not in HogQL

## Changes

Now it is:

![2023-06-15 10 13 46](https://github.com/PostHog/posthog/assets/53387/99170625-da5f-4dbc-b61a-4576a2c2a90c)


## How did you test this code?

Ran the following HogQL queries:

 ```sql
select * from session_replay_events
select * from raw_session_replay_events
```

Verified that the number of rows returned was different

## Side quest

Unrelated to session replay events, running `select count() from some_lazy_table` failed if you didn't select any other fields from this table. Now it works.