### PR TITLE
fix: Fixed empty states for Persons recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -300,7 +300,7 @@ export function SessionRecordingsPlaylist(props: SessionRecordingsPlaylistProps)
                 </span>
                 icon at the top of the list of recordings.
             </LemonBanner>
-            {!personUUID && (shouldShowProductIntroduction || shouldShowEmptyState) && (
+            {(shouldShowProductIntroduction || shouldShowEmptyState) && (
                 <ProductIntroduction
                     productName="Session replay"
                     productKey={ProductKey.SESSION_REPLAY}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -300,7 +300,7 @@ export function SessionRecordingsPlaylist(props: SessionRecordingsPlaylistProps)
                 </span>
                 icon at the top of the list of recordings.
             </LemonBanner>
-            {(shouldShowProductIntroduction || shouldShowEmptyState) && (
+            {!personUUID && (shouldShowProductIntroduction || shouldShowEmptyState) && (
                 <ProductIntroduction
                     productName="Session replay"
                     productKey={ProductKey.SESSION_REPLAY}
@@ -334,42 +334,38 @@ export function SessionRecordingsPlaylist(props: SessionRecordingsPlaylistProps)
                     }
                 />
             )}
-            {!shouldShowEmptyState && (
-                <div
-                    ref={playlistRef}
-                    data-attr="session-recordings-playlist"
-                    className={clsx('SessionRecordingsPlaylist', {
-                        'SessionRecordingsPlaylist--wide': size !== 'small',
-                    })}
-                >
-                    <div className={clsx('SessionRecordingsPlaylist__left-column space-y-4')}>
-                        <RecordingsLists {...props} />
-                    </div>
-                    <div className="SessionRecordingsPlaylist__right-column">
-                        {activeSessionRecording?.id ? (
-                            <SessionRecordingPlayer
-                                playerKey="playlist"
-                                playlistShortId={playlistShortId}
-                                sessionRecordingId={activeSessionRecording?.id}
-                                matching={activeSessionRecording?.matching_events}
-                                recordingStartTime={
-                                    activeSessionRecording ? activeSessionRecording.start_time : undefined
-                                }
-                                nextSessionRecording={nextSessionRecording}
-                            />
-                        ) : (
-                            <div className="mt-20">
-                                <EmptyMessage
-                                    title="No recording selected"
-                                    description="Please select a recording from the list on the left"
-                                    buttonText="Learn more about recordings"
-                                    buttonTo="https://posthog.com/docs/user-guides/recordings"
-                                />
-                            </div>
-                        )}
-                    </div>
+            <div
+                ref={playlistRef}
+                data-attr="session-recordings-playlist"
+                className={clsx('SessionRecordingsPlaylist', {
+                    'SessionRecordingsPlaylist--wide': size !== 'small',
+                })}
+            >
+                <div className={clsx('SessionRecordingsPlaylist__left-column space-y-4')}>
+                    <RecordingsLists {...props} />
                 </div>
-            )}
+                <div className="SessionRecordingsPlaylist__right-column">
+                    {activeSessionRecording?.id ? (
+                        <SessionRecordingPlayer
+                            playerKey="playlist"
+                            playlistShortId={playlistShortId}
+                            sessionRecordingId={activeSessionRecording?.id}
+                            matching={activeSessionRecording?.matching_events}
+                            recordingStartTime={activeSessionRecording ? activeSessionRecording.start_time : undefined}
+                            nextSessionRecording={nextSessionRecording}
+                        />
+                    ) : (
+                        <div className="mt-20">
+                            <EmptyMessage
+                                title="No recording selected"
+                                description="Please select a recording from the list on the left"
+                                buttonText="Learn more about recordings"
+                                buttonTo="https://posthog.com/docs/user-guides/recordings"
+                            />
+                        </div>
+                    )}
+                </div>
+            </div>
         </>
     )
 }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -50,6 +50,7 @@ export const DEFAULT_RECORDING_FILTERS: RecordingFilters = {
 
 const DEFAULT_PERSON_RECORDING_FILTERS: RecordingFilters = {
     ...DEFAULT_RECORDING_FILTERS,
+    date_from: '-21d',
     session_recording_duration: {
         type: PropertyFilterType.Recording,
         key: 'duration',


### PR DESCRIPTION
## Problem

The product intro thing sort of broke persons if there is no data for the default filters. This expands the default to 21 days for Persons and always shows the list, as the current check for having recordings turned on is not good enough.

## Changes

* Fixes this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
