### PR TITLE
chore: make the 0046 clickhouse migration entirely no-op

### DIFF
--- a/posthog/clickhouse/migrations/0046_ensure_kafa_session_replay_table_exists.py
+++ b/posthog/clickhouse/migrations/0046_ensure_kafa_session_replay_table_exists.py
@@ -1,4 +1,6 @@
-operations = [
+from typing import List
+
+operations: List = [
     # this migration has been amended to be entirely No-op
     # it has applied successfully in Prod US where it was a no-op
     # as all tables/columns it affected already existed

--- a/posthog/clickhouse/migrations/0046_ensure_kafa_session_replay_table_exists.py
+++ b/posthog/clickhouse/migrations/0046_ensure_kafa_session_replay_table_exists.py
@@ -1,23 +1,9 @@
-from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.models.session_replay_event.migrations_sql import (
-    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
-    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
-)
-from posthog.models.session_replay_event.sql import (
-    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
-    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
-)
-
 operations = [
-    # manual incident resolution (or the aftermath of it)
-    # left the EU cluster without the kafka table
-    # this command ensures that kafka table is present on any server it is not already on
-    # we have to drop materialized view first so that we're no longer pulling from kakfa
-    # then we drop the kafka table
-    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
-    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    # now we would normally alter the target tables, but here do nothing
-    # and then recreate the materialized views and kafka tables
-    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    # this migration has been amended to be entirely No-op
+    # it has applied successfuly in Prod US where it was a no-op
+    # as all tables/columns it affected already existed
+    # it failed to apply in prod EU but there the change has been applied manually
+    # keeping it here so that hopefully it applies in EU
+    # and then EU and US migration listing are the same
+    # and nobody re-uses the 0046 migration label
 ]

--- a/posthog/clickhouse/migrations/0046_ensure_kafa_session_replay_table_exists.py
+++ b/posthog/clickhouse/migrations/0046_ensure_kafa_session_replay_table_exists.py
@@ -1,6 +1,6 @@
 operations = [
     # this migration has been amended to be entirely No-op
-    # it has applied successfuly in Prod US where it was a no-op
+    # it has applied successfully in Prod US where it was a no-op
     # as all tables/columns it affected already existed
     # it failed to apply in prod EU but there the change has been applied manually
     # keeping it here so that hopefully it applies in EU

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -588,12 +588,6 @@
               "key": "version",
               "type": "integer"
           }
-      ],
-      "whatever": [
-          {
-              "key": "id",
-              "type": "string"
-          }
       ]
   }
   '
@@ -1182,12 +1176,6 @@
           {
               "key": "version",
               "type": "integer"
-          }
-      ],
-      "whatever": [
-          {
-              "key": "id",
-              "type": "string"
           }
       ]
   }


### PR DESCRIPTION
## Problem

While EU is not able to apply mutations on all nodes deploys are failing

## Changes

This migration was effectively a no-op, let's make it completely a no-op

## How did you test this code?

🙈 