### PR TITLE
chore(data-warehouse): add exception msg

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -121,11 +121,14 @@ class QueryViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             self.handle_column_ch_error(e)
             raise ValidationError("Error loading data")
 
-    def handle_column_ch_error(self, error: Exception):
-        match = re.search(r"There's no column.*in table", error.message)
-        if match:
-            # TODO: remove once we support all column types
-            raise ValidationError(match.group(0) + ". Note: While in beta, not all column types may be fully supported")
+    def handle_column_ch_error(self, error):
+        if error.message:
+            match = re.search(r"There's no column.*in table", error.message)
+            if match:
+                # TODO: remove once we support all column types
+                raise ValidationError(
+                    match.group(0) + ". Note: While in beta, not all column types may be fully supported"
+                )
         return
 
     def _tag_client_query_id(self, query_id: str | None):

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -119,7 +119,7 @@ class QueryViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             raise ValidationError(str(e), e.code_name)
         except Exception as e:
             self.handle_column_ch_error(e)
-            raise ValidationError("Error loading data")
+            raise e
 
     def handle_column_ch_error(self, error):
         if error.message:

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -125,9 +125,7 @@ class QueryViewSet(StructuredViewSetMixin, viewsets.ViewSet):
         match = re.search(r"There's no column.*in table", error.message)
         if match:
             # TODO: remove once we support all column types
-            raise ValidationError(
-                match.group(0) + "\n Note: While in beta, not all column types may be fully supported"
-            )
+            raise ValidationError(match.group(0) + ". Note: While in beta, not all column types may be fully supported")
         return
 
     def _tag_client_query_id(self, query_id: str | None):

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -32,6 +32,8 @@ from posthog.rate_limit import TeamRateThrottle
 from posthog.schema import EventsQuery, HogQLQuery, RecentPerformancePageViewNode, HogQLMetadata
 from posthog.utils import relative_date_parse
 
+import re
+
 
 class QueryThrottle(TeamRateThrottle):
     scope = "query"
@@ -115,6 +117,18 @@ class QueryViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             raise ValidationError(str(e))
         except ExposedCHQueryError as e:
             raise ValidationError(str(e), e.code_name)
+        except Exception as e:
+            self.handle_column_ch_error(e)
+            raise ValidationError("Error loading data")
+
+    def handle_column_ch_error(self, error: Exception):
+        match = re.search(r"There's no column.*in table", error.message)
+        if match:
+            # TODO: remove once we support all column types
+            raise ValidationError(
+                match.group(0) + "\n Note: While in beta, not all column types may be fully supported"
+            )
+        return
 
     def _tag_client_query_id(self, query_id: str | None):
         if query_id is not None:


### PR DESCRIPTION
## Problem

- columns not being read from parquet files cause ambiguous message. Context: the parquet file seems to be fine and the data can be read normally using pandas but clickhouse is refusing to query some columns. Needs further investigation but doesn't seem to be a blocker for initial testing purposes

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add clear column error message and note for now

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
