### PR TITLE
fix(experiments): Fix bugs around creating new experiment

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -213,14 +213,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
 
             for variant in validated_data["parameters"]["feature_flag_variants"]:
                 if (
-                    len(
-                        [
-                            ff_variant
-                            for ff_variant in feature_flag.variants
-                            if ff_variant["key"] == variant["key"]
-                            and ff_variant["rollout_percentage"] == variant["rollout_percentage"]
-                        ]
-                    )
+                    len([ff_variant for ff_variant in feature_flag.variants if ff_variant["key"] == variant["key"]])
                     != 1
                 ):
                     raise ValidationError("Can't update feature_flag_variants on Experiment")

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -456,22 +456,46 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["detail"], "Can't update feature_flag_variants on Experiment")
 
-        # Now try changing FF rollout %s
+        # Allow changing FF rollout %s
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+        created_ff.filters = {
+            **created_ff.filters,
+            "multivariate": {
+                "variants": [
+                    {"key": "control", "name": "Control Group", "rollout_percentage": 35},
+                    {"key": "test_1", "name": "Test Variant", "rollout_percentage": 33},
+                    {"key": "test_2", "name": "Test Variant", "rollout_percentage": 32},
+                ]
+            },
+        }
+        created_ff.save()
+
         response = self.client.patch(
             f"/api/projects/{self.team.id}/experiments/{id}",
             {
-                "description": "Bazinga",
+                "description": "Bazinga 222",
                 "parameters": {
                     "feature_flag_variants": [
-                        {"key": "control", "name": "Control Group", "rollout_percentage": 34},
+                        {"key": "control", "name": "Control Group", "rollout_percentage": 33},
                         {"key": "test_1", "name": "Test Variant", "rollout_percentage": 33},
-                        {"key": "test_2", "name": "Test Variant", "rollout_percentage": 32},
+                        {"key": "test_2", "name": "Test Variant", "rollout_percentage": 34},
                     ]
                 },
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.json()["detail"], "Can't update feature_flag_variants on Experiment")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["parameters"]["feature_flag_variants"][0]["key"], "control")
+        self.assertEqual(response.json()["description"], "Bazinga 222")
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+
+        self.assertEqual(created_ff.key, ff_key)
+        self.assertEqual(created_ff.active, True)
+        self.assertEqual(created_ff.filters["multivariate"]["variants"][0]["key"], "control")
+        self.assertEqual(created_ff.filters["multivariate"]["variants"][0]["rollout_percentage"], 35)
+        self.assertEqual(created_ff.filters["multivariate"]["variants"][1]["key"], "test_1")
+        self.assertEqual(created_ff.filters["multivariate"]["variants"][1]["rollout_percentage"], 33)
+        self.assertEqual(created_ff.filters["multivariate"]["variants"][2]["key"], "test_2")
+        self.assertEqual(created_ff.filters["multivariate"]["variants"][2]["rollout_percentage"], 32)
 
         # Now try changing FF keys
         response = self.client.patch(

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -905,8 +905,7 @@ class TestExperimentCRUD(APILicensedTest):
                 },
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.json()["detail"], "Can't update feature_flag_variants on Experiment")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # ensure cache doesn't change either
         cached_flags = get_feature_flags_for_team_in_cache(self.team.pk)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -881,8 +881,8 @@ export const experimentLogic = kea<experimentLogicType>([
             if (id && didPathChange) {
                 const parsedId = id === 'new' ? 'new' : parseInt(id)
                 if (parsedId === 'new') {
-                    actions.setNewExperimentInsight()
                     actions.resetExperiment()
+                    actions.setNewExperimentInsight()
                 }
 
                 if (parsedId !== 'new' && parsedId === values.experimentId) {

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -174,10 +174,10 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                         <LemonDivider />
                         {featureFlag.experiment_set && featureFlag.experiment_set?.length > 0 && (
                             <LemonBanner type="warning">
-                                This feature flag is linked to an experiment. It's recommended to only make changes to
-                                this flag{' '}
+                                This feature flag is linked to an experiment. Edit settings here only for advanced
+                                functionality. If unsure, go back to{' '}
                                 <Link to={urls.experiment(featureFlag.experiment_set[0])}>
-                                    using the experiment creation screen.
+                                    the experiment creation screen.
                                 </Link>
                             </LemonBanner>
                         )}
@@ -756,6 +756,9 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                     {
                                         label: 'Release toggle (boolean)',
                                         value: false,
+                                        disabled: !!(
+                                            featureFlag.experiment_set && featureFlag.experiment_set?.length > 0
+                                        ),
                                     },
                                     {
                                         label: (
@@ -940,6 +943,13 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                                     data-attr={`delete-prop-filter-${index}`}
                                                     noPadding
                                                     onClick={() => removeVariant(index)}
+                                                    disabledReason={
+                                                        featureFlag.experiment_set &&
+                                                        featureFlag.experiment_set?.length > 0
+                                                            ? 'Cannot delete variants from a feature flag that is part of an experiment'
+                                                            : undefined
+                                                    }
+                                                    tooltipPlacement="topRight"
                                                 />
                                             )}
                                         </Row>
@@ -961,6 +971,12 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                 focusVariantKeyField(newIndex)
                             }}
                             icon={<IconPlus />}
+                            disabledReason={
+                                featureFlag.experiment_set && featureFlag.experiment_set?.length > 0
+                                    ? 'Cannot add variants to a feature flag that is part of an experiment'
+                                    : undefined
+                            }
+                            tooltipPlacement="topLeft"
                             center
                         >
                             Add variant


### PR DESCRIPTION
## Problem

Users aren't able to create a new experiment without changing anything. This is because the reset was happening after setting the insight filters 🤦 .

Also clarifies what's possible to change on a flag linked to an experiment

<img width="1254" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/a0fb68ba-3bab-4c55-824a-4f28051de856">


Fixes things mentioned here: https://posthog.slack.com/archives/C04F85S6BGQ/p1687852066616959
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
