### PR TITLE
feat: Use the buffer age as an alternative choice for flushing

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -161,8 +161,8 @@ export class SessionManager {
         const bufferAgeInMemory = now() - this.buffer.createdAt
         const bufferAgeFromReference = referenceNow - this.buffer.oldestKafkaTimestamp
 
-        // We will use whichever age is oldest. This handles the fact that the reference now can get "stuck" if there is no new data in the partition
-        const bufferAge = Math.min(bufferAgeInMemory, bufferAgeFromReference)
+        // We will use whichever age is oldest (largest). This handles the fact that the reference now can get "stuck" if there is no new data in the partition
+        const bufferAge = Math.max(bufferAgeInMemory, bufferAgeFromReference)
 
         logContext['bufferAge'] = bufferAge
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/utils.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon'
+
 import { IncomingRecordingMessage, PersistedRecordingMessage } from './types'
 
 export const convertToPersistedMessage = (message: IncomingRecordingMessage): PersistedRecordingMessage => {
@@ -6,3 +8,6 @@ export const convertToPersistedMessage = (message: IncomingRecordingMessage): Pe
         data: message.events,
     }
 }
+
+// Helper to return now as a milliseconds timestamp
+export const now = () => DateTime.now().toMillis()

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/node'
 import { captureException } from '@sentry/node'
-import { DateTime } from 'luxon'
 import { mkdirSync, rmSync } from 'node:fs'
 import { CODES, HighLevelProducer as RdKafkaProducer, Message, TopicPartition } from 'node-rdkafka-acosom'
 import path from 'path'
@@ -22,6 +21,7 @@ import { OffsetManager } from './blob-ingester/offset-manager'
 import { SessionManager } from './blob-ingester/session-manager'
 import { SessionOffsetHighWaterMark } from './blob-ingester/session-offset-high-water-mark'
 import { IncomingRecordingMessage } from './blob-ingester/types'
+import { now } from './blob-ingester/utils'
 
 // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 require('@sentry/tracing')
@@ -29,7 +29,6 @@ require('@sentry/tracing')
 const groupId = 'session-recordings-blob'
 const sessionTimeout = 30000
 const fetchBatchSize = 500
-const hoursInMillis = (hours: number) => hours * 60 * 60 * 1000
 
 export const bufferFileDir = (root: string) => path.join(root, 'session-buffer-files')
 
@@ -64,8 +63,6 @@ export class SessionRecordingBlobIngester {
     enabledTeams: number[] | null
     // the time at the most recent message of a particular partition
     partitionNow: Record<number, number | null> = {}
-    // the most recent message timestamp seen across all partitions
-    consumerNow: number | null = null
 
     constructor(
         private teamManager: TeamManager,
@@ -96,8 +93,7 @@ export class SessionRecordingBlobIngester {
             .labels({
                 partition: partition.toString(),
             })
-            .set(DateTime.now().toMillis() - timestamp)
-        this.consumerNow = Math.max(timestamp, this.consumerNow ?? -Infinity)
+            .set(now() - timestamp)
 
         const highWaterMarkSpan = sentrySpan?.startChild({
             op: 'checkHighWaterMark',
@@ -370,24 +366,9 @@ export class SessionRecordingBlobIngester {
                 sessionManagerBufferSizes += sessionManager.buffer.size
 
                 // in practice, we will always have a values for latestKafkaMessageTimestamp,
-                let referenceTime = this.partitionNow[sessionManager.partition]
+                const referenceTime = this.partitionNow[sessionManager.partition]
                 if (!referenceTime) {
                     throw new Error('No latestKafkaMessageTimestamp for partition ' + sessionManager.partition)
-                }
-
-                // it is possible for a session to need an idle flush to continue
-                // but for the head of that partition to be within the idle timeout threshold.
-                // for e.g. when no new message is received on the partition
-                // and so, it will never flush on idle.
-                // in that circumstance, we still need to flush the session.
-                // the aim is for no partition to lag more than ten minutes behind "now"
-                // but as traffic isn't distributed evenly between partitions.
-                // if "partition now" is lagging behind "consumer now" then we use "consumer now"
-                // and if there is no "consumer now" then we use "server now"
-                // that way so long as the consumer is running and receiving messages
-                // we will be more likely to flush "stuck" partitions
-                if (DateTime.now().toMillis() - referenceTime >= hoursInMillis(2)) {
-                    referenceTime = this.consumerNow ?? DateTime.now().toMillis()
                 }
 
                 void sessionManager

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -5,6 +5,7 @@ import { DateTime, Settings } from 'luxon'
 
 import { defaultConfig } from '../../../../../src/config/config'
 import { SessionManager } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/session-manager'
+import { now } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/utils'
 import { createIncomingRecordingMessage } from '../fixtures'
 
 jest.mock('fs', () => {
@@ -62,7 +63,7 @@ describe('session-manager', () => {
     })
 
     it('adds a message', async () => {
-        const timestamp = DateTime.now().toMillis() - 10000
+        const timestamp = now() - 10000
         const event = createIncomingRecordingMessage({
             metadata: {
                 timestamp: timestamp,
@@ -145,7 +146,7 @@ describe('session-manager', () => {
         await sessionManager.add(eventOne)
         await sessionManager.add(eventTwo)
 
-        await sessionManager.flushIfSessionBufferIsOld(DateTime.now().toMillis(), flushThreshold)
+        await sessionManager.flushIfSessionBufferIsOld(now(), flushThreshold)
 
         // as a proxy for flush having been called or not
         expect(createReadStream).toHaveBeenCalled()

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -79,6 +79,7 @@ describe('session-manager', () => {
             id: expect.any(String),
             size: 4139, // The size of the event payload - this may change when test data changes
             offsets: [1],
+            createdAt: now(),
             eventsRange: {
                 firstTimestamp: 1679568314158,
                 lastTimestamp: 1679568314158,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -3,6 +3,7 @@ import LibrdKafkaError from 'node-rdkafka-acosom/lib/error'
 import { Pool } from 'pg'
 
 import { defaultConfig } from '../../../../src/config/config'
+import { now } from '../../../../src/main/ingestion-queues/session-recording/blob-ingester/utils'
 import { eachBatch } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-consumer'
 import { TeamManager } from '../../../../src/worker/ingestion/team-manager'
 import { createOrganization, createTeam } from '../../../helpers/sql'
@@ -93,7 +94,7 @@ describe('session-recordings-consumer', () => {
                     team_id: teamId,
                     data: JSON.stringify({
                         event: '$snapshot',
-                        properties: { $snapshot_data: { events_summary: [{ timestamp: DateTime.now().toMillis() }] } },
+                        properties: { $snapshot_data: { events_summary: [{ timestamp: now() }] } },
                     }),
                 }),
                 timestamp: 123,


### PR DESCRIPTION
## Problem

Whilst reviewing [this PR](https://github.com/PostHog/posthog/pull/16215/files) I got quite lost and had a lot of comments so I thought a PR is the easiest way to explain how I think this could work instead. Totally open to either solution but hopefully this gives an easier comparison of the approaches

## Changes

* Adds a `createdAt` to the buffers which means we can use the "realtime" age of the buffer if it is older than the reference age
* I think this handles cases where we have some uneven distribution between partitions and consumption
* It also is very simple as each session manager tracks its own age, removing the likelihood of bugs in the "attempt" tracking (i.e. if we would change the flush interval and forget to change the attempt count limit

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test