### PR TITLE
fix: Temporal service waits for db to be healthy

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -13,6 +13,10 @@ services:
             POSTGRES_USER: posthog
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U posthog']
+            interval: 5s
+            timeout: 5s
 
     redis:
         image: redis:6.2.7-alpine
@@ -143,7 +147,9 @@ services:
             - /var/lib/elasticsearch/data
     temporal:
         depends_on:
-            - db
+            db:
+                condition: service_healthy
+
         environment:
             - DB=postgresql
             - DB_PORT=5432

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -77,6 +77,7 @@ services:
             service: elasticsearch
         expose:
             - 9200
+
     temporal:
         extends:
             file: docker-compose.base.yml


### PR DESCRIPTION
## Problem

In the [CI logs of a recent failure](https://github.com/PostHog/posthog/actions/runs/5278107935/jobs/9547007948?pr=16078) we see:

```
posthog-temporal-1     | 2023-06-15T11:15:54.088Z	ERROR	Unable to create SQL database.	{"error": "unable to connect to DB, tried default DB names: postgres,defaultdb, errors: [pq: the database system is starting up pq: the database system is starting up]", "logging-call-at": "handler.go:94"}
```

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Let's add a healthcheck to the db service and wait for it to be healthy for temporal to run.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
