### PR TITLE
feat: Added support for alternative redis for realtime playback

### DIFF
--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -1,11 +1,11 @@
 # flake8: noqa
-from typing import Optional
+from typing import Dict, Optional
 
 import redis
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-_client_map = {}  # type: Optional[redis.Redis]
+_client_map: Dict[str, redis.Redis] = {}
 
 
 def get_client(redis_url: Optional[str] = None) -> redis.Redis:
@@ -27,3 +27,9 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
         _client_map[redis_url] = client
 
     return _client_map[redis_url]
+
+
+def TEST_clear_clients():
+    global _client_map
+    for key in list(_client_map.keys()):
+        del _client_map[key]

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 _client = None  # type: Optional[redis.Redis]
 
 
-def get_client() -> redis.Redis:
+def get_client(redis_url=settings.REDIS_URL) -> redis.Redis:
     global _client
 
     if _client:
@@ -18,8 +18,8 @@ def get_client() -> redis.Redis:
         import fakeredis
 
         _client = fakeredis.FakeRedis()
-    elif settings.REDIS_URL:
-        _client = redis.from_url(settings.REDIS_URL, db=0)
+    elif redis_url:
+        _client = redis.from_url(redis_url, db=0)
 
     if not _client:
         raise ImproperlyConfigured("Redis not configured!")

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -17,7 +17,7 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
         if settings.TEST:
             import fakeredis
 
-            client = fakeredis.FakeRedis()
+            client = fakeredis.FakeRedis()  # type: ignore
         elif redis_url:
             client = redis.from_url(redis_url, db=0)
 

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -1,11 +1,11 @@
 # flake8: noqa
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import redis
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-_client_map: Dict[str, redis.Redis] = {}
+_client_map: Dict[str, Any] = {}
 
 
 def get_client(redis_url: Optional[str] = None) -> redis.Redis:
@@ -17,7 +17,7 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
         if settings.TEST:
             import fakeredis
 
-            client = fakeredis.FakeRedis()  # type: ignore
+            client = fakeredis.FakeRedis()
         elif redis_url:
             client = redis.from_url(redis_url, db=0)
 

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -14,6 +14,8 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
     global _client_map
 
     if not _client_map.get(redis_url):
+        client: Any = None
+
         if settings.TEST:
             import fakeredis
 

--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -3,6 +3,7 @@ from time import sleep
 from typing import Dict, List, Optional
 
 import structlog
+from posthog import settings
 from posthog.redis import get_client
 
 logger = structlog.get_logger(__name__)
@@ -17,9 +18,8 @@ def get_key(team_id: str, suffix: str) -> str:
     return f"@posthog/replay/snapshots/team-{team_id}/{suffix}"
 
 
-# TODO: Type this better
 def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Optional[List[Dict]]:
-    redis = get_client()
+    redis = get_client(settings.SESSION_RECORDING_REDIS_URL)
     key = get_key(team_id, session_id)
     encoded_snapshots = redis.zrange(key, 0, -1, withscores=True)
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -231,6 +231,15 @@ if not REDIS_URL and get_from_env("POSTHOG_REDIS_HOST", ""):
         os.getenv("POSTHOG_REDIS_PORT", "6379"),
     )
 
+SESSION_RECORDING_REDIS_URL = REDIS_URL
+
+if get_from_env("POSTHOG_SESSION_RECORDING_REDIS_HOST", ""):
+    SESSION_RECORDING_REDIS_URL = "redis://{}:{}/".format(
+        os.getenv("POSTHOG_SESSION_RECORDING_REDIS_HOST", ""),
+        os.getenv("POSTHOG_SESSION_RECORDING_REDIS_PORT", "6379"),
+    )
+
+
 if not REDIS_URL:
     raise ImproperlyConfigured(
         "Env var REDIS_URL or POSTHOG_REDIS_HOST is absolutely required to run this software.\n"

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -17,7 +17,7 @@ class TestRedis(TestCase):
         with self.settings(REDIS_URL="redis://mocked:6379", TEST=False):
             client = get_client()
 
-        assert client == "test"
+        assert client
         assert _client_map == {
             "redis://mocked:6379": "test",
         }

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -1,0 +1,47 @@
+from unittest.mock import ANY, patch
+from posthog.redis import TEST_clear_clients, get_client, _client_map
+
+from django.test.testcases import TestCase
+
+
+class TestRedis(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        TEST_clear_clients()
+
+    @patch("posthog.redis.redis")
+    def test_redis_client_is_created(self, mock_redis):
+        mock_redis.from_url.return_value = "test"
+
+        with self.settings(REDIS_URL="redis://mocked:6379", TEST=False):
+            client = get_client()
+
+        assert client == "test"
+        assert _client_map == {
+            "redis://mocked:6379": "test",
+        }
+        mock_redis.from_url.assert_called_once_with("redis://mocked:6379", db=0)
+
+    def test_redis_client_uses_given_url(self):
+        with self.settings(REDIS_URL="redis://mocked:6379"):
+            assert get_client("redis://other:6379")
+
+        assert _client_map == {
+            "redis://other:6379": ANY,
+        }
+
+    @patch("posthog.redis.redis")
+    def test_redis_client_is_cached_between_calls(self, mock_redis):
+        mock_redis.from_url.return_value = "test"
+
+        with self.settings(REDIS_URL="redis://mocked:6379", TEST=False):
+            assert get_client()
+            mock_redis.from_url.assert_called_once_with("redis://mocked:6379", db=0)
+            mock_redis.from_url.reset_mock()
+
+            assert get_client()
+            mock_redis.from_url.assert_not_called()
+
+            assert get_client("redis://other:6379")
+            mock_redis.from_url.assert_called_once_with("redis://other:6379", db=0)

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -17,8 +17,8 @@ class TestRedis(TestCase):
         with self.settings(REDIS_URL="redis://mocked:6379", TEST=False):
             client = get_client()
 
-        assert client == "test"
-        assert _client_map == {
+        assert client == "test"  # type: ignore
+        assert _client_map == {  # type: ignore
             "redis://mocked:6379": "test",
         }
         mock_redis.from_url.assert_called_once_with("redis://mocked:6379", db=0)

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -17,8 +17,8 @@ class TestRedis(TestCase):
         with self.settings(REDIS_URL="redis://mocked:6379", TEST=False):
             client = get_client()
 
-        assert client == "test"  # type: ignore
-        assert _client_map == {  # type: ignore
+        assert client == "test"
+        assert _client_map == {
             "redis://mocked:6379": "test",
         }
         mock_redis.from_url.assert_called_once_with("redis://mocked:6379", db=0)


### PR DESCRIPTION
## Problem

Now that we have a dedicated session recording redis, we just need to use it in the real time playback code

## Changes

* Adds the new env parsing and adds the option for redis clients to use it


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
