### PR TITLE
feat(hogql): HogQL base classes refactor

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -1,10 +1,10 @@
-import re
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Extra
+from pydantic import Extra
 from pydantic import Field as PydanticField
 
+from posthog.hogql.base import Type, Expr, CTE, ConstantType, UnknownType
 from posthog.hogql.constants import ConstantDataType
 from posthog.hogql.database.models import (
     DatabaseField,
@@ -25,51 +25,6 @@ from posthog.hogql.errors import HogQLException, NotImplementedException
 
 # :NOTE: when you add new AST fields or nodes, add them to CloningVisitor and TraversingVisitor in visitor.py as well.
 # :NOTE2: also search for ":TRICKY:" in "resolver.py" when modifying SelectQuery or JoinExpr
-
-# Given a string like "CorrectHorseBS", match the "H" and "B", so that we can convert this to "correct_horse_bs"
-camel_case_pattern = re.compile(r"(?<!^)(?<![A-Z])(?=[A-Z])")
-
-
-class AST(BaseModel):
-    start: Optional[int] = None
-    end: Optional[int] = None
-
-    class Config:
-        extra = Extra.forbid
-
-    def accept(self, visitor):
-        camel_case_name = camel_case_pattern.sub("_", self.__class__.__name__).lower()
-        method_name = f"visit_{camel_case_name}"
-        if hasattr(visitor, method_name):
-            visit = getattr(visitor, method_name)
-            return visit(self)
-        if hasattr(visitor, "visit_unknown"):
-            return visitor.visit_unknown(self)
-        raise NotImplementedException(f"Visitor has no method {method_name}")
-
-
-class Type(AST):
-    def get_child(self, name: str) -> "Type":
-        raise NotImplementedException("Type.get_child not overridden")
-
-    def has_child(self, name: str) -> bool:
-        return self.get_child(name) is not None
-
-    def resolve_constant_type(self) -> Optional["ConstantType"]:
-        return UnknownType()
-
-
-class Expr(AST):
-    type: Optional[Type] = None
-
-
-class CTE(Expr):
-    """A common table expression."""
-
-    name: str
-    expr: Expr
-    # Whether the CTE is an inlined column "WITH 1 AS a" or a subquery "WITH a AS (SELECT 1)"
-    cte_type: Literal["column", "subquery"]
 
 
 class FieldAliasType(Type):
@@ -214,13 +169,6 @@ class SelectQueryAliasType(Type):
 SelectQueryType.update_forward_refs(SelectQueryAliasType=SelectQueryAliasType)
 
 
-class ConstantType(Type):
-    data_type: ConstantDataType
-
-    def resolve_constant_type(self) -> "ConstantType":
-        return self
-
-
 class IntegerType(ConstantType):
     data_type: ConstantDataType = PydanticField("int", const=True)
 
@@ -235,10 +183,6 @@ class StringType(ConstantType):
 
 class BooleanType(ConstantType):
     data_type: ConstantDataType = PydanticField("bool", const=True)
-
-
-class UnknownType(ConstantType):
-    data_type: ConstantDataType = PydanticField("unknown", const=True)
 
 
 class DateType(ConstantType):

--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -1,0 +1,64 @@
+import re
+from pydantic import BaseModel, Extra
+from typing import Literal, Optional
+
+from posthog.hogql.constants import ConstantDataType
+from posthog.hogql.errors import NotImplementedException
+from pydantic import Field as PydanticField
+
+
+# Given a string like "CorrectHorseBS", match the "H" and "B", so that we can convert this to "correct_horse_bs"
+camel_case_pattern = re.compile(r"(?<!^)(?<![A-Z])(?=[A-Z])")
+
+
+class AST(BaseModel):
+    start: Optional[int] = None
+    end: Optional[int] = None
+
+    class Config:
+        extra = Extra.forbid
+
+    def accept(self, visitor):
+        camel_case_name = camel_case_pattern.sub("_", self.__class__.__name__).lower()
+        method_name = f"visit_{camel_case_name}"
+        if hasattr(visitor, method_name):
+            visit = getattr(visitor, method_name)
+            return visit(self)
+        if hasattr(visitor, "visit_unknown"):
+            return visitor.visit_unknown(self)
+        raise NotImplementedException(f"Visitor has no method {method_name}")
+
+
+class Type(AST):
+    def get_child(self, name: str) -> "Type":
+        raise NotImplementedException("Type.get_child not overridden")
+
+    def has_child(self, name: str) -> bool:
+        return self.get_child(name) is not None
+
+    def resolve_constant_type(self) -> Optional["ConstantType"]:
+        return UnknownType()
+
+
+class Expr(AST):
+    type: Optional[Type] = None
+
+
+class CTE(Expr):
+    """A common table expression."""
+
+    name: str
+    expr: Expr
+    # Whether the CTE is an inlined column "WITH 1 AS a" or a subquery "WITH a AS (SELECT 1)"
+    cte_type: Literal["column", "subquery"]
+
+
+class ConstantType(Type):
+    data_type: ConstantDataType
+
+    def resolve_constant_type(self) -> "ConstantType":
+        return self
+
+
+class UnknownType(ConstantType):
+    data_type: ConstantDataType = PydanticField("unknown", const=True)

--- a/posthog/hogql/database/schema/session_replay_events.py
+++ b/posthog/hogql/database/schema/session_replay_events.py
@@ -113,7 +113,7 @@ class SessionReplayEventsTable(LazyTable):
     def lazy_select(self, requested_fields: Dict[str, List[str]]):
         return select_from_session_replay_events_table(requested_fields)
 
-    def to_printed_clickhouse(self):
+    def to_printed_clickhouse(self, context):
         return "session_replay_events"
 
     def to_printed_hogql(self):

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -4,6 +4,7 @@ from antlr4 import CommonTokenStream, InputStream, ParseTreeVisitor, ParserRuleC
 from antlr4.error.ErrorListener import ErrorListener
 
 from posthog.hogql import ast
+from posthog.hogql.base import AST
 from posthog.hogql.constants import RESERVED_KEYWORDS
 from posthog.hogql.errors import NotImplementedException, HogQLException, SyntaxException
 from posthog.hogql.grammar.HogQLLexer import HogQLLexer
@@ -76,7 +77,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         end = ctx.stop.stop + 1 if ctx.stop else None
         try:
             node = super().visit(ctx)
-            if isinstance(node, ast.AST):
+            if isinstance(node, AST):
                 node.start = start
                 node.end = end
             return node

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -6,6 +6,7 @@ from typing import List, Literal, Optional, Union, cast
 
 
 from posthog.hogql import ast
+from posthog.hogql.base import AST
 from posthog.hogql.constants import (
     CLICKHOUSE_FUNCTIONS,
     HOGQL_AGGREGATIONS,
@@ -96,15 +97,15 @@ class _Printer(Visitor):
         self,
         context: HogQLContext,
         dialect: Literal["hogql", "clickhouse"],
-        stack: Optional[List[ast.AST]] = None,
+        stack: Optional[List[AST]] = None,
         settings: Optional[HogQLSettings] = None,
     ):
         self.context = context
         self.dialect = dialect
-        self.stack: List[ast.AST] = stack or []  # Keep track of all traversed nodes.
+        self.stack: List[AST] = stack or []  # Keep track of all traversed nodes.
         self.settings = settings
 
-    def visit(self, node: ast.AST):
+    def visit(self, node: AST):
         self.stack.append(node)
         response = super().visit(node)
         self.stack.pop()
@@ -685,7 +686,7 @@ class _Printer(Visitor):
     def visit_field_traverser_type(self, type: ast.FieldTraverserType):
         raise HogQLException("Unexpected ast.FieldTraverserType. This should have been resolved.")
 
-    def visit_unknown(self, node: ast.AST):
+    def visit_unknown(self, node: AST):
         raise HogQLException(f"Unknown AST node {type(node).__name__}")
 
     def visit_window_expr(self, node: ast.WindowExpr):

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from posthog.constants import AUTOCAPTURE_EVENT, PropertyOperatorType
 from posthog.hogql import ast
+from posthog.hogql.base import AST
 from posthog.hogql.constants import HOGQL_AGGREGATIONS
 from posthog.hogql.errors import NotImplementedException
 from posthog.hogql.parser import parse_expr
@@ -17,7 +18,7 @@ from posthog.models.property_definition import PropertyType
 from posthog.schema import PropertyOperator
 
 
-def has_aggregation(expr: ast.AST) -> bool:
+def has_aggregation(expr: AST) -> bool:
     finder = AggregationFinder()
     finder.visit(expr)
     return finder.has_aggregation

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -1,20 +1,21 @@
 from typing import Optional
 
 from posthog.hogql import ast
+from posthog.hogql.base import AST, Expr
 from posthog.hogql.errors import HogQLException
 
 
-def clone_expr(expr: ast.Expr, clear_types=False, clear_locations=False) -> ast.Expr:
+def clone_expr(expr: Expr, clear_types=False, clear_locations=False) -> Expr:
     """Clone an expression node."""
     return CloningVisitor(clear_types=clear_types, clear_locations=clear_locations).visit(expr)
 
 
-def clear_locations(expr: ast.Expr) -> ast.Expr:
+def clear_locations(expr: Expr) -> Expr:
     return CloningVisitor(clear_locations=True).visit(expr)
 
 
 class Visitor(object):
-    def visit(self, node: ast.AST):
+    def visit(self, node: AST):
         if node is None:
             return node
 
@@ -30,7 +31,7 @@ class Visitor(object):
 class TraversingVisitor(Visitor):
     """Visitor that traverses the AST tree without returning anything"""
 
-    def visit_expr(self, node: ast.Expr):
+    def visit_expr(self, node: Expr):
         raise HogQLException("Can not visit generic Expr node")
 
     def visit_cte(self, node: ast.CTE):
@@ -236,7 +237,7 @@ class CloningVisitor(Visitor):
         self.clear_types = clear_types
         self.clear_locations = clear_locations
 
-    def visit_expr(self, node: ast.Expr):
+    def visit_expr(self, node: Expr):
         raise HogQLException("Can not visit generic Expr node")
 
     def visit_cte(self, node: ast.CTE):


### PR DESCRIPTION
## Problem

I often want to use `ast.Expr` in files such as `database/*.py`, which gets into a cyclical import loop beween `ast.py` and `database/*.py`. 

## Changes

Moves a few of the most common models out of `ast` into `base`.

Extracted from https://github.com/PostHog/posthog/pull/15194

## How did you test this code?

Tests work. 🤞 