### PR TITLE
fix(discovery): Always consider $feature/ properties as strings

### DIFF
--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 patchedDependencies:
   pg@8.10.0:

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 patchedDependencies:
   pg@8.10.0:

--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -81,7 +81,7 @@ export const detectPropertyDefinitionTypes = (value: unknown, key: string): Prop
         return PropertyType.String
     }
 
-    if (/^\$feature\//i.test(key)) {
+    if (key.indexOf('$feature/') === 0) {
         // $feature/ prefixed properties should always be detected as strings.
         // These are feature flag values, and can be boolean or string.
         // Sometimes the first value sent is boolean (because flag isn't enabled) while

--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -81,6 +81,14 @@ export const detectPropertyDefinitionTypes = (value: unknown, key: string): Prop
         return PropertyType.String
     }
 
+    if (/^\$feature\//i.test(key)) {
+        // $feature/ prefixed properties should always be detected as strings.
+        // These are feature flag values, and can be boolean or string.
+        // Sometimes the first value sent is boolean (because flag isn't enabled) while
+        // subsequent values are not. We don't want this to be misunderstood as a boolean.
+        return PropertyType.String
+    }
+
     if (typeof value === 'number') {
         propertyType = PropertyType.Numeric
 

--- a/plugin-server/tests/worker/ingestion/property-definitions-auto-discovery.test.ts
+++ b/plugin-server/tests/worker/ingestion/property-definitions-auto-discovery.test.ts
@@ -32,4 +32,24 @@ describe('property definitions auto discovery', () => {
             expect(detectPropertyDefinitionTypes('9.7.0', '$app_version')).toEqual(PropertyType.String)
         })
     })
+
+    describe('can detect feature flag properties', () => {
+        it('detects regular feature flag properties as string', () => {
+            expect(detectPropertyDefinitionTypes('10', '$feature/my-feature')).toEqual(PropertyType.String)
+            expect(detectPropertyDefinitionTypes('true', '$feature/my-feature')).toEqual(PropertyType.String)
+            expect(detectPropertyDefinitionTypes('false', '$feature/my-feature')).toEqual(PropertyType.String)
+            expect(detectPropertyDefinitionTypes(12, '$feature/my-feature')).toEqual(PropertyType.String)
+        })
+
+        it('doesnt detect $feature_interaction properties as string', () => {
+            expect(detectPropertyDefinitionTypes('true', '$feature_interaction/my-feature')).toEqual(
+                PropertyType.Boolean
+            )
+            expect(detectPropertyDefinitionTypes('true', '$$feature/my-feature')).toEqual(PropertyType.Boolean)
+            expect(detectPropertyDefinitionTypes('true', ' $feature/my-feature')).toEqual(PropertyType.Boolean)
+            expect(detectPropertyDefinitionTypes('true', '$features/my-feature')).toEqual(PropertyType.Boolean)
+            expect(detectPropertyDefinitionTypes('["a","b","c"]', '$active_feature_flags')).toEqual(PropertyType.String)
+            expect(detectPropertyDefinitionTypes(12, 'feature_flag')).toEqual(PropertyType.Numeric)
+        })
+    })
 })

--- a/plugin-server/tests/worker/ingestion/property-definitions-auto-discovery.test.ts
+++ b/plugin-server/tests/worker/ingestion/property-definitions-auto-discovery.test.ts
@@ -47,6 +47,7 @@ describe('property definitions auto discovery', () => {
             )
             expect(detectPropertyDefinitionTypes('true', '$$feature/my-feature')).toEqual(PropertyType.Boolean)
             expect(detectPropertyDefinitionTypes('true', ' $feature/my-feature')).toEqual(PropertyType.Boolean)
+            expect(detectPropertyDefinitionTypes('true', '$feat/$feature/my-feature')).toEqual(PropertyType.Boolean)
             expect(detectPropertyDefinitionTypes('true', '$features/my-feature')).toEqual(PropertyType.Boolean)
             expect(detectPropertyDefinitionTypes('["a","b","c"]', '$active_feature_flags')).toEqual(PropertyType.String)
             expect(detectPropertyDefinitionTypes(12, 'feature_flag')).toEqual(PropertyType.Numeric)


### PR DESCRIPTION
## Problem

Flag event properties can send 'false', even when they're multivariate. By default always consider flag properties to be strings.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
