### PR TITLE
fix(batch-exports): Fix double encoding of properties in Snowflake

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -302,7 +302,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
                         "uuid": event["uuid"],
                         "event": event["event"],
                         "timestamp": event["timestamp"],
-                        "properties": event["properties"],
+                        "properties": json.loads(event["properties"]),
                         "person_id": event["person_id"],
                     }
                     for event in json_data

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -302,7 +302,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
                         "uuid": event["uuid"],
                         "event": event["event"],
                         "timestamp": event["timestamp"],
-                        "properties": json.loads(event["properties"]),
+                        "properties": json.dumps(event["properties"]),
                         "person_id": event["person_id"],
                     }
                     for event in json_data
@@ -313,6 +313,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
                     {key: value for key, value in event.items() if key not in ("team_id", "_timestamp")}
                     for event in events
                 ]
+                assert json_data[0] == events[0]
                 assert json_data == events
 
         runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -150,7 +150,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                     # this as a followup.
                     row = {
                         **result,
-                        "properties": json.dumps(result.get("properties", {})),
+                        "properties": json.loads(result.get("properties", "{}")),
                     }
 
                     # Write the results to a local file

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -144,8 +144,17 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                     if not result:
                         break
 
+                    # Make sure the properties attribute is parsed as JSON
+                    # TODO: this may well be a change that is worth making in
+                    # the other batch export workflows as well, although I leave
+                    # this as a followup.
+                    row = {
+                        **result,
+                        "properties": json.dumps(result.get("properties", {})),
+                    }
+
                     # Write the results to a local file
-                    local_results_file.write(json.dumps(result).encode("utf-8"))
+                    local_results_file.write(json.dumps(row).encode("utf-8"))
                     local_results_file.write("\n".encode("utf-8"))
 
                     # Write results to Snowflake when the file reaches 50MB and


### PR DESCRIPTION
Previously we were simply writing the JSON representation of the
properties to the Snowflake table. This meant that the properties
were double encoded, and the user would have to decode them
themselves.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
