### PR TITLE
chore(support-modal): Strip out `#supportModal` from links

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -19,7 +19,7 @@ function getSessionReplayLink(): string {
         0
     )
     const link = `http://go/session/${posthog?.sessionRecording?.sessionId}?t=${recordingStartTime}`
-    return `Session: ${link} (at ${window.location.href})`
+    return `Session: ${link} (at ${window.location.href.replace(/&supportModal=.+($|&)?/, '$1')})`
 }
 
 function getDjangoAdminLink(


### PR DESCRIPTION
## Problem

Currently in support tickets when you click the link where the user was at the time of the report, you're gonna see the modal pop up, because it's part of the URL.

## Changes

Made it so that the modal doesn't pop up thanks to the `supportModal` hash param being stripped out.
