### PR TITLE
chore(ci): push vanilla posthog image to ECR

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -48,6 +48,17 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: aws-ecr
+              uses: aws-actions/amazon-ecr-login@v1
+
             - name: Build and push container images
               id: build
               uses: depot/build-push-action@v1
@@ -57,7 +68,7 @@ jobs:
                   cache-from: type=gha # always pull the layers from GHA
                   cache-to: type=gha,mode=max # always push the layers to GHA
                   push: true
-                  tags: posthog/posthog:latest
+                  tags: posthog/posthog:latest,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:master
                   platforms: linux/amd64,linux/arm64
 
     posthog_cloud_build:


### PR DESCRIPTION
## Problem

Now that we have removed all the references to the private `posthog-cloud` repo, we should be able to run the "vanilla" docker image on cloud, and remove that second image build altogether.

## Changes

To allow us to test it and revert quickly, this PR pushes the `posthog/posthog` image as a new `posthog-cloud:master` tag on the ECR, but still pushes `posthog-cloud:latest`, that we can fallback to. Once we have built confidence by running the new image for a couple of days, we'll stop pushing the `latest` tag and remove it from the ECR to avoid reusing it.

My previous attempt with https://github.com/PostHog/posthog/pull/15918 tried to push `posthog:latest` to the ECR, but this failed because each image in the ECR has to be terraformed separately.

The alternative would be to terraform a new `posthog` ECR image, push `posthog:latest` to it, and then remove the old `posthog-cloud` repo. WDYT?

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
