### PR TITLE
chore(snowflake): remove create database/schema

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -282,8 +282,6 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
 
                 assert contains_queries_in_order(
                     queries,
-                    'CREATE DATABASE IF NOT EXISTS "PostHog"',
-                    'CREATE SCHEMA IF NOT EXISTS "PostHog"."test"',
                     'USE DATABASE "PostHog"',
                     'USE SCHEMA "test"',
                     'CREATE TABLE IF NOT EXISTS "PostHog"."test"."events"',

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -102,20 +102,6 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
 
         try:
             cursor = conn.cursor()
-            cursor.execute(
-                f"""
-                CREATE DATABASE IF NOT EXISTS "{inputs.database}"
-                COMMENT = 'PostHog generated database'
-                """
-            )
-
-            cursor.execute(
-                f"""
-                CREATE SCHEMA IF NOT EXISTS "{inputs.database}"."{inputs.schema}"
-                COMMENT = 'PostHog generated schema'
-                """
-            )
-
             cursor.execute(f'USE DATABASE "{inputs.database}"')
             cursor.execute(f'USE SCHEMA "{inputs.schema}"')
 


### PR DESCRIPTION
That's a tall ask w.r.t. permissions. Instead just require CREATE TABLE
permissions. The [existing plugin](https://github.com/PostHog/snowflake-export-plugin/blob/main/index.ts) does not 
require these FWIW

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
