### PR TITLE
fix: duration filter must be present

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
@@ -1,4 +1,9 @@
-import { sessionRecordingsListLogic, RECORDINGS_LIMIT, DEFAULT_RECORDING_FILTERS } from './sessionRecordingsListLogic'
+import {
+    sessionRecordingsListLogic,
+    RECORDINGS_LIMIT,
+    DEFAULT_RECORDING_FILTERS,
+    defaultRecordingDurationFilter,
+} from './sessionRecordingsListLogic'
 import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 import { router } from 'kea-router'
@@ -377,7 +382,25 @@ describe('sessionRecordingsListLogic', () => {
                     },
                 })
         })
+
+        it('reads filters from the URL and defaults the duration filter', async () => {
+            router.actions.push('/replay', {
+                filters: {
+                    actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                },
+            })
+
+            await expectLogic(logic)
+                .toDispatchActions(['replaceFilters'])
+                .toMatchValues({
+                    filters: {
+                        actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                        session_recording_duration: defaultRecordingDurationFilter,
+                    },
+                })
+        })
     })
+
     describe('person specific logic', () => {
         beforeEach(() => {
             logic = sessionRecordingsListLogic({

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -5,6 +5,7 @@ import {
     AnyPropertyFilter,
     PropertyFilterType,
     PropertyOperator,
+    RecordingDurationFilter,
     RecordingFilters,
     SessionRecordingId,
     SessionRecordingsResponse,
@@ -32,13 +33,14 @@ interface HashParams {
 export const RECORDINGS_LIMIT = 20
 export const PINNED_RECORDINGS_LIMIT = 100 // NOTE: This is high but avoids the need for pagination for now...
 
+export const defaultRecordingDurationFilter: RecordingDurationFilter = {
+    type: PropertyFilterType.Recording,
+    key: 'duration',
+    value: 60,
+    operator: PropertyOperator.GreaterThan,
+}
 export const DEFAULT_RECORDING_FILTERS: RecordingFilters = {
-    session_recording_duration: {
-        type: PropertyFilterType.Recording,
-        key: 'duration',
-        value: 60,
-        operator: PropertyOperator.GreaterThan,
-    },
+    session_recording_duration: defaultRecordingDurationFilter,
     properties: [],
     events: [],
     actions: [],
@@ -277,7 +279,13 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         filters: [
             props.filters || getDefaultFilters(props.personUUID),
             {
-                replaceFilters: (_, { filters }) => filters,
+                replaceFilters: (_, { filters }) => {
+                    return {
+                        ...filters,
+                        session_recording_duration:
+                            filters.session_recording_duration || defaultRecordingDurationFilter,
+                    }
+                },
                 setFilters: (state, { filters }) => ({
                     ...state,
                     ...filters,


### PR DESCRIPTION
## Problem

Session recording filters must always have a duration filter

See https://posthoghelp.zendesk.com/agent/tickets/3596 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/6592)

## Changes

Does not allow replace filter to set an invalid duration filter

## How did you test this code?

* developer test
* checked it fixed reported problem locally