### PR TITLE
fix(surveys): survey sent event name and filter property bug fix

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -317,7 +317,7 @@ export function SurveyReleaseSummary({
                     <span className="simple-tag tag-light-blue text-primary-alt">{survey.conditions.selector}</span>
                 </div>
             )}
-            {(targetingFlagFilters?.groups?.[0].properties?.length || 0) > 0 && (
+            {(targetingFlagFilters?.groups?.[0]?.properties?.length || 0) > 0 && (
                 <div className="flex flex-row font-medium gap-1">
                     <span>User conditions:</span>{' '}
                 </div>
@@ -325,7 +325,7 @@ export function SurveyReleaseSummary({
             {targetingFlagFilters?.groups?.map((group, index) => (
                 <>
                     {index > 0 && <div className="text-primary-alt font-semibold text-xs ml-2 py-1">OR</div>}
-                    {group.properties.map((property, idx) => (
+                    {group.properties?.map((property, idx) => (
                         <>
                             <div className="feature-flag-property-display" key={idx}>
                                 {idx === 0 ? (


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- fix bug where clicking and deleting a property condition causes erroring bc of release summary
- change the event for "survey sent" to not include the survey's name and filtered by ID
 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
