### PR TITLE
fix: show data warehouse empty state or product intro properly

### DIFF
--- a/frontend/src/scenes/data-warehouse/DataWarehouse.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehouse.tsx
@@ -1,5 +1,4 @@
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
-import { userLogic } from 'scenes/userLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -9,6 +8,7 @@ import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductI
 import { ProductKey } from '~/types'
 import { databaseSceneLogic } from 'scenes/data-management/database/databaseSceneLogic'
 import { DataWarehouseTablesContainer } from './DataWarehouseTables'
+import { dataWarehouseSceneLogic } from './dataWarehouseSceneLogic'
 
 export const scene: SceneExport = {
     component: DataWarehouse,
@@ -16,7 +16,7 @@ export const scene: SceneExport = {
 }
 
 export function DataWarehouse(): JSX.Element {
-    const { user } = useValues(userLogic)
+    const { shouldShowEmptyState, shouldShowProductIntroduction } = useValues(dataWarehouseSceneLogic)
 
     return (
         <div>
@@ -49,7 +49,7 @@ export function DataWarehouse(): JSX.Element {
                     </div>
                 }
             />
-            {!user?.has_seen_product_intro_for?.[ProductKey.DATA_WAREHOUSE] && (
+            {(shouldShowProductIntroduction || shouldShowEmptyState) && (
                 <ProductIntroduction
                     productName={'Data Warehouse'}
                     thingName={'data warehouse table'}
@@ -57,12 +57,12 @@ export function DataWarehouse(): JSX.Element {
                         'Bring your production database, revenue data, CRM contacts or any other data into PostHog.'
                     }
                     action={() => router.actions.push(urls.dataWarehouseTable('new'))}
-                    isEmpty={true}
+                    isEmpty={shouldShowEmptyState}
                     docsURL="https://posthog.com/docs/data/data-warehouse"
                     productKey={ProductKey.DATA_WAREHOUSE}
                 />
             )}
-            <DataWarehouseTablesContainer />
+            {!shouldShowEmptyState && <DataWarehouseTablesContainer />}
         </div>
     )
 }

--- a/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.tsx
@@ -1,11 +1,10 @@
-import { afterMount, kea, path, selectors } from 'kea'
+import { afterMount, connect, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api, { PaginatedResponse } from 'lib/api'
-
 import { DatabaseSchemaQueryResponseField } from '~/queries/schema'
-import { DataWarehouseTable } from '~/types'
-
+import { DataWarehouseTable, ProductKey } from '~/types'
 import type { dataWarehouseSceneLogicType } from './dataWarehouseSceneLogicType'
+import { userLogic } from 'scenes/userLogic'
 
 export interface DatabaseSceneRow {
     name: string
@@ -14,6 +13,9 @@ export interface DatabaseSceneRow {
 
 export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
     path(['scenes', 'warehouse', 'dataWarehouseSceneLogic']),
+    connect(() => ({
+        values: [userLogic, ['user']],
+    })),
     loaders({
         dataWarehouse: [
             null as PaginatedResponse<DataWarehouseTable> | null,
@@ -38,6 +40,18 @@ export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
                             columns: table.columns,
                         } as DatabaseSceneRow)
                 )
+            },
+        ],
+        shouldShowEmptyState: [
+            (s) => [s.tables, s.dataWarehouseLoading],
+            (tables, dataWarehouseLoading): boolean => {
+                return tables?.length == 0 && !dataWarehouseLoading
+            },
+        ],
+        shouldShowProductIntroduction: [
+            (s) => [s.user],
+            (user): boolean => {
+                return !user?.has_seen_product_intro_for?.[ProductKey.DATA_WAREHOUSE]
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Noticed that the new data warehouse scene didn't have the proper logic for showing the empty state or product intro at the right time / with the right content. Since we're opening it up to people may as well have it behaving properly.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

As with other uses of this component, it now shows the intro if someone hasn't seen the intro yet, and shows the empty state if there are no tables created yet.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
