### PR TITLE
fix(surveys): highlight full release

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -10,6 +10,7 @@ import {
     LemonDivider,
     LemonInput,
     LemonSelect,
+    LemonTag,
     LemonTextArea,
     Link,
 } from '@posthog/lemon-ui'
@@ -317,7 +318,9 @@ export function SurveyReleaseSummary({
                         This survey will be released to users who match <b>all</b> of the following:
                     </>
                 ) : (
-                    'This survey will be released to everyone'
+                    <LemonTag type="highlight">
+                        <span className="text-sm">This survey will be released to everyone</span>
+                    </LemonTag>
                 )}
             </div>
             {survey.linked_flag_id && (

--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -315,11 +315,14 @@ export function SurveyReleaseSummary({
                 survey.conditions?.selector ||
                 targetingFlagFilters ? (
                     <>
-                        This survey will be released to users who match <b>all</b> of the following:
+                        This survey {survey.start_date ? 'is' : 'will be'} released to users who match <b>all</b> of the
+                        following:
                     </>
                 ) : (
                     <LemonTag type="highlight">
-                        <span className="text-sm">This survey will be released to everyone</span>
+                        <span className="text-sm">
+                            This survey {survey.start_date ? 'is' : 'will be'} released to everyone
+                        </span>
                     </LemonTag>
                 )}
             </div>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Highlight when surveys are going to be released to everyone.

<img width="440" alt="Screen Shot 2023-06-27 at 3 44 36 PM" src="https://github.com/PostHog/posthog/assets/25164963/21526d9b-41eb-498d-bf7b-e12a3068317f">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
