### PR TITLE
fix(flags): Dont send static cohorts for local evaluation

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -416,7 +416,8 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
                     # don't duplicate queries for already added cohorts
                     if id not in cohorts:
                         cohort = Cohort.objects.get(id=id)
-                        cohorts[cohort.pk] = cohort.properties.to_dict()
+                        if not cohort.is_static:
+                            cohorts[cohort.pk] = cohort.properties.to_dict()
 
         # Add request for analytics
         increment_request_count(self.team.pk, 1, FlagRequestType.LOCAL_EVALUATION)


### PR DESCRIPTION
## Problem

Noticed via surveys that static cohorts when locally evaluated default to true, because we're sending an empty property group with them.

This doesn't make sense, since we can't evaluate static cohorts locally (these need the personID mapping, while all we have is the current distinct ID).

This PR fixes this by not sending static cohort properties for local evaluation.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
