### PR TITLE
chore: add settings param for run_sql_with_exceptions migrations function

### DIFF
--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -3,12 +3,12 @@ from infi.clickhouse_orm import migrations
 from posthog.clickhouse.client.execute import sync_execute
 
 
-def run_sql_with_exceptions(sql: str):
+def run_sql_with_exceptions(sql: str, settings={}):
     """
     migrations.RunSQL does not raise exceptions, so we need to wrap it in a function that does.
     """
 
     def run_sql(database):
-        sync_execute(sql)
+        sync_execute(sql, settings=settings)
 
     return migrations.RunPython(run_sql)

--- a/posthog/clickhouse/migrations/0045_session_replay_events_size.py
+++ b/posthog/clickhouse/migrations/0045_session_replay_events_size.py
@@ -11,6 +11,9 @@ from posthog.models.session_replay_event.sql import (
     KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
 )
 
+settings = {
+    "max_execution_time": "43200",
+}
 
 operations = [
     # we have to drop materialized view first so that we're no longer pulling from kakfa
@@ -18,9 +21,9 @@ operations = [
     run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
     run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     # now we can alter the target tables
-    run_sql_with_exceptions(ADD_SIZE_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    run_sql_with_exceptions(ADD_SIZE_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    run_sql_with_exceptions(ADD_SIZE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_SIZE_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL(), settings=settings),
+    run_sql_with_exceptions(ADD_SIZE_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(), settings=settings),
+    run_sql_with_exceptions(ADD_SIZE_SESSION_REPLAY_EVENTS_TABLE_SQL(), settings=settings),
     # and then recreate the materialized views and kafka tables
     run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),


### PR DESCRIPTION
## Problem

Migrations are timing out on EU and we should have some way to allow long running migrations longer than 120 seconds to complete.

## Changes

Allow settings to be passed to run_sql routine in migrations

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
