### PR TITLE
feat: gzip support for plugin server kafka

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && \
     "gcc" \
     "python3" \
     "libssl-dev" \
-    "zlib-dev" \
+    "zlib1g-dev" \
     && \
     rm -rf /var/lib/apt/lists/* && \
     corepack enable && \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && \
     "gcc" \
     "python3" \
     "libssl-dev" \
+    "zlib-dev" \
     && \
     rm -rf /var/lib/apt/lists/* && \
     corepack enable && \


### PR DESCRIPTION
## Problem

Stacked on top of #16239

## Changes

Installs the dependency that https://github.com/confluentinc/librdkafka#requirements suggests we need so that we can use gzip in kafka consumers in plugin server

## How did you test this code?

Train wifi is not interested in downloading the docker dependencies... opening this PR instead 🙈 