### PR TITLE
feat: Display more of the element chain

### DIFF
--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -98,7 +98,6 @@ export function HTMLElementsDisplay({
         chosenSelector,
         chosenSelectorMatchCount,
         messageStatus,
-        elements,
         hasHiddenElements,
         parsedElements,
     } = useValues(logic)
@@ -106,7 +105,7 @@ export function HTMLElementsDisplay({
 
     return (
         <div className="flex flex-col gap-1">
-            {editable && !!elements.length && (
+            {editable && !!parsedElements.length && (
                 <div>
                     Selector: <CodeSnippet thing={'chosen selector'}>{chosenSelector}</CodeSnippet>
                 </div>
@@ -122,7 +121,7 @@ export function HTMLElementsDisplay({
                 </LemonBanner>
             )}
             <div className="px-4 rounded bg-default">
-                {elements.length ? (
+                {parsedElements.length ? (
                     <>
                         {hasHiddenElements && (
                             <pre

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -147,7 +147,8 @@ export function HTMLElementsDisplay({
                                 data-attr="elements-display-show-more-of-chain"
                                 onClick={showMoreOfElementsChain}
                             >
-                                Show 3 more parents ({hiddenParentLevels} hidden)
+                                Show {Math.min(3, hiddenParentLevels)} more parent{hiddenParentLevels > 1 && 's'} (
+                                {hiddenParentLevels} hidden)
                             </pre>
                         )}
                         <Tags

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -60,29 +60,6 @@ function Tags({
     )
 }
 
-function Crumbs({ elements }: { elements: ElementType[] }): JSX.Element {
-    return (
-        <ul dir="rtl" className="w-full flex px-0 py-2 m-0 overflow-y-auto">
-            {elements.map((element, index) => {
-                return (
-                    <li key={index} dir="ltr" className="whitespace-no-wrap p-0 m-0 shrink-0">
-                        <pre className={clsx('text-white text-sm px-2 py-1 m-0', index === 0 && 'bg-default-dark')}>
-                            {element.tag_name}
-                            {element.attr_id ? `#${element.attr_id}` : undefined}
-                            {(element.attr_class || []).map((elementClass) => {
-                                if (!elementClass.trim()) {
-                                    return undefined
-                                }
-                                return `.${elementClass}`
-                            })}
-                        </pre>
-                    </li>
-                )
-            })}
-        </ul>
-    )
-}
-
 let uniqueNode = 0
 
 interface HTMLElementsDisplayPropsBase {
@@ -151,7 +128,6 @@ export function HTMLElementsDisplay({
                 ) : (
                     <div className="text-side">No elements to display</div>
                 )}
-                <Crumbs elements={providedElements} />
             </div>
         </div>
     )

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -127,6 +127,7 @@ export function HTMLElementsDisplay({
                         {hasHiddenElements && (
                             <pre
                                 className="p-0 m-0 italic text-white text-sm opacity-50 cursor-pointer"
+                                data-attr="elements-display-show-more-of-chain"
                                 onClick={showMoreOfElementsChain}
                             >
                                 Show hidden elements

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -6,6 +6,7 @@ import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 import { CodeSnippet } from 'lib/components/CodeSnippet'
 import { ParsedCSSSelector } from 'lib/components/HTMLElementsDisplay/preselectWithCSS'
+import { Fade } from '../Fade/Fade'
 
 function indent(level: number): string {
     return Array(level).fill('    ').join('')
@@ -18,10 +19,12 @@ function CloseAllTags({ elements }: { elements: ElementType[] }): JSX.Element {
                 .reverse()
                 .slice(1)
                 .map((element, index) => (
-                    <pre className="whitespace-pre-wrap break-all p-0 m-0 rounded-none text-white text-sm" key={index}>
-                        {indent(elements.length - index - 2)}
-                        &lt;/{element.tag_name}&gt;
-                    </pre>
+                    <Fade key={`${element.tag_name}-closing-${index}`} visible={true}>
+                        <pre className="whitespace-pre-wrap break-all p-0 m-0 rounded-none text-white text-sm">
+                            {indent(elements.length - index - 2)}
+                            &lt;/{element.tag_name}&gt;
+                        </pre>
+                    </Fade>
                 ))}
         </>
     )
@@ -43,17 +46,20 @@ function Tags({
     return (
         <>
             {elements.map((element, index) => {
+                const invertedIndex = elements.length - 1 - index
+
                 return (
-                    <SelectableElement
-                        key={`${element.tag_name}-${index}`}
-                        element={element}
-                        isDeepestChild={index === elements.length - 1}
-                        onChange={(s) => (editable ? onChange(index, s) : undefined)}
-                        readonly={!editable}
-                        indent={indent(index)}
-                        highlight={highlight}
-                        parsedCSSSelector={parsedCSSSelectors[index]}
-                    />
+                    <Fade key={`${element.tag_name}-${invertedIndex}`} visible={true}>
+                        <SelectableElement
+                            element={element}
+                            isDeepestChild={index === elements.length - 1}
+                            onChange={(s) => (editable ? onChange(index, s) : undefined)}
+                            readonly={!editable}
+                            indent={indent(index)}
+                            highlight={highlight}
+                            parsedCSSSelector={parsedCSSSelectors[index]}
+                        />
+                    </Fade>
                 )
             })}
         </>

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -19,7 +19,13 @@ function CloseAllTags({ elements }: { elements: ElementType[] }): JSX.Element {
                 .reverse()
                 .slice(1)
                 .map((element, index) => (
-                    <Fade key={`${element.tag_name}-closing-${index}`} visible={true}>
+                    <Fade
+                        key={`${element.tag_name}-closing-${index}`}
+                        visible={true}
+                        style={{
+                            position: 'static',
+                        }}
+                    >
                         <pre className="whitespace-pre-wrap break-all p-0 m-0 rounded-none text-white text-sm">
                             {indent(elements.length - index - 2)}
                             &lt;/{element.tag_name}&gt;
@@ -49,7 +55,13 @@ function Tags({
                 const invertedIndex = elements.length - 1 - index
 
                 return (
-                    <Fade key={`${element.tag_name}-${invertedIndex}`} visible={true}>
+                    <Fade
+                        key={`${element.tag_name}-${invertedIndex}`}
+                        visible={true}
+                        style={{
+                            position: 'static',
+                        }}
+                    >
                         <SelectableElement
                             element={element}
                             isDeepestChild={index === elements.length - 1}

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -125,7 +125,7 @@ export function HTMLElementsDisplay({
                     <>
                         {hasHiddenElements && (
                             <pre
-                                className="p-0 m-0 italic text-white text-sm opacity-50 cursor-pointer"
+                                className="py-2 px-0 m-0 italic text-white text-sm opacity-50 cursor-pointer"
                                 data-attr="elements-display-show-more-of-chain"
                                 onClick={showMoreOfElementsChain}
                             >

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -104,7 +104,7 @@ export function HTMLElementsDisplay({
         chosenSelector,
         chosenSelectorMatchCount,
         messageStatus,
-        hasHiddenElements,
+        hiddenParentLevels,
         parsedElements,
     } = useValues(logic)
     const { setParsedSelectors, showMoreOfElementsChain } = useActions(logic)
@@ -129,13 +129,13 @@ export function HTMLElementsDisplay({
             <div className="px-4 rounded bg-default">
                 {parsedElements.length ? (
                     <>
-                        {hasHiddenElements && (
+                        {hiddenParentLevels > 0 && (
                             <pre
                                 className="py-2 px-0 m-0 italic text-white text-sm opacity-50 cursor-pointer"
                                 data-attr="elements-display-show-more-of-chain"
                                 onClick={showMoreOfElementsChain}
                             >
-                                Show hidden elements
+                                Show 3 more parents ({hiddenParentLevels} hidden)
                             </pre>
                         )}
                         <Tags

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -93,8 +93,16 @@ export function HTMLElementsDisplay({
     const [key] = useState(() => `HtmlElementsDisplay.${uniqueNode++}`)
 
     const logic = htmlElementsDisplayLogic({ checkUniqueness, onChange, key, startingSelector, providedElements })
-    const { parsedSelectors, chosenSelector, chosenSelectorMatchCount, messageStatus, elements } = useValues(logic)
-    const { setParsedSelectors } = useActions(logic)
+    const {
+        parsedSelectors,
+        chosenSelector,
+        chosenSelectorMatchCount,
+        messageStatus,
+        elements,
+        hasHiddenElements,
+        parsedElements,
+    } = useValues(logic)
+    const { setParsedSelectors, showMoreOfElementsChain } = useActions(logic)
 
     return (
         <div className="flex flex-col gap-1">
@@ -116,8 +124,16 @@ export function HTMLElementsDisplay({
             <div className="px-4 rounded bg-default">
                 {elements.length ? (
                     <>
+                        {hasHiddenElements && (
+                            <pre
+                                className="p-0 m-0 italic text-white text-sm opacity-50 cursor-pointer"
+                                onClick={showMoreOfElementsChain}
+                            >
+                                Show hidden elements
+                            </pre>
+                        )}
                         <Tags
-                            elements={elements}
+                            elements={parsedElements}
                             highlight={highlight}
                             editable={editable}
                             parsedCSSSelectors={parsedSelectors}

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -140,7 +140,7 @@ export function HTMLElementsDisplay({
                             parsedCSSSelectors={parsedSelectors}
                             onChange={(index, s) => setParsedSelectors({ ...parsedSelectors, [index]: s })}
                         />
-                        <CloseAllTags elements={elements} />
+                        <CloseAllTags elements={parsedElements} />
                     </>
                 ) : (
                     <div className="text-side">No elements to display</div>

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -60,6 +60,29 @@ function Tags({
     )
 }
 
+function Crumbs({ elements }: { elements: ElementType[] }): JSX.Element {
+    return (
+        <ul dir="rtl" className="w-full flex px-0 py-2 m-0 overflow-y-auto">
+            {elements.map((element, index) => {
+                return (
+                    <li key={index} dir="ltr" className="whitespace-no-wrap p-0 m-0 shrink-0">
+                        <pre className={clsx('text-white text-sm px-2 py-1 m-0', index === 0 && 'bg-default-dark')}>
+                            {element.tag_name}
+                            {element.attr_id ? `#${element.attr_id}` : undefined}
+                            {(element.attr_class || []).map((elementClass) => {
+                                if (!elementClass.trim()) {
+                                    return undefined
+                                }
+                                return `.${elementClass}`
+                            })}
+                        </pre>
+                    </li>
+                )
+            })}
+        </ul>
+    )
+}
+
 let uniqueNode = 0
 
 interface HTMLElementsDisplayPropsBase {
@@ -128,6 +151,7 @@ export function HTMLElementsDisplay({
                 ) : (
                     <div className="text-side">No elements to display</div>
                 )}
+                <Crumbs elements={providedElements} />
             </div>
         </div>
     )

--- a/frontend/src/lib/components/HTMLElementsDisplay/htmlElementsDisplayLogic.ts
+++ b/frontend/src/lib/components/HTMLElementsDisplay/htmlElementsDisplayLogic.ts
@@ -20,7 +20,7 @@ export interface HtmlElementDisplayLogicProps {
 
 export const elementsChain = (providedElements: ElementType[] | undefined): ElementType[] => {
     const safeElements = [...(providedElements || [])]
-    return safeElements.reverse().slice(Math.max(safeElements.length - 10, 1))
+    return safeElements.reverse()
 }
 
 export const htmlElementsDisplayLogic = kea<htmlElementsDisplayLogicType>([
@@ -30,6 +30,7 @@ export const htmlElementsDisplayLogic = kea<htmlElementsDisplayLogicType>([
     actions({
         setParsedSelectors: (selectors: Record<number, ParsedCSSSelector>) => ({ selectors }),
         setElements: (providedElements: ElementType[]) => ({ providedElements }),
+        showMoreOfElementsChain: true,
     }),
     reducers(({ props }) => ({
         elements: [
@@ -40,6 +41,12 @@ export const htmlElementsDisplayLogic = kea<htmlElementsDisplayLogicType>([
             {} as Record<number, ParsedCSSSelector>,
             {
                 setParsedSelectors: (_, { selectors }) => selectors,
+            },
+        ],
+        visibleElements: [
+            10,
+            {
+                showMoreOfElementsChain: (state) => state + 3,
             },
         ],
     })),
@@ -109,6 +116,18 @@ export const htmlElementsDisplayLogic = kea<htmlElementsDisplayLogicType>([
                     : chosenSelectorMatchCount === 1
                     ? 'success'
                     : 'warning'
+            },
+        ],
+        hasHiddenElements: [
+            (s) => [s.elements, s.visibleElements],
+            (elements, visibleElements) => {
+                return elements.length > visibleElements
+            },
+        ],
+        parsedElements: [
+            (s) => [s.elements, s.visibleElements],
+            (elements, visibleElements) => {
+                return elements.slice(Math.max(elements.length - visibleElements, 0))
             },
         ],
     })),

--- a/frontend/src/lib/components/HTMLElementsDisplay/htmlElementsDisplayLogic.ts
+++ b/frontend/src/lib/components/HTMLElementsDisplay/htmlElementsDisplayLogic.ts
@@ -118,10 +118,10 @@ export const htmlElementsDisplayLogic = kea<htmlElementsDisplayLogicType>([
                     : 'warning'
             },
         ],
-        hasHiddenElements: [
+        hiddenParentLevels: [
             (s) => [s.elements, s.visibleElements],
             (elements, visibleElements) => {
-                return elements.length > visibleElements
+                return Math.max(elements.length - visibleElements, 0)
             },
         ],
         parsedElements: [

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -29,7 +29,7 @@ function toElementsChain(element: HTMLElement): ElementType[] {
     return chain.map(
         (element, index) =>
             ({
-                attr_class: element.getAttribute('class') || undefined,
+                attr_class: element.getAttribute('class')?.split(' '),
                 attr_id: element.getAttribute('id') || undefined,
                 attributes: Array.from(element.attributes).reduce((acc, attr) => {
                     if (!acc[attr.name]) {
@@ -42,7 +42,7 @@ function toElementsChain(element: HTMLElement): ElementType[] {
                 href: element.getAttribute('href') || undefined,
                 tag_name: element.tagName.toLowerCase(),
                 text: index === 0 ? element.innerText : undefined,
-            } as ElementType)
+            } satisfies ElementType)
     )
 }
 

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -22,7 +22,7 @@ function newAction(element: HTMLElement | null, dataAttributes: string[] = []): 
 function toElementsChain(element: HTMLElement): ElementType[] {
     const chain: HTMLElement[] = []
     let currentElement: HTMLElement | null | undefined = element
-    while (currentElement && chain.length <= 10 && currentElement !== document.body) {
+    while (currentElement && currentElement !== document.documentElement) {
         chain.push(currentElement)
         currentElement = currentElement.parentElement
     }

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -22,7 +22,7 @@ function newAction(element: HTMLElement | null, dataAttributes: string[] = []): 
 function toElementsChain(element: HTMLElement): ElementType[] {
     const chain: HTMLElement[] = []
     let currentElement: HTMLElement | null | undefined = element
-    while (currentElement && chain.length <= 10 && currentElement !== document.body) {
+    while (currentElement && currentElement !== document.body.parentNode) {
         chain.push(currentElement)
         currentElement = currentElement.parentElement
     }

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -42,7 +42,7 @@ function toElementsChain(element: HTMLElement): ElementType[] {
                 href: element.getAttribute('href') || undefined,
                 tag_name: element.tagName.toLowerCase(),
                 text: index === 0 ? element.innerText : undefined,
-            } satisfies ElementType)
+            } as ElementType)
     )
 }
 

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -22,7 +22,7 @@ function newAction(element: HTMLElement | null, dataAttributes: string[] = []): 
 function toElementsChain(element: HTMLElement): ElementType[] {
     const chain: HTMLElement[] = []
     let currentElement: HTMLElement | null | undefined = element
-    while (currentElement && currentElement !== document.body.parentNode) {
+    while (currentElement && chain.length <= 10 && currentElement !== document.body) {
         chain.push(currentElement)
         currentElement = currentElement.parentElement
     }

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 from django.db.models.query import Prefetch
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
-from rest_framework import mixins, request, response, serializers, viewsets
+from rest_framework import mixins, request, response, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
@@ -18,7 +18,7 @@ from posthog.api.documentation import PropertiesSerializer, extend_schema
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.client import query_with_columns, sync_execute
 from posthog.hogql.constants import DEFAULT_RETURNED_ROWS, MAX_SELECT_RETURNED_ROWS
-from posthog.models import Element, Filter, Person
+from posthog.models import Filter, Person
 from posthog.models.event.query_event_list import query_events_list
 from posthog.models.event.sql import GET_CUSTOM_EVENTS, SELECT_ONE_EVENT_SQL
 from posthog.models.event.util import ClickhouseEventSerializer
@@ -31,25 +31,6 @@ from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedR
 from posthog.utils import convert_property_value, flatten
 
 QUERY_DEFAULT_EXPORT_LIMIT = 3_500
-
-
-class ElementSerializer(serializers.ModelSerializer):
-    event = serializers.CharField()
-
-    class Meta:
-        model = Element
-        fields = [
-            "event",
-            "text",
-            "tag_name",
-            "attr_class",
-            "href",
-            "attr_id",
-            "nth_child",
-            "nth_of_type",
-            "attributes",
-            "order",
-        ]
 
 
 class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -172,7 +153,6 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
     def retrieve(
         self, request: request.Request, pk: Optional[Union[int, str]] = None, *args: Any, **kwargs: Any
     ) -> response.Response:
-
         if not isinstance(pk, str) or not UUIDT.is_valid_uuid(pk):
             return response.Response(
                 {"detail": "Invalid UUID", "code": "invalid", "type": "validation_error"}, status=400

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 from django.db.models.query import Prefetch
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
-from rest_framework import mixins, request, response, viewsets
+from rest_framework import mixins, request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
@@ -18,7 +18,7 @@ from posthog.api.documentation import PropertiesSerializer, extend_schema
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.client import query_with_columns, sync_execute
 from posthog.hogql.constants import DEFAULT_RETURNED_ROWS, MAX_SELECT_RETURNED_ROWS
-from posthog.models import Filter, Person
+from posthog.models import Element, Filter, Person
 from posthog.models.event.query_event_list import query_events_list
 from posthog.models.event.sql import GET_CUSTOM_EVENTS, SELECT_ONE_EVENT_SQL
 from posthog.models.event.util import ClickhouseEventSerializer
@@ -31,6 +31,25 @@ from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedR
 from posthog.utils import convert_property_value, flatten
 
 QUERY_DEFAULT_EXPORT_LIMIT = 3_500
+
+
+class ElementSerializer(serializers.ModelSerializer):
+    event = serializers.CharField()
+
+    class Meta:
+        model = Element
+        fields = [
+            "event",
+            "text",
+            "tag_name",
+            "attr_class",
+            "href",
+            "attr_id",
+            "nth_child",
+            "nth_of_type",
+            "attributes",
+            "order",
+        ]
 
 
 class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -153,6 +172,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
     def retrieve(
         self, request: request.Request, pk: Optional[Union[int, str]] = None, *args: Any, **kwargs: Any
     ) -> response.Response:
+
         if not isinstance(pk, str) or not UUIDT.is_valid_uuid(pk):
             return response.Response(
                 {"detail": "Invalid UUID", "code": "invalid", "type": "validation_error"}, status=400


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Addresses https://github.com/PostHog/posthog/issues/14347#issue-1593836021

The solution that was chosen was one recommended mainly by @pauldambra. 

It's a `Show 3 more parents (X hidden)` at the top of the element chain and fades in 3 every time it's clicked.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

https://github.com/PostHog/posthog/assets/5631091/8eb527ae-f565-4f70-a39a-eb81e39413e8

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

### Testing events

1. Filter _Events_ by _Auto Capture_

2. Expand multiple events and view the _Elements_ associated

3. Click on _Show 3 more parents_

4. Ensure only the new elements fade in

### Testing actions

1. Create a new _Action_ under _Data Management_

2. Choose to Inspect an element from your website

6. Inspect multiple of the available buttons and create an action for each

7. Click on _Edit the selectors_ and view the _Elements_ associated

8. Click on _Show 3 more parents_

9. Ensure only the new elements fade in