### PR TITLE
fix(hogql): lambdas can access the higher scope

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -165,6 +165,8 @@ class SelectQueryType(Type):
     ctes: Dict[str, CTE] = PydanticField(default_factory=dict)
     # all from and join subqueries without aliases
     anonymous_tables: List[Union["SelectQueryType", "SelectUnionQueryType"]] = PydanticField(default_factory=list)
+    # the parent select query, if this is a lambda
+    parent: Optional[Union["SelectQueryType", "SelectUnionQueryType"]] = None
 
     def get_alias_for_table_type(self, table_type: TableOrSelectType) -> Optional[str]:
         for key, value in self.tables.items():

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -286,7 +286,8 @@ class Resolver(CloningVisitor):
 
         # Each Lambda is a new scope in field name resolution.
         # This type keeps track of all lambda arguments that are in scope.
-        node_type = ast.SelectQueryType()
+        node_type = ast.SelectQueryType(parent=self.scopes[-1] if len(self.scopes) > 0 else None)
+
         for arg in node.args:
             node_type.aliases[arg] = ast.FieldAliasType(alias=arg, type=ast.LambdaArgumentType(name=arg))
 
@@ -447,6 +448,10 @@ def lookup_field_by_name(scope: ast.SelectQueryType, name: str) -> Optional[ast.
             raise ResolverException(f"Ambiguous query. Found multiple sources for field: {name}")
         elif len(tables_with_field) == 1:
             return tables_with_field[0].get_child(name)
+
+        if scope.parent:
+            return lookup_field_by_name(scope.parent, name)
+
         return None
 
 


### PR DESCRIPTION
## Problem

@pauldambra said this query fails in HogQL, but works in ClickHouse:

```sql
WITH
    reverse(arrayMap(i -> (toHour(now()) - i + 24) % 24, range(24))) AS hours ,
    toHour(now()) AS current_hour
SELECT
    event
    ,arrayMap(h  -> if(indexOf(hours_of_day, ((h + current_hour) % 24)) != 0, event_counts[indexOf(hours_of_day, ((h + current_hour) % 24))], 0), hours) AS counts_per_hour
FROM
(
    SELECT
        event,
        groupArray(hour) AS hours_of_day,
        groupArray(count) AS event_counts
    FROM
    (
        SELECT
            event,
            toHour(timestamp) AS hour,
            count() AS count
        FROM events
        WHERE timestamp >= now() - INTERVAL 24 HOUR
        GROUP BY event, hour
    )
    GROUP BY event
) 
```

## Changes

Makes the query work 

## How did you test this code?

Ran it, should probably add a test.