### PR TITLE
fix(ingestion): use transaction client for feature flags

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1027,7 +1027,8 @@ export class DB {
     public async addFeatureFlagHashKeysForMergedPerson(
         teamID: Team['id'],
         sourcePersonID: Person['id'],
-        targetPersonID: Person['id']
+        targetPersonID: Person['id'],
+        client: PoolClient
     ): Promise<void> {
         // Delete and insert in a single query to ensure
         // this function is safe wherever it is run.
@@ -1050,7 +1051,8 @@ export class DB {
                 ON CONFLICT DO NOTHING
             `,
             [teamID, sourcePersonID, targetPersonID],
-            'addFeatureFlagHashKeysForMergedPerson'
+            'addFeatureFlagHashKeysForMergedPerson',
+            client
         )
     }
 

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -594,7 +594,7 @@ export class PersonState {
     private async handleTablesDependingOnPersonID(
         sourcePerson: Person,
         targetPerson: Person,
-        client?: PoolClient
+        client: PoolClient
     ): Promise<void> {
         // When personIDs change, update places depending on a person_id foreign key
 
@@ -607,7 +607,12 @@ export class PersonState {
         )
 
         // For FeatureFlagHashKeyOverrides
-        await this.db.addFeatureFlagHashKeysForMergedPerson(sourcePerson.team_id, sourcePerson.id, targetPerson.id)
+        await this.db.addFeatureFlagHashKeysForMergedPerson(
+            sourcePerson.team_id,
+            sourcePerson.id,
+            targetPerson.id,
+            client
+        )
     }
 }
 


### PR DESCRIPTION
We were not reusing the PG client for the update of feature flag
overrides before which I believe is not desired behaviour.

We were investigating the issue of the UPDATE posthog_cohortpeople query
being the last query to have run in the transaction which was idle and
noticed that the feature flag overrides query is being run immediately
after, which seemed odd that we didn't see _that_ query as the last one.
It's possible that you get into a state where e.g. the pgpool is
saturated, we run the cohort query, then the feature flag query tries to
run, but there are no connections available, so it waits for one to be,
but that never happens.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
