### PR TITLE
ci(temporal): add logging to backend tests for docker compose

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -85,7 +85,8 @@ runs:
 
         - name: Wait for Temporal
           shell: bash
-          run: bin/check_temporal_up
+          run: |
+              bin/check_temporal_up
 
         - name: Determine if --snapshot-update should be on
           # Skip on forks (due to GITHUB_TOKEN being read-only in PRs coming from them) except for persons-on-events
@@ -119,6 +120,11 @@ runs:
                   --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
                   --durations=100 --durations-min=1.0 --store-durations \
                   $PYTEST_ARGS
+
+        - name: Show docker compose log
+          if: ${{ always() }}
+          shell: bash
+          run: docker compose -f docker-compose.dev.yml logs --tail=5000
 
         # Post-tests
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -64,7 +64,7 @@ jobs:
                         - frontend/src/queries/schema.json # Used for generating schema.py
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-backend.yml
-                        - .github/workflows/backend-tests-action/action.yml
+                        - .github/actions/run-backend-tests/action.yml
                         # We use docker compose for tests, make sure we rerun on
                         # changes to docker-compose.dev.yml e.g. dependency
                         # version changes

--- a/posthog/api/test/__snapshots__/test_preflight.ambr
+++ b/posthog/api/test/__snapshots__/test_preflight.ambr
@@ -71,6 +71,7 @@
          "posthog_team"."live_events_columns",
          "posthog_team"."recording_domains",
          "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
          "posthog_team"."correlation_config",
          "posthog_team"."session_recording_retention_period_days",
          "posthog_team"."plugins_opt_in",


### PR DESCRIPTION
Sometimes we fail when waiting for temporal. I want to see what's going
on.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
