### PR TITLE
feat(event-explorer): do not inject CSS classes

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -108,9 +108,6 @@
             &:not(:first-child) {
                 border-top: 1px solid var(--border);
             }
-            &:not(:first-child).row-type-\$exception {
-                border-top: 1px solid var(--danger-dark);
-            }
             > th,
             > td {
                 padding-left: 1rem;

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -475,7 +475,6 @@ export function DataTable({ query, setQuery, context, cachedResults }: DataTable
                                 'DataTable__row--category_row': !!label,
                                 'border border-danger-dark bg-danger-highlight':
                                     result && result[0] && result[0]['event'] === '$exception',
-                                [`row-type-${result?.[0]?.event}`]: result && result[0] && result[0]['event'],
                             })
                         }
                     />


### PR DESCRIPTION
## Problem

An event name with the word "block" in it breaks CSS. See [issue](https://posthoghelp.zendesk.com/agent/tickets/3564).

## Changes

Removes some code.

## How did you test this code?

Removing this line made no difference in the appearance when editing the CSS via "inspect".