### PR TITLE
fix: don't let idle partitions get stuck in the blob ingester

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -67,7 +67,9 @@ export const flushOnAgePredicate = (
 ) => {
     return (sessionStartTimestamp: number): { shouldFlush: boolean; extraLogContext: Record<string, any> } => {
         const bufferAge = referenceNow - sessionStartTimestamp
-        const shouldFlush = referenceNowFlushAttemptCount > 5 || bufferAge > flushThresholdSeconds
+        // for now hardcode this threshold. At 30 seconds per flush, this is 15 minutes of trying to flush and failing
+        const tooManyAttempts = referenceNowFlushAttemptCount > 30
+        const shouldFlush = tooManyAttempts || bufferAge > flushThresholdSeconds
 
         const extraLogContext = {
             referenceTime: referenceNow,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/flush-on-age-predicate.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/flush-on-age-predicate.test.ts
@@ -1,0 +1,26 @@
+import { flushOnAgePredicate } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-blob-consumer'
+
+describe('flush on age predicate', () => {
+    it.each([
+        ['copes when times are back to front', 100, 100, 0, 201, false, -101],
+        ['does not flush exactly on threshold', 200, 100, 0, 100, false, 100],
+        ['flushes when past threshold', 200, 100, 0, 99, true, 101],
+        ['flushes when not past threshold but attempt count is too high', 200, 100, 6, 199, true, 1],
+    ])(
+        'flush predicate behaves as expected: %s',
+        (
+            _description,
+            referenceNow,
+            flushThreshold,
+            referenceNowFlushAttemptCount,
+            sessionStartTimestamp,
+            expectedFlush,
+            expectedBufferAge
+        ) => {
+            const predicate = flushOnAgePredicate(referenceNow, flushThreshold, referenceNowFlushAttemptCount)
+            const result = predicate(sessionStartTimestamp)
+            expect(result.shouldFlush).toEqual(expectedFlush)
+            expect(result.extraLogContext.bufferAge).toEqual(expectedBufferAge)
+        }
+    )
+})

--- a/plugin-server/tests/main/ingestion-queues/session-recording/flush-on-age-predicate.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/flush-on-age-predicate.test.ts
@@ -5,7 +5,8 @@ describe('flush on age predicate', () => {
         ['copes when times are back to front', 100, 100, 0, 201, false, -101],
         ['does not flush exactly on threshold', 200, 100, 0, 100, false, 100],
         ['flushes when past threshold', 200, 100, 0, 99, true, 101],
-        ['flushes when not past threshold but attempt count is too high', 200, 100, 6, 199, true, 1],
+        ['flushes when not past threshold and attempt count is not yet too high', 200, 100, 30, 199, false, 1],
+        ['flushes when not past threshold but attempt count is too high', 200, 100, 31, 199, true, 1],
     ])(
         'flush predicate behaves as expected: %s',
         (


### PR DESCRIPTION
## Problem

We sometimes observe the blob ingester get stuck. A partition does not receive a message and so, for a session which is not big enough to flush on size, we do not flush on age as quickly as we would like.

## Changes

The blob consumer already tracks the "partition now" for each partition. Now whenever that changes an attempt count for that reference now is reset.

Each time the reference now is used as a marker to determine if a session should flush based on age the attempt count is incremented. Over a certain number of attempts the session manager is instructed to always flush

In order to simplify responsibilities the blob consumer constructs a predicate which is passed to the session manager. The session manager passes its session start to the predicate and receives a true/false response.

This made testing way simpler. And, less importantly, opens the way to pass different predicates in different circumstances

## How did you test this code?

Developer tests
