### PR TITLE
fix: Added catch for full screen request

### DIFF
--- a/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.scss
+++ b/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.scss
@@ -1,8 +1,11 @@
 .DraggableToNotebook {
     position: relative;
-    // Weird hack - this fixes chrome from not correctly identifying the bounds of the component for the drag preview
-    // https://github.com/react-dnd/react-dnd/issues/832#issuecomment-442071628
-    transform: translate3d(0, 0, 0);
+
+    &--dragging {
+        // Weird hack - this fixes chrome from not correctly identifying the bounds of the component for the drag preview
+        // https://github.com/react-dnd/react-dnd/issues/832#issuecomment-442071628
+        transform: translate3d(0, 0, 0);
+    }
 
     &[draggable='true'] {
         cursor: grab;

--- a/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.tsx
+++ b/frontend/src/scenes/notebooks/AddToNotebook/DraggableToNotebook.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { NotebookNodeType } from '~/types'
 import { useKeyHeld } from 'lib/hooks/useKeyHeld'
 import './DraggableToNotebook.scss'
@@ -29,6 +29,7 @@ export function DraggableToNotebook({
     className,
 }: DraggableToNotebookProps): JSX.Element {
     const { setNotebookSideBarShown } = useActions(notebookSidebarLogic)
+    const [isDragging, setIsDragging] = useState(false)
     const keyHeld = useKeyHeld('Alt')
 
     if (!node && !properties && !href) {
@@ -48,12 +49,14 @@ export function DraggableToNotebook({
                         'DraggableToNotebook',
                         className,
                         noOverflow && 'DraggableToNotebook--no-overflow',
-                        keyHeld && 'DraggableToNotebook--highlighted'
+                        keyHeld && 'DraggableToNotebook--highlighted',
+                        isDragging && 'DraggableToNotebook--dragging'
                     )}
                     draggable={draggable}
                     onDragStart={
                         draggable
                             ? (e: any) => {
+                                  setIsDragging(true)
                                   if (href) {
                                       const url = window.location.origin + href
                                       e.dataTransfer.setData('text/uri-list', url)
@@ -65,6 +68,7 @@ export function DraggableToNotebook({
                               }
                             : undefined
                     }
+                    onDragEnd={() => setIsDragging(false)}
                 >
                     {keyHeld ? (
                         <div className="DraggableToNotebook__highlighter">

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -739,7 +739,9 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
         setIsFullScreen: ({ isFullScreen }) => {
             if (isFullScreen) {
-                props.playerRef?.current?.requestFullscreen()
+                props.playerRef?.current?.requestFullscreen().catch((error) => {
+                    console.warn('Failed to enable native full-screen mode:', error)
+                })
             } else if (document.fullscreenElement === props.playerRef?.current) {
                 document.exitFullscreen()
             }


### PR DESCRIPTION
## Problem

We were getting a lot of errors about full screen where the permissions weren't given or it wasn't supported - [Sentry](https://posthog.sentry.io/issues/4208563168/?query=is%3Aunresolved&referrer=issue-stream&stream_index=16)

## Changes

* Fixes it by catching
* Also improves the UI when not allowed as there were some weird bugs due to the Draggable wrapper.
* Made draggable only apply the hack when actually dragging



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
