### PR TITLE
fix(taxonomic-selector): Don't show `distinct_id` property as special

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -142,17 +142,6 @@ export const KEY_MAPPING: KeyMappingInterface = {
             description: 'The search engine the user came in from (if any). This is last-touch.',
             examples: ['Google', 'DuckDuckGo'],
         },
-        distinct_id: {
-            label: 'Distinct ID',
-            description: (
-                <span>
-                    Distinct ID either given by calling{' '}
-                    <pre style={{ display: 'inline' }}>posthog.identify('distinct id')</pre> or generated automatically
-                    if the user is anonymous.
-                </span>
-            ),
-            examples: ['1234', '16ff262c4301e5-0aa346c03894bc-39667c0e-1aeaa0-16ff262c431767'],
-        },
         $active_feature_flags: {
             label: 'Active Feature Flags',
             description: 'Keys of the feature flags that were active while this event was sent.',


### PR DESCRIPTION
## Problem

We are showing the `distinct_id` _property_ with special PostHog flair, despite it being basically completely unreliable, and not having ~~an underscore~~ a dollar sign. This is confusing, [see this internal thread with a customer](https://posthog.slack.com/archives/C04F85S6BGQ/p1687424130875549?thread_ts=1687420056.378919&cid=C04F85S6BGQ).

CC @neilkakkar 

## Changes

No longer showing `distinct_id` as special.