### PR TITLE
feat: control accepted session replay dates

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { captureException } from '@sentry/node'
+import { captureException, captureMessage } from '@sentry/node'
+import { DateTime } from 'luxon'
 import { HighLevelProducer as RdKafkaProducer, Message, NumberNullUndefined } from 'node-rdkafka-acosom'
 
 import {
@@ -285,6 +286,27 @@ const eachMessage =
                             event.ip,
                             event.properties || {}
                         )
+                        // the replay record timestamp has to be valid and be within a reasonable diff from now
+                        if (replayRecord !== null) {
+                            const asDate = DateTime.fromSQL(replayRecord.first_timestamp)
+                            if (!asDate.isValid || Math.abs(asDate.diffNow('months').months) >= 0.99) {
+                                captureMessage(
+                                    `Invalid replay record timestamp: ${replayRecord.first_timestamp} for event ${messagePayload.uuid}`,
+                                    {
+                                        extra: {
+                                            replayRecord,
+                                            uuid: clickHouseRecord.uuid,
+                                            timestamp: clickHouseRecord.timestamp,
+                                        },
+                                        tags: {
+                                            team: team.id,
+                                            session_id: clickHouseRecord.session_id,
+                                        },
+                                    }
+                                )
+                                replayRecord = null
+                            }
+                        }
                     } catch (e) {
                         status.warn('??', 'session_replay_summarizer_error', { error: e })
                         captureException(e, {


### PR DESCRIPTION
## Problem

We see session recording dates very far in the future and past... that's no bueno

## Changes

Only allow a session recording into the session replay table (and so make it accessible for listing and playing) if it has a valid timestamp within a month of today.

Why a month? -> arbitrary value that is big enough to not clash with lag after an incident but not so big we'll have lots of unnecessary parts in CH

## How did you test this code?

added developer tests, confirmed replay could still ingest locally