### PR TITLE
feat: Add delete button for exports

### DIFF
--- a/frontend/src/scenes/exports/ExportsList.tsx
+++ b/frontend/src/scenes/exports/ExportsList.tsx
@@ -2,11 +2,12 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from '../urls'
 import { LemonButton } from '../../lib/lemon-ui/LemonButton'
 import { LemonTag } from '../../lib/lemon-ui/LemonTag/LemonTag'
-import { IconPlay, IconPause } from 'lib/lemon-ui/icons'
-import { useCurrentTeamId, useExports, useExportAction } from './api'
+import { IconPlay, IconPause, IconDelete } from 'lib/lemon-ui/icons'
+import { useCurrentTeamId, useExports, useExportAction, useDeleteExport } from './api'
 import { LemonTable } from '../../lib/lemon-ui/LemonTable'
 import { Link } from 'lib/lemon-ui/Link'
 import clsx from 'clsx'
+import { useCallback } from 'react'
 
 export const scene: SceneExport = {
     component: Exports,
@@ -91,7 +92,7 @@ export function Exports(): JSX.Element {
                     },
                     {
                         title: 'Actions',
-                        render: function Render(_, export_) {
+                        render: function Render(_, export_, index) {
                             const {
                                 executeExportAction: pauseExport,
                                 loading: pausing,
@@ -102,6 +103,16 @@ export function Exports(): JSX.Element {
                                 loading: resuming,
                                 error: resumeError,
                             } = useExportAction(currentTeamId, export_.id, 'unpause')
+
+                            const deleteCallback = useCallback(() => {
+                                exports.pop(index)
+                            })
+
+                            const { deleteExport, deleting, _ } = useDeleteExport(
+                                currentTeamId,
+                                export_.id,
+                                deleteCallback
+                            )
 
                             return (
                                 <div className={clsx('flex flex-wrap')}>
@@ -124,6 +135,18 @@ export function Exports(): JSX.Element {
                                         icon={export_.paused ? <IconPlay /> : <IconPause />}
                                         tooltip={export_.paused ? 'Resume this BatchExport' : 'Pause this BatchExport'}
                                         loading={pausing || resuming}
+                                        disabled={deleting}
+                                    />
+                                    <LemonButton
+                                        status="primary"
+                                        type="secondary"
+                                        onClick={() => {
+                                            deleteExport()
+                                        }}
+                                        icon={<IconDelete />}
+                                        tooltip="Permanently delete this BatchExport"
+                                        loading={deleting}
+                                        disabled={pausing || resuming}
                                     />
                                 </div>
                             )

--- a/frontend/src/scenes/exports/ExportsList.tsx
+++ b/frontend/src/scenes/exports/ExportsList.tsx
@@ -140,7 +140,7 @@ export function Exports(): JSX.Element {
                                         onClick={() => {
                                             deleteExport().then(() => {
                                                 if (deleteError === null) {
-                                                    updateCallback()
+                                                    updateCallback(undefined)
                                                     lemonToast['success'](
                                                         <>
                                                             <b>{export_.name}</b> has been deleted

--- a/frontend/src/scenes/exports/api-mocks.ts
+++ b/frontend/src/scenes/exports/api-mocks.ts
@@ -62,7 +62,7 @@ export const createExportServiceHandlers = (
             },
         },
         delete: {
-            '/api/projects/:team_id/batch_exports/:export_id': (req: any, res: any, ctx: any) => {
+            '/api/projects/:team_id/batch_exports/:export_id': (_: any, res: any, ctx: any) => {
                 return res(ctx.delay(1000))
             },
         },

--- a/frontend/src/scenes/exports/api-mocks.ts
+++ b/frontend/src/scenes/exports/api-mocks.ts
@@ -61,6 +61,11 @@ export const createExportServiceHandlers = (
                 return res(ctx.delay(1000), ctx.json(exports[id]))
             },
         },
+        delete: {
+            '/api/projects/:team_id/batch_exports/:export_id': (req: any, res: any, ctx: any) => {
+                return res(ctx.delay(1000))
+            },
+        },
     }
 
     return { handlers, exports }

--- a/frontend/src/scenes/exports/api.ts
+++ b/frontend/src/scenes/exports/api.ts
@@ -27,7 +27,7 @@ export const useExports = (
     teamId: number
 ): {
     exportsState: UseExportsReturnType
-    updateCallback: () => Promise<void>
+    updateCallback: (signal: AbortSignal | undefined) => void
 } => {
     // Returns a list of exports for the given team. While we are fetching the
     // list, we return a loading: true as part of the state. On component
@@ -42,7 +42,7 @@ export const useExports = (
     })
 
     const updateCallback = useCallback(
-        (signal) => {
+        (signal: AbortSignal | undefined) => {
             fetch(`/api/projects/${teamId}/batch_exports/`, { signal })
                 .then((response) => response.json() as Promise<BatchExportsResponse>)
                 .then((data) => {

--- a/frontend/src/scenes/exports/api.ts
+++ b/frontend/src/scenes/exports/api.ts
@@ -23,7 +23,12 @@ type UseExportsReturnType = {
     exports?: BatchExport[]
 }
 
-export const useExports = (teamId: number): UseExportsReturnType => {
+export const useExports = (
+    teamId: number
+): {
+    exportsState: UseExportsReturnType
+    updateCallback: () => Promise<void>
+} => {
     // Returns a list of exports for the given team. While we are fetching the
     // list, we return a loading: true as part of the state. On component
     // unmount we ensure that we clean up the fetch request by use of the
@@ -36,24 +41,31 @@ export const useExports = (teamId: number): UseExportsReturnType => {
         error: undefined,
     })
 
+    const updateCallback = useCallback(
+        (signal) => {
+            fetch(`/api/projects/${teamId}/batch_exports/`, { signal })
+                .then((response) => response.json() as Promise<BatchExportsResponse>)
+                .then((data) => {
+                    setExports({ loading: false, exports: data.results, error: undefined })
+                })
+                .catch((error) => {
+                    setExports({ loading: false, exports: undefined, error })
+                })
+        },
+        [teamId]
+    )
+
     // Make the actual fetch request as a side effect.
     useEffect(() => {
         const controller = new AbortController()
         const signal = controller.signal
 
-        fetch(`/api/projects/${teamId}/batch_exports/`, { signal })
-            .then((response) => response.json() as Promise<BatchExportsResponse>)
-            .then((data) => {
-                setExports({ loading: false, exports: data.results, error: undefined })
-            })
-            .catch((error) => {
-                setExports({ loading: false, exports: undefined, error })
-            })
+        updateCallback(signal)
 
         return () => controller.abort()
     }, [teamId])
 
-    return state
+    return { exportsState: state, updateCallback }
 }
 
 type S3Destination = {
@@ -134,10 +146,9 @@ export const useCreateExport = (): {
 
 export const useDeleteExport = (
     teamId: number,
-    exportId: string,
-    deleteCallback: () => Promise<void>
+    exportId: string
 ): {
-    deleteExport: (teamId: number, exportData: BatchExportData) => Promise<void>
+    deleteExport: () => Promise<void>
     deleting: boolean
     error: Error | null
 } => {
@@ -153,7 +164,6 @@ export const useDeleteExport = (
         return api.delete(`/api/projects/${teamId}/batch_exports/${exportId}`).then((response) => {
             if (response.ok) {
                 setState({ deleting: false, error: null })
-                deleteCallback()
             } else {
                 // TODO: parse the error response.
                 const error = new Error(response.statusText)

--- a/frontend/src/scenes/exports/api.ts
+++ b/frontend/src/scenes/exports/api.ts
@@ -132,6 +132,40 @@ export const useCreateExport = (): {
     return { createExport, ...state }
 }
 
+export const useDeleteExport = (
+    teamId: number,
+    exportId: string,
+    deleteCallback: () => Promise<void>
+): {
+    deleteExport: (teamId: number, exportData: BatchExportData) => Promise<void>
+    deleting: boolean
+    error: Error | null
+} => {
+    // Return a callback that can be used to delete an export. We also include
+    // the deleting state and error. We take a callback to update any state after delete.
+    const [state, setState] = useState<{ deleting: boolean; error: Error | null }>({
+        deleting: false,
+        error: null,
+    })
+
+    const deleteExport = useCallback(() => {
+        setState({ deleting: true, error: null })
+        return api.delete(`/api/projects/${teamId}/batch_exports/${exportId}`).then((response) => {
+            if (response.ok) {
+                setState({ deleting: false, error: null })
+                deleteCallback()
+            } else {
+                // TODO: parse the error response.
+                const error = new Error(response.statusText)
+                setState({ deleting: false, error: error })
+                throw error
+            }
+        })
+    }, [teamId, exportId])
+
+    return { deleteExport, ...state }
+}
+
 export const useExportAction = (
     teamId: number,
     exportId: string,


### PR DESCRIPTION
## Problem

There is no way to delete batch exports... not anymore! 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Added a delete button and testing mocks.

![Kooha-2023-06-15-16-08-50](https://github.com/PostHog/posthog/assets/18740659/53802a18-c8cc-49d7-9e2e-6726f537ddb5)

TODO: ~Add a notification?~ Undo? Thoughts?

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
