### PR TITLE
fix: use the support form on email verify instead of mailto

### DIFF
--- a/frontend/src/scenes/authentication/signup/verify-email/VerifyEmail.tsx
+++ b/frontend/src/scenes/authentication/signup/verify-email/VerifyEmail.tsx
@@ -5,6 +5,8 @@ import { HeartHog, MailHog, SurprisedHog } from 'lib/components/hedgehogs'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { SceneExport } from 'scenes/sceneTypes'
 import { verifyEmailLogic } from './verifyEmailLogic'
+import { SupportModal } from 'lib/components/Support/SupportModal'
+import { supportLogic } from 'lib/components/Support/supportLogic'
 
 export const scene: SceneExport = {
     component: VerifyEmail,
@@ -14,10 +16,17 @@ export const scene: SceneExport = {
 export const VerifyEmailHelpLinks = (): JSX.Element => {
     const { requestVerificationLink } = useActions(verifyEmailLogic)
     const { uuid } = useValues(verifyEmailLogic)
+    const { openSupportLoggedOutForm } = useActions(supportLogic)
 
     return (
         <div className="flex flex-row gap-x-4">
-            <LemonButton type="secondary" className="mt-8" to={'mailto:hey@posthog.com'}>
+            <LemonButton
+                type="secondary"
+                className="mt-8"
+                onClick={() => {
+                    openSupportLoggedOutForm(null, null, 'bug', 'login')
+                }}
+            >
                 Contact support
             </LemonButton>
             {uuid && (
@@ -31,6 +40,7 @@ export const VerifyEmailHelpLinks = (): JSX.Element => {
                     Request a new link
                 </LemonButton>
             )}
+            <SupportModal loggedIn={false} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The email verification scene had a "contact support" button in case of issues that had people emailing hey@posthog.com. This should use the support form instead.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Opens the support form when someone clicks the button instead of using a `mailto`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 🖱️ 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
