### PR TITLE
fix: duplicate import that broke storybook

### DIFF
--- a/frontend/src/scenes/surveys/SurveyAppearance.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearance.tsx
@@ -67,7 +67,7 @@ const posthogLogoSVG = (
     </svg>
 )
 // This should be synced to the UI of the surveys app plugin
-function BaseAppearance({ question, appearance }: { question: string; appearance: SurveyAppearance }): JSX.Element {
+function BaseAppearance({ question, appearance }: { question: string; appearance: SurveyAppearanceType }): JSX.Element {
     const [hasText, setHasText] = useState(false)
 
     return (

--- a/frontend/src/scenes/surveys/SurveyAppearance.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearance.tsx
@@ -1,14 +1,14 @@
 import './SurveyAppearance.scss'
 import { LemonInput } from '@posthog/lemon-ui'
 import { useState } from 'react'
-import { SurveyAppearance } from '~/types'
+import { SurveyAppearance as SurveyAppearanceType } from '~/types'
 
 interface SurveyAppearanceProps {
     // type: string
     question: string
-    appearance: SurveyAppearance
+    appearance: SurveyAppearanceType
     readOnly?: boolean
-    onAppearanceChange: (appearance: SurveyAppearance) => void
+    onAppearanceChange: (appearance: SurveyAppearanceType) => void
 }
 export function SurveyAppearance({
     question,


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/16217 broke storybook builds. This fixes it.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use unique names.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Storybook now builds locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
