### PR TITLE
fix: Only say not found if its the first page

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -232,8 +232,9 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
 
         recording.load_snapshots(limit, offset)
 
-        if not recording.snapshot_data_by_window_id:
-            raise exceptions.NotFound("Snapshots not found")
+        if offset == 0:
+            if not recording.snapshot_data_by_window_id:
+                raise exceptions.NotFound("Snapshots not found")
 
         if recording.can_load_more_snapshots:
             next_url = format_query_params_absolute_url(request, offset + limit, limit) if True else None


### PR DESCRIPTION
## Problem

We respond with an error if we can't load the next page of results but is actually more useful to simply respond with the empty list as pagination estimates are anyways a guess.

## Changes

* Only error for 0 offset

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
