### PR TITLE
fix: support go links consistency

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -31,7 +31,7 @@ function getDjangoAdminLink(
         return ''
     }
     const link = `http://go/admin${cloudRegion}/${user.email}`
-    return `Admin: ${link} (project ID ${currentTeamId})`
+    return `Admin: ${link} (Organization: '${user.organization?.name}'; Project: ${currentTeamId}:'${user.team?.name}')`
 }
 
 function getSentryLink(user: UserType | null, cloudRegion: Region | undefined): string {

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -30,7 +30,7 @@ function getDjangoAdminLink(
     if (!user || !cloudRegion) {
         return ''
     }
-    const link = `http://go/admin${cloudRegion}/?q=${user.email}`
+    const link = `http://go/admin${cloudRegion}/${user.email}`
     return `Admin: ${link} (project ID ${currentTeamId})`
 }
 
@@ -38,7 +38,7 @@ function getSentryLink(user: UserType | null, cloudRegion: Region | undefined): 
     if (!user || !cloudRegion) {
         return ''
     }
-    const link = `http://go/sentry${cloudRegion}/?q=${user.team?.id}`
+    const link = `http://go/sentry${cloudRegion}/${user.team?.id}`
     return `Sentry: ${link}`
 }
 


### PR DESCRIPTION
We can handle the ?q= within golinks. See http://go/.detail/sentryUS for an example, which also broke those links

This is better, because if we choose to change where the links link to we don't want to be stripping something from the front of the path

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
