### PR TITLE
fix: minor billing UI fixes

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -115,6 +115,8 @@ export function Billing(): JSX.Element {
         return url
     }
 
+    const upgradeAllProductsLink = getUpgradeAllProductsLink()
+
     return (
         <div ref={ref}>
             {!isOnboarding && (
@@ -245,11 +247,11 @@ export function Billing(): JSX.Element {
 
             <div className="flex justify-between">
                 <h2>Products</h2>
-                {isOnboarding && getUpgradeAllProductsLink() && (
+                {isOnboarding && upgradeAllProductsLink && (
                     <LemonButton
                         type="primary"
                         icon={<IconPlus />}
-                        to={getUpgradeAllProductsLink()}
+                        to={upgradeAllProductsLink}
                         disableClientSideRouting
                     >
                         Upgrade all

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -85,6 +85,7 @@ export function Billing(): JSX.Element {
             return ''
         }
         let url = '/api/billing-v2/activation?products='
+        let productsToUpgrade = ''
         for (const product of products) {
             if (product.subscribed || product.contact_support || product.inclusion_only) {
                 continue
@@ -96,15 +97,18 @@ export function Billing(): JSX.Element {
             if (!upgradePlanKey) {
                 continue
             }
-            url += `${product.type}:${upgradePlanKey},`
+            productsToUpgrade += `${product.type}:${upgradePlanKey},`
             if (product.addons?.length) {
                 for (const addon of product.addons) {
-                    url += `${addon.type}:${addon.plans[0].plan_key},`
+                    productsToUpgrade += `${addon.type}:${addon.plans[0].plan_key},`
                 }
             }
         }
         // remove the trailing comma that will be at the end of the url
-        url = url.slice(0, -1)
+        if (!productsToUpgrade) {
+            return ''
+        }
+        url += productsToUpgrade.slice(0, -1)
         if (redirectPath) {
             url += `&redirect_path=${redirectPath}`
         }
@@ -241,14 +245,14 @@ export function Billing(): JSX.Element {
 
             <div className="flex justify-between">
                 <h2>Products</h2>
-                {isOnboarding && (
+                {isOnboarding && getUpgradeAllProductsLink() && (
                     <LemonButton
                         type="primary"
                         icon={<IconPlus />}
                         to={getUpgradeAllProductsLink()}
                         disableClientSideRouting
                     >
-                        Upgrade All
+                        Upgrade all
                     </LemonButton>
                 )}
             </div>

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -319,7 +319,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                         type="primary"
                                         to="mailto:sales@posthog.com?subject=Enterprise%20plan%20request"
                                     >
-                                        Contact support
+                                        Get in touch
                                     </LemonButton>
                                 </>
                             ) : (

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -535,45 +535,53 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                             <h4 className={`${product.subscribed ? 'text-success-dark' : 'text-warning-dark'}`}>
                                 You're on the {product.subscribed ? 'paid' : 'free'} plan for {product.name}.
                             </h4>
-                            <p className="ml-0 max-w-200">
-                                {product.subscribed ? 'You now' : 'Upgrade to'} get sweet features such as:
-                            </p>
-                            <div>
-                                {additionalFeaturesOnUpgradedPlan?.map((feature, i) => {
-                                    return (
-                                        i < 3 && (
+                            {additionalFeaturesOnUpgradedPlan?.length > 0 ? (
+                                <>
+                                    <p className="ml-0 max-w-200">
+                                        {product.subscribed ? 'You now' : 'Upgrade to'} get sweet features such as:
+                                    </p>
+                                    <div>
+                                        {additionalFeaturesOnUpgradedPlan?.map((feature, i) => {
+                                            return (
+                                                i < 3 && (
+                                                    <div className="flex gap-x-2 items-center mb-2">
+                                                        <IconCheckCircleOutline className="text-success" />
+                                                        <Tooltip key={feature.key} title={feature.description}>
+                                                            <b>{feature.name} </b>
+                                                        </Tooltip>
+                                                    </div>
+                                                )
+                                            )
+                                        })}
+                                        {!billing?.has_active_subscription && (
                                             <div className="flex gap-x-2 items-center mb-2">
                                                 <IconCheckCircleOutline className="text-success" />
-                                                <Tooltip key={feature.key} title={feature.description}>
-                                                    <b>{feature.name} </b>
+                                                <Tooltip
+                                                    title={
+                                                        'Multiple projects, Feature flags, Experiments, Integrations, Apps, and more'
+                                                    }
+                                                >
+                                                    <b>Upgraded platform features</b>
                                                 </Tooltip>
                                             </div>
-                                        )
-                                    )
-                                })}
-                                {!billing?.has_active_subscription && (
-                                    <div className="flex gap-x-2 items-center mb-2">
-                                        <IconCheckCircleOutline className="text-success" />
-                                        <Tooltip
-                                            title={
-                                                'Multiple projects, Feature flags, Experiments, Integrations, Apps, and more'
-                                            }
-                                        >
-                                            <b>Upgraded platform features</b>
-                                        </Tooltip>
+                                        )}
+                                        <div className="flex gap-x-2 items-center mb-2">
+                                            <IconCheckCircleOutline className="text-success" />
+                                            {product.subscribed ? (
+                                                <b>And more</b>
+                                            ) : (
+                                                <Link onClick={toggleIsPlanComparisonModalOpen}>
+                                                    <b>And more...</b>
+                                                </Link>
+                                            )}
+                                        </div>
                                     </div>
-                                )}
-                                <div className="flex gap-x-2 items-center mb-2">
-                                    <IconCheckCircleOutline className="text-success" />
-                                    {product.subscribed ? (
-                                        <b>And more</b>
-                                    ) : (
-                                        <Link onClick={toggleIsPlanComparisonModalOpen}>
-                                            <b>And more...</b>
-                                        </Link>
-                                    )}
-                                </div>
-                            </div>
+                                </>
+                            ) : (
+                                <p className="ml-0 max-w-200">
+                                    You've got access to all the features we offer for {product.name}.
+                                </p>
+                            )}
                             {upgradePlan?.tiers?.[0].unit_amount_usd &&
                                 parseInt(upgradePlan?.tiers?.[0].unit_amount_usd) === 0 && (
                                     <p className="ml-0 mb-0 mt-4">


### PR DESCRIPTION
## Problem

@Twixes found some confusing UI and bugs in the billing ingestion screen.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- For Enterprise plans, Contact support -> Get in touch
- Only show the Upgrade All button if there are still more plans to upgrade to
- If someone is on a non-default plan, the billing response won't have `plans` data, so we don't know the features they have. While this is probably a more involved fix in the billing response, for now we can just say "you get all the features yo"

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
