### PR TITLE
fix(data-warehouse): workaround for faulty tuple in array typing

### DIFF
--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -9,6 +9,7 @@ class S3Table(FunctionCallTable):
     format: str = "CSVWithNames"
     access_key: Optional[str] = None
     access_secret: Optional[str] = None
+    structure: str = ""
 
     def to_printed_hogql(self):
         return escape_hogql_identifier(self.name)
@@ -16,12 +17,11 @@ class S3Table(FunctionCallTable):
     def to_printed_clickhouse(self, context):
         escaped_url = context.add_value(self.url)
         escaped_format = context.add_value(self.format)
+        escaped_structure = context.add_value(self.structure)
 
         if self.access_key and self.access_secret:
             escaped_access_key = context.add_value(self.access_key)
             escaped_access_secret = context.add_value(self.access_secret)
 
-            return (
-                f"s3Cluster('posthog', {escaped_url}, {escaped_access_key}, {escaped_access_secret}, {escaped_format})"
-            )
+            return f"s3Cluster('posthog', {escaped_url}, {escaped_access_key}, {escaped_access_secret}, {escaped_format}, {escaped_structure})"
         return f"s3Cluster('posthog', {escaped_url}, {escaped_format})"

--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -9,7 +9,7 @@ class S3Table(FunctionCallTable):
     format: str = "CSVWithNames"
     access_key: Optional[str] = None
     access_secret: Optional[str] = None
-    structure: str = ""
+    structure: Optional[str] = None
 
     def to_printed_hogql(self):
         return escape_hogql_identifier(self.name)
@@ -19,9 +19,17 @@ class S3Table(FunctionCallTable):
         escaped_format = context.add_value(self.format)
         escaped_structure = context.add_value(self.structure)
 
+        expr = f"s3Cluster('posthog', {escaped_url}"
+
         if self.access_key and self.access_secret:
             escaped_access_key = context.add_value(self.access_key)
             escaped_access_secret = context.add_value(self.access_secret)
 
-            return f"s3Cluster('posthog', {escaped_url}, {escaped_access_key}, {escaped_access_secret}, {escaped_format}, {escaped_structure})"
-        return f"s3Cluster('posthog', {escaped_url}, {escaped_format})"
+            expr += f", {escaped_access_key}, {escaped_access_secret}"
+
+        expr += f", {escaped_format}"
+
+        if self.structure:
+            expr += f", {escaped_structure}"
+
+        return f"{expr})"

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -43,5 +43,5 @@ class TestDatabase(BaseTest):
         )
         self.assertEqual(
             response.clickhouse,
-            f"SELECT whatever.id FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_2)s, %(hogql_val_3)s, %(hogql_val_1)s) AS whatever LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
+            f"SELECT whatever.id FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_3)s, %(hogql_val_4)s, %(hogql_val_1)s, %(hogql_val_2)s) AS whatever LIMIT 100 SETTINGS readonly=2, max_execution_time=60",
         )

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -12,6 +12,7 @@ from posthog.hogql.database.models import (
     BooleanDatabaseField,
 )
 from posthog.hogql.database.s3_table import S3Table
+import re
 
 ClickhouseHogqlMapping = {
     "String": StringDatabaseField,
@@ -82,9 +83,15 @@ class DataWarehouseTable(CreatedMetaFields, UUIDModel, DeletedMetaFields):
             raise Exception("Columns must be fetched and saved to use in HogQL.")
 
         fields = {}
+        structure = []
         for column, type in self.columns.items():
             if type.startswith("Nullable("):
                 type = type.replace("Nullable(", "")[:-1]
+
+            if type.startswith("Array("):
+                type = self.remove_named_tuples(type)
+
+            structure.append(f"{column} {type}")
             type = type.partition("(")[0]
             type = ClickhouseHogqlMapping[type]
             fields[column] = type(name=column)
@@ -96,7 +103,20 @@ class DataWarehouseTable(CreatedMetaFields, UUIDModel, DeletedMetaFields):
             access_key=self.credential.access_key,
             access_secret=self.credential.access_secret,
             fields=fields,
+            structure=", ".join(structure),
         )
+
+    def remove_named_tuples(self, type):
+        """Remove named tuples from query"""
+        tokenified_type = re.split(r"(\W)", type)
+        filtered_tokens = [
+            token
+            for token in tokenified_type
+            if token == "Nullable"
+            or (len(token) == 1 and not token.isalnum())
+            or token in ClickhouseHogqlMapping.keys()
+        ]
+        return "".join(filtered_tokens)
 
     def _safe_expose_ch_error(self, err):
         err = wrap_query_error(err)

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -88,6 +88,7 @@ class DataWarehouseTable(CreatedMetaFields, UUIDModel, DeletedMetaFields):
             if type.startswith("Nullable("):
                 type = type.replace("Nullable(", "")[:-1]
 
+            # TODO: remove when addressed https://github.com/ClickHouse/ClickHouse/issues/37594
             if type.startswith("Array("):
                 type = self.remove_named_tuples(type)
 

--- a/posthog/warehouse/models/test/test_table.py
+++ b/posthog/warehouse/models/test/test_table.py
@@ -35,3 +35,30 @@ class TestTable(BaseTest):
             credential=credential,
         )
         self.assertEqual(list(table.hogql_definition().fields.keys()), ["id", "timestamp", "mrr", "offset"])
+
+    def test_hogql_definition_tuple_patch(self):
+
+        credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)
+        table = DataWarehouseTable.objects.create(
+            name="bla",
+            url_pattern="https://databeach-hackathon.s3.amazonaws.com/tim_test/test_events6.pqt",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            columns={
+                "id": "String",
+                "timestamp": "DateTime64(3, 'UTC')",
+                "mrr": "Nullable(Int64)",
+                "complex_field": "Array(Tuple(type Nullable(String), value Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))))",
+                "tuple_field": "Tuple(type Nullable(String), value Nullable(String), _airbyte_additional_properties Map(String, Nullable(String)))",
+                "offset": "UInt32",
+            },
+            credential=credential,
+        )
+        self.assertEqual(
+            list(table.hogql_definition().fields.keys()),
+            ["id", "timestamp", "mrr", "complex_field", "tuple_field", "offset"],
+        )
+        self.assertEqual(
+            table.hogql_definition().structure,
+            "id String, timestamp DateTime64(3, 'UTC'), mrr Int64, complex_field Array(Tuple( Nullable(String),  Nullable(String),  Map(String, Nullable(String)))), tuple_field Tuple(type Nullable(String), value Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))), offset UInt32",
+        )


### PR DESCRIPTION
## Problem

- https://github.com/ClickHouse/ClickHouse/issues/37594
- Tuples in arrays aren't mapped properly in s3 extension

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- remove names in the tuple type that cause query to fail

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
