### PR TITLE
fix(surveys): fix metrics display and hogql query

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -207,8 +207,12 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                           <div>
                                               {surveyMetricsQueries && (
                                                   <div className="flex flex-row gap-4 mb-4">
-                                                      <Query query={surveyMetricsQueries.surveysShown} />
-                                                      <Query query={surveyMetricsQueries.surveysDismissed} />
+                                                      <div className="flex-1">
+                                                          <Query query={surveyMetricsQueries.surveysShown} />
+                                                      </div>
+                                                      <div className="flex-1">
+                                                          <Query query={surveyMetricsQueries.surveysDismissed} />
+                                                      </div>
                                                   </div>
                                               )}
                                               {surveyLoading ? <LemonSkeleton /> : <Query query={dataTableQuery} />}

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -84,9 +84,9 @@ export const getSurveyDataQuery = (surveyName: string): DataTableNode => {
     return surveyDataQuery
 }
 
-export const getSurveyMetricsQueries = (surveyId: string, surveyName: string): SurveyMetricsQueries => {
-    const surveysShownHogqlQuery = `select count() as 'survey shown' from events where event == '${surveyName} survey shown' and properties.$survey_id == '${surveyId}'`
-    const surveysDismissedHogqlQuery = `select count() as 'survey dismissed' from events where event == '${surveyName} survey dismissed' and properties.$survey_id == '${surveyId}'`
+export const getSurveyMetricsQueries = (surveyId: string): SurveyMetricsQueries => {
+    const surveysShownHogqlQuery = `select count() as 'survey shown' from events where event like '%shown%' and properties.$survey_id == '${surveyId}'`
+    const surveysDismissedHogqlQuery = `select count() as 'survey dismissed' from events where event like '%dismissed%' and properties.$survey_id == '${surveyId}'`
     return {
         surveysShown: {
             kind: NodeKind.DataTableNode,
@@ -169,7 +169,7 @@ export const surveyLogic = kea<surveyLogicType>([
         loadSurveySuccess: ({ survey }) => {
             if (survey.start_date) {
                 actions.setDataTableQuery(getSurveyDataQuery(survey.name))
-                actions.setSurveyMetricsQueries(getSurveyMetricsQueries(survey.id, survey.name))
+                actions.setSurveyMetricsQueries(getSurveyMetricsQueries(survey.id))
             }
             if (survey.targeting_flag?.filters?.groups) {
                 actions.setTargetingFlagFilters(survey.targeting_flag.filters.groups)

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -85,8 +85,8 @@ export const getSurveyDataQuery = (surveyName: string): DataTableNode => {
 }
 
 export const getSurveyMetricsQueries = (surveyId: string): SurveyMetricsQueries => {
-    const surveysShownHogqlQuery = `select count() as 'survey shown' from events where event like '%shown%' and properties.$survey_id == '${surveyId}'`
-    const surveysDismissedHogqlQuery = `select count() as 'survey dismissed' from events where event like '%dismissed%' and properties.$survey_id == '${surveyId}'`
+    const surveysShownHogqlQuery = `select count() as 'survey shown' from events where event == 'survey shown' and properties.$survey_id == '${surveyId}'`
+    const surveysDismissedHogqlQuery = `select count() as 'survey dismissed' from events where event == 'survey dismissed' and properties.$survey_id == '${surveyId}'`
     return {
         surveysShown: {
             kind: NodeKind.DataTableNode,


### PR DESCRIPTION
## Problem

1. Notebooks feature flag had squished the flex box displays of the components
2. Query should be more inclusive in case users want to send in "survey shown" events without the name in the title

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
