### PR TITLE
refactor(exports): remove unnecessary f-string when logging row count

### DIFF
--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -36,7 +36,7 @@ async def get_rows_count(client: ChClient, team_id: int, interval_start: str, in
     )
 
     if row is None:
-        raise ValueError(f"Unexpected result from ClickHouse: {row}")
+        raise ValueError("Unexpected result from ClickHouse: `None` returned for count query")
 
     return row["count"]
 


### PR DESCRIPTION
I think we were maybe formatting something else in this string before,
but it's always None now.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
