### PR TITLE
feat(hogvm): async operations for in cohort support (HogVM part 3)

### DIFF
--- a/hogvm/CHANGELOG.md
+++ b/hogvm/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2023-06-28 - In Cohort
 
-### Operations added
+### New async operations
 
 ```bash
 IN_COHORT = 27     # [val2, val1, IREGEX]               # val1 in cohort val2

--- a/hogvm/CHANGELOG.md
+++ b/hogvm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # HogQL bytecode changelog 
 
+## 2023-06-28 - In Cohort
+
+### Operations added
+
+```bash
+IN_COHORT = 27     # [val2, val1, IREGEX]               # val1 in cohort val2
+NOT_IN_COHORT = 28 # [val2, val1, NOT_IREGEX]           # val1 not in cohort val2
+```
+
 ## 2023-06-28 - First version
 
 ### Operations added

--- a/hogvm/README.md
+++ b/hogvm/README.md
@@ -58,19 +58,26 @@ NULL = 31          # [NULL]                             # null
 STRING = 32        # [STRING, 'text']                   # 'text'
 INTEGER = 33       # [INTEGER, 123]                     # 123
 FLOAT = 34         # [FLOAT, 123.12]                    # 123.01
-
-# Added for completion, but not yet implemented. Stay tuned!
-IN_COHORT = 27     # [val2, val1, IREGEX]               # val1 in cohort val2
-NOT_IN_COHORT = 28 # [val2, val1, NOT_IREGEX]           # val1 not in cohort val2
 ```
 
 ### Async Operations
 
-Some operations aren't resolved directly, but asked back to the caller. These include:
+Some operations can't be computed directly, and are thus asked back to the caller. These include:
 
 ```bash
 IN_COHORT = 27     # [val2, val1, IREGEX]               # val1 in cohort val2
 NOT_IN_COHORT = 28 # [val2, val1, NOT_IREGEX]           # val1 not in cohort val2
+```
+
+The arguments for these instructions will be passed on to the provided `async_operation(*args)` in reverse:
+
+```python
+def async_operation(*args):
+    if args[0] == op.IN_COHORT:
+        return db.queryInCohort(args[1], args[2])
+    return False
+
+execute_bytecode(to_bytecode("'user_id' in cohort 2"), {}, async_operation)
 ```
 
 ### Functions
@@ -96,6 +103,7 @@ In HogQL equality comparisons, `null` is treated as any other variable. Its pres
 ```
 
 Nulls are just ignored in `concat`
+
 
 ## Known broken features
 

--- a/hogvm/README.md
+++ b/hogvm/README.md
@@ -64,6 +64,15 @@ IN_COHORT = 27     # [val2, val1, IREGEX]               # val1 in cohort val2
 NOT_IN_COHORT = 28 # [val2, val1, NOT_IREGEX]           # val1 not in cohort val2
 ```
 
+### Async Operations
+
+Some operations aren't resolved directly, but asked back to the caller. These include:
+
+```bash
+IN_COHORT = 27     # [val2, val1, IREGEX]               # val1 in cohort val2
+NOT_IN_COHORT = 28 # [val2, val1, NOT_IREGEX]           # val1 not in cohort val2
+```
+
 ### Functions
 
 A PostHog HogQL Bytecode Certified Parser must also implement the following function calls:

--- a/hogvm/python/execute.py
+++ b/hogvm/python/execute.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Callable, Optional
 
 from hogvm.python.operation import Operation, HOGQL_BYTECODE_IDENTIFIER
 
@@ -33,7 +33,9 @@ def to_concat_arg(arg) -> str:
     return str(arg)
 
 
-def execute_bytecode(bytecode: List[Any], fields: Dict[str, Any]) -> Any:
+def execute_bytecode(
+    bytecode: List[Any], fields: Dict[str, Any], async_operation: Optional[Callable[..., Any]] = None
+) -> Any:
     try:
         stack = []
         iterator = iter(bytecode)
@@ -94,6 +96,16 @@ def execute_bytecode(bytecode: List[Any], fields: Dict[str, Any]) -> Any:
                     stack.append(stack.pop() in stack.pop())
                 case Operation.NOT_IN:
                     stack.append(stack.pop() not in stack.pop())
+                case Operation.IN_COHORT:
+                    if async_operation is None:
+                        raise HogVMException("HogVM async_operation IN_COHORT not provided")
+                    args = [Operation.IN_COHORT, stack.pop(), stack.pop()]
+                    stack.append(async_operation(*args))
+                case Operation.NOT_IN_COHORT:
+                    if async_operation is None:
+                        raise HogVMException("HogVM async_operation NOT_IN_COHORT not provided")
+                    args = [Operation.NOT_IN_COHORT, stack.pop(), stack.pop()]
+                    stack.append(async_operation(*args))
                 case Operation.REGEX:
                     args = [stack.pop(), stack.pop()]
                     stack.append(bool(re.search(re.compile(args[1]), args[0])))

--- a/hogvm/python/test/test_execute.py
+++ b/hogvm/python/test/test_execute.py
@@ -104,3 +104,30 @@ class TestBytecodeExecute(BaseTest):
         with self.assertRaises(Exception) as e:
             execute_bytecode([_H, op.TRUE, op.TRUE, op.NOT], {})
         self.assertEqual(str(e.exception), "Invalid bytecode. More than one value left on stack")
+
+    def test_async_operations(self):
+        def async_operation(*args):
+            if args[0] == op.IN_COHORT:
+                return args[1] == "my_id" or args[2] == 2
+            elif args[0] == op.NOT_IN_COHORT:
+                return not (args[1] == "my_id" or args[2] == 2)
+            return False
+
+        self.assertEqual(
+            execute_bytecode([_H, op.INTEGER, 1, op.STRING, "my_id", op.IN_COHORT], {}, async_operation), True
+        )
+        self.assertEqual(
+            execute_bytecode([_H, op.INTEGER, 1, op.STRING, "other_id", op.IN_COHORT], {}, async_operation), False
+        )
+        self.assertEqual(
+            execute_bytecode([_H, op.INTEGER, 2, op.STRING, "other_id", op.IN_COHORT], {}, async_operation), True
+        )
+        self.assertEqual(
+            execute_bytecode([_H, op.INTEGER, 1, op.STRING, "my_id", op.NOT_IN_COHORT], {}, async_operation), False
+        )
+        self.assertEqual(
+            execute_bytecode([_H, op.INTEGER, 1, op.STRING, "other_id", op.NOT_IN_COHORT], {}, async_operation), True
+        )
+        self.assertEqual(
+            execute_bytecode([_H, op.INTEGER, 2, op.STRING, "other_id", op.NOT_IN_COHORT], {}, async_operation), False
+        )

--- a/hogvm/typescript/src/__tests__/bytecode.test.ts
+++ b/hogvm/typescript/src/__tests__/bytecode.test.ts
@@ -1,99 +1,156 @@
 import { executeHogQLBytecode, Operation as op } from '../bytecode'
 
 describe('HogQL Bytecode', () => {
-    test('execution results', () => {
+    test('execution results', async () => {
         const fields = { properties: { foo: 'bar' } }
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.PLUS], fields)).toBe(3)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.MINUS], fields)).toBe(-1)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 3, op.MULTIPLY], fields)).toBe(6)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 3, op.DIVIDE], fields)).toBe(1.5)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 3, op.MOD], fields)).toBe(1)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.AND, 2], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 0, op.INTEGER, 1, op.OR, 2], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 0, op.INTEGER, 1, op.AND, 2], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 1, op.INTEGER, 0, op.INTEGER, 1, op.OR, 3], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.PLUS], fields)).toBe(3)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.MINUS], fields)).toBe(-1)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 3, op.MULTIPLY], fields)).toBe(6)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 3, op.DIVIDE], fields)).toBe(1.5)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 3, op.MOD], fields)).toBe(1)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.AND, 2], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 0, op.INTEGER, 1, op.OR, 2], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 0, op.INTEGER, 1, op.AND, 2], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 1, op.INTEGER, 0, op.INTEGER, 1, op.OR, 3], fields)).toBe(
+            true
+        )
         expect(
-            executeHogQLBytecode(['_h', op.INTEGER, 0, op.INTEGER, 1, op.AND, 2, op.INTEGER, 1, op.AND, 2], fields)
+            await executeHogQLBytecode(
+                ['_h', op.INTEGER, 0, op.INTEGER, 1, op.AND, 2, op.INTEGER, 1, op.AND, 2],
+                fields
+            )
         ).toBe(false)
         expect(
-            executeHogQLBytecode(
+            await executeHogQLBytecode(
                 ['_h', op.INTEGER, 2, op.INTEGER, 1, op.OR, 2, op.INTEGER, 2, op.INTEGER, 1, op.OR, 2, op.AND, 2],
                 fields
             )
         ).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.TRUE, op.NOT], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.EQ], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.NOT_EQ], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.LT], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.LT_EQ], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.GT], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.GT_EQ], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.LIKE], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, '%a%', op.STRING, 'baa', op.LIKE], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, '%x%', op.STRING, 'baa', op.LIKE], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, '%A%', op.STRING, 'baa', op.ILIKE], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, '%C%', op.STRING, 'baa', op.ILIKE], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.NOT_LIKE], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.NOT_ILIKE], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'car', op.STRING, 'a', op.IN], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'car', op.STRING, 'a', op.NOT_IN], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'a', op.REGEX], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.REGEX], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'a', op.NOT_REGEX], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.NOT_REGEX], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'kala', op.IREGEX], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'kala', op.IREGEX], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'AL', op.STRING, 'kala', op.IREGEX], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'kala', op.NOT_IREGEX], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'kala', op.NOT_IREGEX], fields)).toBe(true)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'AL', op.STRING, 'kala', op.NOT_IREGEX], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'bla', op.STRING, 'properties', op.FIELD, 2], fields)).toBe(null)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'foo', op.STRING, 'properties', op.FIELD, 2], fields)).toBe('bar')
-        expect(executeHogQLBytecode(['_h', op.STRING, 'another', op.STRING, 'arg', op.CALL, 'concat', 2], fields)).toBe(
-            'arganother'
-        )
-        expect(executeHogQLBytecode(['_h', op.NULL, op.INTEGER, 1, op.CALL, 'concat', 2], fields)).toBe('1')
-        expect(executeHogQLBytecode(['_h', op.FALSE, op.TRUE, op.CALL, 'concat', 2], fields)).toBe('truefalse')
-        expect(executeHogQLBytecode(['_h', op.STRING, 'e.*', op.STRING, 'test', op.CALL, 'match', 2], fields)).toBe(
-            true
-        )
-        expect(executeHogQLBytecode(['_h', op.STRING, '^e.*', op.STRING, 'test', op.CALL, 'match', 2], fields)).toBe(
+        expect(await executeHogQLBytecode(['_h', op.TRUE, op.NOT], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.EQ], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.NOT_EQ], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.LT], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.LT_EQ], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.GT], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, op.GT_EQ], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.LIKE], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '%a%', op.STRING, 'baa', op.LIKE], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '%x%', op.STRING, 'baa', op.LIKE], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '%A%', op.STRING, 'baa', op.ILIKE], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '%C%', op.STRING, 'baa', op.ILIKE], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.NOT_LIKE], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.NOT_ILIKE], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'car', op.STRING, 'a', op.IN], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'car', op.STRING, 'a', op.NOT_IN], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'a', op.REGEX], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.REGEX], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'a', op.NOT_REGEX], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'a', op.NOT_REGEX], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'kala', op.IREGEX], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'kala', op.IREGEX], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'AL', op.STRING, 'kala', op.IREGEX], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '.*', op.STRING, 'kala', op.NOT_IREGEX], fields)).toBe(
             false
         )
-        expect(executeHogQLBytecode(['_h', op.STRING, 'x.*', op.STRING, 'test', op.CALL, 'match', 2], fields)).toBe(
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'b', op.STRING, 'kala', op.NOT_IREGEX], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'AL', op.STRING, 'kala', op.NOT_IREGEX], fields)).toBe(
             false
         )
-        expect(executeHogQLBytecode(['_h', op.INTEGER, 1, op.CALL, 'toString', 1], fields)).toBe('1')
-        expect(executeHogQLBytecode(['_h', op.FLOAT, 1.5, op.CALL, 'toString', 1], fields)).toBe('1.5')
-        expect(executeHogQLBytecode(['_h', op.TRUE, op.CALL, 'toString', 1], fields)).toBe('true')
-        expect(executeHogQLBytecode(['_h', op.NULL, op.CALL, 'toString', 1], fields)).toBe('null')
-        expect(executeHogQLBytecode(['_h', op.STRING, 'string', op.CALL, 'toString', 1], fields)).toBe('string')
-        expect(executeHogQLBytecode(['_h', op.STRING, '1', op.CALL, 'toInt', 1], fields)).toBe(1)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'bla', op.CALL, 'toInt', 1], fields)).toBe(null)
-        expect(executeHogQLBytecode(['_h', op.STRING, '1.2', op.CALL, 'toFloat', 1], fields)).toBe(1.2)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'bla', op.CALL, 'toFloat', 1], fields)).toBe(null)
-        expect(executeHogQLBytecode(['_h', op.STRING, 'asd', op.CALL, 'toUUID', 1], fields)).toBe('asd')
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'bla', op.STRING, 'properties', op.FIELD, 2], fields)).toBe(
+            null
+        )
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'foo', op.STRING, 'properties', op.FIELD, 2], fields)).toBe(
+            'bar'
+        )
+        expect(
+            await executeHogQLBytecode(['_h', op.STRING, 'another', op.STRING, 'arg', op.CALL, 'concat', 2], fields)
+        ).toBe('arganother')
+        expect(await executeHogQLBytecode(['_h', op.NULL, op.INTEGER, 1, op.CALL, 'concat', 2], fields)).toBe('1')
+        expect(await executeHogQLBytecode(['_h', op.FALSE, op.TRUE, op.CALL, 'concat', 2], fields)).toBe('truefalse')
+        expect(
+            await executeHogQLBytecode(['_h', op.STRING, 'e.*', op.STRING, 'test', op.CALL, 'match', 2], fields)
+        ).toBe(true)
+        expect(
+            await executeHogQLBytecode(['_h', op.STRING, '^e.*', op.STRING, 'test', op.CALL, 'match', 2], fields)
+        ).toBe(false)
+        expect(
+            await executeHogQLBytecode(['_h', op.STRING, 'x.*', op.STRING, 'test', op.CALL, 'match', 2], fields)
+        ).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.INTEGER, 1, op.CALL, 'toString', 1], fields)).toBe('1')
+        expect(await executeHogQLBytecode(['_h', op.FLOAT, 1.5, op.CALL, 'toString', 1], fields)).toBe('1.5')
+        expect(await executeHogQLBytecode(['_h', op.TRUE, op.CALL, 'toString', 1], fields)).toBe('true')
+        expect(await executeHogQLBytecode(['_h', op.NULL, op.CALL, 'toString', 1], fields)).toBe('null')
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'string', op.CALL, 'toString', 1], fields)).toBe('string')
+        expect(await executeHogQLBytecode(['_h', op.STRING, '1', op.CALL, 'toInt', 1], fields)).toBe(1)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'bla', op.CALL, 'toInt', 1], fields)).toBe(null)
+        expect(await executeHogQLBytecode(['_h', op.STRING, '1.2', op.CALL, 'toFloat', 1], fields)).toBe(1.2)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'bla', op.CALL, 'toFloat', 1], fields)).toBe(null)
+        expect(await executeHogQLBytecode(['_h', op.STRING, 'asd', op.CALL, 'toUUID', 1], fields)).toBe('asd')
 
-        expect(executeHogQLBytecode(['_h', op.NULL, op.INTEGER, 1, op.EQ], fields)).toBe(false)
-        expect(executeHogQLBytecode(['_h', op.NULL, op.INTEGER, 1, op.NOT_EQ], fields)).toBe(true)
+        expect(await executeHogQLBytecode(['_h', op.NULL, op.INTEGER, 1, op.EQ], fields)).toBe(false)
+        expect(await executeHogQLBytecode(['_h', op.NULL, op.INTEGER, 1, op.NOT_EQ], fields)).toBe(true)
     })
 
-    test('error handling', () => {
+    test('error handling', async () => {
         const fields = { properties: { foo: 'bar' } }
-        expect(() => executeHogQLBytecode([], fields)).toThrowError("Invalid HogQL bytecode, must start with '_h'")
-        expect(() => executeHogQLBytecode(['_h'], fields)).toThrowError('Invalid HogQL bytecode, stack is empty')
-        expect(() => executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, 'InvalidOp'], fields)).toThrowError(
-            'Unexpected node while running bytecode: InvalidOp'
+        await expect(executeHogQLBytecode([], fields)).rejects.toThrowError(
+            "Invalid HogQL bytecode, must start with '_h'"
         )
-        expect(() =>
-            executeHogQLBytecode(['_h', op.STRING, 'another', op.STRING, 'arg', op.CALL, 'invalidFunc', 2], fields)
-        ).toThrowError('Unsupported function call: invalidFunc')
-        expect(() => executeHogQLBytecode(['_h', op.INTEGER], fields)).toThrowError('Unexpected end of bytecode')
-        expect(() => executeHogQLBytecode(['_h', op.CALL, 'match', 1], fields)).toThrowError(
+        await expect(executeHogQLBytecode(['_h'], fields)).rejects.toThrowError(
             'Invalid HogQL bytecode, stack is empty'
         )
-        expect(() => executeHogQLBytecode(['_h', op.TRUE, op.TRUE, op.NOT], fields)).toThrowError(
+        await expect(
+            executeHogQLBytecode(['_h', op.INTEGER, 2, op.INTEGER, 1, 'InvalidOp'], fields)
+        ).rejects.toThrowError('Unexpected node while running bytecode: InvalidOp')
+        await expect(
+            executeHogQLBytecode(['_h', op.STRING, 'another', op.STRING, 'arg', op.CALL, 'invalidFunc', 2], fields)
+        ).rejects.toThrowError('Unsupported function call: invalidFunc')
+        await expect(executeHogQLBytecode(['_h', op.INTEGER], fields)).rejects.toThrowError(
+            'Unexpected end of bytecode'
+        )
+        await expect(executeHogQLBytecode(['_h', op.CALL, 'match', 1], fields)).rejects.toThrowError(
+            'Invalid HogQL bytecode, stack is empty'
+        )
+        await expect(executeHogQLBytecode(['_h', op.TRUE, op.TRUE, op.NOT], fields)).rejects.toThrowError(
             'Invalid bytecode. More than one value left on stack'
         )
+    })
+
+    test('async operations', async () => {
+        function asyncOperation(...args: any[]): any {
+            if (args[0] == op.IN_COHORT) {
+                return args[1] == 'my_id' || args[2] == 2
+            } else if (args[0] == op.NOT_IN_COHORT) {
+                return !(args[1] == 'my_id' || args[2] == 2)
+            }
+            return false
+        }
+
+        expect(
+            await executeHogQLBytecode(['_h', op.INTEGER, 1, op.STRING, 'my_id', op.IN_COHORT], {}, asyncOperation)
+        ).toEqual(true)
+        expect(
+            await executeHogQLBytecode(['_h', op.INTEGER, 1, op.STRING, 'other_id', op.IN_COHORT], {}, asyncOperation)
+        ).toEqual(false)
+        expect(
+            await executeHogQLBytecode(['_h', op.INTEGER, 2, op.STRING, 'other_id', op.IN_COHORT], {}, asyncOperation)
+        ).toEqual(true)
+        expect(
+            await executeHogQLBytecode(['_h', op.INTEGER, 1, op.STRING, 'my_id', op.NOT_IN_COHORT], {}, asyncOperation)
+        ).toEqual(false)
+        expect(
+            await executeHogQLBytecode(
+                ['_h', op.INTEGER, 1, op.STRING, 'other_id', op.NOT_IN_COHORT],
+                {},
+                asyncOperation
+            )
+        ).toEqual(true)
+        expect(
+            await executeHogQLBytecode(
+                ['_h', op.INTEGER, 2, op.STRING, 'other_id', op.NOT_IN_COHORT],
+                {},
+                asyncOperation
+            )
+        ).toEqual(false)
     })
 })

--- a/hogvm/typescript/src/bytecode.ts
+++ b/hogvm/typescript/src/bytecode.ts
@@ -58,7 +58,11 @@ function toConcatArg(arg: any): string {
     return arg === null ? '' : String(arg)
 }
 
-export function executeHogQLBytecode(bytecode: any[], fields: Record<string, any>): any {
+export async function executeHogQLBytecode(
+    bytecode: any[],
+    fields: Record<string, any>,
+    asyncOperation?: (...args: any[]) => any | Promise<any>
+): Promise<any> {
     let temp: any
     const stack: any[] = []
 
@@ -171,6 +175,13 @@ export function executeHogQLBytecode(bytecode: any[], fields: Record<string, any
             case Operation.NOT_IN:
                 temp = popStack()
                 stack.push(!popStack().includes(temp))
+                break
+            case Operation.IN_COHORT:
+            case Operation.NOT_IN_COHORT:
+                if (!asyncOperation) {
+                    throw new Error('HogVM async operation IN_COHORT not provided')
+                }
+                stack.push(await asyncOperation(bytecode[i], popStack(), popStack()))
                 break
             case Operation.REGEX:
                 temp = popStack()


### PR DESCRIPTION
## Problem

HogVM is not able to call `IN_COHORT`. 

## Changes

Adds a standardised `async_operation` / `asyncOperation` construct, which is used to make database queries and other async operations.

The plugin server actually makes a simple postgres DB query when answering this question.

## How did you test this code?

Wrote tests for both the Python and TypeScript implementations.

## Next step:

- Actually connecting this to action matching the plugin server.
- Support for inlining cohorts when possible