### PR TITLE
refactor(insights): remove legacy code (1/x)

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -15,7 +15,7 @@ import { AnimationType } from 'lib/animations/animations'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 
 import { InsightDisplayConfig } from './InsightDisplayConfig'
-import { FunnelCanvasLabelDataExploration } from 'scenes/funnels/FunnelCanvasLabel'
+import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { TrendInsight } from 'scenes/trends/Trends'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { Paths } from 'scenes/paths/Paths'
@@ -226,7 +226,7 @@ export function InsightContainer({
                         )}
 
                         <div>
-                            {isFunnels ? <FunnelCanvasLabelDataExploration /> : null}
+                            {isFunnels ? <FunnelCanvasLabel /> : null}
                             {isPaths ? <PathCanvasLabel /> : null}
                             {!disableLegendButton && <InsightLegendButtonDataExploration />}
                         </div>

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -15,7 +15,7 @@ import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { FunnelDisplayLayoutPicker } from 'scenes/insights/views/Funnels/FunnelDisplayLayoutPicker'
 import { FunnelBinsPicker } from 'scenes/insights/views/Funnels/FunnelBinsPicker'
-import { ValueOnSeriesFilterDataExploration } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
+import { ValueOnSeriesFilter } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
 
 interface InsightDisplayConfigProps {
     disableTable: boolean
@@ -81,7 +81,7 @@ export function InsightDisplayConfig({ disableTable }: InsightDisplayConfigProps
 
                 {showValueOnSeries && (
                     <ConfigFilter>
-                        <ValueOnSeriesFilterDataExploration />
+                        <ValueOnSeriesFilter />
                     </ConfigFilter>
                 )}
             </div>

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -13,7 +13,7 @@ import { PathStepPicker } from 'scenes/insights/views/Paths/PathStepPicker'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
 import { ChartFilter } from 'lib/components/ChartFilter'
-import { FunnelDisplayLayoutPickerDataExploration } from 'scenes/insights/views/Funnels/FunnelDisplayLayoutPicker'
+import { FunnelDisplayLayoutPicker } from 'scenes/insights/views/Funnels/FunnelDisplayLayoutPicker'
 import { FunnelBinsPicker } from 'scenes/insights/views/Funnels/FunnelBinsPicker'
 import { ValueOnSeriesFilterDataExploration } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
 
@@ -100,7 +100,7 @@ export function InsightDisplayConfig({ disableTable }: InsightDisplayConfigProps
 
                 {showFunnelDisplayLayout && (
                     <ConfigFilter>
-                        <FunnelDisplayLayoutPickerDataExploration />
+                        <FunnelDisplayLayoutPicker />
                     </ConfigFilter>
                 )}
 

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -14,7 +14,7 @@ import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { FunnelDisplayLayoutPickerDataExploration } from 'scenes/insights/views/Funnels/FunnelDisplayLayoutPicker'
-import { FunnelBinsPickerDataExploration } from 'scenes/insights/views/Funnels/FunnelBinsPicker'
+import { FunnelBinsPicker } from 'scenes/insights/views/Funnels/FunnelBinsPicker'
 import { ValueOnSeriesFilterDataExploration } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
 
 interface InsightDisplayConfigProps {
@@ -106,7 +106,7 @@ export function InsightDisplayConfig({ disableTable }: InsightDisplayConfigProps
 
                 {showFunnelBins && (
                     <ConfigFilter>
-                        <FunnelBinsPickerDataExploration />
+                        <FunnelBinsPicker />
                     </ConfigFilter>
                 )}
             </div>

--- a/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
@@ -1,5 +1,4 @@
 import { useValues, useActions } from 'kea'
-// import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { InsightType, FilterType, InsightLogicProps } from '~/types'

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -3,67 +3,20 @@ import React from 'react'
 import { useActions, useValues } from 'kea'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { funnelLogic } from './funnelLogic'
 import { funnelDataLogic } from './funnelDataLogic'
 
 import { Link } from '@posthog/lemon-ui'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconInfo } from 'lib/lemon-ui/icons'
-import { InsightFilter } from '~/queries/schema'
-import { FunnelsFilterType, FunnelTimeConversionMetrics, FunnelVizType } from '~/types'
+import { FunnelVizType } from '~/types'
 import { humanFriendlyDuration, percentage } from 'lib/utils'
-import { FunnelStepsPicker, FunnelStepsPickerDataExploration } from 'scenes/insights/views/Funnels/FunnelStepsPicker'
-import { Noun } from '~/models/groupsModel'
+import { FunnelStepsPicker } from 'scenes/insights/views/Funnels/FunnelStepsPicker'
 
-export function FunnelCanvasLabelDataExploration(): JSX.Element | null {
+export function FunnelCanvasLabel(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { conversionMetrics, aggregationTargetLabel, funnelsFilter } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
-    return (
-        <FunnelCanvasLabelComponent
-            conversionMetrics={conversionMetrics}
-            aggregationTargetLabel={aggregationTargetLabel}
-            funnelsFilter={funnelsFilter}
-            updateInsightFilter={updateInsightFilter}
-            isUsingDataExploration
-        />
-    )
-}
-
-export function FunnelCanvasLabel(): JSX.Element | null {
-    const { insightProps } = useValues(insightLogic)
-    const { conversionMetrics, aggregationTargetLabel, filters } = useValues(funnelLogic(insightProps))
-    const { setFilters } = useActions(funnelLogic(insightProps))
-
-    return (
-        <FunnelCanvasLabelComponent
-            conversionMetrics={conversionMetrics}
-            aggregationTargetLabel={aggregationTargetLabel}
-            funnelsFilter={filters}
-            updateInsightFilter={(filters: InsightFilter) => {
-                setFilters(filters as Partial<FunnelsFilterType>)
-            }}
-        />
-    )
-}
-
-type FunnelCanvasLabelComponentProps = {
-    aggregationTargetLabel: Noun
-    conversionMetrics: FunnelTimeConversionMetrics
-    funnelsFilter?: FunnelsFilterType | null
-    updateInsightFilter: (insightFilter: InsightFilter) => void
-    isUsingDataExploration?: boolean
-}
-
-function FunnelCanvasLabelComponent({
-    aggregationTargetLabel,
-    conversionMetrics,
-    funnelsFilter,
-    updateInsightFilter,
-    isUsingDataExploration,
-}: FunnelCanvasLabelComponentProps): JSX.Element | null {
-    const StepsPicker = isUsingDataExploration ? FunnelStepsPickerDataExploration : FunnelStepsPicker
     const labels = [
         ...(funnelsFilter?.funnel_viz_type === FunnelVizType.Steps
             ? [
@@ -91,7 +44,7 @@ function FunnelCanvasLabelComponent({
                           </Tooltip>
                           <span>Average time to convert</span>
                       </span>
-                      {funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert && <StepsPicker />}
+                      {funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert && <FunnelStepsPicker />}
                       <span className="text-muted-alt mr-1">:</span>
                       {funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert ? (
                           <span className="font-bold">{humanFriendlyDuration(conversionMetrics.averageTime)}</span>
@@ -110,7 +63,7 @@ function FunnelCanvasLabelComponent({
             ? [
                   <>
                       <span className="text-muted-alt">Conversion rate</span>
-                      <StepsPicker />
+                      <FunnelStepsPicker />
                   </>,
               ]
             : []),

--- a/frontend/src/scenes/insights/EditorFilters/ValueOnSeriesFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ValueOnSeriesFilter.tsx
@@ -3,21 +3,15 @@ import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { insightLogic } from '../insightLogic'
 import { valueOnSeriesFilterLogic } from './valueOnSeriesFilterLogic'
 
-type ValuesOnSeriesFilterProps = { onChange: (checked: boolean) => void; checked: boolean }
-
-export function ValueOnSeriesFilterDataExploration(): JSX.Element {
+export function ValueOnSeriesFilter(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { valueOnSeries } = useValues(valueOnSeriesFilterLogic(insightProps))
     const { setValueOnSeries } = useActions(valueOnSeriesFilterLogic(insightProps))
-    return <ValueOnSeriesFilter checked={valueOnSeries} onChange={setValueOnSeries} />
-}
 
-// the component is used in the non data exploration case and wrapped by above component for data exploration
-export function ValueOnSeriesFilter({ checked, onChange }: ValuesOnSeriesFilterProps): JSX.Element {
     return (
         <LemonCheckbox
-            onChange={onChange}
-            checked={checked}
+            checked={valueOnSeries}
+            onChange={setValueOnSeries}
             label={<span className="font-normal">Show values on series</span>}
             bordered
             size="small"

--- a/frontend/src/scenes/insights/LegacyInsightContainer.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightContainer.tsx
@@ -1,6 +1,5 @@
 import { Card, Col, Row } from 'antd'
 import { LegacyInsightDisplayConfig } from 'scenes/insights/LegacyInsightDisplayConfig'
-import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { ComputationTimeWithRefresh } from 'scenes/insights/ComputationTimeWithRefresh'
 import { ChartDisplayType, ExporterFormat, FunnelVizType, InsightType, ItemMode } from '~/types'
 import { TrendInsight } from 'scenes/trends/Trends'
@@ -16,7 +15,6 @@ import {
     InsightTimeoutState,
 } from 'scenes/insights/EmptyStates'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
-import clsx from 'clsx'
 import { PathCanvasLabel } from 'scenes/paths/PathsLabel'
 import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
 import { InsightLegendButton } from 'lib/components/InsightLegend/InsightLegendButton'
@@ -199,25 +197,6 @@ export function LegacyInsightContainer({
                 className="insights-graph-container"
             >
                 <div>
-                    {isFunnelsFilter(filters) ? (
-                        <div
-                            className={clsx(
-                                'insights-graph-header',
-                                {
-                                    funnels: isFunnelsFilter(filters),
-                                },
-                                'justify-between',
-                                'items-center',
-                                'flex',
-                                'flex-row'
-                            )}
-                        >
-                            <div className="flex flex-col">
-                                {isFunnelsFilter(filters) ? <FunnelCanvasLabel /> : null}
-                            </div>
-                        </div>
-                    ) : null}
-
                     {!disableLastComputation || !!filters.sampling_factor ? (
                         <Row
                             className="insights-graph-header computation-time-and-sampling-notice"

--- a/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
@@ -7,7 +7,6 @@ import { NON_VALUES_ON_SERIES_DISPLAY_TYPES, FEATURE_FLAGS, NON_TIME_SERIES_DISP
 import { ChartDisplayType, FilterType, FunnelVizType, InsightType, ItemMode, TrendsFilterType } from '~/types'
 
 import { InsightDateFilter } from './filters/InsightDateFilter'
-import { FunnelDisplayLayoutPicker } from './views/Funnels/FunnelDisplayLayoutPicker'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -164,14 +163,6 @@ export function LegacyInsightDisplayConfig({ filters, disableTable }: InsightDis
                         )}
                         <ConfigFilter>
                             <ChartFilter filters={filters} />
-                        </ConfigFilter>
-                    </>
-                )}
-
-                {isFunnels && filters.funnel_viz_type === FunnelVizType.Steps && (
-                    <>
-                        <ConfigFilter>
-                            <FunnelDisplayLayoutPicker />
                         </ConfigFilter>
                     </>
                 )}

--- a/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
@@ -58,8 +58,7 @@ export function LegacyInsightDisplayConfig({ filters, disableTable }: InsightDis
                     </ConfigFilter>
                 )}
 
-                {isTrendsFilter(filters) &&
-                !filters.breakdown_type &&
+                {!filters.breakdown_type &&
                 !filters.compare &&
                 (!filters.display || filters.display === ChartDisplayType.ActionsLineGraph) &&
                 featureFlags[FEATURE_FLAGS.SMOOTHING_INTERVAL] ? (
@@ -77,11 +76,10 @@ export function LegacyInsightDisplayConfig({ filters, disableTable }: InsightDis
             <div className="flex items-center space-x-4 flex-wrap my-2 grow justify-end">
                 {isFilterWithDisplay(filters) && (
                     <>
-                        {isTrendsFilter(filters) && (
-                            <ConfigFilter>
-                                <UnitPicker filters={filters} setFilters={setFilters} />
-                            </ConfigFilter>
-                        )}
+                        <ConfigFilter>
+                            <UnitPicker filters={filters} setFilters={setFilters} />
+                        </ConfigFilter>
+
                         <ConfigFilter>
                             <ChartFilter filters={filters} />
                         </ConfigFilter>

--- a/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
@@ -3,7 +3,7 @@ import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
 import { SmoothingFilter } from 'lib/components/SmoothingFilter/SmoothingFilter'
-import { NON_VALUES_ON_SERIES_DISPLAY_TYPES, FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
+import { FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { ChartDisplayType, FilterType, InsightType, ItemMode, TrendsFilterType } from '~/types'
 
 import { InsightDateFilter } from './filters/InsightDateFilter'
@@ -11,14 +11,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
-import {
-    isFilterWithDisplay,
-    isStickinessFilter,
-    isTrendsFilter,
-    isAreaChartDisplay,
-    isLifecycleFilter,
-} from 'scenes/insights/sharedUtils'
-import { ValueOnSeriesFilter } from './EditorFilters/ValueOnSeriesFilter'
+import { isFilterWithDisplay, isTrendsFilter, isAreaChartDisplay } from 'scenes/insights/sharedUtils'
 
 interface InsightDisplayConfigProps {
     filters: FilterType
@@ -36,12 +29,6 @@ const showCompareFilter = function (filters: Partial<FilterType>): boolean {
     return !isAreaChartDisplay(filters)
 }
 
-const showValueOnSeriesFilter = (filters: FilterType): boolean => {
-    return !NON_VALUES_ON_SERIES_DISPLAY_TYPES.includes(
-        (filters as TrendsFilterType).display || ChartDisplayType.ActionsLineGraph
-    )
-}
-
 function ConfigFilter(props: PropsWithChildren<ReactNode>): JSX.Element {
     return <span className="space-x-2 flex items-center text-sm">{props.children}</span>
 }
@@ -54,7 +41,7 @@ export function LegacyInsightDisplayConfig({ filters, disableTable }: InsightDis
 
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const { setFilters, setFiltersMerge } = useActions(insightLogic)
+    const { setFilters } = useActions(insightLogic)
 
     return (
         <div className="flex justify-between items-center flex-wrap" data-attr="insight-filters">
@@ -84,28 +71,6 @@ export function LegacyInsightDisplayConfig({ filters, disableTable }: InsightDis
                 {showCompareFilter(filters) && (
                     <ConfigFilter>
                         <CompareFilter />
-                    </ConfigFilter>
-                )}
-
-                {showValueOnSeriesFilter(filters) && (
-                    <ConfigFilter>
-                        <ValueOnSeriesFilter
-                            checked={
-                                !!(
-                                    ((isTrendsFilter(filters) ||
-                                        isStickinessFilter(filters) ||
-                                        isLifecycleFilter(filters)) &&
-                                        (filters as TrendsFilterType).show_values_on_series) ||
-                                    // pie charts have value checked by default
-                                    (isTrendsFilter(filters) &&
-                                        filters.display === ChartDisplayType.ActionsPie &&
-                                        filters.show_values_on_series === undefined)
-                                )
-                            }
-                            onChange={(checked) => {
-                                setFiltersMerge({ show_values_on_series: checked } as TrendsFilterType)
-                            }}
-                        />
                     </ConfigFilter>
                 )}
             </div>

--- a/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/LegacyInsightDisplayConfig.tsx
@@ -8,7 +8,6 @@ import { ChartDisplayType, FilterType, FunnelVizType, InsightType, ItemMode, Tre
 
 import { InsightDateFilter } from './filters/InsightDateFilter'
 import { FunnelDisplayLayoutPicker } from './views/Funnels/FunnelDisplayLayoutPicker'
-import { FunnelBinsPicker } from './views/Funnels/FunnelBinsPicker'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -175,11 +174,6 @@ export function LegacyInsightDisplayConfig({ filters, disableTable }: InsightDis
                             <FunnelDisplayLayoutPicker />
                         </ConfigFilter>
                     </>
-                )}
-                {isFunnels && filters.funnel_viz_type === FunnelVizType.TimeToConvert && (
-                    <ConfigFilter>
-                        <FunnelBinsPicker />
-                    </ConfigFilter>
                 )}
             </div>
         </div>

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -809,28 +809,6 @@ export const insightLogic = kea<insightLogicType>([
             }
 
             actions.reportInsightViewed(values.insight, filters, previousFilters)
-
-            const backendFilterChanged = !objectsEqual(
-                Object.assign({}, values.filters, {
-                    layout: undefined,
-                    hidden_legend_keys: undefined,
-                    funnel_advanced: undefined,
-                    show_legend: undefined,
-                }),
-                Object.assign({}, values.loadedFilters, {
-                    layout: undefined,
-                    hidden_legend_keys: undefined,
-                    funnel_advanced: undefined,
-                    show_legend: undefined,
-                })
-            )
-
-            // (Re)load results when filters have changed or if there's no result yet
-            if (backendFilterChanged || !values.insight?.result) {
-                if (props.disableDataExploration && !values.insight?.query) {
-                    actions.loadResults()
-                }
-            }
         },
         reportInsightViewedForRecentInsights: async () => {
             // Report the insight being viewed to our '/viewed' endpoint. Used for "recently viewed insights"
@@ -1087,10 +1065,6 @@ export const insightLogic = kea<insightLogicType>([
         },
         loadInsightSuccess: async ({ insight }) => {
             actions.reportInsightViewed(insight, insight?.filters || {})
-            // loaded `/api/projects/:id/insights`, but it didn't have `results`, so make another query
-            if (props.disableDataExploration && !insight.result && !insight.query && values.filters) {
-                actions.loadResults()
-            }
         },
         toggleInsightLegend: () => {
             const newFilters: Partial<TrendsFilterType> = {

--- a/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { BIN_COUNT_AUTO } from 'lib/constants'
 import { InputNumber, Select } from 'antd'
 import { BinCountValue } from '~/types'
@@ -7,7 +6,6 @@ import { BarChartOutlined } from '@ant-design/icons'
 import clsx from 'clsx'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { FunnelsFilter } from '~/queries/schema'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 
 // Constraints as defined in funnel_time_to_convert.py:34
@@ -42,7 +40,7 @@ const options: BinOption[] = [
 
 type FunnelBinsPickerProps = { disabled?: boolean }
 
-export function FunnelBinsPickerDataExploration(props: FunnelBinsPickerProps): JSX.Element {
+export function FunnelBinsPicker({ disabled }: FunnelBinsPickerProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { funnelsFilter, numericBinCount } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
@@ -51,43 +49,6 @@ export function FunnelBinsPickerDataExploration(props: FunnelBinsPickerProps): J
         updateInsightFilter({ bin_count: binCount && binCount !== BIN_COUNT_AUTO ? binCount : undefined })
     }
 
-    return (
-        <FunnelBinsPickerComponent
-            funnelsFilter={funnelsFilter}
-            setBinCount={setBinCount}
-            numericBinCount={numericBinCount}
-            {...props}
-        />
-    )
-}
-
-export function FunnelBinsPicker(props: FunnelBinsPickerProps): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
-    const { filters, numericBinCount } = useValues(funnelLogic(insightProps))
-    const { setBinCount } = useActions(funnelLogic(insightProps))
-
-    return (
-        <FunnelBinsPickerComponent
-            funnelsFilter={filters}
-            setBinCount={setBinCount}
-            numericBinCount={numericBinCount}
-            {...props}
-        />
-    )
-}
-
-type FunnelBinsPickerComponentProps = FunnelBinsPickerProps & {
-    funnelsFilter?: FunnelsFilter | null
-    setBinCount: (binCount: BinCountValue) => void
-    numericBinCount: number
-}
-
-function FunnelBinsPickerComponent({
-    funnelsFilter,
-    setBinCount,
-    numericBinCount,
-    disabled,
-}: FunnelBinsPickerComponentProps): JSX.Element {
     return (
         <Select
             id="funnel-bin-filter"

--- a/frontend/src/scenes/insights/views/Funnels/FunnelDisplayLayoutPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelDisplayLayoutPicker.tsx
@@ -1,36 +1,15 @@
 import { useActions, useValues } from 'kea'
-import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { FunnelLayout } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { LemonSelect } from '@posthog/lemon-ui'
 import { IconFunnelHorizontal, IconFunnelVertical } from 'lib/lemon-ui/icons'
-import { FunnelsFilter } from '~/queries/schema'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
-
-export function FunnelDisplayLayoutPickerDataExploration(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
-    const { insightFilter } = useValues(funnelDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
-
-    return <FunnelDisplayLayoutPickerComponent {...insightFilter} setFilters={updateInsightFilter} />
-}
 
 export function FunnelDisplayLayoutPicker(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { filters } = useValues(funnelLogic(insightProps))
-    const { setFilters } = useActions(funnelLogic(insightProps))
+    const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
-    return <FunnelDisplayLayoutPickerComponent {...filters} setFilters={setFilters} />
-}
-
-type FunnelDisplayLayoutPickerComponentProps = {
-    setFilters: (filters: FunnelsFilter) => void
-} & FunnelsFilter
-
-export function FunnelDisplayLayoutPickerComponent({
-    layout,
-    setFilters,
-}: FunnelDisplayLayoutPickerComponentProps): JSX.Element {
     const options = [
         {
             title: 'Graph Display Options',
@@ -51,8 +30,8 @@ export function FunnelDisplayLayoutPickerComponent({
 
     return (
         <LemonSelect
-            value={layout || FunnelLayout.vertical}
-            onChange={(layout: FunnelLayout | null) => layout && setFilters({ layout })}
+            value={funnelsFilter?.layout || FunnelLayout.vertical}
+            onChange={(layout: FunnelLayout | null) => layout && updateInsightFilter({ layout })}
             dropdownMatchSelectWidth={false}
             data-attr="funnel-bar-layout-selector"
             options={options}

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
@@ -1,14 +1,12 @@
 import { useActions, useValues } from 'kea'
-import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { EntityFilter } from '~/types'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
-import { FunnelsFilter } from '~/queries/schema'
 import { LemonSelect, LemonSelectOptions, LemonSelectOption } from '@posthog/lemon-ui'
 
-export function FunnelStepsPickerDataExploration(): JSX.Element | null {
+export function FunnelStepsPicker(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { series, isFunnelWithEnoughSteps, funnelsFilter } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
@@ -16,52 +14,8 @@ export function FunnelStepsPickerDataExploration(): JSX.Element | null {
         updateInsightFilter({ funnel_from_step, funnel_to_step })
     }
 
-    return (
-        <FunnelStepsPickerComponent
-            filterSteps={series || []}
-            numberOfSeries={series?.length || 0}
-            isFunnelWithEnoughSteps={isFunnelWithEnoughSteps}
-            funnelsFilter={funnelsFilter}
-            onChange={onChange}
-        />
-    )
-}
-
-export function FunnelStepsPicker(): JSX.Element | null {
-    const { insightProps } = useValues(insightLogic)
-    const { filters, numberOfSeries, isFunnelWithEnoughSteps, filterSteps } = useValues(funnelLogic(insightProps))
-    const { changeStepRange } = useActions(funnelLogic(insightProps))
-
-    const onChange = (funnel_from_step?: number, funnel_to_step?: number): void => {
-        changeStepRange(funnel_from_step, funnel_to_step)
-    }
-
-    return (
-        <FunnelStepsPickerComponent
-            filterSteps={filterSteps}
-            numberOfSeries={numberOfSeries}
-            isFunnelWithEnoughSteps={isFunnelWithEnoughSteps}
-            funnelsFilter={filters}
-            onChange={onChange}
-        />
-    )
-}
-
-type FunnelStepsPickerComponentProps = {
-    filterSteps: Record<string, any>[]
-    numberOfSeries: number
-    isFunnelWithEnoughSteps: boolean
-    funnelsFilter?: FunnelsFilter | null
-    onChange: (funnel_from_step?: number, funnel_to_step?: number) => void
-}
-
-export function FunnelStepsPickerComponent({
-    filterSteps,
-    numberOfSeries,
-    isFunnelWithEnoughSteps,
-    funnelsFilter,
-    onChange,
-}: FunnelStepsPickerComponentProps): JSX.Element | null {
+    const filterSteps = series || []
+    const numberOfSeries = series?.length || 0
     const fromRange = isFunnelWithEnoughSteps ? Array.from(Array(Math.max(numberOfSeries)).keys()).slice(0, -1) : [0]
     const toRange = isFunnelWithEnoughSteps
         ? Array.from(Array(Math.max(numberOfSeries)).keys()).slice((funnelsFilter?.funnel_from_step ?? 0) + 1)

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
@@ -24,16 +24,14 @@ export function FunnelStepsPicker(): JSX.Element | null {
     const optionsForRange = (range: number[]): LemonSelectOptions<number> => {
         return range
             .map((stepIndex): LemonSelectOption<number> | null => {
-                // data exploration has no order on series and instead relies on array order
-                const stepFilter = filterSteps.find((f) => f.order === stepIndex) || filterSteps[stepIndex]
-                return stepFilter
+                return filterSteps[stepIndex]
                     ? {
                           value: stepIndex,
                           label: `Step ${stepIndex + 1}`,
                           labelInMenu: (
                               <>
                                   <span>Step ${stepIndex + 1} – </span>
-                                  <EntityFilterInfo filter={stepFilter as EntityFilter} />
+                                  <EntityFilterInfo filter={filterSteps[stepIndex] as EntityFilter} />
                               </>
                           ),
                       }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2017,8 +2017,6 @@ export interface InsightLogicProps {
     cachedInsight?: Partial<InsightModel> | null
     /** enable this to avoid API requests */
     doNotLoad?: boolean
-    /** Temporary hack to disable data exploration to enable result fetching. */
-    disableDataExploration?: boolean
 }
 
 export interface SetInsightOptions {


### PR DESCRIPTION
## Problem

Some of the insight components have a legacy, non-data exploration variatn.

## Changes

This PR:
- removes the disableDataExploration flag that enabled results loading for experiments
- remove the legacy variants of the FunnelCanvasLabel, FunnelStepsPicker, FunnelBinsPicker, FunnelDisplayLayoutPicker and ValueOnSeriesFilter
- cleans up code in LegacyInsightDisplayConfig

## How did you test this code?

Manual testing