### PR TITLE
chore(deps): commit updated pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -13331,7 +13331,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}


### PR DESCRIPTION
## Problem

For some reason posthog-bot commits pnpm-lock.yaml with an old version
https://github.com/PostHog/posthog/commit/e9ec59f9d1205d32f9ad97b66aeed1b6699d9360#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519.  This causes `pnpm i` to spit out a new pnpm-lock.yaml locally.

## Changes

This PR commits said pnpm-lock.yaml.

I've opened up a [separate PR against posthog/posthog-js](https://github.com/PostHog/posthog-js/pull/704) that removes the pnpm version param from pnpm/action-setup, as it should use the [packageManager field in package.json](https://github.com/pnpm/action-setup#version).

## How did you test this code?

Running PostHog locally