### PR TITLE
chore(ingestion): add consumption and production metrics

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion-kafkajs.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion-kafkajs.ts
@@ -13,6 +13,7 @@ import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { latestOffsetTimestampGauge } from '../metrics'
 import { IngestionOverflowMode } from './each-batch-ingestion'
 import {
+    ingestionOverflowingMessagesTotal,
     ingestionParallelism,
     ingestionParallelismPotential,
     kafkaBatchOffsetCommitted,
@@ -256,6 +257,7 @@ function computeKey(pluginEvent: PipelineEvent): string {
 }
 
 async function emitToOverflow(queue: KafkaJSIngestionConsumer, kafkaMessages: KafkaMessage[]) {
+    ingestionOverflowingMessagesTotal.inc(kafkaMessages.length)
     await Promise.all(
         kafkaMessages.map((message) =>
             queue.pluginsServer.kafkaProducer.queueMessage(

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -12,6 +12,7 @@ import { ingestionPartitionKeyOverflowed } from '../analytics-events-ingestion-c
 import { IngestionConsumer } from '../kafka-queue'
 import { latestOffsetTimestampGauge } from '../metrics'
 import {
+    ingestionOverflowingMessagesTotal,
     ingestionParallelism,
     ingestionParallelismPotential,
     kafkaBatchOffsetCommitted,
@@ -234,6 +235,7 @@ function computeKey(pluginEvent: PipelineEvent): string {
 }
 
 async function emitToOverflow(queue: IngestionConsumer, kafkaMessages: Message[]) {
+    ingestionOverflowingMessagesTotal.inc(kafkaMessages.length)
     await Promise.all(
         kafkaMessages.map((message) =>
             queue.pluginsServer.kafkaProducer.produce({

--- a/plugin-server/src/main/ingestion-queues/batch-processing/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/metrics.ts
@@ -1,7 +1,6 @@
-// The following two counters can be used to see how often we start,
-
 import { Counter, exponentialBuckets, Histogram } from 'prom-client' // but fail to commit offsets, which can cause duplicate events
 
+// The following two counters can be used to see how often we start,
 // but fail to commit offsets, which can cause duplicate events
 export const kafkaBatchStart = new Counter({
     name: 'ingestion_kafka_batch_start',
@@ -10,6 +9,11 @@ export const kafkaBatchStart = new Counter({
 export const kafkaBatchOffsetCommitted = new Counter({
     name: 'ingestion_kafka_batch_committed_offsets',
     help: 'Number of times we have committed kafka offsets',
+})
+
+export const ingestionOverflowingMessagesTotal = new Counter({
+    name: 'ingestion_overflowing_messages_total',
+    help: 'Count of messages rerouted to the overflow topic.',
 })
 
 export const ingestionParallelism = new Histogram({


### PR DESCRIPTION
## Problem

The ingestion rdkafka change was reverted because we noticed that the overflow generated duplicate events. If that were to happen again, these metrics should give us proper visibility on whether the cause is the reroute it self of the overflow consumer. Having this metric will also:

- allow us to track production rates with a lower delay than the MSK metrics
- track it per pod to detect possible outliers

## Changes

- add several `pod * topic` cardinality metrics to the kafka producer and consumers
- add the `ingestion_overflowing_messages_total` metric to make sure that rerouting is not causing duplicates

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
