### PR TITLE
feat: leave some kafka headroom when packing messages

### DIFF
--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -1,4 +1,5 @@
 import json
+import math
 import random
 import string
 from datetime import datetime
@@ -730,7 +731,8 @@ def test_new_ingestion_groups_using_snapshot_bytes_if_possible(raw_snapshot_even
 
     assert [event["properties"]["$snapshot_bytes"] for event in events] == [106, 1072, 159]
 
-    assert list(mock_capture_flow(events, max_size_bytes=106 + 1072 + 50)[1]) == [
+    space_with_headroom = math.ceil((106 + 1072 + 50) * 1.05)
+    assert list(mock_capture_flow(events, max_size_bytes=space_with_headroom)[1]) == [
         {
             "event": "$snapshot_items",
             "properties": {

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -152,6 +152,8 @@ def preprocess_replay_events(events: List[Event], max_size_bytes=1024 * 1024) ->
     if len(events) == 0:
         return []
 
+    size_with_headroom = max_size_bytes * 0.95  # Leave 5% headroom
+
     distinct_id = events[0]["properties"]["distinct_id"]
     session_id = events[0]["properties"]["$session_id"]
     window_id = events[0]["properties"].get("$window_id")
@@ -178,7 +180,7 @@ def preprocess_replay_events(events: List[Event], max_size_bytes=1024 * 1024) ->
             additional_bytes = event["properties"]["$snapshot_bytes"]
             additional_data = flatten([event["properties"]["$snapshot_data"]], max_depth=1)
 
-            if not current_event or current_event_size + additional_bytes > max_size_bytes:
+            if not current_event or current_event_size + additional_bytes > size_with_headroom:
                 # If adding the new data would put us over the max size, yield the current event and start a new one
                 if current_event:
                     yield current_event
@@ -194,7 +196,7 @@ def preprocess_replay_events(events: List[Event], max_size_bytes=1024 * 1024) ->
         snapshot_data_list = list(flatten([event["properties"]["$snapshot_data"] for event in events], max_depth=1))
 
         # 2. Otherwise, try and group all the events if they are small enough
-        if byte_size_dict(snapshot_data_list) < max_size_bytes:
+        if byte_size_dict(snapshot_data_list) < size_with_headroom:
             event = new_event(snapshot_data_list)
             yield event
         else:
@@ -214,7 +216,7 @@ def preprocess_replay_events(events: List[Event], max_size_bytes=1024 * 1024) ->
                 yield event
 
             # Try and group the rest
-            if byte_size_dict(other_snapshots) < max_size_bytes:
+            if byte_size_dict(other_snapshots) < size_with_headroom:
                 event = new_event(other_snapshots)
                 yield event
             else:

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -195,7 +195,7 @@ KAFKA_BASE64_KEYS = get_from_env("KAFKA_BASE64_KEYS", False, type_cast=str_to_bo
 
 SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES: int = get_from_env(
     "SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES",
-    1024 * 1024 * 0.95,  # a little less than 1MB to account for overhead
+    1024 * 1024,  # 1MB
     type_cast=int,
 )
 


### PR DESCRIPTION
## Problem

When we're writing kafka messages we intermittently see `kafka.errors.MessageSizeTooLargeError` which are very close to the limit.

We assume this means that sometimes we can pack very close to the limit and some extra data is added (e.g. headers 🤷‍♀️) that push us over the limit

## Changes

Always give 5% headroom

## How did you test this code?

🙈 
