### PR TITLE
fix: no flash of empty state

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
@@ -15,347 +15,377 @@ describe('sessionRecordingsListLogic', () => {
     let logic: ReturnType<typeof sessionRecordingsListLogic.build>
     const aRecording = { id: 'abc', viewed: false, recording_duration: 10 }
     const listOfSessionRecordings = [aRecording]
-    jest.setTimeout(500)
 
-    beforeEach(() => {
-        useMocks({
-            get: {
-                '/api/projects/:team/session_recordings/properties': {
-                    results: [
-                        { id: 's1', properties: { blah: 'blah1' } },
-                        { id: 's2', properties: { blah: 'blah2' } },
-                    ],
-                },
-
-                '/api/projects/:team/session_recordings': (req) => {
-                    const { searchParams } = req.url
-                    if (
-                        (searchParams.get('events')?.length || 0) > 0 &&
-                        JSON.parse(searchParams.get('events') || '[]')[0]?.['id'] === '$autocapture'
-                    ) {
-                        return [
-                            200,
-                            {
-                                results: ['List of recordings filtered by events'],
-                            },
-                        ]
-                    } else if (searchParams.get('person_uuid') === 'cool_user_99') {
-                        return [
-                            200,
-                            {
-                                results: ["List of specific user's recordings from server"],
-                            },
-                        ]
-                    } else if (searchParams.get('offset') === `${RECORDINGS_LIMIT}`) {
-                        return [
-                            200,
-                            {
-                                results: [`List of recordings offset by ${RECORDINGS_LIMIT}`],
-                            },
-                        ]
-                    } else if (
-                        searchParams.get('date_from') === '2021-10-05' &&
-                        searchParams.get('date_to') === '2021-10-20'
-                    ) {
-                        return [
-                            200,
-                            {
-                                results: ['Recordings filtered by date'],
-                            },
-                        ]
-                    } else if (JSON.parse(searchParams.get('session_recording_duration') ?? '{}')['value'] === 600) {
-                        return [
-                            200,
-                            {
-                                results: ['Recordings filtered by duration'],
-                            },
-                        ]
-                    }
-                    return [
-                        200,
-                        {
-                            results: listOfSessionRecordings,
-                        },
-                    ]
-                },
-                '/api/projects/:team/session_recording_playlists/:playlist_id/recordings': () => {
-                    return [
-                        200,
-                        {
-                            results: ['Pinned recordings'],
-                        },
-                    ]
-                },
-            },
-        })
-        initKeaTests()
-    })
-
-    describe('global logic', () => {
+    describe('with no recordings to load', () => {
         beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/projects/:team/session_recordings/properties': {
+                        results: [],
+                    },
+
+                    '/api/projects/:team/session_recordings': { has_next: false, results: [] },
+                    '/api/projects/:team/session_recording_playlists/:playlist_id/recordings': {
+                        results: [],
+                    },
+                },
+            })
+            initKeaTests()
             logic = sessionRecordingsListLogic({
                 key: 'tests',
-                playlistShortId: 'playlist-test',
                 updateSearchParams: true,
             })
             logic.mount()
         })
 
-        describe('core assumptions', () => {
-            it('loads recent recordings and pinned recordings after mounting', async () => {
-                await expectLogic(logic)
-                    .toDispatchActionsInAnyOrder(['loadSessionRecordingsSuccess', 'loadPinnedRecordingsSuccess'])
-                    .toMatchValues({
-                        sessionRecordings: listOfSessionRecordings,
-                        pinnedRecordingsResponse: {
-                            results: ['Pinned recordings'],
-                        },
-                    })
+        describe('should show empty state', () => {
+            it('starts out false', async () => {
+                await expectLogic(logic).toMatchValues({ shouldShowEmptyState: false })
+            })
+
+            it('is true if after API call is made there are no results', async () => {
+                await expectLogic(logic, () => {
+                    // load is called on mount
+                    // logic.actions.loadSessionRecordings()
+                    logic.actions.setSelectedRecordingId('abc')
+                })
+                    .toDispatchActionsInAnyOrder(['loadSessionRecordings', 'loadSessionRecordingsSuccess'])
+                    .toMatchValues({ shouldShowEmptyState: true })
             })
         })
+    })
 
-        describe('activeSessionRecording', () => {
-            it('starts as null', () => {
-                expectLogic(logic).toMatchValues({ activeSessionRecording: undefined })
+    describe('with recordings to load', () => {
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/projects/:team/session_recordings/properties': {
+                        results: [
+                            { id: 's1', properties: { blah: 'blah1' } },
+                            { id: 's2', properties: { blah: 'blah2' } },
+                        ],
+                    },
+
+                    '/api/projects/:team/session_recordings': (req) => {
+                        const { searchParams } = req.url
+                        if (
+                            (searchParams.get('events')?.length || 0) > 0 &&
+                            JSON.parse(searchParams.get('events') || '[]')[0]?.['id'] === '$autocapture'
+                        ) {
+                            return [
+                                200,
+                                {
+                                    results: ['List of recordings filtered by events'],
+                                },
+                            ]
+                        } else if (searchParams.get('person_uuid') === 'cool_user_99') {
+                            return [
+                                200,
+                                {
+                                    results: ["List of specific user's recordings from server"],
+                                },
+                            ]
+                        } else if (searchParams.get('offset') === `${RECORDINGS_LIMIT}`) {
+                            return [
+                                200,
+                                {
+                                    results: [`List of recordings offset by ${RECORDINGS_LIMIT}`],
+                                },
+                            ]
+                        } else if (
+                            searchParams.get('date_from') === '2021-10-05' &&
+                            searchParams.get('date_to') === '2021-10-20'
+                        ) {
+                            return [
+                                200,
+                                {
+                                    results: ['Recordings filtered by date'],
+                                },
+                            ]
+                        } else if (
+                            JSON.parse(searchParams.get('session_recording_duration') ?? '{}')['value'] === 600
+                        ) {
+                            return [
+                                200,
+                                {
+                                    results: ['Recordings filtered by duration'],
+                                },
+                            ]
+                        }
+                        return [
+                            200,
+                            {
+                                results: listOfSessionRecordings,
+                            },
+                        ]
+                    },
+                    '/api/projects/:team/session_recording_playlists/:playlist_id/recordings': () => {
+                        return [
+                            200,
+                            {
+                                results: ['Pinned recordings'],
+                            },
+                        ]
+                    },
+                },
             })
-            it('is set by setSessionRecordingId', async () => {
-                expectLogic(logic, () => logic.actions.setSelectedRecordingId('abc'))
-                    .toDispatchActions(['loadSessionRecordingsSuccess'])
-                    .toMatchValues({
-                        selectedRecordingId: 'abc',
+            initKeaTests()
+        })
+
+        describe('global logic', () => {
+            beforeEach(() => {
+                logic = sessionRecordingsListLogic({
+                    key: 'tests',
+                    playlistShortId: 'playlist-test',
+                    updateSearchParams: true,
+                })
+                logic.mount()
+            })
+
+            describe('core assumptions', () => {
+                it('loads recent recordings and pinned recordings after mounting', async () => {
+                    await expectLogic(logic)
+                        .toDispatchActionsInAnyOrder(['loadSessionRecordingsSuccess', 'loadPinnedRecordingsSuccess'])
+                        .toMatchValues({
+                            sessionRecordings: listOfSessionRecordings,
+                            pinnedRecordingsResponse: {
+                                results: ['Pinned recordings'],
+                            },
+                        })
+                })
+            })
+
+            describe('should show empty state', () => {
+                it('starts out false', async () => {
+                    await expectLogic(logic).toMatchValues({ shouldShowEmptyState: false })
+                })
+            })
+
+            describe('activeSessionRecording', () => {
+                it('starts as null', () => {
+                    expectLogic(logic).toMatchValues({ activeSessionRecording: undefined })
+                })
+                it('is set by setSessionRecordingId', async () => {
+                    expectLogic(logic, () => logic.actions.setSelectedRecordingId('abc'))
+                        .toDispatchActions(['loadSessionRecordingsSuccess'])
+                        .toMatchValues({
+                            selectedRecordingId: 'abc',
+                            activeSessionRecording: listOfSessionRecordings[0],
+                        })
+                    expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
+                })
+
+                it('is partial if sessionRecordingId not in list', async () => {
+                    expectLogic(logic, () => logic.actions.setSelectedRecordingId('not-in-list'))
+                        .toDispatchActions(['loadSessionRecordingsSuccess'])
+                        .toMatchValues({
+                            selectedRecordingId: 'not-in-list',
+                            activeSessionRecording: { id: 'not-in-list' },
+                        })
+                    expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'not-in-list')
+                })
+
+                it('is read from the URL on the session recording page', async () => {
+                    router.actions.push('/replay', {}, { sessionRecordingId: 'abc' })
+                    expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
+
+                    await expectLogic(logic)
+                        .toDispatchActionsInAnyOrder(['setSelectedRecordingId', 'loadSessionRecordingsSuccess'])
+                        .toMatchValues({
+                            selectedRecordingId: 'abc',
+                            activeSessionRecording: listOfSessionRecordings[0],
+                        })
+                })
+
+                it('mounts and loads the recording when a recording is opened', () => {
+                    expectLogic(logic, async () => await logic.actions.setSelectedRecordingId('abcd'))
+                        .toMount(sessionRecordingDataLogic({ sessionRecordingId: 'abcd' }))
+                        .toDispatchActions(['loadEntireRecording'])
+                })
+
+                it('returns the first session recording if none selected', () => {
+                    expectLogic(logic).toDispatchActions(['loadSessionRecordingsSuccess']).toMatchValues({
+                        selectedRecordingId: undefined,
                         activeSessionRecording: listOfSessionRecordings[0],
                     })
-                expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
-            })
-
-            it('is partial if sessionRecordingId not in list', async () => {
-                expectLogic(logic, () => logic.actions.setSelectedRecordingId('not-in-list'))
-                    .toDispatchActions(['loadSessionRecordingsSuccess'])
-                    .toMatchValues({
-                        selectedRecordingId: 'not-in-list',
-                        activeSessionRecording: { id: 'not-in-list' },
-                    })
-                expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'not-in-list')
-            })
-
-            it('is read from the URL on the session recording page', async () => {
-                router.actions.push('/replay', {}, { sessionRecordingId: 'abc' })
-                expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
-
-                await expectLogic(logic)
-                    .toDispatchActionsInAnyOrder(['setSelectedRecordingId', 'loadSessionRecordingsSuccess'])
-                    .toMatchValues({
-                        selectedRecordingId: 'abc',
-                        activeSessionRecording: listOfSessionRecordings[0],
-                    })
-            })
-
-            it('mounts and loads the recording when a recording is opened', () => {
-                expectLogic(logic, async () => await logic.actions.setSelectedRecordingId('abcd'))
-                    .toMount(sessionRecordingDataLogic({ sessionRecordingId: 'abcd' }))
-                    .toDispatchActions(['loadEntireRecording'])
-            })
-
-            it('returns the first session recording if none selected', () => {
-                expectLogic(logic).toDispatchActions(['loadSessionRecordingsSuccess']).toMatchValues({
-                    selectedRecordingId: undefined,
-                    activeSessionRecording: listOfSessionRecordings[0],
+                    expect(router.values.searchParams).not.toHaveProperty('sessionRecordingId', 'not-in-list')
                 })
-                expect(router.values.searchParams).not.toHaveProperty('sessionRecordingId', 'not-in-list')
-            })
-        })
-
-        describe('entityFilters', () => {
-            it('starts with default values', () => {
-                expectLogic(logic).toMatchValues({ filters: DEFAULT_RECORDING_FILTERS })
             })
 
-            it('is set by setFilters and loads filtered results and sets the url', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.setFilters({
-                        events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
-                    })
+            describe('entityFilters', () => {
+                it('starts with default values', () => {
+                    expectLogic(logic).toMatchValues({ filters: DEFAULT_RECORDING_FILTERS })
                 })
-                    .toDispatchActions(['setFilters', 'loadSessionRecordings', 'loadSessionRecordingsSuccess'])
-                    .toMatchValues({
-                        sessionRecordings: ['List of recordings filtered by events'],
-                    })
-                expect(router.values.searchParams.filters).toHaveProperty('events', [
-                    { id: '$autocapture', type: 'events', order: 0, name: '$autocapture' },
-                ])
-            })
-        })
 
-        describe('date range', () => {
-            it('is set by setFilters and fetches results from server and sets the url', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.setFilters({
-                        date_from: '2021-10-05',
-                        date_to: '2021-10-20',
+                it('is set by setFilters and loads filtered results and sets the url', async () => {
+                    await expectLogic(logic, () => {
+                        logic.actions.setFilters({
+                            events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
+                        })
                     })
+                        .toDispatchActions(['setFilters', 'loadSessionRecordings', 'loadSessionRecordingsSuccess'])
+                        .toMatchValues({
+                            sessionRecordings: ['List of recordings filtered by events'],
+                        })
+                    expect(router.values.searchParams.filters).toHaveProperty('events', [
+                        { id: '$autocapture', type: 'events', order: 0, name: '$autocapture' },
+                    ])
                 })
-                    .toMatchValues({
-                        filters: expect.objectContaining({
+            })
+
+            describe('date range', () => {
+                it('is set by setFilters and fetches results from server and sets the url', async () => {
+                    await expectLogic(logic, () => {
+                        logic.actions.setFilters({
                             date_from: '2021-10-05',
                             date_to: '2021-10-20',
-                        }),
+                        })
                     })
-                    .toDispatchActions(['setFilters', 'loadSessionRecordingsSuccess'])
-                    .toMatchValues({ sessionRecordings: ['Recordings filtered by date'] })
+                        .toMatchValues({
+                            filters: expect.objectContaining({
+                                date_from: '2021-10-05',
+                                date_to: '2021-10-20',
+                            }),
+                        })
+                        .toDispatchActions(['setFilters', 'loadSessionRecordingsSuccess'])
+                        .toMatchValues({ sessionRecordings: ['Recordings filtered by date'] })
 
-                expect(router.values.searchParams.filters).toHaveProperty('date_from', '2021-10-05')
-                expect(router.values.searchParams.filters).toHaveProperty('date_to', '2021-10-20')
-            })
-        })
-        describe('duration filter', () => {
-            it('is set by setFilters and fetches results from server and sets the url', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.setFilters({
-                        session_recording_duration: {
-                            type: PropertyFilterType.Recording,
-                            key: 'duration',
-                            value: 600,
-                            operator: PropertyOperator.LessThan,
-                        },
-                    })
+                    expect(router.values.searchParams.filters).toHaveProperty('date_from', '2021-10-05')
+                    expect(router.values.searchParams.filters).toHaveProperty('date_to', '2021-10-20')
                 })
-                    .toMatchValues({
-                        filters: expect.objectContaining({
+            })
+            describe('duration filter', () => {
+                it('is set by setFilters and fetches results from server and sets the url', async () => {
+                    await expectLogic(logic, () => {
+                        logic.actions.setFilters({
                             session_recording_duration: {
                                 type: PropertyFilterType.Recording,
                                 key: 'duration',
                                 value: 600,
                                 operator: PropertyOperator.LessThan,
                             },
-                        }),
+                        })
                     })
-                    .toDispatchActions(['setFilters', 'loadSessionRecordingsSuccess'])
-                    .toMatchValues({ sessionRecordings: ['Recordings filtered by duration'] })
+                        .toMatchValues({
+                            filters: expect.objectContaining({
+                                session_recording_duration: {
+                                    type: PropertyFilterType.Recording,
+                                    key: 'duration',
+                                    value: 600,
+                                    operator: PropertyOperator.LessThan,
+                                },
+                            }),
+                        })
+                        .toDispatchActions(['setFilters', 'loadSessionRecordingsSuccess'])
+                        .toMatchValues({ sessionRecordings: ['Recordings filtered by duration'] })
 
-                expect(router.values.searchParams.filters).toHaveProperty('session_recording_duration', {
-                    type: PropertyFilterType.Recording,
-                    key: 'duration',
-                    value: 600,
-                    operator: PropertyOperator.LessThan,
-                })
-            })
-        })
-
-        describe('fetch pinned recordings', () => {
-            beforeEach(() => {
-                logic = sessionRecordingsListLogic({
-                    key: 'static-tests',
-                    playlistShortId: 'static-playlist-test',
-                })
-                logic.mount()
-            })
-            it('calls list session recordings for static playlists', async () => {
-                await expectLogic(logic)
-                    .toDispatchActions(['loadPinnedRecordingsSuccess'])
-                    .toMatchValues({
-                        pinnedRecordingsResponse: {
-                            results: ['Pinned recordings'],
-                        },
+                    expect(router.values.searchParams.filters).toHaveProperty('session_recording_duration', {
+                        type: PropertyFilterType.Recording,
+                        key: 'duration',
+                        value: 600,
+                        operator: PropertyOperator.LessThan,
                     })
-            })
-        })
-
-        describe('set recording from hash param', () => {
-            it('loads the correct recording from the hash params', async () => {
-                router.actions.push('/replay/recent', {}, { sessionRecordingId: 'abc' })
-
-                logic = sessionRecordingsListLogic({
-                    key: 'hash-recording-tests',
-                    updateSearchParams: true,
                 })
-                logic.mount()
-
-                await expectLogic(logic).toDispatchActions(['loadSessionRecordingsSuccess']).toMatchValues({
-                    selectedRecordingId: 'abc',
-                })
-
-                logic.actions.setSelectedRecordingId('1234')
             })
-        })
 
-        describe('sessionRecording.viewed', () => {
-            it('changes when setSelectedRecordingId is called', async () => {
-                await expectLogic(logic)
-                    .toFinishAllListeners()
-                    .toMatchValues({
-                        sessionRecordingsResponse: {
-                            results: [{ ...aRecording }],
-                        },
-                        sessionRecordings: [
-                            {
-                                ...aRecording,
+            describe('fetch pinned recordings', () => {
+                beforeEach(() => {
+                    logic = sessionRecordingsListLogic({
+                        key: 'static-tests',
+                        playlistShortId: 'static-playlist-test',
+                    })
+                    logic.mount()
+                })
+                it('calls list session recordings for static playlists', async () => {
+                    await expectLogic(logic)
+                        .toDispatchActions(['loadPinnedRecordingsSuccess'])
+                        .toMatchValues({
+                            pinnedRecordingsResponse: {
+                                results: ['Pinned recordings'],
                             },
-                        ],
+                        })
+                })
+            })
+
+            describe('set recording from hash param', () => {
+                it('loads the correct recording from the hash params', async () => {
+                    router.actions.push('/replay/recent', {}, { sessionRecordingId: 'abc' })
+
+                    logic = sessionRecordingsListLogic({
+                        key: 'hash-recording-tests',
+                        updateSearchParams: true,
+                    })
+                    logic.mount()
+
+                    await expectLogic(logic).toDispatchActions(['loadSessionRecordingsSuccess']).toMatchValues({
+                        selectedRecordingId: 'abc',
                     })
 
-                await expectLogic(logic, () => {
-                    logic.actions.setSelectedRecordingId('abc')
+                    logic.actions.setSelectedRecordingId('1234')
                 })
-                    .toFinishAllListeners()
-                    .toMatchValues({
-                        sessionRecordingsResponse: {
-                            results: [
+            })
+
+            describe('sessionRecording.viewed', () => {
+                it('changes when setSelectedRecordingId is called', async () => {
+                    await expectLogic(logic)
+                        .toFinishAllListeners()
+                        .toMatchValues({
+                            sessionRecordingsResponse: {
+                                results: [{ ...aRecording }],
+                                has_next: undefined,
+                                has_called_api: true,
+                            },
+                            sessionRecordings: [
+                                {
+                                    ...aRecording,
+                                },
+                            ],
+                        })
+
+                    await expectLogic(logic, () => {
+                        logic.actions.setSelectedRecordingId('abc')
+                    })
+                        .toFinishAllListeners()
+                        .toMatchValues({
+                            sessionRecordingsResponse: {
+                                results: [
+                                    {
+                                        ...aRecording,
+                                        viewed: true,
+                                    },
+                                ],
+                                has_called_api: true,
+                            },
+                            sessionRecordings: [
                                 {
                                     ...aRecording,
                                     viewed: true,
                                 },
                             ],
-                        },
-                        sessionRecordings: [
-                            {
-                                ...aRecording,
-                                viewed: true,
-                            },
-                        ],
-                    })
-            })
-
-            it('is set by setFilters and loads filtered results', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.setFilters({
-                        events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
-                    })
+                        })
                 })
-                    .toDispatchActions(['setFilters', 'loadSessionRecordings', 'loadSessionRecordingsSuccess'])
-                    .toMatchValues({
-                        sessionRecordings: ['List of recordings filtered by events'],
+
+                it('is set by setFilters and loads filtered results', async () => {
+                    await expectLogic(logic, () => {
+                        logic.actions.setFilters({
+                            events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
+                        })
                     })
-            })
-        })
-
-        it('reads filters from the URL', async () => {
-            router.actions.push('/replay', {
-                filters: {
-                    actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
-                    events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
-                    date_from: '2021-10-01',
-                    date_to: '2021-10-10',
-                    offset: 50,
-                    session_recording_duration: {
-                        type: PropertyFilterType.Recording,
-                        key: 'duration',
-                        value: 600,
-                        operator: PropertyOperator.LessThan,
-                    },
-                },
+                        .toDispatchActions(['setFilters', 'loadSessionRecordings', 'loadSessionRecordingsSuccess'])
+                        .toMatchValues({
+                            sessionRecordings: ['List of recordings filtered by events'],
+                        })
+                })
             })
 
-            await expectLogic(logic)
-                .toDispatchActions(['setFilters'])
-                .toMatchValues({
+            it('reads filters from the URL', async () => {
+                router.actions.push('/replay', {
                     filters: {
-                        events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
                         actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                        events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
                         date_from: '2021-10-01',
                         date_to: '2021-10-10',
                         offset: 50,
-                        console_logs: [],
-                        properties: [],
                         session_recording_duration: {
                             type: PropertyFilterType.Recording,
                             key: 'duration',
@@ -364,97 +394,118 @@ describe('sessionRecordingsListLogic', () => {
                         },
                     },
                 })
-        })
 
-        it('reads filters from the URL and defaults the duration filter', async () => {
-            router.actions.push('/replay', {
-                filters: {
-                    actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
-                },
+                await expectLogic(logic)
+                    .toDispatchActions(['setFilters'])
+                    .toMatchValues({
+                        filters: {
+                            events: [{ id: '$autocapture', type: 'events', order: 0, name: '$autocapture' }],
+                            actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                            date_from: '2021-10-01',
+                            date_to: '2021-10-10',
+                            offset: 50,
+                            console_logs: [],
+                            properties: [],
+                            session_recording_duration: {
+                                type: PropertyFilterType.Recording,
+                                key: 'duration',
+                                value: 600,
+                                operator: PropertyOperator.LessThan,
+                            },
+                        },
+                    })
             })
 
-            await expectLogic(logic)
-                .toDispatchActions(['setFilters'])
-                .toMatchValues({
-                    customFilters: {
-                        actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
-                    },
+            it('reads filters from the URL and defaults the duration filter', async () => {
+                router.actions.push('/replay', {
                     filters: {
                         actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
-                        session_recording_duration: defaultRecordingDurationFilter,
-                        console_logs: [],
-                        date_from: '-7d',
-                        date_to: null,
-                        events: [],
-                        properties: [],
                     },
                 })
-        })
-    })
 
-    describe('person specific logic', () => {
-        beforeEach(() => {
-            logic = sessionRecordingsListLogic({
-                key: 'cool_user_99',
-                personUUID: 'cool_user_99',
-                updateSearchParams: true,
+                await expectLogic(logic)
+                    .toDispatchActions(['setFilters'])
+                    .toMatchValues({
+                        customFilters: {
+                            actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                        },
+                        filters: {
+                            actions: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                            session_recording_duration: defaultRecordingDurationFilter,
+                            console_logs: [],
+                            date_from: '-7d',
+                            date_to: null,
+                            events: [],
+                            properties: [],
+                        },
+                    })
             })
-            logic.mount()
         })
 
-        it('loads session recordings for a specific user', async () => {
-            await expectLogic(logic)
-                .toDispatchActions(['loadSessionRecordingsSuccess'])
-                .toMatchValues({ sessionRecordings: ["List of specific user's recordings from server"] })
-        })
-
-        it('reads sessionRecordingId from the URL on the person page', async () => {
-            router.actions.push('/person/123', {}, { sessionRecordingId: 'abc' })
-            expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
-
-            await expectLogic(logic).toDispatchActions([logic.actionCreators.setSelectedRecordingId('abc')])
-        })
-    })
-
-    describe('total filters count', () => {
-        beforeEach(() => {
-            logic = sessionRecordingsListLogic({
-                key: 'cool_user_99',
-                personUUID: 'cool_user_99',
-                updateSearchParams: true,
+        describe('person specific logic', () => {
+            beforeEach(() => {
+                logic = sessionRecordingsListLogic({
+                    key: 'cool_user_99',
+                    personUUID: 'cool_user_99',
+                    updateSearchParams: true,
+                })
+                logic.mount()
             })
-            logic.mount()
-        })
-        it('starts with a count of zero', async () => {
-            await expectLogic(logic).toMatchValues({ totalFiltersCount: 0 })
-        })
 
-        it('counts console log filters', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.setFilters({
-                    console_logs: ['warn', 'error'],
-                } satisfies Partial<RecordingFilters>)
-            }).toMatchValues({ totalFiltersCount: 2 })
-        })
-    })
-
-    describe('resetting filters', () => {
-        beforeEach(() => {
-            logic = sessionRecordingsListLogic({
-                key: 'cool_user_99',
-                personUUID: 'cool_user_99',
-                updateSearchParams: true,
+            it('loads session recordings for a specific user', async () => {
+                await expectLogic(logic)
+                    .toDispatchActions(['loadSessionRecordingsSuccess'])
+                    .toMatchValues({ sessionRecordings: ["List of specific user's recordings from server"] })
             })
-            logic.mount()
+
+            it('reads sessionRecordingId from the URL on the person page', async () => {
+                router.actions.push('/person/123', {}, { sessionRecordingId: 'abc' })
+                expect(router.values.searchParams).toHaveProperty('sessionRecordingId', 'abc')
+
+                await expectLogic(logic).toDispatchActions([logic.actionCreators.setSelectedRecordingId('abc')])
+            })
         })
 
-        it('resets console log filters', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.setFilters({
-                    console_logs: ['warn', 'error'],
-                } satisfies Partial<RecordingFilters>)
-                logic.actions.resetFilters()
-            }).toMatchValues({ totalFiltersCount: 0 })
+        describe('total filters count', () => {
+            beforeEach(() => {
+                logic = sessionRecordingsListLogic({
+                    key: 'cool_user_99',
+                    personUUID: 'cool_user_99',
+                    updateSearchParams: true,
+                })
+                logic.mount()
+            })
+            it('starts with a count of zero', async () => {
+                await expectLogic(logic).toMatchValues({ totalFiltersCount: 0 })
+            })
+
+            it('counts console log filters', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.setFilters({
+                        console_logs: ['warn', 'error'],
+                    } satisfies Partial<RecordingFilters>)
+                }).toMatchValues({ totalFiltersCount: 2 })
+            })
+        })
+
+        describe('resetting filters', () => {
+            beforeEach(() => {
+                logic = sessionRecordingsListLogic({
+                    key: 'cool_user_99',
+                    personUUID: 'cool_user_99',
+                    updateSearchParams: true,
+                })
+                logic.mount()
+            })
+
+            it('resets console log filters', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.setFilters({
+                        console_logs: ['warn', 'error'],
+                    } satisfies Partial<RecordingFilters>)
+                    logic.actions.resetFilters()
+                }).toMatchValues({ totalFiltersCount: 0 })
+            })
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -333,10 +333,6 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         shouldShowEmptyState: [
             (s) => [s.sessionRecordingsResponse, s.customFilters],
             (sessionRecordingsResponse: SessionRecordingsResponse, customFilters: RecordingFilters | null): boolean => {
-                console.log('shouldShowEmptyState', {
-                    customFilters,
-                    sessionRecordingsResponse,
-                })
                 return (
                     sessionRecordingsResponse?.results.length === 0 &&
                     !!sessionRecordingsResponse?.has_called_api &&

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -209,6 +209,7 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                                 ? values.sessionRecordingsResponse?.has_next ?? true
                                 : response.has_next,
                         results: mergedResults,
+                        has_called_api: true,
                     }
                 },
                 setSelectedRecordingId: async ({ id }) => {
@@ -227,6 +228,7 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                     return {
                         has_next: values.sessionRecordingsResponse.has_next,
                         results: updatedResults,
+                        has_called_api: values.sessionRecordingsResponse.has_called_api || false,
                     }
                 },
             },
@@ -329,9 +331,17 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
     })),
     selectors({
         shouldShowEmptyState: [
-            (s) => [s.sessionRecordings, s.customFilters, s.sessionRecordingsResponseLoading],
-            (sessionRecordings, customFilters, sessionRecordingsResponseLoading): boolean => {
-                return !sessionRecordingsResponseLoading && sessionRecordings.length === 0 && !customFilters
+            (s) => [s.sessionRecordingsResponse, s.customFilters],
+            (sessionRecordingsResponse: SessionRecordingsResponse, customFilters: RecordingFilters | null): boolean => {
+                console.log('shouldShowEmptyState', {
+                    customFilters,
+                    sessionRecordingsResponse,
+                })
+                return (
+                    sessionRecordingsResponse?.results.length === 0 &&
+                    !!sessionRecordingsResponse?.has_called_api &&
+                    !customFilters
+                )
             },
         ],
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -710,6 +710,11 @@ export interface LocalRecordingFilters extends RecordingFilters {
 export interface SessionRecordingsResponse {
     results: SessionRecordingType[]
     has_next: boolean
+    // it is possible to "receive" a response without calling the API
+    // e.g. when the `setSessionRecordingId` action is received
+    // in that case we can appear to receive an "empty" response
+    // and show an incorrect state to the user
+    has_called_api?: boolean
 }
 
 export type EntityType = 'actions' | 'events' | 'new_entity'


### PR DESCRIPTION
## Problem

When visiting the replay page with a session recording id in the query param the empty state flashes.

This is because the `setSelectedRecordingId` action patches the session recording response so the viewed state in the playlist stays in sync with the backend. This means there's a short window if the session id is in the URL where the API appears to have an empty response.

## Changes

* adds a flag so the selector can distinguish between an empty response and an empty response from the API

## How did you test this code?

developer tests
