### PR TITLE
chore: Remove docker-compose logging now that flakyness is no more

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -121,11 +121,6 @@ runs:
                   --durations=100 --durations-min=1.0 --store-durations \
                   $PYTEST_ARGS
 
-        - name: Show docker compose log
-          if: ${{ always() }}
-          shell: bash
-          run: docker compose -f docker-compose.dev.yml logs --tail=5000
-
         # Post-tests
 
         - name: Upload updated timing data as artifacts


### PR DESCRIPTION
## Problem

We were dumping the docker-compose CI logs to help identify an issue with Temporal. That issue appears to now be fixed (see #16079), so the log dump is not needed anymore.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Revert the docker-compose logging added in #16072

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
