### PR TITLE
fix(hogql): null handling with == and != comparisons

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -352,7 +352,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
-             AND (and(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%example%'), notEquals('bla', 'a%sd')))
+             AND (and(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%example%'), 1))
            GROUP BY pdi.person_id)
         GROUP BY start_of_period,
                  status)
@@ -426,7 +426,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
-             AND (and(like(nullIf(nullIf(events.`mat_$current_url`, ''), 'null'), '%example%'), notEquals('bla', 'a%sd')))
+             AND (and(like(nullIf(nullIf(events.`mat_$current_url`, ''), 'null'), '%example%'), 1))
            GROUP BY pdi.person_id)
         GROUP BY start_of_period,
                  status)

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -24,7 +24,7 @@
        AND event IN ['user did things', 'user signed up']
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-       AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), notEquals('bla', 'a%sd')))
+       AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 1))
      GROUP BY value
      ORDER BY count DESC, value DESC
      LIMIT 25
@@ -101,7 +101,7 @@
                       AND event IN ['user did things', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
                       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-                      AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), notEquals('bla', 'a%sd')))
+                      AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 1))
                       AND (step_0 = 1
                            OR step_1 = 1) )))
            WHERE step_0 = 1 ))
@@ -171,7 +171,7 @@
                    AND event IN ['user did things', 'user signed up']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-                   AND ((and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), notEquals('bla', 'a%sd')))
+                   AND ((and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 1))
                         AND (like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%')))
                    AND (step_0 = 1
                         OR step_1 = 1) ))
@@ -218,11 +218,11 @@
                         pdi.person_id as person_id,
                         person.person_props as person_props ,
                         if(event = 'user signed up'
-                           AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), notEquals('bla', 'a%sd'))
+                           AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 1)
                                 AND like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%')), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'user did things'
-                           AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), notEquals('bla', 'a%sd'))
+                           AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 1)
                                 AND like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%')), 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
@@ -441,7 +441,7 @@
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-          AND ((and(greater(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), notEquals('bla', 'a%sd')))
+          AND ((and(greater(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 1))
                AND (like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%')))
         GROUP BY date)
      GROUP BY day_start
@@ -509,7 +509,7 @@
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-          AND ((and(greater(toInt64OrNull(nullIf(nullIf(events.mat_int_value, ''), 'null')), 10), notEquals('bla', 'a%sd')))
+          AND ((and(greater(toInt64OrNull(nullIf(nullIf(events.mat_int_value, ''), 'null')), 10), 1))
                AND (like(nullIf(nullIf(pmat_fish, ''), 'null'), '%fish%')))
         GROUP BY date)
      GROUP BY day_start
@@ -551,7 +551,7 @@
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-          AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), notEquals('bla', 'a%sd'))
+          AND (and(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 1)
                AND like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'))
         GROUP BY date)
      GROUP BY day_start
@@ -593,7 +593,7 @@
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
-          AND (and(less(toInt64OrNull(nullIf(nullIf(events.mat_int_value, ''), 'null')), 10), notEquals('bla', 'a%sd'))
+          AND (and(less(toInt64OrNull(nullIf(nullIf(events.mat_int_value, ''), 'null')), 10), 1)
                AND like(nullIf(nullIf(pmat_fish, ''), 'null'), '%fish%'))
         GROUP BY date)
      GROUP BY day_start

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -7,7 +7,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -23,7 +23,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -39,7 +39,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', ''), '%/%'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', ''), '%/%'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -55,7 +55,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -71,7 +71,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -87,7 +87,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ilike(nullIf(nullIf(events.mat_path, ''), 'null'), '%/%'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ilike(nullIf(nullIf(events.mat_path, ''), 'null'), '%/%'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -99,7 +99,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2023-01-12 12:14:05.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2023-01-12 12:14:05.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -111,7 +111,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-12 00:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-12 00:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -123,7 +123,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-01 00:00:00.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2019-01-12 00:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-01 00:00:00.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2019-01-12 00:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -137,7 +137,7 @@
          events.distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
   FROM events
-  WHERE equals(events.team_id, 2)
+  WHERE ifNull(equals(events.team_id, 2), 0)
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60
@@ -150,7 +150,7 @@
          events.distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null')
   FROM events
-  WHERE equals(events.team_id, 2)
+  WHERE ifNull(equals(events.team_id, 2), 0)
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60
@@ -165,7 +165,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -181,7 +181,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals('a%sd', 'foo'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -197,7 +197,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals('a%sd', 'a%sd'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -213,7 +213,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -229,7 +229,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -245,7 +245,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals('a%sd', 'foo'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -261,7 +261,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals('a%sd', 'a%sd'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -277,7 +277,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -297,17 +297,17 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id AS distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 2)
+     WHERE ifNull(equals(person_distinct_id2.team_id, 2), 0)
      GROUP BY person_distinct_id2.distinct_id
-     HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+     HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', ''), person.version) AS properties___email,
             person.id AS id
      FROM person
-     WHERE equals(person.team_id, 2)
+     WHERE ifNull(equals(person.team_id, 2), 0)
      GROUP BY person.id
-     HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(events.team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ifNull(equals(events__pdi__person.properties___email, 'tom@posthog.com'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -327,17 +327,17 @@
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
             person_distinct_id2.distinct_id AS distinct_id
      FROM person_distinct_id2
-     WHERE equals(person_distinct_id2.team_id, 2)
+     WHERE ifNull(equals(person_distinct_id2.team_id, 2), 0)
      GROUP BY person_distinct_id2.distinct_id
-     HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+     HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
   INNER JOIN
     (SELECT argMax(nullIf(nullIf(person.pmat_email, ''), 'null'), person.version) AS properties___email,
             person.id AS id
      FROM person
-     WHERE equals(person.team_id, 2)
+     WHERE ifNull(equals(person.team_id, 2), 0)
      GROUP BY person.id
-     HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(events.team_id, 2), equals(events__pdi__person.properties___email, 'tom@posthog.com'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
+  WHERE and(ifNull(equals(events.team_id, 2), 0), ifNull(equals(events__pdi__person.properties___email, 'tom@posthog.com'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -350,7 +350,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
   ORDER BY count() DESC
   LIMIT 101
@@ -364,7 +364,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
   HAVING and(greater(count(), 1))
   ORDER BY count() DESC
@@ -379,7 +379,7 @@
   SELECT nullIf(nullIf(events.mat_key, ''), 'null'),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
   ORDER BY count() DESC
   LIMIT 101
@@ -393,7 +393,7 @@
   SELECT nullIf(nullIf(events.mat_key, ''), 'null'),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
   HAVING and(greater(count(), 1))
   ORDER BY count() DESC
@@ -409,7 +409,7 @@
          events.distinct_id,
          events.distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -424,7 +424,7 @@
          events.distinct_id,
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -437,7 +437,7 @@
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   ORDER BY tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -450,7 +450,7 @@
   SELECT count(),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   GROUP BY events.event
   ORDER BY count() DESC
   LIMIT 101
@@ -464,7 +464,7 @@
   SELECT count(),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), or(equals(events.event, 'sign up'), like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), '%val2')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
+  WHERE and(ifNull(equals(events.team_id, 2), 0), or(ifNull(equals(events.event, 'sign up'), 0), like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), '%val2')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')))
   GROUP BY events.event
   ORDER BY count() DESC, events.event ASC
   LIMIT 101

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -398,6 +398,10 @@ class Call(Expr):
     distinct: Optional[bool] = None
 
 
+class JoinConstraint(Expr):
+    expr: Expr
+
+
 class JoinExpr(Expr):
     # :TRICKY: When adding new fields, make sure they're handled in visitor.py and resolver.py
     type: Optional[TableOrSelectType]
@@ -406,7 +410,7 @@ class JoinExpr(Expr):
     table: Optional[Union["SelectQuery", "SelectUnionQuery", Field]] = None
     alias: Optional[str] = None
     table_final: Optional[bool] = None
-    constraint: Optional[Expr] = None
+    constraint: Optional["JoinConstraint"] = None
     next_join: Optional["JoinExpr"] = None
     sample: Optional["SampleExpr"] = None
 

--- a/posthog/hogql/database/schema/person_distinct_ids.py
+++ b/posthog/hogql/database/schema/person_distinct_ids.py
@@ -42,10 +42,12 @@ def join_with_person_distinct_ids_table(from_table: str, to_table: str, requeste
     join_expr = ast.JoinExpr(table=select_from_person_distinct_ids_table(requested_fields))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table
-    join_expr.constraint = ast.CompareOperation(
-        op=ast.CompareOperationOp.Eq,
-        left=ast.Field(chain=[from_table, "distinct_id"]),
-        right=ast.Field(chain=[to_table, "distinct_id"]),
+    join_expr.constraint = ast.JoinConstraint(
+        expr=ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=[from_table, "distinct_id"]),
+            right=ast.Field(chain=[to_table, "distinct_id"]),
+        )
     )
     return join_expr
 

--- a/posthog/hogql/database/schema/person_overrides.py
+++ b/posthog/hogql/database/schema/person_overrides.py
@@ -39,10 +39,12 @@ def join_with_person_overrides_table(from_table: str, to_table: str, requested_f
     join_expr = ast.JoinExpr(table=select_from_person_overrides_table(requested_fields))
     join_expr.join_type = "LEFT OUTER JOIN"
     join_expr.alias = to_table
-    join_expr.constraint = ast.CompareOperation(
-        op=ast.CompareOperationOp.Eq,
-        left=ast.Field(chain=[from_table, "person_id"]),
-        right=ast.Field(chain=[to_table, "old_person_id"]),
+    join_expr.constraint = ast.JoinConstraint(
+        expr=ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=[from_table, "person_id"]),
+            right=ast.Field(chain=[to_table, "old_person_id"]),
+        )
     )
     return join_expr
 

--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -40,10 +40,12 @@ def join_with_persons_table(from_table: str, to_table: str, requested_fields: Di
     join_expr = ast.JoinExpr(table=select_from_persons_table(requested_fields))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table
-    join_expr.constraint = ast.CompareOperation(
-        op=ast.CompareOperationOp.Eq,
-        left=ast.Field(chain=[from_table, "person_id"]),
-        right=ast.Field(chain=[to_table, "id"]),
+    join_expr.constraint = ast.JoinConstraint(
+        expr=ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=[from_table, "person_id"]),
+            right=ast.Field(chain=[to_table, "id"]),
+        )
     )
     return join_expr
 

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -580,6 +580,12 @@
               "key": "version",
               "type": "integer"
           }
+      ],
+      "whatever": [
+          {
+              "key": "id",
+              "type": "string"
+          }
       ]
   }
   '
@@ -1160,6 +1166,12 @@
           {
               "key": "version",
               "type": "integer"
+          }
+      ],
+      "whatever": [
+          {
+              "key": "id",
+              "type": "string"
           }
       ]
   }

--- a/posthog/hogql/functions/test/test_cohort.py
+++ b/posthog/hogql/functions/test/test_cohort.py
@@ -14,6 +14,8 @@ not_call = lambda x: ast.Call(name="not", args=[x])
 
 
 class TestCohort(BaseTest):
+    maxDiff = None
+
     def _create_random_events(self) -> str:
         random_uuid = str(UUIDT())
         _create_person(
@@ -39,7 +41,7 @@ class TestCohort(BaseTest):
         )
         self.assertEqual(
             response.clickhouse,
-            f"SELECT events.event FROM events WHERE and(equals(events.team_id, {self.team.pk}), in(events.person_id, (SELECT cohortpeople.person_id FROM cohortpeople WHERE and(equals(cohortpeople.team_id, {self.team.pk}), equals(cohortpeople.cohort_id, {cohort.pk})) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version HAVING greater(sum(cohortpeople.sign), 0))), equals(events.event, %(hogql_val_0)s)) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+            f"SELECT events.event FROM events WHERE and(ifNull(equals(events.team_id, {self.team.pk}), 0), in(events.person_id, (SELECT cohortpeople.person_id FROM cohortpeople WHERE and(ifNull(equals(cohortpeople.team_id, {self.team.pk}), 0), ifNull(equals(cohortpeople.cohort_id, {cohort.pk}), 0)) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version HAVING greater(sum(cohortpeople.sign), 0))), ifNull(equals(events.event, %(hogql_val_0)s), 0)) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
         )
         self.assertEqual(
             response.hogql,
@@ -60,7 +62,7 @@ class TestCohort(BaseTest):
         )
         self.assertEqual(
             response.clickhouse,
-            f"SELECT events.event FROM events WHERE and(equals(events.team_id, {self.team.pk}), in(events.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(equals(person_static_cohort.team_id, {self.team.pk}), equals(person_static_cohort.cohort_id, {cohort.pk}))))) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+            f"SELECT events.event FROM events WHERE and(ifNull(equals(events.team_id, {self.team.pk}), 0), in(events.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(ifNull(equals(person_static_cohort.team_id, {self.team.pk}), 0), ifNull(equals(person_static_cohort.cohort_id, {cohort.pk}), 0))))) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
         )
         self.assertEqual(
             response.hogql,
@@ -80,7 +82,7 @@ class TestCohort(BaseTest):
         )
         self.assertEqual(
             response.clickhouse,
-            f"SELECT events.event FROM events WHERE and(equals(events.team_id, {self.team.pk}), in(events.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(equals(person_static_cohort.team_id, {self.team.pk}), equals(person_static_cohort.cohort_id, {cohort.pk}))))) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+            f"SELECT events.event FROM events WHERE and(ifNull(equals(events.team_id, {self.team.pk}), 0), in(events.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(ifNull(equals(person_static_cohort.team_id, {self.team.pk}), 0), ifNull(equals(person_static_cohort.cohort_id, {cohort.pk}), 0))))) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
         )
         self.assertEqual(
             response.hogql,

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -275,7 +275,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         column_expr_list = self.visit(ctx.columnExprList())
         if len(column_expr_list) != 1:
             raise NotImplementedException(f"Unsupported: JOIN ... ON with multiple expressions")
-        return column_expr_list[0]
+        return ast.JoinConstraint(expr=column_expr_list[0])
 
     def visitSampleClause(self, ctx: HogQLParser.SampleClauseContext):
         ratio_expressions = ctx.ratioExpr()

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -348,15 +348,32 @@ class _Printer(Visitor):
         left = self.visit(node.left)
         right = self.visit(node.right)
         if node.op == ast.CompareOperationOp.Eq:
-            if isinstance(node.right, ast.Constant) and node.right.value is None:
-                return f"isNull({left})"
+            if isinstance(node.left, ast.Constant) and isinstance(node.right, ast.Constant):
+                return "1" if node.left.value == node.right.value else "0"
+            elif isinstance(node.right, ast.Constant):
+                if node.right.value is None:
+                    return f"isNull({left})"
+                return f"ifNull(equals({left}, {right}), 0)"
+            elif isinstance(node.left, ast.Constant) and node.left.value is None:
+                if node.left.value is None:
+                    return f"isNull({right})"
+                return f"ifNull(equals({left}, {right}), 0)"
             else:
-                return f"equals({left}, {right})"
+                return f"ifNull(equals({left}, {right}), isNull({left}) and isNull({right}))"
         elif node.op == ast.CompareOperationOp.NotEq:
-            if isinstance(node.right, ast.Constant) and node.right.value is None:
-                return f"isNotNull({left})"
+            if isinstance(node.left, ast.Constant) and isinstance(node.right, ast.Constant):
+                return "1" if node.left.value != node.right.value else "0"
+            elif isinstance(node.right, ast.Constant):
+                if node.right.value is None:
+                    return f"isNotNull({left})"
+                return f"ifNull(notEquals({left}, {right}), 1)"
+            elif isinstance(node.left, ast.Constant) and node.left.value is None:
+                if node.left.value is None:
+                    return f"isNotNull({right})"
+                return f"ifNull(notEquals({left}, {right}), 1)"
             else:
-                return f"notEquals({left}, {right})"
+                return f"ifNull(notEquals({left}, {right}), isNotNull({left}) or isNotNull({right}))"
+
         elif node.op == ast.CompareOperationOp.Gt:
             return f"greater({left}, {right})"
         elif node.op == ast.CompareOperationOp.GtE:

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -354,7 +354,9 @@ class _Printer(Visitor):
         if node.op == ast.CompareOperationOp.Eq:
             if isinstance(node.left, ast.Constant) and isinstance(node.right, ast.Constant):
                 return "1" if node.left.value == node.right.value else "0"
-            elif self.in_join_on:  # TODO: get this info from the stack (needs clause support)
+            elif (
+                self.in_join_on or self.dialect == "hogql"
+            ):  # TODO: get this info from the stack (needs clause support)
                 return f"equals({left}, {right})"
             elif isinstance(node.right, ast.Constant):
                 if node.right.value is None:
@@ -369,7 +371,9 @@ class _Printer(Visitor):
         elif node.op == ast.CompareOperationOp.NotEq:
             if isinstance(node.left, ast.Constant) and isinstance(node.right, ast.Constant):
                 return "1" if node.left.value != node.right.value else "0"
-            elif self.in_join_on:  # TODO: get this info from the stack (needs clause support)
+            elif (
+                self.in_join_on or self.dialect == "hogql"
+            ):  # TODO: get this info from the stack (needs clause support)
                 return f"notEquals({left}, {right})"
             elif isinstance(node.right, ast.Constant):
                 if node.right.value is None:

--- a/posthog/hogql/test/test_parser.py
+++ b/posthog/hogql/test/test_parser.py
@@ -619,7 +619,7 @@ class TestParser(BaseTest):
                     next_join=ast.JoinExpr(
                         join_type="JOIN",
                         table=ast.Field(chain=["events2"]),
-                        constraint=ast.Constant(value=1),
+                        constraint=ast.JoinConstraint(expr=ast.Constant(value=1)),
                     ),
                 ),
             ),
@@ -633,7 +633,7 @@ class TestParser(BaseTest):
                     next_join=ast.JoinExpr(
                         join_type="LEFT OUTER JOIN",
                         table=ast.Field(chain=["events2"]),
-                        constraint=ast.Constant(value=1),
+                        constraint=ast.JoinConstraint(expr=ast.Constant(value=1)),
                     ),
                 ),
             ),
@@ -647,11 +647,11 @@ class TestParser(BaseTest):
                     next_join=ast.JoinExpr(
                         join_type="LEFT OUTER JOIN",
                         table=ast.Field(chain=["events2"]),
-                        constraint=ast.Constant(value=1),
+                        constraint=ast.JoinConstraint(expr=ast.Constant(value=1)),
                         next_join=ast.JoinExpr(
                             join_type="RIGHT ANY JOIN",
                             table=ast.Field(chain=["events3"]),
-                            constraint=ast.Constant(value=2),
+                            constraint=ast.JoinConstraint(expr=ast.Constant(value=2)),
                         ),
                     ),
                 ),
@@ -687,19 +687,23 @@ class TestParser(BaseTest):
                         join_type="LEFT JOIN",
                         table=ast.Field(chain=["person_distinct_id"]),
                         alias="pdi",
-                        constraint=ast.CompareOperation(
-                            op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=["pdi", "distinct_id"]),
-                            right=ast.Field(chain=["e", "distinct_id"]),
+                        constraint=ast.JoinConstraint(
+                            expr=ast.CompareOperation(
+                                op=ast.CompareOperationOp.Eq,
+                                left=ast.Field(chain=["pdi", "distinct_id"]),
+                                right=ast.Field(chain=["e", "distinct_id"]),
+                            )
                         ),
                         next_join=ast.JoinExpr(
                             join_type="LEFT JOIN",
                             table=ast.Field(chain=["persons"]),
                             alias="p",
-                            constraint=ast.CompareOperation(
-                                op=ast.CompareOperationOp.Eq,
-                                left=ast.Field(chain=["p", "id"]),
-                                right=ast.Field(chain=["pdi", "person_id"]),
+                            constraint=ast.JoinConstraint(
+                                expr=ast.CompareOperation(
+                                    op=ast.CompareOperationOp.Eq,
+                                    left=ast.Field(chain=["p", "id"]),
+                                    right=ast.Field(chain=["pdi", "person_id"]),
+                                )
                             ),
                         ),
                     ),

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1106,3 +1106,38 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 )
             ],
         )
+
+    def test_null_equality(self):
+        expected = [
+            ("null", "!=", "2", 1),
+            ("2", "!=", "null", 1),
+            ("3", "!=", "4", 1),
+            ("3", "!=", "3", 0),
+            ("null", "!=", "null", 0),
+            ("null", "=", "2", 0),
+            ("2", "=", "null", 0),
+            ("3", "=", "4", 0),
+            ("3", "=", "3", 1),
+            ("null", "=", "null", 1),
+        ]
+
+        for (a, op, b, res) in expected:
+            # works when selecting directly
+            query = f"select {a} {op} {b}"
+            response = execute_hogql_query(query, team=self.team)
+            self.assertEqual(response.results, [(res,)], query)
+
+            # works when selecting via a subquery
+            query = f"select a {op} b from (select {a} as a, {b} as b)"
+            response = execute_hogql_query(query, team=self.team)
+            self.assertEqual(response.results, [(res,)], query)
+
+            # works when selecting via a subquery
+            query = f"select {a} {op} b from (select {b} as b)"
+            response = execute_hogql_query(query, team=self.team)
+            self.assertEqual(response.results, [(res,)], query)
+
+            # works when selecting via a subquery
+            query = f"select a {op} {b} from (select {a} as a)"
+            response = execute_hogql_query(query, team=self.team)
+            self.assertEqual(response.results, [(res,)], query)

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -18,6 +18,8 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _
 
 
 class TestQuery(ClickhouseTestMixin, APIBaseTest):
+    maxDiff = None
+
     def _create_random_events(self) -> str:
         random_uuid = str(UUIDT())
         _create_person(
@@ -48,7 +50,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT count(), events.event FROM events WHERE and(equals(events.team_id, {self.team.id}), equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT count(), events.event FROM events WHERE and(ifNull(equals(events.team_id, {self.team.id}), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_1)s), 0)) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -63,7 +65,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT count, event FROM (SELECT count() AS count, events.event FROM events WHERE and(equals(events.team_id, {self.team.id}), equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY events.event) GROUP BY count, event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT count, event FROM (SELECT count() AS count, events.event FROM events WHERE and(ifNull(equals(events.team_id, {self.team.id}), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_1)s), 0)) GROUP BY events.event) GROUP BY count, event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -78,7 +80,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT c.count, c.event FROM (SELECT count(*) AS count, events.event FROM events WHERE and(equals(events.team_id, {self.team.id}), equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_1)s)) GROUP BY events.event) AS c GROUP BY c.count, c.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT c.count, c.event FROM (SELECT count(*) AS count, events.event FROM events WHERE and(ifNull(equals(events.team_id, {self.team.id}), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_1)s), 0)) GROUP BY events.event) AS c GROUP BY c.count, c.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -93,7 +95,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT DISTINCT persons.properties___sneaky_mail FROM (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), person.version) AS properties___sneaky_mail, argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''), person.version) AS properties___random_uuid, person.id AS id FROM person WHERE equals(person.team_id, {self.team.id}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS persons WHERE equals(persons.properties___random_uuid, %(hogql_val_2)s) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT DISTINCT persons.properties___sneaky_mail FROM (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), person.version) AS properties___sneaky_mail, argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''), person.version) AS properties___random_uuid, person.id AS id FROM person WHERE ifNull(equals(person.team_id, {self.team.id}), 0) GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS persons WHERE ifNull(equals(persons.properties___random_uuid, %(hogql_val_2)s), 0) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -107,7 +109,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT DISTINCT person_distinct_ids.person_id, person_distinct_ids.distinct_id FROM (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.id}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS person_distinct_ids LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT DISTINCT person_distinct_ids.person_id, person_distinct_ids.distinct_id FROM (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.id}), 0) GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS person_distinct_ids LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -132,7 +134,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, toTimeZone(e.timestamp, %(hogql_val_0)s), pdi.distinct_id, p.id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(p.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '') FROM events AS e LEFT JOIN person_distinct_id2 AS pdi ON equals(pdi.distinct_id, e.distinct_id) LEFT JOIN person AS p ON equals(p.id, pdi.person_id) WHERE and(equals(p.team_id, {self.team.id}), equals(pdi.team_id, {self.team.id}), equals(e.team_id, {self.team.id})) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT e.event, toTimeZone(e.timestamp, %(hogql_val_0)s), pdi.distinct_id, p.id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(p.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '') FROM events AS e LEFT JOIN person_distinct_id2 AS pdi ON equals(pdi.distinct_id, e.distinct_id) LEFT JOIN person AS p ON equals(p.id, pdi.person_id) WHERE and(ifNull(equals(p.team_id, {self.team.id}), 0), ifNull(equals(pdi.team_id, {self.team.id}), 0), ifNull(equals(e.team_id, {self.team.id}), 0)) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -165,9 +167,9 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT e.event, toTimeZone(e.timestamp, %(hogql_val_0)s), pdi.person_id FROM events AS e INNER JOIN (SELECT person_distinct_id2.distinct_id, "
                 f"argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id FROM person_distinct_id2 WHERE "
-                f"equals(person_distinct_id2.team_id, {self.team.id}) GROUP BY person_distinct_id2.distinct_id HAVING "
-                f"equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS pdi ON "
-                f"equals(e.distinct_id, pdi.distinct_id) WHERE equals(e.team_id, {self.team.id}) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                f"ifNull(equals(person_distinct_id2.team_id, {self.team.id}), 0) GROUP BY person_distinct_id2.distinct_id HAVING "
+                f"ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS pdi ON "
+                f"equals(e.distinct_id, pdi.distinct_id) WHERE ifNull(equals(e.team_id, {self.team.id}), 0) LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -185,7 +187,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT events.event, toTimeZone(events.timestamp, %(hogql_val_0)s), events__pdi.distinct_id, events__pdi.person_id FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT events.event, toTimeZone(events.timestamp, %(hogql_val_0)s), events__pdi.distinct_id, events__pdi.person_id FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -209,7 +211,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, toTimeZone(e.timestamp, %(hogql_val_0)s), e__pdi.distinct_id, e__pdi.person_id FROM events AS e INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT e.event, toTimeZone(e.timestamp, %(hogql_val_0)s), e__pdi.distinct_id, e__pdi.person_id FROM events AS e INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) WHERE ifNull(equals(e.team_id, {self.team.pk}), 0) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(response.results[0][0], "random event")
             self.assertEqual(response.results[0][2], "bla")
@@ -231,9 +233,9 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT pdi.distinct_id, toTimeZone(pdi__person.created_at, %(hogql_val_0)s) FROM person_distinct_id2 AS pdi INNER JOIN (SELECT "
                 f"argMax(person.created_at, person.version) AS created_at, person.id AS id FROM person WHERE "
-                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, "
-                f"person.version), 0)) AS pdi__person ON equals(pdi.person_id, pdi__person.id) WHERE "
-                f"equals(pdi.team_id, {self.team.pk}) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, "
+                f"person.version), 0), 0)) AS pdi__person ON equals(pdi.person_id, pdi__person.id) WHERE "
+                f"ifNull(equals(pdi.team_id, {self.team.pk}), 0) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(response.results[0][0], "bla")
             self.assertEqual(response.results[0][1], datetime.datetime(2020, 1, 10, 0, 0, tzinfo=timezone.utc))
@@ -254,9 +256,9 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT pdi.distinct_id, pdi__person.properties___sneaky_mail FROM person_distinct_id2 AS pdi INNER JOIN "
                 f"(SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), person.version) "
-                f"AS properties___sneaky_mail, person.id AS id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id "
-                f"HAVING equals(argMax(person.is_deleted, person.version), 0)) AS pdi__person ON "
-                f"equals(pdi.person_id, pdi__person.id) WHERE equals(pdi.team_id, {self.team.pk}) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"AS properties___sneaky_mail, person.id AS id FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id "
+                f"HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS pdi__person ON "
+                f"equals(pdi.person_id, pdi__person.id) WHERE ifNull(equals(pdi.team_id, {self.team.pk}), 0) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(response.results[0][0], "bla")
             self.assertEqual(response.results[0][1], "tim@posthog.com")
@@ -273,12 +275,12 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT events.event, toTimeZone(events.timestamp, %(hogql_val_0)s), events__pdi.distinct_id, events__pdi__person.id FROM events "
                 f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
-                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
-                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
-                f"person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
-                f"INNER JOIN (SELECT person.id AS id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING "
-                f"equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON "
-                f"equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10"
+                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, "
+                f"person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
+                f"INNER JOIN (SELECT person.id AS id FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id HAVING "
+                f"ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person ON "
+                f"equals(events__pdi.person_id, events__pdi__person.id) WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10"
                 f" SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
@@ -302,13 +304,13 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT events.event, toTimeZone(events.timestamp, %(hogql_val_1)s), events__pdi.distinct_id, events__pdi__person.properties___sneaky_mail FROM events "
                 f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
-                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
-                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) "
+                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) "
                 f"AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN (SELECT "
                 f"argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), person.version) "
-                f"AS properties___sneaky_mail, person.id AS id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING "
-                f"equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON equals(events__pdi.person_id, "
-                f"events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"AS properties___sneaky_mail, person.id AS id FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id HAVING "
+                f"ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person ON equals(events__pdi.person_id, "
+                f"events__pdi__person.id) WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -330,13 +332,13 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT e.event, toTimeZone(e.timestamp, %(hogql_val_1)s), e__pdi.distinct_id, e__pdi__person.properties___sneaky_mail FROM events AS e "
                 f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
-                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
-                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
-                f"person_distinct_id2.version), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) INNER JOIN "
+                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, "
+                f"person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) INNER JOIN "
                 f"(SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), "
-                f"person.version) AS properties___sneaky_mail, person.id AS id FROM person WHERE equals(person.team_id, {self.team.pk}) "
-                f"GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS e__pdi__person ON "
-                f"equals(e__pdi.person_id, e__pdi__person.id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10"
+                f"person.version) AS properties___sneaky_mail, person.id AS id FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) "
+                f"GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS e__pdi__person ON "
+                f"equals(e__pdi.person_id, e__pdi__person.id) WHERE ifNull(equals(e.team_id, {self.team.pk}), 0) LIMIT 10"
                 f" SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
@@ -359,12 +361,12 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT e.event, toTimeZone(e.timestamp, %(hogql_val_1)s), e__pdi__person.properties___sneaky_mail FROM events AS e INNER JOIN (SELECT "
                 f"argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id "
-                f"FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id "
-                f"HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS e__pdi ON equals(e.distinct_id, "
+                f"FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) GROUP BY person_distinct_id2.distinct_id "
+                f"HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, "
                 f"e__pdi.distinct_id) INNER JOIN (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), "
                 f"'^\"|\"$', ''), person.version) AS properties___sneaky_mail, person.id AS id FROM person WHERE "
-                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
-                f"AS e__pdi__person ON equals(e__pdi.person_id, e__pdi__person.id) WHERE equals(e.team_id, {self.team.pk}) LIMIT 10"
+                f"ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) "
+                f"AS e__pdi__person ON equals(e__pdi.person_id, e__pdi__person.id) WHERE ifNull(equals(e.team_id, {self.team.pk}), 0) LIMIT 10"
                 f" SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
@@ -384,12 +386,12 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             expected = (
                 f"SELECT s__pdi__person.properties___sneaky_mail, count() FROM events AS s INNER JOIN (SELECT argMax(person_distinct_id2.person_id, "
                 f"person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE "
-                f"equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING "
-                f"equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS s__pdi ON "
+                f"ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) GROUP BY person_distinct_id2.distinct_id HAVING "
+                f"ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS s__pdi ON "
                 f"equals(s.distinct_id, s__pdi.distinct_id) INNER JOIN (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, "
                 f"%(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), person.version) AS properties___sneaky_mail, person.id AS id FROM person WHERE "
-                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
-                f"AS s__pdi__person ON equals(s__pdi.person_id, s__pdi__person.id) WHERE equals(s.team_id, {self.team.pk}) "
+                f"ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) "
+                f"AS s__pdi__person ON equals(s__pdi.person_id, s__pdi__person.id) WHERE ifNull(equals(s.team_id, {self.team.pk}), 0) "
                 f"GROUP BY s__pdi__person.properties___sneaky_mail LIMIT 10 SETTINGS readonly=2, max_execution_time=60"
             )
             self.assertEqual(response.clickhouse, expected)
@@ -409,7 +411,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(
                 response.clickhouse,
                 f"SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), "
-                f"count() FROM events AS s WHERE equals(s.team_id, {self.team.pk}) GROUP BY "
+                f"count() FROM events AS s WHERE ifNull(equals(s.team_id, {self.team.pk}), 0) GROUP BY "
                 f"replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '') LIMIT 10"
                 f" SETTINGS readonly=2, max_execution_time=60",
             )
@@ -432,14 +434,14 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 response.clickhouse,
                 f"SELECT events.event, toTimeZone(events.timestamp, %(hogql_val_1)s), events__pdi__person.id, events__pdi__person.properties___sneaky_mail "
                 f"FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
-                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
-                f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, "
-                f"person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
+                f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) "
+                f"GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, "
+                f"person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) "
                 f"INNER JOIN (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), "
                 f"'^\"|\"$', ''), person.version) AS properties___sneaky_mail, person.id AS id FROM person WHERE "
-                f"equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) "
+                f"ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) "
                 f"AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id) "
-                f"WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -460,7 +462,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT events.event, toTimeZone(events.timestamp, %(hogql_val_0)s), events.person_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '') FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT events.event, toTimeZone(events.timestamp, %(hogql_val_0)s), events.person_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '') FROM events WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(
                 response.hogql,
@@ -501,7 +503,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 )
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT events.event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(events.team_id, {self.team.pk}), in(events__pdi.person_id, (SELECT cohortpeople.person_id FROM cohortpeople WHERE and(equals(cohortpeople.team_id, {self.team.pk}), equals(cohortpeople.cohort_id, {cohort.pk})) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version HAVING greater(sum(cohortpeople.sign), 0)))) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                    f"SELECT events.event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(ifNull(equals(events.team_id, {self.team.pk}), 0), in(events__pdi.person_id, (SELECT cohortpeople.person_id FROM cohortpeople WHERE and(ifNull(equals(cohortpeople.team_id, {self.team.pk}), 0), ifNull(equals(cohortpeople.cohort_id, {cohort.pk}), 0)) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version HAVING greater(sum(cohortpeople.sign), 0)))) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
                 )
                 self.assertEqual(response.results, [("$pageview", 2)])
 
@@ -517,9 +519,9 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 )
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT events.event, count(*) FROM events WHERE and(equals(events.team_id, {self.team.pk}), in(events.person_id, "
-                    f"(SELECT cohortpeople.person_id FROM cohortpeople WHERE and(equals(cohortpeople.team_id, {self.team.pk}), "
-                    f"equals(cohortpeople.cohort_id, {cohort.pk})) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, "
+                    f"SELECT events.event, count(*) FROM events WHERE and(ifNull(equals(events.team_id, {self.team.pk}), 0), in(events.person_id, "
+                    f"(SELECT cohortpeople.person_id FROM cohortpeople WHERE and(ifNull(equals(cohortpeople.team_id, {self.team.pk}), 0), "
+                    f"ifNull(equals(cohortpeople.cohort_id, {cohort.pk}), 0)) GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, "
                     f"cohortpeople.version HAVING greater(sum(cohortpeople.sign), 0)))) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
                 )
                 self.assertEqual(response.results, [("$pageview", 2)])
@@ -554,7 +556,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT events.event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(equals(events.team_id, {self.team.pk}), in(events__pdi.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(equals(person_static_cohort.team_id, {self.team.pk}), equals(person_static_cohort.cohort_id, {cohort.pk}))))) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                    f"SELECT events.event, count() FROM events INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) WHERE and(ifNull(equals(events.team_id, {self.team.pk}), 0), in(events__pdi.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(ifNull(equals(person_static_cohort.team_id, {self.team.pk}), 0), ifNull(equals(person_static_cohort.cohort_id, {cohort.pk}), 0))))) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
                 )
 
             with override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=True):
@@ -570,7 +572,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 self.assertEqual(response.results, [("$pageview", 1)])
                 self.assertEqual(
                     response.clickhouse,
-                    f"SELECT events.event, count(*) FROM events WHERE and(equals(events.team_id, {self.team.pk}), in(events.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(equals(person_static_cohort.team_id, {self.team.pk}), equals(person_static_cohort.cohort_id, {cohort.pk}))))) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+                    f"SELECT events.event, count(*) FROM events WHERE and(ifNull(equals(events.team_id, {self.team.pk}), 0), in(events.person_id, (SELECT person_static_cohort.person_id FROM person_static_cohort WHERE and(ifNull(equals(person_static_cohort.team_id, {self.team.pk}), 0), ifNull(equals(person_static_cohort.cohort_id, {cohort.pk}), 0))))) GROUP BY events.event LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
                 )
 
     def test_join_with_property_materialized_session_id(self):
@@ -596,7 +598,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, s.session_id FROM events AS e LEFT JOIN session_recording_events AS s ON equals(s.session_id, nullIf(nullIf(e.`$session_id`, ''), 'null')) WHERE and(equals(s.team_id, {self.team.pk}), equals(e.team_id, {self.team.pk}), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT e.event, s.session_id FROM events AS e LEFT JOIN session_recording_events AS s ON equals(s.session_id, nullIf(nullIf(e.`$session_id`, ''), 'null')) WHERE and(ifNull(equals(s.team_id, {self.team.pk}), 0), ifNull(equals(e.team_id, {self.team.pk}), 0), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(response.results, [("$pageview", "111"), ("$pageview", "111")])
 
@@ -606,7 +608,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, s.session_id FROM session_recording_events AS s LEFT JOIN events AS e ON equals(nullIf(nullIf(e.`$session_id`, ''), 'null'), s.session_id) WHERE and(equals(e.team_id, {self.team.pk}), equals(s.team_id, {self.team.pk}), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT e.event, s.session_id FROM session_recording_events AS s LEFT JOIN events AS e ON equals(nullIf(nullIf(e.`$session_id`, ''), 'null'), s.session_id) WHERE and(ifNull(equals(e.team_id, {self.team.pk}), 0), ifNull(equals(s.team_id, {self.team.pk}), 0), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(response.results, [("$pageview", "111"), ("$pageview", "111")])
 
@@ -633,7 +635,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, s.session_id FROM events AS e LEFT JOIN session_recording_events AS s ON equals(s.session_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')) WHERE and(equals(s.team_id, {self.team.pk}), equals(e.team_id, {self.team.pk}), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT e.event, s.session_id FROM events AS e LEFT JOIN session_recording_events AS s ON equals(s.session_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')) WHERE and(ifNull(equals(s.team_id, {self.team.pk}), 0), ifNull(equals(e.team_id, {self.team.pk}), 0), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(response.results, [("$pageview", "111"), ("$pageview", "111")])
 
@@ -643,7 +645,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(
                 response.clickhouse,
-                f"SELECT e.event, s.session_id FROM session_recording_events AS s LEFT JOIN events AS e ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), s.session_id) WHERE and(equals(e.team_id, {self.team.pk}), equals(s.team_id, {self.team.pk}), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
+                f"SELECT e.event, s.session_id FROM session_recording_events AS s LEFT JOIN events AS e ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), s.session_id) WHERE and(ifNull(equals(e.team_id, {self.team.pk}), 0), ifNull(equals(s.team_id, {self.team.pk}), 0), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''))) LIMIT 10 SETTINGS readonly=2, max_execution_time=60",
             )
             self.assertEqual(response.results, [("$pageview", "111"), ("$pageview", "111")])
 
@@ -700,7 +702,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 f"SELECT col_a, arrayZip((sumMap(g.1, g.2) AS x).1, x.2) AS r FROM "
                 f"(SELECT col_a, groupArray(tuple(col_b, col_c)) AS g FROM "
                 f"(SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '') AS col_a, "
-                f"events.event AS col_b, count() AS col_c FROM events WHERE equals(events.team_id, {self.team.pk}) "
+                f"events.event AS col_b, count() AS col_c FROM events WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) "
                 f"GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''), events.event) "
                 f"GROUP BY col_a) "
                 f"GROUP BY col_a ORDER BY col_a ASC LIMIT 100 "
@@ -966,7 +968,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 f"(SELECT PIVOT_FUNCTION_1.col_a, arrayZip((sumMap(PIVOT_FUNCTION_1.g.1, PIVOT_FUNCTION_1.g.2) AS x).1, x.2) AS r "
                 f"FROM (SELECT PIVOT_TABLE_COL_ABC.col_a, groupArray(tuple(PIVOT_TABLE_COL_ABC.col_b, PIVOT_TABLE_COL_ABC.col_c)) AS g "
                 f"FROM (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '') "
-                f"AS col_a, events.event AS col_b, count() AS col_c FROM events WHERE equals(events.team_id, {self.team.pk}) "
+                f"AS col_a, events.event AS col_b, count() AS col_c FROM events WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) "
                 f"GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), "
                 f"'^\"|\"$', ''), events.event) AS PIVOT_TABLE_COL_ABC GROUP BY PIVOT_TABLE_COL_ABC.col_a) AS PIVOT_FUNCTION_1 "
                 f"GROUP BY PIVOT_FUNCTION_1.col_a) AS PIVOT_FUNCTION_2 ORDER BY PIVOT_FUNCTION_2.col_a ASC "
@@ -1012,7 +1014,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 f"(SELECT PIVOT_FUNCTION_1.col_a, arrayZip((sumMap(PIVOT_FUNCTION_1.g.1, PIVOT_FUNCTION_1.g.2) AS x).1, x.2) AS r FROM "
                 f"(SELECT PIVOT_TABLE_COL_ABC.col_a, groupArray(tuple(PIVOT_TABLE_COL_ABC.col_b, PIVOT_TABLE_COL_ABC.col_c)) AS g FROM "
                 f"(SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '') AS col_a, "
-                f"events.event AS col_b, count() AS col_c FROM events WHERE equals(events.team_id, {self.team.pk}) "
+                f"events.event AS col_b, count() AS col_c FROM events WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) "
                 f"GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''), "
                 f"events.event) AS PIVOT_TABLE_COL_ABC GROUP BY PIVOT_TABLE_COL_ABC.col_a) AS PIVOT_FUNCTION_1 "
                 f"GROUP BY PIVOT_FUNCTION_1.col_a) AS PIVOT_FUNCTION_2) AS final ORDER BY final.col_a ASC LIMIT 100 "

--- a/posthog/hogql/test/test_visitor.py
+++ b/posthog/hogql/test/test_visitor.py
@@ -76,10 +76,12 @@ class TestVisitor(BaseTest):
                         next_join=ast.JoinExpr(
                             join_type="INNER",
                             table=ast.Field(chain=["f"]),
-                            constraint=ast.CompareOperation(
-                                op=ast.CompareOperationOp.Eq,
-                                left=ast.Field(chain=["d"]),
-                                right=ast.Field(chain=["e"]),
+                            constraint=ast.JoinConstraint(
+                                expr=ast.CompareOperation(
+                                    op=ast.CompareOperationOp.Eq,
+                                    left=ast.Field(chain=["d"]),
+                                    right=ast.Field(chain=["e"]),
+                                )
                             ),
                         ),
                         sample=ast.SampleExpr(

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -8,6 +8,8 @@ from posthog.test.base import BaseTest
 
 
 class TestPropertyTypes(BaseTest):
+    maxDiff = None
+
     def setUp(self):
         super().setUp()
         PropertyDefinition.objects.get_or_create(
@@ -49,8 +51,8 @@ class TestPropertyTypes(BaseTest):
             "SELECT multiply("
             "toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')), "
             "toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''))), "
-            "equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_3)s) "
-            f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10000"
+            "ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_3)s), 0) "
+            f"FROM events WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10000"
         )
         self.assertEqual(printed, expected)
 
@@ -62,7 +64,7 @@ class TestPropertyTypes(BaseTest):
             "SELECT toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')), "
             "parseDateTime64BestEffortOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
             "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_3)s), ''), 'null'), '^\"|\"$', '') "
-            f"FROM person WHERE equals(person.team_id, {self.team.pk}) LIMIT 10000"
+            f"FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) LIMIT 10000"
         )
         self.assertEqual(printed, expected)
 
@@ -74,7 +76,7 @@ class TestPropertyTypes(BaseTest):
             "SELECT toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')), "
             "parseDateTime64BestEffortOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', ''), 6, %(hogql_val_2)s), "
             "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_3)s), ''), 'null'), '^\"|\"$', '') "
-            f"FROM person WHERE equals(person.team_id, {self.team.pk}) LIMIT 10000"
+            f"FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) LIMIT 10000"
         )
         self.assertEqual(printed, expected)
 
@@ -86,11 +88,11 @@ class TestPropertyTypes(BaseTest):
             "toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '')), "
             "toFloat64OrNull(events__pdi__person.properties___tickets)) FROM events INNER JOIN "
             "(SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 "
-            f"WHERE equals(person_distinct_id2.team_id, {self.team.pk}) GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) AS events__pdi "
+            f"WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS events__pdi "
             "ON equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN (SELECT "
             "argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), person.version) AS properties___tickets, "
-            f"person.id AS id FROM person WHERE equals(person.team_id, {self.team.pk}) GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person "
-            f"ON equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10000"
+            f"person.id AS id FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person "
+            f"ON equals(events__pdi.person_id, events__pdi__person.id) WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10000"
         )
         self.assertEqual(printed, expected)
 
@@ -100,13 +102,13 @@ class TestPropertyTypes(BaseTest):
         expected = (
             f"SELECT parseDateTime64BestEffortOrNull(events__pdi__person.properties___provided_timestamp, 6, %(hogql_val_1)s) FROM events "
             f"INNER JOIN (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, "
-            f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE equals(person_distinct_id2.team_id, {self.team.pk}) "
-            f"GROUP BY person_distinct_id2.distinct_id HAVING equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0)) "
+            f"person_distinct_id2.distinct_id AS distinct_id FROM person_distinct_id2 WHERE ifNull(equals(person_distinct_id2.team_id, {self.team.pk}), 0) "
+            f"GROUP BY person_distinct_id2.distinct_id HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) "
             f"AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) INNER JOIN (SELECT "
             f"argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), "
-            f"person.version) AS properties___provided_timestamp, person.id AS id FROM person WHERE equals(person.team_id, {self.team.pk}) "
-            f"GROUP BY person.id HAVING equals(argMax(person.is_deleted, person.version), 0)) AS events__pdi__person ON "
-            f"equals(events__pdi.person_id, events__pdi__person.id) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10000"
+            f"person.version) AS properties___provided_timestamp, person.id AS id FROM person WHERE ifNull(equals(person.team_id, {self.team.pk}), 0) "
+            f"GROUP BY person.id HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person ON "
+            f"equals(events__pdi.person_id, events__pdi__person.id) WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10000"
         )
         self.assertEqual(printed, expected)
 
@@ -115,7 +117,7 @@ class TestPropertyTypes(BaseTest):
         printed = self._print_select("select person.properties.provided_timestamp from events")
         expected = (
             f"SELECT parseDateTime64BestEffortOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, "
-            f"%(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), 6, %(hogql_val_1)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10000"
+            f"%(hogql_val_0)s), ''), 'null'), '^\"|\"$', ''), 6, %(hogql_val_1)s) FROM events WHERE ifNull(equals(events.team_id, {self.team.pk}), 0) LIMIT 10000"
         )
         self.assertEqual(printed, expected)
 

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -229,6 +229,9 @@ class TraversingVisitor(Visitor):
     def visit_window_frame_expr(self, node: ast.WindowFrameExpr):
         pass
 
+    def visit_join_constraint(self, node: ast.JoinConstraint):
+        self.visit(node.expr)
+
 
 class CloningVisitor(Visitor):
     """Visitor that traverses and clones the AST tree. Clears types."""
@@ -484,3 +487,6 @@ class CloningVisitor(Visitor):
             frame_type=node.frame_type,
             frame_value=node.frame_value,
         )
+
+    def visit_join_constraint(self, node: ast.JoinConstraint):
+        return ast.JoinConstraint(expr=self.visit(node.expr))

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
@@ -453,14 +453,14 @@
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id ,
          countIf(event = '$pageview'
-                 AND (equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome')
-                      AND equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'))) as count_event_match_0 ,
+                 AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
+                      AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0))) as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
                                 events.window_id), event = '$pageview'
-                               AND (equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome')
-                                    AND equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'))) as matching_events_0
+                               AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
+                                    AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0))) as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -532,12 +532,12 @@
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id ,
          countIf(event = '$pageview'
-                 AND (equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'))) as count_event_match_0 ,
+                 AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0))) as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
                                 events.window_id), event = '$pageview'
-                               AND (equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'))) as matching_events_0
+                               AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0))) as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -595,14 +595,14 @@
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id ,
          countIf(event = '$pageview'
-                 AND (equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Chrome')
-                      AND equals(nullIf(nullIf(pmat_email, ''), 'null'), 'bla'))) as count_event_match_0 ,
+                 AND (ifNull(equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Chrome'), 0)
+                      AND ifNull(equals(nullIf(nullIf(pmat_email, ''), 'null'), 'bla'), 0))) as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
                                 events.window_id), event = '$pageview'
-                               AND (equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Chrome')
-                                    AND equals(nullIf(nullIf(pmat_email, ''), 'null'), 'bla'))) as matching_events_0
+                               AND (ifNull(equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Chrome'), 0)
+                                    AND ifNull(equals(nullIf(nullIf(pmat_email, ''), 'null'), 'bla'), 0))) as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -674,12 +674,12 @@
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id ,
          countIf(event = '$pageview'
-                 AND (equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Firefox'))) as count_event_match_0 ,
+                 AND (ifNull(equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Firefox'), 0))) as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
                                 events.window_id), event = '$pageview'
-                               AND (equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Firefox'))) as matching_events_0
+                               AND (ifNull(equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Firefox'), 0))) as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,


### PR DESCRIPTION
## Problem

Reported by a customer. If searching "something that could be null" != "anything", my expectation on what should happen (everything matches) is not valid. Instead we see no rows:

<img width="1424" alt="image" src="https://github.com/PostHog/posthog/assets/53387/40e1598c-85b8-4656-b5bd-c59e3a73f557">

## Changes

Fixes this:

<img width="1418" alt="image" src="https://github.com/PostHog/posthog/assets/53387/3f60e561-3979-4ff8-af42-bb9420883985">

I now made all `a = b` and `a != b` cases behave as I'd expect, for every case of `a` and `b` (null or not). This works whether they're passed as constants, or for example returned from a subquery. When they're constants, we can do some additional optimisations.

## How did you test this code?

Updated all the tests to match the new reality.