### PR TITLE
refactor(css): Unify font stack

### DIFF
--- a/frontend/src/exporter/Exporter.scss
+++ b/frontend/src/exporter/Exporter.scss
@@ -7,7 +7,7 @@ html.export-type-image {
     }
 
     body {
-        // We hard-code a font so that rendered images are the same no matter which platform it is rendered on.
+        // We put Inter first so that rendered images are the same no matter which platform it is rendered on.
         font-family: 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
             'Segoe UI Symbol';
     }

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.scss
@@ -40,7 +40,7 @@
             align-items: center;
 
             .title {
-                font-family: Inter;
+                font-family: var(--font-sans);
                 font-style: normal;
                 font-weight: 600;
                 font-size: 11px;

--- a/frontend/src/scenes/plugins/source/PluginSource.scss
+++ b/frontend/src/scenes/plugins/source/PluginSource.scss
@@ -1,6 +1,6 @@
 .PluginSource {
     .ant-form-item-explain-error {
         white-space: pre-wrap;
-        font-family: monospace;
+        font-family: var(--font-mono);
     }
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -170,8 +170,7 @@ input::-ms-clear {
     padding: 0.75rem;
     margin-bottom: 0.5rem;
     border-radius: var(--radius);
-    font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial, sans-serif,
-        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    font-family: var(--font-sans);
     border: 1px solid var(--border);
     box-shadow: var(--shadow-elevation);
     font-size: 1rem;
@@ -517,7 +516,7 @@ input::-ms-clear {
     }
 
     &.or-light-grey {
-        font-family: Inter;
+        font-family: var(--font-sans);
         background-color: var(--mid);
         text-align: center;
         max-width: 50px;
@@ -655,6 +654,13 @@ body {
         letter-spacing: 0.5px;
         margin-bottom: 0.25rem;
         line-height: 1.5rem;
+    }
+
+    pre,
+    code,
+    kbd,
+    samp {
+        font-family: var(--font-mono);
     }
 
     // AntD uses its own border color for the bottom of tab lists, but we want to use `var(--border)`

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -819,12 +819,11 @@ $decorations: underline, overline, line-through, no-underline;
 }
 
 .font-sans {
-    font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial, sans-serif,
-        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    font-family: var(--font-sans);
 }
 
 .font-mono {
-    font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
+    font-family: var(--font-mono);
 }
 
 .opacity-0 {

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -163,6 +163,9 @@ $_lifecycle_dormant: $_danger;
     --opacity-disabled: 0.6;
     --font-medium: 500;
     --font-semibold: 600;
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', Helvetica, Arial,
+        sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --font-mono: ui-monospace, 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
 
     // Colors of the PostHog logo
     --brand-blue: #1d4aff;

--- a/frontend/src/toolbar/styles.scss
+++ b/frontend/src/toolbar/styles.scss
@@ -5,7 +5,7 @@
 
     // reset fonts
     all: initial;
-    font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+    font-family: var(--font-sans);
     font-size: 14px;
     line-height: 1.5;
 }


### PR DESCRIPTION
## Problem

We did not have font variables for our font stack, and in a few places we were using underspecified `font-family` (like just `Inter`, no fallback).

## Changes

Unified all the font families in CSS.