### PR TITLE
feat: start replay from event timestamp

### DIFF
--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -9,6 +9,7 @@ import { IconLink, IconPlayCircle } from 'lib/lemon-ui/icons'
 import { useActions } from 'kea'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { copyToClipboard, insightUrlForEvent } from 'lib/utils'
+import { dayjs } from 'lib/dayjs'
 
 interface EventActionProps {
     event: EventType
@@ -63,9 +64,10 @@ export function EventRowActions({ event }: EventActionProps): JSX.Element {
                             onClick={(e) => {
                                 e.preventDefault()
                                 if (event.properties.$session_id) {
-                                    openSessionPlayer({
-                                        id: event.properties.$session_id,
-                                    })
+                                    openSessionPlayer(
+                                        { id: event.properties.$session_id },
+                                        dayjs(event.timestamp).valueOf()
+                                    )
                                 }
                             }}
                             fullWidth

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -32,6 +32,7 @@ import { LemonDivider } from '@posthog/lemon-ui'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { SessionPlayerModal } from 'scenes/session-recordings/player/modal/SessionPlayerModal'
 import { ExportWithConfirmation } from '~/queries/nodes/DataTable/ExportWithConfirmation'
+import { dayjs } from 'lib/dayjs'
 
 export interface FixedFilters {
     action_id?: ActionType['id']
@@ -357,9 +358,10 @@ export function EventsTable({
                                             status="stealth"
                                             onClick={() => {
                                                 event.properties.$session_id &&
-                                                    openSessionPlayer({
-                                                        id: event.properties.$session_id,
-                                                    })
+                                                    openSessionPlayer(
+                                                        { id: event.properties.$session_id },
+                                                        dayjs(event.timestamp).valueOf()
+                                                    )
                                             }}
                                             fullWidth
                                             sideIcon={<IconPlayCircle />}

--- a/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.test.ts
@@ -43,10 +43,13 @@ describe('sessionPlayerModalLogic', () => {
         })
 
         it('is read from the URL on the session recording page', async () => {
-            router.actions.push('/replay', {}, { sessionRecordingId: 'abc' })
+            router.actions.push('/replay', { timestamp: 12345678 }, { sessionRecordingId: 'abc' })
             expect(router.values.hashParams).toHaveProperty('sessionRecordingId', 'abc')
+            expect(router.values.searchParams).toHaveProperty('timestamp', 12345678)
 
-            await expectLogic(logic).toDispatchActions([logic.actionCreators.openSessionPlayer({ id: 'abc' })])
+            await expectLogic(logic).toDispatchActions([
+                logic.actionCreators.openSessionPlayer({ id: 'abc' }, 12345678),
+            ])
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -122,6 +122,17 @@ describe('sessionRecordingPlayerLogic', () => {
             })
             resumeKeaLoadersErrors()
         })
+        it('ensures the cache initialization is reset after the player is unmounted', async () => {
+            logic.unmount()
+            logic = sessionRecordingPlayerLogic({ sessionRecordingId: '2', playerKey: 'test' })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['initializePlayerFromStart'])
+            expect(logic.cache.hasInitialized).toBeTruthy()
+
+            logic.unmount()
+            expect(logic.cache.hasInitialized).toBeFalsy()
+        })
     })
 
     describe('delete session recording', () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -418,7 +418,10 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 if (!cache.hasInitialized) {
                     cache.hasInitialized = true
                     const searchParams = fromParamsGivenUrl(window.location.search)
-                    if (searchParams.t) {
+                    if (searchParams.timestamp) {
+                        const desiredStartTime = Number(searchParams.timestamp)
+                        actions.seekToTimestamp(desiredStartTime, true)
+                    } else if (searchParams.t) {
                         const desiredStartTime = Number(searchParams.t) * 1000
                         actions.seekToTime(desiredStartTime)
                     }
@@ -758,6 +761,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
     beforeUnmount(({ values, actions, cache }) => {
         cache.resetConsoleWarn?.()
+        cache.hasInitialized = false
         clearTimeout(cache.consoleWarnDebounceTimer)
         document.removeEventListener('fullscreenchange', cache.fullScreenListener)
         values.player?.replayer?.pause()


### PR DESCRIPTION
## Problem

Addresses https://github.com/PostHog/posthog/issues/15111

## Changes

Include the event timestamp as a query param when opening the session player. The player will attempt to initialise from the timestamp if present.

Fixes a bug with the initalization of the cache where it was being persisted across multiple instances of the player logic being mounted / unmounted

## How did you test this code?

Added tests
