### PR TITLE
fix: replay filters bug report

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
@@ -7,7 +7,7 @@ import {
 import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 import { router } from 'kea-router'
-import { PropertyFilterType, PropertyOperator } from '~/types'
+import { PropertyFilterType, PropertyOperator, RecordingFilters } from '~/types'
 import { useMocks } from '~/mocks/jest'
 import { sessionRecordingDataLogic } from '../player/sessionRecordingDataLogic'
 
@@ -422,6 +422,28 @@ describe('sessionRecordingsListLogic', () => {
             expect(router.values.hashParams).toHaveProperty('sessionRecordingId', 'abc')
 
             await expectLogic(logic).toDispatchActions([logic.actionCreators.setSelectedRecordingId('abc')])
+        })
+    })
+
+    describe('total filters count', () => {
+        beforeEach(() => {
+            logic = sessionRecordingsListLogic({
+                key: 'cool_user_99',
+                personUUID: 'cool_user_99',
+                updateSearchParams: true,
+            })
+            logic.mount()
+        })
+        it('starts with a count of zero', async () => {
+            await expectLogic(logic).toMatchValues({ totalFiltersCount: 0 })
+        })
+
+        it('counts console log filters', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({
+                    console_logs: ['warn', 'error'],
+                } satisfies Partial<RecordingFilters>)
+            }).toMatchValues({ totalFiltersCount: 2 })
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
@@ -446,4 +446,24 @@ describe('sessionRecordingsListLogic', () => {
             }).toMatchValues({ totalFiltersCount: 2 })
         })
     })
+
+    describe('resetting filters', () => {
+        beforeEach(() => {
+            logic = sessionRecordingsListLogic({
+                key: 'cool_user_99',
+                personUUID: 'cool_user_99',
+                updateSearchParams: true,
+            })
+            logic.mount()
+        })
+
+        it('resets console log filters', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({
+                    console_logs: ['warn', 'error'],
+                } satisfies Partial<RecordingFilters>)
+                logic.actions.resetFilters()
+            }).toMatchValues({ totalFiltersCount: 0 })
+        })
+    })
 })

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -39,6 +39,7 @@ export const defaultRecordingDurationFilter: RecordingDurationFilter = {
     value: 60,
     operator: PropertyOperator.GreaterThan,
 }
+
 export const DEFAULT_RECORDING_FILTERS: RecordingFilters = {
     session_recording_duration: defaultRecordingDurationFilter,
     properties: [],

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -46,6 +46,7 @@ export const DEFAULT_RECORDING_FILTERS: RecordingFilters = {
     actions: [],
     date_from: '-7d',
     date_to: null,
+    console_logs: [],
 }
 
 const DEFAULT_PERSON_RECORDING_FILTERS: RecordingFilters = {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -452,7 +452,8 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                     (equal(filters.session_recording_duration, defaultFilters.session_recording_duration) ? 0 : 1) +
                     (filters.date_from === defaultFilters.date_from && filters.date_to === defaultFilters.date_to
                         ? 0
-                        : 1)
+                        : 1) +
+                    (filters.console_logs?.length || 0)
                 )
             },
         ],


### PR DESCRIPTION
## Problem

In [this community slack message](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1687161406948489?thread_ts=1686998285.706169&cid=C01GLBKHKQT) a user reports 

* Enabling the console filter doesn’t highlight the filter icon
* Clicking “Reset” in the filter panel doesn’t remove the console filter

## Changes

fixes those

## How did you test this code?

developer tests and 👀 locally