### PR TITLE
chore(data-warehouse): show config data in expandable and allow deletions

### DIFF
--- a/frontend/src/scenes/data-management/database/DatabaseTables.tsx
+++ b/frontend/src/scenes/data-management/database/DatabaseTables.tsx
@@ -9,15 +9,35 @@ import { DatabaseTable } from './DatabaseTable'
 
 export function DatabaseTablesContainer(): JSX.Element {
     const { filteredTables, databaseLoading } = useValues(databaseSceneLogic)
-    return <DatabaseTables tables={filteredTables} loading={databaseLoading} />
+    return (
+        <DatabaseTables
+            tables={filteredTables}
+            loading={databaseLoading}
+            renderRow={(row: DatabaseSceneRow) => {
+                return (
+                    <div className="px-4 py-3">
+                        <div className="mt-2">
+                            <span className="card-secondary">Columns</span>
+                            <DatabaseTable table={row.name} tables={filteredTables} />
+                        </div>
+                    </div>
+                )
+            }}
+        />
+    )
 }
 
-interface DatabaseTablesProps {
-    tables: DatabaseSceneRow[]
+interface DatabaseTablesProps<T> {
+    tables: T[]
     loading: boolean
+    renderRow: (row: T) => JSX.Element
 }
 
-export function DatabaseTables({ tables, loading }: DatabaseTablesProps): JSX.Element {
+export function DatabaseTables<T extends DatabaseSceneRow>({
+    tables,
+    loading,
+    renderRow,
+}: DatabaseTablesProps<T>): JSX.Element {
     return (
         <>
             <LemonTable
@@ -28,7 +48,7 @@ export function DatabaseTables({ tables, loading }: DatabaseTablesProps): JSX.El
                         title: 'Table',
                         key: 'name',
                         dataIndex: 'name',
-                        render: function RenderTable(table, obj: DatabaseSceneRow) {
+                        render: function RenderTable(table, obj: T) {
                             const query: DataTableNode = {
                                 kind: NodeKind.DataTableNode,
                                 full: true,
@@ -63,13 +83,7 @@ export function DatabaseTables({ tables, loading }: DatabaseTablesProps): JSX.El
                     },
                 ]}
                 expandable={{
-                    expandedRowRender: function renderExpand(row) {
-                        return (
-                            <div className="px-4 py-3">
-                                <DatabaseTable table={row.name} tables={tables} />
-                            </div>
-                        )
-                    },
+                    expandedRowRender: renderRow,
                     rowExpandable: () => true,
                     noIndent: true,
                 }}

--- a/frontend/src/scenes/data-management/database/DatabaseTables.tsx
+++ b/frontend/src/scenes/data-management/database/DatabaseTables.tsx
@@ -1,4 +1,4 @@
-import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { useValues } from 'kea'
 import { databaseSceneLogic, DatabaseSceneRow } from 'scenes/data-management/database/databaseSceneLogic'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
@@ -27,16 +27,18 @@ export function DatabaseTablesContainer(): JSX.Element {
     )
 }
 
-interface DatabaseTablesProps<T> {
+interface DatabaseTablesProps<T extends Record<string, any>> {
     tables: T[]
     loading: boolean
     renderRow: (row: T) => JSX.Element
+    extraColumns?: LemonTableColumns<T>
 }
 
 export function DatabaseTables<T extends DatabaseSceneRow>({
     tables,
     loading,
     renderRow,
+    extraColumns = [],
 }: DatabaseTablesProps<T>): JSX.Element {
     return (
         <>
@@ -81,6 +83,7 @@ export function DatabaseTables<T extends DatabaseSceneRow>({
                             )
                         },
                     },
+                    ...extraColumns,
                 ]}
                 expandable={{
                     expandedRowRender: renderRow,

--- a/frontend/src/scenes/data-warehouse/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehouseTables.tsx
@@ -1,10 +1,16 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { DatabaseTables } from 'scenes/data-management/database/DatabaseTables'
 import { DataWarehouseSceneRow, dataWarehouseSceneLogic } from './dataWarehouseSceneLogic'
 import { DatabaseTable } from 'scenes/data-management/database/DatabaseTable'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonButton } from '@posthog/lemon-ui'
+import { deleteWithUndo } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
 
 export function DataWarehouseTablesContainer(): JSX.Element {
     const { tables, dataWarehouseLoading } = useValues(dataWarehouseSceneLogic)
+    const { loadDataWarehouse } = useActions(dataWarehouseSceneLogic)
+    const { currentTeamId } = useValues(teamLogic)
     return (
         <DatabaseTables
             tables={tables}
@@ -27,6 +33,34 @@ export function DataWarehouseTablesContainer(): JSX.Element {
                     </div>
                 )
             }}
+            extraColumns={[
+                {
+                    width: 0,
+                    render: function Render(_, warehouseTable: DataWarehouseSceneRow) {
+                        return (
+                            <More
+                                overlay={
+                                    <>
+                                        <LemonButton
+                                            status="danger"
+                                            onClick={() => {
+                                                deleteWithUndo({
+                                                    endpoint: `projects/${currentTeamId}/warehouse_table`,
+                                                    object: { name: warehouseTable.name, id: warehouseTable.id },
+                                                    callback: loadDataWarehouse,
+                                                })
+                                            }}
+                                            fullWidth
+                                        >
+                                            Delete table
+                                        </LemonButton>
+                                    </>
+                                }
+                            />
+                        )
+                    },
+                },
+            ]}
         />
     )
 }

--- a/frontend/src/scenes/data-warehouse/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehouseTables.tsx
@@ -1,8 +1,32 @@
 import { useValues } from 'kea'
 import { DatabaseTables } from 'scenes/data-management/database/DatabaseTables'
-import { dataWarehouseSceneLogic } from './dataWarehouseSceneLogic'
+import { DataWarehouseSceneRow, dataWarehouseSceneLogic } from './dataWarehouseSceneLogic'
+import { DatabaseTable } from 'scenes/data-management/database/DatabaseTable'
 
 export function DataWarehouseTablesContainer(): JSX.Element {
     const { tables, dataWarehouseLoading } = useValues(dataWarehouseSceneLogic)
-    return <DatabaseTables tables={tables} loading={dataWarehouseLoading} />
+    return (
+        <DatabaseTables
+            tables={tables}
+            loading={dataWarehouseLoading}
+            renderRow={(row: DataWarehouseSceneRow) => {
+                return (
+                    <div className="px-4 py-3">
+                        <div className="flex flex-col">
+                            <span className="card-secondary mt-2">Files URL pattern</span>
+                            <span>{row.url_pattern}</span>
+
+                            <span className="card-secondary mt-2">File format</span>
+                            <span>{row.format}</span>
+                        </div>
+
+                        <div className="mt-2">
+                            <span className="card-secondary">Columns</span>
+                            <DatabaseTable table={row.name} tables={tables} />
+                        </div>
+                    </div>
+                )
+            }}
+        />
+    )
 }

--- a/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.tsx
@@ -12,6 +12,11 @@ export interface DatabaseSceneRow {
     columns: DatabaseSchemaQueryResponseField[]
 }
 
+export interface DataWarehouseSceneRow extends DatabaseSceneRow {
+    url_pattern: string
+    format: string
+}
+
 export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
     path(['scenes', 'warehouse', 'dataWarehouseSceneLogic']),
     loaders({
@@ -26,7 +31,7 @@ export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
     selectors({
         tables: [
             (s) => [s.dataWarehouse],
-            (warehouse): DatabaseSceneRow[] => {
+            (warehouse): DataWarehouseSceneRow[] => {
                 if (!warehouse) {
                     return []
                 }
@@ -36,7 +41,9 @@ export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
                         ({
                             name: table.name,
                             columns: table.columns,
-                        } as DatabaseSceneRow)
+                            url_pattern: table.url_pattern,
+                            format: table.format,
+                        } as DataWarehouseSceneRow)
                 )
             },
         ],

--- a/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.tsx
@@ -13,6 +13,7 @@ export interface DatabaseSceneRow {
 }
 
 export interface DataWarehouseSceneRow extends DatabaseSceneRow {
+    id: string
     url_pattern: string
     format: string
 }
@@ -39,6 +40,7 @@ export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
                 return warehouse.results.map(
                     (table: DataWarehouseTable) =>
                         ({
+                            id: table.id,
                             name: table.name,
                             columns: table.columns,
                             url_pattern: table.url_pattern,

--- a/posthog/warehouse/api/table.py
+++ b/posthog/warehouse/api/table.py
@@ -32,7 +32,7 @@ class TableSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = DataWarehouseTable
-        fields = ["id", "name", "format", "created_by", "created_at", "url_pattern", "credential", "columns"]
+        fields = ["id", "deleted", "name", "format", "created_by", "created_at", "url_pattern", "credential", "columns"]
         read_only_fields = ["id", "created_by", "created_at", "columns"]
 
     def get_columns(self, table: DataWarehouseTable) -> Dict[str, str]:
@@ -72,9 +72,12 @@ class TableViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         if not isinstance(self.request.user, User) or self.request.user.current_team is None:
             raise NotAuthenticated()
 
-        return (
-            self.queryset.filter(team_id=self.team_id)
-            .exclude(deleted=True)
-            .prefetch_related("created_by")
-            .order_by(self.ordering)
-        )
+        if self.action == "list":
+            return (
+                self.queryset.filter(team_id=self.team_id)
+                .exclude(deleted=True)
+                .prefetch_related("created_by")
+                .order_by(self.ordering)
+            )
+
+        return self.queryset.filter(team_id=self.team_id).prefetch_related("created_by").order_by(self.ordering)


### PR DESCRIPTION
## Problem

- can't see what the url pattern/format type of the added table is
- can't delete tables

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- add this information on the expndable dropdown
- add deletion

<!-- If there are frontend changes, please include screenshots. -->
<img width="714" alt="Screenshot 2023-06-26 at 8 26 38 AM" src="https://github.com/PostHog/posthog/assets/13127476/b6b84c17-b5a6-4dc0-b65f-69edfc86271a">

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
