### PR TITLE
fix: high-water mark committing before updating

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -23,16 +23,16 @@ const offsetHighWaterMarkKey = (prefix: string, tp: TopicPartition) => {
 export class SessionOffsetHighWaterMark {
     private topicPartitionWaterMarks: Record<string, Record<string, number>> = {}
 
-    getWatermarkFor(topic: string, partition: number): Record<string, number> {
-        const key = `${topic}-${partition}`
+    getWatermarkFor(tp: TopicPartition): Record<string, number> {
+        const key = `${tp.topic}-${tp.partition}`
         if (!this.topicPartitionWaterMarks[key]) {
             this.topicPartitionWaterMarks[key] = {}
         }
         return this.topicPartitionWaterMarks[key]
     }
 
-    private setWaterMarkFor(topic: string, partition: number, sessionId: string, offset: number) {
-        const key = `${topic}-${partition}`
+    private setWaterMarkFor(tp: TopicPartition, sessionId: string, offset: number) {
+        const key = `${tp.topic}-${tp.partition}`
         if (!this.topicPartitionWaterMarks[key]) {
             this.topicPartitionWaterMarks[key] = {}
         }
@@ -73,7 +73,7 @@ export class SessionOffsetHighWaterMark {
                     offset,
                     updatedCount,
                 })
-                this.setWaterMarkFor(tp.topic, tp.partition, sessionId, offset)
+                this.setWaterMarkFor(tp, sessionId, offset)
             })
         } catch (error) {
             status.error('🧨', 'WrittenOffsetCache failed to add high-water mark for partition', {
@@ -151,7 +151,7 @@ export class SessionOffsetHighWaterMark {
                     ...tp,
                     offset,
                 })
-                const currentHighWaterMarks = this.getWatermarkFor(tp.topic, tp.partition)
+                const currentHighWaterMarks = this.getWatermarkFor(tp)
                 // remove each key in currentHighWaterMarks that has an offset less than or equal to the offset we just committed
                 Object.keys(currentHighWaterMarks).forEach((sessionId) => {
                     if (currentHighWaterMarks[sessionId] <= offset) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -22,6 +22,23 @@ const offsetHighWaterMarkKey = (prefix: string, tp: TopicPartition) => {
  */
 export class SessionOffsetHighWaterMark {
     private topicPartitionWaterMarks: Record<string, Record<string, number>> = {}
+
+    getWatermarkFor(topic: string, partition: number): Record<string, number> {
+        const key = `${topic}-${partition}`
+        if (!this.topicPartitionWaterMarks[key]) {
+            this.topicPartitionWaterMarks[key] = {}
+        }
+        return this.topicPartitionWaterMarks[key]
+    }
+
+    private setWaterMarkFor(topic: string, partition: number, sessionId: string, offset: number) {
+        const key = `${topic}-${partition}`
+        if (!this.topicPartitionWaterMarks[key]) {
+            this.topicPartitionWaterMarks[key] = {}
+        }
+        this.topicPartitionWaterMarks[key][sessionId] = offset
+    }
+
     private getAllPromise: Promise<Record<string, number> | null> | null = null
     constructor(private redisPool: RedisPool, private keyPrefix = '@posthog/replay/partition-high-water-marks') {}
 
@@ -56,7 +73,7 @@ export class SessionOffsetHighWaterMark {
                     offset,
                     updatedCount,
                 })
-                this.topicPartitionWaterMarks[`${tp.topic}-${tp.partition}`][sessionId] = offset
+                this.setWaterMarkFor(tp.topic, tp.partition, sessionId, offset)
             })
         } catch (error) {
             status.error('🧨', 'WrittenOffsetCache failed to add high-water mark for partition', {
@@ -134,7 +151,7 @@ export class SessionOffsetHighWaterMark {
                     ...tp,
                     offset,
                 })
-                const currentHighWaterMarks = this.topicPartitionWaterMarks[`${tp.topic}-${tp.partition}`] || {}
+                const currentHighWaterMarks = this.getWatermarkFor(tp.topic, tp.partition)
                 // remove each key in currentHighWaterMarks that has an offset less than or equal to the offset we just committed
                 Object.keys(currentHighWaterMarks).forEach((sessionId) => {
                     if (currentHighWaterMarks[sessionId] <= offset) {
@@ -162,6 +179,12 @@ export class SessionOffsetHighWaterMark {
         }
     }
 
+    /**
+     * if there isn't already a high-water mark for this topic partition
+     * then this method calls getAll to get all the high-water marks for this topic partition
+     * it assumes that it has the latest high-water marks for this topic partition
+     * so that callers are safe to drop messages
+     */
     public async isBelowHighWaterMark(tp: TopicPartition, sessionId: string, offset: number): Promise<boolean> {
         if (!this.topicPartitionWaterMarks[tp.partition]) {
             const highWaterMarks = await this.getAll(tp)

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -134,7 +134,7 @@ export class SessionOffsetHighWaterMark {
                     ...tp,
                     offset,
                 })
-                const currentHighWaterMarks = this.topicPartitionWaterMarks[`${tp.topic}-${tp.partition}`]
+                const currentHighWaterMarks = this.topicPartitionWaterMarks[`${tp.topic}-${tp.partition}`] || {}
                 // remove each key in currentHighWaterMarks that has an offset less than or equal to the offset we just committed
                 Object.keys(currentHighWaterMarks).forEach((sessionId) => {
                     if (currentHighWaterMarks[sessionId] <= offset) {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
@@ -38,7 +38,9 @@ describe('session offset high-water mark', () => {
 
         it('can add a high-water mark', async () => {
             await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 123)
-            expect(sessionOffsetHighWaterMark.getWatermarkFor('topic', 1)).toEqual({ 'some-session': 123 })
+            expect(sessionOffsetHighWaterMark.getWatermarkFor({ topic: 'topic', partition: 1 })).toEqual({
+                'some-session': 123,
+            })
         })
     })
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
@@ -35,6 +35,11 @@ describe('session offset high-water mark', () => {
             expect(inMemoryResults).toEqual({})
             expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({})
         })
+
+        it('can add a high-water mark', async () => {
+            await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 123)
+            expect(sessionOffsetHighWaterMark.getWatermarkFor('topic', 1)).toEqual({ 'some-session': 123 })
+        })
     })
 
     describe('with existing high-water marks', () => {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
@@ -22,12 +22,6 @@ describe('session offset high-water mark', () => {
     beforeEach(async () => {
         ;[hub, closeHub] = await createHub()
         sessionOffsetHighWaterMark = new SessionOffsetHighWaterMark(hub.redisPool, keyPrefix)
-        // works even before anything is written to redis
-        expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toStrictEqual({})
-
-        await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 123)
-        await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'another-session', 12)
-        await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 2 }, 'a-third-session', 1)
     })
 
     afterEach(async () => {
@@ -35,61 +29,80 @@ describe('session offset high-water mark', () => {
         await closeHub()
     })
 
-    it('can get high-water marks for all sessions for a partition', async () => {
-        expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({
-            'some-session': 123,
-            'another-session': 12,
+    describe('with no existing high-water marks', () => {
+        it('can remove all high-water marks based on a given offset', async () => {
+            const inMemoryResults = await sessionOffsetHighWaterMark.onCommit({ topic: 'topic', partition: 1 }, 12)
+            expect(inMemoryResults).toEqual({})
+            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({})
         })
     })
 
-    it('can remove all high-water marks based on a given offset', async () => {
-        const inMemoryResults = await sessionOffsetHighWaterMark.onCommit({ topic: 'topic', partition: 1 }, 12)
-        // the commit updates the in-memory cache
-        expect(inMemoryResults).toEqual({
-            'some-session': 123,
+    describe('with existing high-water marks', () => {
+        beforeEach(async () => {
+            // works even before anything is written to redis
+            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toStrictEqual({})
+
+            await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 123)
+            await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'another-session', 12)
+            await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 2 }, 'a-third-session', 1)
         })
 
-        // the commit updates redis
-        // removes all high-water marks that are <= 12
-        expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({
-            'some-session': 123,
-        })
-        // does not affect other partitions
-        expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 2 })).toEqual({
-            'a-third-session': 1,
-        })
-    })
-
-    it('can check if an offset is below the high-water mark', async () => {
-        const partitionOneTestCases: [number, boolean][] = [
-            [124, false],
-            [123, true],
-            [12, true],
-            [11, true],
-            [1, true],
-            [0, true],
-        ]
-        await Promise.allSettled(
-            partitionOneTestCases.map(async ([offset, expected]) => {
-                expect(
-                    await sessionOffsetHighWaterMark.isBelowHighWaterMark(
-                        { topic: 'topic', partition: 1 },
-                        'some-session',
-                        offset
-                    )
-                ).toBe(expected)
+        it('can get high-water marks for all sessions for a partition', async () => {
+            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({
+                'some-session': 123,
+                'another-session': 12,
             })
-        )
-    })
+        })
 
-    it('can check if an offset is below the high-water mark even if we have never seen it before', async () => {
-        // there is nothing for a partition? we are always below the high-water mark
-        expect(
-            await sessionOffsetHighWaterMark.isBelowHighWaterMark(
-                { topic: 'topic', partition: 1 },
-                'anything we did not add yet',
-                5432
+        it('can remove all high-water marks based on a given offset', async () => {
+            const inMemoryResults = await sessionOffsetHighWaterMark.onCommit({ topic: 'topic', partition: 1 }, 12)
+            // the commit updates the in-memory cache
+            expect(inMemoryResults).toEqual({
+                'some-session': 123,
+            })
+
+            // the commit updates redis
+            // removes all high-water marks that are <= 12
+            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({
+                'some-session': 123,
+            })
+            // does not affect other partitions
+            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 2 })).toEqual({
+                'a-third-session': 1,
+            })
+        })
+
+        it('can check if an offset is below the high-water mark', async () => {
+            const partitionOneTestCases: [number, boolean][] = [
+                [124, false],
+                [123, true],
+                [12, true],
+                [11, true],
+                [1, true],
+                [0, true],
+            ]
+            await Promise.allSettled(
+                partitionOneTestCases.map(async ([offset, expected]) => {
+                    expect(
+                        await sessionOffsetHighWaterMark.isBelowHighWaterMark(
+                            { topic: 'topic', partition: 1 },
+                            'some-session',
+                            offset
+                        )
+                    ).toBe(expected)
+                })
             )
-        ).toBe(false)
+        })
+
+        it('can check if an offset is below the high-water mark even if we have never seen it before', async () => {
+            // there is nothing for a partition? we are always below the high-water mark
+            expect(
+                await sessionOffsetHighWaterMark.isBelowHighWaterMark(
+                    { topic: 'topic', partition: 1 },
+                    'anything we did not add yet',
+                    5432
+                )
+            ).toBe(false)
+        })
     })
 })


### PR DESCRIPTION
## Problem

The high-water mark tracking was written as if `getAll` had always been called first, but that wasn't true.

## Changes

Make getting and setting safe even when no high-water mark has been written for a topic-partition

## How did you test this code?

developer tests to prove the problem and fix it