### PR TITLE
fix(hogql): alias special chars

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -562,7 +562,10 @@ class _Printer(Visitor):
         inside = self.visit(node.expr)
         if isinstance(node.expr, ast.Alias):
             inside = f"({inside})"
-        return f"{inside} AS {self._print_identifier(node.alias)}"
+        alias = self._print_identifier(node.alias)
+        if "%" in alias:
+            raise HogQLException(f"Alias '{alias}' contains unsupported character '%'")
+        return f"{inside} AS {alias}"
 
     def visit_table_type(self, type: ast.TableType):
         if self.dialect == "clickhouse":

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -564,7 +564,7 @@ class _Printer(Visitor):
             inside = f"({inside})"
         alias = self._print_identifier(node.alias)
         if "%" in alias:
-            raise HogQLException(f"Alias '{alias}' contains unsupported character '%'")
+            raise HogQLException(f"Alias \"{node.alias}\" contains unsupported character '%'")
         return f"{inside} AS {alias}"
 
     def visit_table_type(self, type: ast.TableType):

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -255,6 +255,7 @@ class TestPrinter(BaseTest):
         self._assert_expr_error("person.chipotle", "Field not found: chipotle")
         self._assert_expr_error("properties.0", "SQL indexes start from one, not from zero. E.g: array[1]")
         self._assert_expr_error("properties.id.0", "SQL indexes start from one, not from zero. E.g: array[1]")
+        self._assert_expr_error("blas as `as%d`", "Alias 'as%d' contains unsupported character '%'")
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_expr_parse_errors_poe_on(self):

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -255,7 +255,7 @@ class TestPrinter(BaseTest):
         self._assert_expr_error("person.chipotle", "Field not found: chipotle")
         self._assert_expr_error("properties.0", "SQL indexes start from one, not from zero. E.g: array[1]")
         self._assert_expr_error("properties.id.0", "SQL indexes start from one, not from zero. E.g: array[1]")
-        self._assert_expr_error("blas as `as%d`", "Alias 'as%d' contains unsupported character '%'")
+        self._assert_expr_error("event as `as%d`", "Alias \"as%d\" contains unsupported character '%'")
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_expr_parse_errors_poe_on(self):


### PR DESCRIPTION
## Problem

Using some characters in aliases caused queries to error.

## Changes

Limits erroneous characters.

## How did you test this code?

In the query editor