### PR TITLE
feat: show a notice when impersonating another user

### DIFF
--- a/frontend/src/layout/navigation/ProjectNotice.tsx
+++ b/frontend/src/layout/navigation/ProjectNotice.tsx
@@ -95,6 +95,10 @@ export function ProjectNotice(): JSX.Element | null {
             },
             type: 'warning',
         },
+        is_impersonated: {
+            message: 'You are currently impersonating another user.',
+            type: 'warning',
+        },
     }
 
     const relevantNotice = NOTICES[projectNoticeVariant]

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -16,6 +16,7 @@ export type ProjectNoticeVariant =
     | 'real_project_with_no_events'
     | 'invite_teammates'
     | 'unverified_email'
+    | 'is_impersonated'
 
 export const navigationLogic = kea<navigationLogicType>({
     path: ['layout', 'navigation', 'navigationLogic'],
@@ -203,8 +204,9 @@ export const navigationLogic = kea<navigationLogicType>({
                 if (!organization) {
                     return null
                 }
-
-                if (currentTeam?.is_demo && !preflight?.demo) {
+                if (user?.is_impersonated) {
+                    return ['is_impersonated', false]
+                } else if (currentTeam?.is_demo && !preflight?.demo) {
                     // If the project is a demo one, show a project-level warning
                     // Don't show this project-level warning in the PostHog demo environemnt though,
                     // as then Announcement is shown instance-wide


### PR DESCRIPTION
## Problem

Sometimes I wonder "why is all the content gone?" when I'm impersonating a user, and it takes me a minute to realize that I'm impersonating a user.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Maybe a notice will help?

![image](https://github.com/PostHog/posthog/assets/18598166/dbcc1cf9-38e7-448c-bae5-b93769d63409)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
