### PR TITLE
refactor(insights): remove legacy code (4/x)

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -27,7 +27,7 @@ import { ResizeHandle1D, ResizeHandle2D } from '../handles'
 import './InsightCard.scss'
 import { ActionsHorizontalBar, ActionsLineGraph, ActionsPie } from 'scenes/trends/viz'
 import { DashboardInsightsTable } from 'scenes/insights/views/InsightsTable/DashboardInsightsTable'
-import { Funnel } from 'scenes/funnels/Funnel'
+import { FunnelDataExploration } from 'scenes/funnels/Funnel'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { Paths } from 'scenes/paths/Paths'
 
@@ -92,7 +92,7 @@ const displayMap: Record<
     },
     FunnelContainer: {
         className: 'funnel',
-        element: Funnel,
+        element: FunnelDataExploration,
     },
     RetentionContainer: {
         className: 'retention',

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -27,7 +27,7 @@ import { ResizeHandle1D, ResizeHandle2D } from '../handles'
 import './InsightCard.scss'
 import { ActionsHorizontalBar, ActionsLineGraph, ActionsPie } from 'scenes/trends/viz'
 import { DashboardInsightsTable } from 'scenes/insights/views/InsightsTable/DashboardInsightsTable'
-import { FunnelDataExploration } from 'scenes/funnels/Funnel'
+import { Funnel } from 'scenes/funnels/Funnel'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { Paths } from 'scenes/paths/Paths'
 
@@ -92,7 +92,7 @@ const displayMap: Record<
     },
     FunnelContainer: {
         className: 'funnel',
-        element: FunnelDataExploration,
+        element: Funnel,
     },
     RetentionContainer: {
         className: 'retention',

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -19,7 +19,7 @@ import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { TrendInsight } from 'scenes/trends/Trends'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { Paths } from 'scenes/paths/Paths'
-import { InsightsTableDataExploration } from 'scenes/insights/views/InsightsTable/InsightsTable'
+import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
 import {
     FunnelInvalidExclusionState,
     FunnelSingleStepState,
@@ -174,7 +174,7 @@ export function InsightContainer({
                         </div>
                     )}
 
-                    <InsightsTableDataExploration
+                    <InsightsTable
                         isLegend
                         filterKey="trends_TRENDS"
                         canEditSeriesNameInline={!trendsFilter?.formula && insightMode === ItemMode.Edit}

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -1,5 +1,6 @@
 import { LemonSelectOptionLeaf } from 'lib/lemon-ui/LemonSelect'
 import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
+import { TrendsFilter } from '~/queries/schema'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
 
 const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled'] as const
@@ -14,13 +15,13 @@ export const INSIGHT_UNIT_OPTIONS: LemonSelectOptionLeaf<AggregationAxisFormat>[
 ]
 
 export const formatAggregationAxisValue = (
-    filters: Partial<TrendsFilterType> | undefined,
+    trendsFilter: TrendsFilter | null | undefined | Partial<TrendsFilterType>,
     value: number | string
 ): string => {
     value = Number(value)
     let formattedValue = humanFriendlyNumber(value)
-    if (filters?.aggregation_axis_format) {
-        switch (filters?.aggregation_axis_format) {
+    if (trendsFilter?.aggregation_axis_format) {
+        switch (trendsFilter?.aggregation_axis_format) {
             case 'duration':
                 formattedValue = humanFriendlyDuration(value)
                 break
@@ -38,7 +39,9 @@ export const formatAggregationAxisValue = (
                 break
         }
     }
-    return `${filters?.aggregation_axis_prefix || ''}${formattedValue}${filters?.aggregation_axis_postfix || ''}`
+    return `${trendsFilter?.aggregation_axis_prefix || ''}${formattedValue}${
+        trendsFilter?.aggregation_axis_postfix || ''
+    }`
 }
 
 export const axisLabel = (chartDisplayType: ChartDisplayType | undefined): string => {

--- a/frontend/src/scenes/insights/views/InsightsTable/DashboardInsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/DashboardInsightsTable.tsx
@@ -1,7 +1,6 @@
-import { BindLogic, useValues } from 'kea'
+import { useValues } from 'kea'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { trendsLogic } from 'scenes/trends/trendsLogic'
 
 import { InsightsTable } from './InsightsTable'
 
@@ -11,12 +10,6 @@ import { InsightsTable } from './InsightsTable'
 export function DashboardInsightsTable(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     return (
-        <BindLogic logic={trendsLogic} props={insightProps}>
-            <InsightsTable
-                filterKey={`dashboard_${insightProps.dashboardItemId}`}
-                embedded
-                canCheckUncheckSeries={false}
-            />
-        </BindLogic>
+        <InsightsTable filterKey={`dashboard_${insightProps.dashboardItemId}`} embedded canCheckUncheckSeries={false} />
     )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.stories.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.stories.tsx
@@ -3,47 +3,34 @@ import { BindLogic } from 'kea'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { useStorybookMocks } from '~/mocks/browser'
-import { InsightsTableComponent, InsightsTableComponentProps } from './InsightsTable'
+import { InsightsTable } from './InsightsTable'
+import { BaseMathType, InsightLogicProps } from '~/types'
 
 export default {
-    title: 'Insights/InsightsTableComponent',
-    component: InsightsTableComponent,
-} as ComponentMeta<typeof InsightsTableComponent>
+    title: 'Insights/InsightsTable',
+    component: InsightsTable,
+} as ComponentMeta<typeof InsightsTable>
 
-import { AggregationType } from './insightsTableDataLogic'
-import { CalcColumnState } from './insightsTableLogic'
+let uniqueNode = 0
 
-const Template: ComponentStory<typeof InsightsTableComponent> = (props: Partial<InsightsTableComponentProps>) => {
+const Template: ComponentStory<typeof InsightsTable> = (props, { parameters }) => {
+    const [dashboardItemId] = useState(() => `InsightTableStory.${uniqueNode++}`)
+
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const insight = require('../../__mocks__/trendsLineBreakdown.json')
-    const insightProps = { dashboardItemId: `${insight.short_id}` }
 
-    const [aggregation, setAggregation] = useState(AggregationType.Total)
-
-    useStorybookMocks({
-        get: {
-            '/api/projects/:team_id/insights/': (_, __, ctx) => [
-                ctx.status(200),
-                ctx.json({
-                    count: 1,
-                    results: [{ ...insight, short_id: insight.short_id, id: insight.id }],
-                }),
-            ],
+    const insightProps = {
+        dashboardItemId,
+        cachedInsight: {
+            ...insight,
+            short_id: dashboardItemId,
+            filters: { ...insight.filters, ...parameters.mergeFilters },
         },
-    })
+    } as InsightLogicProps
 
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
-            <InsightsTableComponent
-                aggregation={aggregation}
-                setAggregationType={(state: CalcColumnState) => setAggregation(AggregationType[state])}
-                isTrends
-                isNonTimeSeriesDisplay={false}
-                allowAggregation
-                handleSeriesEditClick={() => {}}
-                {...props}
-            />
+            <InsightsTable {...props} />
         </BindLogic>
     )
 }
@@ -62,13 +49,23 @@ Embedded.args = {
 }
 
 export const Hourly = Template.bind({})
-Hourly.args = {
-    interval: 'hour',
+Hourly.parameters = {
+    mergeFilters: { interval: 'hour' },
 }
 
 export const Aggregation = Template.bind({})
-Aggregation.args = {
-    allowAggregation: true,
+Aggregation.parameters = {
+    mergeFilters: {
+        events: [
+            {
+                id: '$pageview',
+                name: '$pageview',
+                type: 'events',
+                order: 0,
+                math: BaseMathType.UniqueSessions,
+            },
+        ],
+    },
 }
 
 export const CanEditSeriesName = Template.bind({})

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -1,19 +1,18 @@
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { cohortsModel } from '~/models/cohortsModel'
-import { ChartDisplayType, IntervalType, ItemMode, TrendsFilterType } from '~/types'
-import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
+import { ChartDisplayType, ItemMode } from '~/types'
+import { CalcColumnState } from './insightsTableLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { entityFilterLogic } from '../../filters/ActionFilter/entityFilterLogic'
 import './InsightsTable.scss'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
 import { countryCodeToName } from '../WorldMap'
-import { NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
-import { isFilterWithDisplay, isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 
 import { SeriesCheckColumnTitle, SeriesCheckColumnItem } from './columns/SeriesCheckColumn'
 import { SeriesColumnItem } from './columns/SeriesColumn'
@@ -22,7 +21,6 @@ import { WorldMapColumnTitle, WorldMapColumnItem } from './columns/WorldMapColum
 import { AggregationColumnItem, AggregationColumnTitle } from './columns/AggregationColumn'
 import { ValueColumnItem, ValueColumnTitle } from './columns/ValueColumn'
 import { AggregationType, insightsTableDataLogic } from './insightsTableDataLogic'
-import { BreakdownFilter, TrendsFilter } from '~/queries/schema'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 interface InsightsTableProps {
@@ -39,8 +37,16 @@ interface InsightsTableProps {
     isMainInsightView?: boolean
 }
 
-export function InsightsTableDataExploration({ filterKey, ...rest }: InsightsTableProps): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
+export function InsightsTable({
+    filterKey,
+    isLegend = false,
+    embedded = false,
+    canEditSeriesNameInline = false,
+    canCheckUncheckSeries = true,
+    isMainInsightView = false,
+}: InsightsTableProps): JSX.Element {
+    const { insightProps, isInDashboardContext, insight, isSingleSeries } = useValues(insightLogic)
+    const { insightMode } = useValues(insightSceneLogic)
     const { isNonTimeSeriesDisplay, compare, isTrends, display, interval, breakdown, trendsFilter } = useValues(
         insightVizDataLogic(insightProps)
     )
@@ -57,106 +63,7 @@ export function InsightsTableDataExploration({ filterKey, ...rest }: InsightsTab
             entityFilter.actions.showModal()
         }
     }
-    return (
-        <InsightsTableComponent
-            isNonTimeSeriesDisplay={isNonTimeSeriesDisplay}
-            compare={!!compare}
-            isTrends={isTrends}
-            trendsFilter={trendsFilter}
-            display={display ?? undefined}
-            interval={interval ?? undefined}
-            breakdown={breakdown ?? undefined}
-            allowAggregation={allowAggregation}
-            aggregation={aggregation}
-            setAggregationType={(state: CalcColumnState) => setAggregationType(state as AggregationType)}
-            handleSeriesEditClick={handleSeriesEditClick}
-            {...rest}
-        />
-    )
-}
 
-export function InsightsTable({ filterKey, ...rest }: InsightsTableProps): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
-    const { filters } = useValues(trendsLogic(insightProps))
-    const hasMathUniqueFilter = !!(
-        filters.actions?.find(({ math }) => math === 'dau') || filters.events?.find(({ math }) => math === 'dau')
-    )
-    const logic = insightsTableLogic({ hasMathUniqueFilter, filters })
-    const { calcColumnState, showTotalCount } = useValues(logic)
-    const { setCalcColumnState } = useActions(logic)
-
-    const isNonTimeSeriesDisplay =
-        isFilterWithDisplay(filters) && !!filters.display && NON_TIME_SERIES_DISPLAY_TYPES.includes(filters.display)
-
-    const handleSeriesEditClick = (item: IndexedTrendResult): void => {
-        const typeKey = filterKey
-        const entityFilter = entityFilterLogic.findMounted({
-            typeKey,
-        })
-        if (entityFilter) {
-            entityFilter.actions.selectFilter(item.action)
-            entityFilter.actions.showModal()
-        }
-    }
-
-    return (
-        <InsightsTableComponent
-            isNonTimeSeriesDisplay={isNonTimeSeriesDisplay}
-            compare={isTrendsFilter(filters) && !!filters.compare}
-            isTrends={isTrendsFilter(filters)}
-            trendsFilter={{
-                aggregation_axis_format: (filters as TrendsFilterType).aggregation_axis_format,
-                aggregation_axis_prefix: (filters as TrendsFilterType).aggregation_axis_prefix,
-                aggregation_axis_postfix: (filters as TrendsFilterType).aggregation_axis_postfix,
-            }}
-            display={(filters as TrendsFilterType).display}
-            interval={(filters as TrendsFilterType).interval}
-            breakdown={{
-                breakdown: filters.breakdown,
-            }}
-            allowAggregation={!!showTotalCount}
-            aggregation={calcColumnState}
-            setAggregationType={setCalcColumnState}
-            handleSeriesEditClick={handleSeriesEditClick}
-            {...rest}
-        />
-    )
-}
-
-export type InsightsTableComponentProps = Omit<InsightsTableProps, 'filterKey'> & {
-    isTrends: boolean
-    trendsFilter?: TrendsFilter | null
-    display?: ChartDisplayType
-    interval?: IntervalType
-    breakdown?: BreakdownFilter
-    isNonTimeSeriesDisplay: boolean
-    compare?: boolean
-    allowAggregation: boolean
-    aggregation: CalcColumnState
-    setAggregationType: (state: CalcColumnState) => void
-    handleSeriesEditClick: (item: IndexedTrendResult) => void
-}
-
-export function InsightsTableComponent({
-    isLegend = false,
-    embedded = false,
-    canEditSeriesNameInline = false,
-    canCheckUncheckSeries = true,
-    isMainInsightView = false,
-    isNonTimeSeriesDisplay,
-    isTrends,
-    trendsFilter,
-    display,
-    interval,
-    breakdown,
-    compare,
-    allowAggregation,
-    aggregation,
-    setAggregationType,
-    handleSeriesEditClick,
-}: InsightsTableComponentProps): JSX.Element | null {
-    const { insightProps, isInDashboardContext, insight, isSingleSeries } = useValues(insightLogic)
-    const { insightMode } = useValues(insightSceneLogic)
     const { cohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
@@ -258,7 +165,7 @@ export function InsightsTableComponent({
                 <AggregationColumnTitle
                     isNonTimeSeriesDisplay={isNonTimeSeriesDisplay}
                     aggregation={aggregation}
-                    setAggregationType={setAggregationType}
+                    setAggregationType={(state: CalcColumnState) => setAggregationType(state as AggregationType)}
                 />
             ),
             render: (_: any, item: IndexedTrendResult) => (

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -23,7 +23,7 @@ import { ValueColumnItem, ValueColumnTitle } from './columns/ValueColumn'
 import { AggregationType, insightsTableDataLogic } from './insightsTableDataLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-interface InsightsTableProps {
+export interface InsightsTableProps {
     /** Whether this is just a legend instead of standalone insight viz. Default: false. */
     isLegend?: boolean
     /** Whether this is table is embedded in another card or whether it should be a card of its own. Default: false. */

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
@@ -52,7 +52,7 @@ export function SeriesCheckColumnItem({
 }: SeriesCheckColumnItemProps): JSX.Element {
     return (
         <LemonCheckbox
-            color={getSeriesColor(item.seriesIndex, compare)}
+            color={getSeriesColor(item.seriesIndex, compare || false)}
             checked={!hiddenLegendKeys[item.id]}
             onChange={() => toggleVisibility(item.id)}
             disabled={!canCheckUncheckSeries}

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
@@ -39,7 +39,7 @@ type SeriesCheckColumnItemProps = {
     item: IndexedTrendResult
     canCheckUncheckSeries: boolean
     hiddenLegendKeys: Record<string, boolean | undefined>
-    compare?: boolean
+    compare?: boolean | null
     toggleVisibility: (id: number) => void
 }
 

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
@@ -11,7 +11,7 @@ type SeriesColumnItemProps = {
     item: IndexedTrendResult
     indexedResults: IndexedTrendResult[]
     canEditSeriesNameInline: boolean
-    compare?: boolean
+    compare?: boolean | null
     handleEditClick: (item: IndexedTrendResult) => void
     hasMultipleSeries?: boolean
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
@@ -29,7 +29,7 @@ export function SeriesColumnItem({
     return (
         <div className="series-name-wrapper-col">
             <InsightLabel
-                seriesColor={getSeriesColor(item.seriesIndex, compare)}
+                seriesColor={getSeriesColor(item.seriesIndex, compare || false)}
                 action={item.action}
                 fallbackName={item.breakdown_value === '' ? 'None' : item.label}
                 hasMultipleSeries={hasMultipleSeries}

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/ValueColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/ValueColumn.tsx
@@ -10,8 +10,8 @@ import { TrendsFilter } from '~/queries/schema'
 type ValueColumnTitleProps = {
     index: number
     indexedResults: IndexedTrendResult[]
-    compare?: boolean
-    interval?: IntervalType
+    compare?: boolean | null
+    interval?: IntervalType | null
 }
 
 export function ValueColumnTitle({ index, indexedResults, compare, interval }: ValueColumnTitleProps): JSX.Element {

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -11,7 +11,6 @@ import { worldMapLogic } from './worldMapLogic'
 import { countryCodeToFlag, countryCodeToName } from './countryCodes'
 import { countryVectors } from './countryVectors'
 import { groupsModel } from '~/models/groupsModel'
-import { toLocalFilters } from '../../filters/ActionFilter/entityFilterLogic'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 import { BRAND_BLUE_HSL, gradateColor } from 'lib/colors'
@@ -23,7 +22,9 @@ const WORLD_MAP_TOOLTIP_OFFSET_PX = 8
 
 function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGElement> {
     const { insightProps } = useValues(insightLogic)
-    const { filters, isTooltipShown, currentTooltip, tooltipCoordinates } = useValues(worldMapLogic(insightProps))
+    const { series, trendsFilter, isTooltipShown, currentTooltip, tooltipCoordinates } = useValues(
+        worldMapLogic(insightProps)
+    )
     const { aggregationLabel } = useValues(groupsModel)
 
     const svgRef = useRef<SVGSVGElement>(null)
@@ -57,11 +58,11 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
                                     </div>
                                 )
                             }
-                            renderCount={(value: number) => <>{formatAggregationAxisValue(filters, value)}</>}
+                            renderCount={(value: number) => <>{formatAggregationAxisValue(trendsFilter, value)}</>}
                             showHeader={false}
                             hideColorCol
                             hideInspectActorsSection={!showPersonsModal || !currentTooltip[1]}
-                            groupTypeLabel={aggregationLabel(toLocalFilters(filters)[0].math_group_type_index).plural}
+                            groupTypeLabel={aggregationLabel(series?.[0].math_group_type_index).plural}
                         />
                     )}
                 </>,
@@ -175,9 +176,8 @@ const WorldMapSVG = React.memo(
 
 export function WorldMap({ showPersonsModal = true }: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const localLogic = worldMapLogic(insightProps)
-    const { countryCodeToSeries, maxAggregatedValue } = useValues(localLogic)
-    const { showTooltip, hideTooltip, updateTooltipCoordinates } = useActions(localLogic)
+    const { countryCodeToSeries, maxAggregatedValue } = useValues(worldMapLogic(insightProps))
+    const { showTooltip, hideTooltip, updateTooltipCoordinates } = useActions(worldMapLogic(insightProps))
 
     const svgRef = useWorldMapTooltip(showPersonsModal)
 

--- a/frontend/src/scenes/insights/views/WorldMap/countryCodes.ts
+++ b/frontend/src/scenes/insights/views/WorldMap/countryCodes.ts
@@ -279,4 +279,13 @@ export const countryCodeToName = {
     MQ: 'Martinique',
     AX: 'Åland Islands',
     BQ: 'Caribbean Netherlands',
+    AQ: 'Antarctica',
+    BV: 'Bouvet Island',
+    CC: 'Cocos (Keeling) Islands',
+    CX: 'Christmas Island',
+    HM: 'Heard Island and McDonald Islands',
+    NF: 'Norfolk Island',
+    SJ: 'Svalbard and Jan Mayen',
+    UM: 'United States Minor Outlying Islands',
+    YT: 'Mayotte',
 }

--- a/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
@@ -43,7 +43,7 @@ export const worldMapLogic = kea<worldMapLogicType>([
             (insightData): Record<string, TrendResult> =>
                 Object.fromEntries(
                     Array.isArray(insightData?.result)
-                        ? insightData.result.map((series: TrendResult) => [series.breakdown_value, series])
+                        ? (insightData?.result as TrendResult[]).map((series) => [series.breakdown_value, series])
                         : []
                 ),
         ],
@@ -51,7 +51,7 @@ export const worldMapLogic = kea<worldMapLogicType>([
             (s) => [s.insightData],
             (insightData) =>
                 Array.isArray(insightData?.result)
-                    ? Math.max(...insightData.result.map((series: TrendResult) => series.aggregated_value))
+                    ? Math.max(...(insightData?.result as TrendResult[]).map((series) => series.aggregated_value))
                     : 0,
         ],
     }),

--- a/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
@@ -1,5 +1,5 @@
 import { kea, props, key, path, connect, actions, reducers, selectors } from 'kea'
-import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { InsightLogicProps, TrendResult } from '~/types'
 import { keyForInsightLogicProps } from '../../sharedUtils'
 import type { worldMapLogicType } from './worldMapLogicType'
@@ -8,8 +8,8 @@ export const worldMapLogic = kea<worldMapLogicType>([
     props({} as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'WorldMap', 'worldMapLogic', key]),
-    connect(() => ({
-        values: [insightLogic, ['insight', 'filters']],
+    connect((props: InsightLogicProps) => ({
+        values: [insightVizDataLogic(props), ['insightData', 'trendsFilter', 'series']],
     })),
     actions({
         showTooltip: (countryCode: string, countrySeries: TrendResult | null) => ({ countryCode, countrySeries }),
@@ -39,19 +39,19 @@ export const worldMapLogic = kea<worldMapLogicType>([
     }),
     selectors({
         countryCodeToSeries: [
-            (s) => [s.insight],
-            (insight): Record<string, TrendResult> =>
+            (s) => [s.insightData],
+            (insightData): Record<string, TrendResult> =>
                 Object.fromEntries(
-                    Array.isArray(insight.result)
-                        ? insight.result.map((series: TrendResult) => [series.breakdown_value, series])
+                    Array.isArray(insightData?.result)
+                        ? insightData.result.map((series: TrendResult) => [series.breakdown_value, series])
                         : []
                 ),
         ],
         maxAggregatedValue: [
-            (s) => [s.insight],
-            (insight) =>
-                Array.isArray(insight.result)
-                    ? Math.max(...insight.result.map((series: TrendResult) => series.aggregated_value))
+            (s) => [s.insightData],
+            (insightData) =>
+                Array.isArray(insightData?.result)
+                    ? Math.max(...insightData.result.map((series: TrendResult) => series.aggregated_value))
                     : 0,
         ],
     }),

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { ActionsPie, ActionsLineGraph, ActionsHorizontalBar } from './viz'
 import { trendsLogic } from './trendsLogic'
 import { ChartDisplayType, InsightType, ItemMode } from '~/types'
-import { InsightsTableDataExploration } from 'scenes/insights/views/InsightsTable/InsightsTable'
+import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { WorldMap } from 'scenes/insights/views/WorldMap'
@@ -35,7 +35,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
             return <BoldNumber />
         }
         if (display === ChartDisplayType.ActionsTable) {
-            const ActionsTable = InsightsTableDataExploration
+            const ActionsTable = InsightsTable
             return (
                 <ActionsTable
                     embedded


### PR DESCRIPTION
## Problem

Some of the insight components have a legacy, non-data exploration variant.

## Changes

This PR:
- converts the BoldNumber visualization to rely on query nodes, not filters
- converts the WorldMap visualization to rely on query nodes, not filters
- removes the legacy variant of InsightsTable, but it still relies on filters

## How did you test this code?

Manual testing