### PR TITLE
feat: Swap to search icon for recordings

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -16,6 +16,7 @@ export interface LemonSwitchProps {
     size?: 'small' | 'medium'
     icon?: React.ReactElement | null
     handleContent?: React.ReactElement | null
+    'aria-label'?: string
 }
 
 /** Counter used for collision-less automatic switch IDs. */
@@ -33,10 +34,16 @@ export function LemonSwitch({
     labelClassName,
     icon,
     'data-attr': dataAttr,
+    'aria-label': ariaLabel,
     handleContent,
 }: LemonSwitchProps): JSX.Element {
     const id = useMemo(() => rawId || `lemon-switch-${switchCounter++}`, [rawId])
     const [isActive, setIsActive] = useState(false)
+
+    const conditionalProps = {}
+    if (ariaLabel) {
+        conditionalProps['aria-label'] = ariaLabel
+    }
 
     return (
         <div
@@ -68,6 +75,7 @@ export function LemonSwitch({
                 onMouseOut={() => setIsActive(false)}
                 data-attr={dataAttr}
                 disabled={disabled}
+                {...conditionalProps}
             >
                 <div className="LemonSwitch__slider" />
                 <div className="LemonSwitch__handle">{handleContent}</div>

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -12,7 +12,7 @@ import './SessionRecordingsPlaylist.scss'
 import { SessionRecordingPlayer } from '../player/SessionRecordingPlayer'
 import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
 import { LemonButton, LemonDivider, LemonSwitch } from '@posthog/lemon-ui'
-import { IconFilter, IconPause, IconPlay, IconSettings, IconWithCount } from 'lib/lemon-ui/icons'
+import { IconFilter, IconMagnifier, IconPause, IconPlay, IconSettings, IconWithCount } from 'lib/lemon-ui/icons'
 import { SessionRecordingsList } from './SessionRecordingsList'
 import clsx from 'clsx'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
@@ -134,18 +134,6 @@ export function RecordingsLists({
                                 </Tooltip>
                             ) : null}
 
-                            <LemonButton
-                                noPadding
-                                status={showFilters ? 'primary' : 'primary-alt'}
-                                type={showFilters ? 'primary' : 'tertiary'}
-                                icon={
-                                    <IconWithCount count={totalFiltersCount}>
-                                        <IconFilter />
-                                    </IconWithCount>
-                                }
-                                onClick={() => setShowFilters(!showFilters)}
-                            />
-
                             <Tooltip
                                 title={
                                     <div className="text-center">
@@ -174,6 +162,19 @@ export function RecordingsLists({
                                     />
                                 </span>
                             </Tooltip>
+
+                            <LemonButton
+                                size="small"
+                                status={showFilters ? 'primary' : 'primary-alt'}
+                                type={showFilters ? 'tertiary' : 'tertiary'}
+                                active={showFilters}
+                                icon={
+                                    <IconWithCount count={totalFiltersCount}>
+                                        <IconMagnifier />
+                                    </IconWithCount>
+                                }
+                                onClick={() => setShowFilters(!showFilters)}
+                            />
                         </>
                     }
                     subheader={

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -12,7 +12,7 @@ import './SessionRecordingsPlaylist.scss'
 import { SessionRecordingPlayer } from '../player/SessionRecordingPlayer'
 import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
 import { LemonButton, LemonDivider, LemonSwitch } from '@posthog/lemon-ui'
-import { IconFilter, IconMagnifier, IconPause, IconPlay, IconSettings, IconWithCount } from 'lib/lemon-ui/icons'
+import { IconMagnifier, IconPause, IconPlay, IconSettings, IconWithCount } from 'lib/lemon-ui/icons'
 import { SessionRecordingsList } from './SessionRecordingsList'
 import clsx from 'clsx'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
@@ -294,7 +294,7 @@ export function SessionRecordingsPlaylist(props: SessionRecordingsPlaylistProps)
             <LemonBanner dismissKey="replay-filter-change" type="info" className="mb-2">
                 <b>Filters have moved!</b> You can now find all filters including time and duration by clicking the{' '}
                 <span className="mx-1 text-lg">
-                    <IconFilter />
+                    <IconMagnifier />
                 </span>
                 icon at the top of the list of recordings.
             </LemonBanner>

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -145,6 +145,7 @@ export function RecordingsLists({
                             >
                                 <span>
                                     <LemonSwitch
+                                        aria-label="Autoplay next recording"
                                         checked={!!autoplayDirection}
                                         onChange={toggleAutoplayDirection}
                                         handleContent={
@@ -164,6 +165,7 @@ export function RecordingsLists({
                             </Tooltip>
 
                             <LemonButton
+                                tooltip={'filter recordings'}
                                 size="small"
                                 status={showFilters ? 'primary' : 'primary-alt'}
                                 type={showFilters ? 'tertiary' : 'tertiary'}


### PR DESCRIPTION
## Problem

A few times people didn't seem to recognize the filter icon. I think for the context of recordings a search icon makes way more sense.


## Changes

* Changes it to a search icon and slightly changes the colors

|Before|After|
|----|----|
|<img width="366" alt="Screenshot 2023-06-22 at 18 35 05" src="https://github.com/PostHog/posthog/assets/2536520/aebc8226-8c65-49ee-b92a-f6d6c1a08a3d">|<img width="368" alt="Screenshot 2023-06-22 at 18 33 43" src="https://github.com/PostHog/posthog/assets/2536520/bac47e2a-2d54-4afc-8d59-5796fd5f15bf">|
|<img width="364" alt="Screenshot 2023-06-22 at 18 35 09" src="https://github.com/PostHog/posthog/assets/2536520/40314231-b11a-4996-a85c-21e15deaed5f">|<img width="374" alt="Screenshot 2023-06-22 at 18 33 48" src="https://github.com/PostHog/posthog/assets/2536520/6034cb22-9943-4e79-83ac-56a573c6e975">|



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
