### PR TITLE
fix: make sure the timestamp is a datetime object

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -922,7 +922,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         }
 
     @patch("posthog.tasks.usage_report.Client")
-    def test_capture_event_called_with_string_timestamp(self, mock_client) -> None:
+    def test_capture_event_called_with_string_timestamp(self, mock_client: MagicMock) -> None:
         organization = Organization.objects.create()
         mock_posthog = MagicMock()
         mock_client.return_value = mock_posthog

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2,10 +2,11 @@ from datetime import datetime
 from typing import Any, Dict, List
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 from uuid import uuid4
-from django.test import TestCase
 
 import structlog
 from dateutil.relativedelta import relativedelta
+from dateutil.tz import tzutc
+from django.test import TestCase
 from django.utils.timezone import now
 from freezegun import freeze_time
 
@@ -24,7 +25,7 @@ from posthog.models.plugin import PluginConfig
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.schema import EventsQuery
 from posthog.session_recordings.test.test_factory import create_snapshot
-from posthog.tasks.usage_report import send_all_org_usage_reports
+from posthog.tasks.usage_report import capture_event, send_all_org_usage_reports
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseDestroyTablesMixin,
@@ -60,7 +61,6 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
         self.org_2_team_3 = Team.objects.create(organization=self.org_2, name="Team 3 org 2")
 
         with self.settings(USE_TZ=False):
-
             # Events for internal org
             distinct_id = str(uuid4())
             _create_person(distinct_ids=[distinct_id], team=self.org_internal_team_0)
@@ -250,7 +250,6 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
         PluginConfig.objects.create(plugin=plugin, enabled=enabled, order=1)
 
     def _test_usage_report(self) -> List[dict]:
-
         with self.settings(SITE_URL="http://test.posthog.com"):
             self._create_sample_usage_data()
             self._create_plugin("Installed but not enabled", False)
@@ -586,7 +585,6 @@ class TestFeatureFlagsUsageReport(TestCase, ClickhouseTestMixin):
     @patch("posthog.tasks.usage_report.Client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_usage_report_decide_requests(self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock) -> None:
-
         self._setup_teams()
         for i in range(10):
             _create_event(
@@ -689,7 +687,6 @@ class TestFeatureFlagsUsageReport(TestCase, ClickhouseTestMixin):
     def test_usage_report_local_evaluation_requests(
         self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock
     ) -> None:
-
         self._setup_teams()
         for i in range(10):
             _create_event(
@@ -907,7 +904,6 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
     @patch("posthog.tasks.usage_report.Client")
     @patch("requests.post")
     def test_org_usage_updated_correctly(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
-
         mockresponse = Mock()
         mock_post.return_value = mockresponse
         mockresponse.status_code = 200
@@ -925,13 +921,20 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             "period": ["2021-10-01T00:00:00Z", "2021-10-31T00:00:00Z"],
         }
 
+    @patch("posthog.tasks.usage_report.Client")
+    def test_capture_event_called_with_string_timestamp(self, mock_client) -> None:
+        organization = Organization.objects.create()
+        mock_posthog = MagicMock()
+        mock_client.return_value = mock_posthog
+        capture_event(mock_client, "test event", organization.id, {"prop1": "val1"}, "2021-10-10T23:01:00.00Z")
+        assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
+
 
 class SendNoUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
     @freeze_time("2021-10-10T23:01:00Z")
     @patch("posthog.tasks.usage_report.Client")
     @patch("requests.post")
     def test_usage_not_sent_if_zero(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
-
         mock_posthog = MagicMock()
         mock_client.return_value = mock_posthog
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -787,8 +787,8 @@ def send_all_org_usage_reports(
 
         # First capture the events to PostHog
         if not skip_capture_event:
-            at_date = at_date.isoformat() if at_date else None
-            capture_report.delay(capture_event_name, org_id, full_report_dict, at_date)
+            at_date_str = at_date.isoformat() if at_date else None
+            capture_report.delay(capture_event_name, org_id, full_report_dict, at_date_str)
 
         # Then capture the events to Billing
         if has_non_zero_usage(full_report):

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -787,6 +787,7 @@ def send_all_org_usage_reports(
 
         # First capture the events to PostHog
         if not skip_capture_event:
+            at_date = at_date.isoformat() if at_date else None
             capture_report.delay(capture_event_name, org_id, full_report_dict, at_date)
 
         # Then capture the events to Billing

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -284,7 +284,7 @@ def capture_event(
     name: str,
     organization_id: str,
     properties: Dict[str, Any],
-    timestamp: Optional[datetime] = None,
+    timestamp: Optional[Union[datetime, str]] = None,
 ) -> None:
     if timestamp and isinstance(timestamp, str):
         try:

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -6,18 +6,18 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Optional,
     Sequence,
     Tuple,
     TypedDict,
     Union,
     cast,
-    Literal,
 )
 
-import dateutil
 import requests
 import structlog
+from dateutil import parser
 from django.conf import settings
 from django.db import connection
 from django.db.models import Count, Q
@@ -38,8 +38,8 @@ from posthog.models.organization import Organization
 from posthog.models.plugin import PluginConfig
 from posthog.models.team.team import Team
 from posthog.models.utils import namedtuplefetchall
-from posthog.settings import INSTANCE_TAG, CLICKHOUSE_CLUSTER
-from posthog.utils import get_helm_info_env, get_instance_realm, get_machine_id, get_previous_day, get_instance_region
+from posthog.settings import CLICKHOUSE_CLUSTER, INSTANCE_TAG
+from posthog.utils import get_helm_info_env, get_instance_realm, get_instance_region, get_machine_id, get_previous_day
 from posthog.version import VERSION
 
 logger = structlog.get_logger(__name__)
@@ -286,6 +286,12 @@ def capture_event(
     properties: Dict[str, Any],
     timestamp: Optional[datetime] = None,
 ) -> None:
+    if timestamp and isinstance(timestamp, str):
+        try:
+            timestamp = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            timestamp = None
+
     if is_cloud():
         org_owner = get_org_owner_or_first_user(organization_id)
         distinct_id = org_owner.distinct_id if org_owner and org_owner.distinct_id else f"org-{organization_id}"
@@ -520,7 +526,7 @@ def send_all_org_usage_reports(
 ) -> List[dict]:  # Dict[str, OrgReport]:
     capture_event_name = capture_event_name or "organization usage report"
 
-    at_date = dateutil.parser.parse(at) if at else None
+    at_date = parser.parse(at) if at else None
     period = get_previous_day(at=at_date)
     period_start, period_end = period
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -288,7 +288,7 @@ def capture_event(
 ) -> None:
     if timestamp and isinstance(timestamp, str):
         try:
-            timestamp = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
+            timestamp = parser.isoparse(timestamp)
         except ValueError:
             timestamp = None
 


### PR DESCRIPTION
## Problem

Celery doesn't deserialize datetime objects we pass to it with the JSON serializer. Because of this, when we run usage reports manually and set a timestamp on the event, the timestamp just ends up as a string, which means that the event capture fails. This explains why decide usage has been missing when usage reports fail and I have to re-run them (when they run properly on the cron we don't set the timestamp on the event). 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

In the capture_event task, check if the timestamp is a string, and if so, try to convert it to a datetime object. If that fails, then just set it to None so we get the event, just with the wrong timestamp (we can use the `period` that is included in the event to do proper filtering of the timespan we are looking for).

There are other serializers (yaml, pickle) but when I tried those it said disallowed, presumably because of possible security issues with pickle at least. Because we know what is likely to end up in this task I think the approach I've taken (if it's a string, convert it to a datetime) is fine, but open to feedback.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
