### PR TITLE
feat: Event Pipeline to throw instead of silently failing 2

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -207,8 +207,13 @@ export class EventPipelineRunner {
             // for a reason that we control and that is transient.
             return true
         }
-        // TODO: Blacklist via env of errors we're going to put into DLQ instead of taking Kafka lag
-        return false
+        if (
+            process.env.DROP_EVENTS_FOR_ERRORS === '*' ||
+            process.env.DROP_EVENTS_FOR_ERRORS?.split(',').some((event) => err.message.startsWith(event))
+        ) {
+            false
+        }
+        return true
     }
 
     private async handleError(err: any, currentStepName: string, currentArgs: any, teamId: number, sentToDql: boolean) {

--- a/plugin-server/tests/worker/dead-letter-queue.test.ts
+++ b/plugin-server/tests/worker/dead-letter-queue.test.ts
@@ -59,9 +59,12 @@ describe('events dead letter queue', () => {
     })
 
     test('events get sent to dead letter queue on error', async () => {
-        await expect(workerTasks.runEventPipeline(hub, { event: createEvent() })).rejects.toThrow(
-            'database unavailable'
-        )
+        const ingestResponse1 = await workerTasks.runEventPipeline(hub, { event: createEvent() })
+        expect(ingestResponse1).toEqual({
+            lastStep: 'prepareEventStep',
+            error: 'database unavailable',
+            args: expect.anything(),
+        })
         expect(generateEventDeadLetterQueueMessage).toHaveBeenCalled()
 
         await delayUntilEventIngested(() => hub.db.fetchDeadLetterQueueEvents(), 1)

--- a/plugin-server/tests/worker/dead-letter-queue.test.ts
+++ b/plugin-server/tests/worker/dead-letter-queue.test.ts
@@ -59,12 +59,9 @@ describe('events dead letter queue', () => {
     })
 
     test('events get sent to dead letter queue on error', async () => {
-        const ingestResponse1 = await workerTasks.runEventPipeline(hub, { event: createEvent() })
-        expect(ingestResponse1).toEqual({
-            lastStep: 'prepareEventStep',
-            error: 'database unavailable',
-            args: expect.anything(),
-        })
+        await expect(workerTasks.runEventPipeline(hub, { event: createEvent() })).rejects.toThrow(
+            'database unavailable'
+        )
         expect(generateEventDeadLetterQueueMessage).toHaveBeenCalled()
 
         await delayUntilEventIngested(() => hub.db.fetchDeadLetterQueueEvents(), 1)

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -165,7 +165,7 @@ describe('EventPipelineRunner', () => {
             it('runs and increments metrics', async () => {
                 jest.mocked(prepareEventStep).mockRejectedValue(error)
 
-                await runner.runEventPipeline(pipelineEvent)
+                await expect(runner.runEventPipeline(pipelineEvent)).rejects.toThrow('testError')
 
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'populateTeamDataStep',
@@ -185,7 +185,7 @@ describe('EventPipelineRunner', () => {
             it('emits failures to dead letter queue until createEvent', async () => {
                 jest.mocked(prepareEventStep).mockRejectedValue(error)
 
-                await runner.runEventPipeline(pipelineEvent)
+                await expect(runner.runEventPipeline(pipelineEvent)).rejects.toThrow('testError')
 
                 expect(hub.db.kafkaProducer.queueMessage).toHaveBeenCalledTimes(1)
                 expect(JSON.parse(hub.db.kafkaProducer.queueMessage.mock.calls[0][0].messages[0].value)).toMatchObject({

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -165,7 +165,7 @@ describe('EventPipelineRunner', () => {
             it('runs and increments metrics', async () => {
                 jest.mocked(prepareEventStep).mockRejectedValue(error)
 
-                await expect(runner.runEventPipeline(pipelineEvent)).rejects.toThrow('testError')
+                await runner.runEventPipeline(pipelineEvent)
 
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'populateTeamDataStep',
@@ -185,7 +185,7 @@ describe('EventPipelineRunner', () => {
             it('emits failures to dead letter queue until createEvent', async () => {
                 jest.mocked(prepareEventStep).mockRejectedValue(error)
 
-                await expect(runner.runEventPipeline(pipelineEvent)).rejects.toThrow('testError')
+                await runner.runEventPipeline(pipelineEvent)
 
                 expect(hub.db.kafkaProducer.queueMessage).toHaveBeenCalledTimes(1)
                 expect(JSON.parse(hub.db.kafkaProducer.queueMessage.mock.calls[0][0].messages[0].value)).toMatchObject({


### PR DESCRIPTION
## Problem

Based on https://github.com/PostHog/posthog/pull/15851 so see the last commit only.
Flips the switch and we'll start by default taking Kafka lag instead of dropping events to DLQ.
We can via an ENV revert to the old functionality (dropping all events) or for specific events.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
