### PR TITLE
chore(exports): try calling heartbeat a bit more often

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -47,7 +47,9 @@ export async function eachBatch(
             }
 
             const lastBatchMessage = messageBatch[messageBatch.length - 1]
-            await Promise.all(messageBatch.map((message: KafkaMessage) => eachMessage(message, queue)))
+            await Promise.all(
+                messageBatch.map((message: KafkaMessage) => eachMessage(message, queue).then(() => heartbeat()))
+            )
 
             // this if should never be false, but who can trust computers these days
             if (lastBatchMessage) {

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -48,7 +48,7 @@ export async function eachBatch(
 
             const lastBatchMessage = messageBatch[messageBatch.length - 1]
             await Promise.all(
-                messageBatch.map((message: KafkaMessage) => eachMessage(message, queue).then(() => heartbeat()))
+                messageBatch.map((message: KafkaMessage) => eachMessage(message, queue).finally(() => heartbeat()))
             )
 
             // this if should never be false, but who can trust computers these days

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -131,7 +131,7 @@ describe('eachBatchX', () => {
 
     describe('eachBatch', () => {
         it('calls eachMessage with the correct arguments', async () => {
-            const eachMessage = jest.fn()
+            const eachMessage = jest.fn(() => Promise.resolve())
             const batch = createKafkaJSBatch(event)
             await eachBatch(batch, queue, eachMessage, groupIntoBatches, 'key')
 
@@ -139,7 +139,7 @@ describe('eachBatchX', () => {
         })
 
         it('tracks metrics based on the key', async () => {
-            const eachMessage = jest.fn()
+            const eachMessage = jest.fn(() => Promise.resolve())
             await eachBatch(createKafkaJSBatch(event), queue, eachMessage, groupIntoBatches, 'my_key')
 
             expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(


### PR DESCRIPTION
Looks like we end up rebalancing often. Possibly because we're not
sending the heartbeats in time and the session timing out.

This won't help always, but maybe it gives us a better chance of 
staying in the group.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
