### PR TITLE
fix: briefly stop ch ingestion while materializing columns

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -74,7 +74,7 @@ def materialize(
     execute_on_cluster = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""
 
     # prevent schema from getting out of sync on new parts coming in while the column is added
-    sync_execute(f"DETACH VIEW IF EXISTS {table}_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'")
+    sync_execute(f"DETACH VIEW IF EXISTS {table}_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC")
 
     if table == "events":
         sync_execute(

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -114,7 +114,7 @@ def materialize(
         settings={"alter_sync": 1},
     )
 
-    sync_execute(f"ATTACH TABLE IF NOT EXISTS {table} ON CLUSTER '{CLICKHOUSE_CLUSTER}'")
+    sync_execute(f"ATTACH TABLE IF NOT EXISTS {table}_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC")
 
     if create_minmax_index:
         add_minmax_index(table, column_name)


### PR DESCRIPTION
it's likely that we're getting old parts having out of sync schemas because they came in during the time the column was being added and then never get optimized since they don't get touched again.

thus, let's stop ingestion while running the ALTER TABLE

I checked and adding columns usually takes like 50ms so this should be fine