### PR TITLE
fix(insights): fix insight refresh on navigation (2/2)

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -152,6 +152,7 @@ export const FEATURE_FLAGS = {
     FF_DASHBOARD_TEMPLATES: 'ff-dashboard-templates', // owner: @EDsCODE
     SHOW_PRODUCT_INTRO_EXISTING_PRODUCTS: 'show-product-intro-existing-products', // owner: @raquelmsmith
     SESSION_RECORDING_SHOW_CONSOLE_LOGS_FILTER: 'session-recording-show-console-logs-filter', // owner: #team-monitoring
+    TMP_ROLLOUT_SAVED_INSIGHT_REFRESH_ON_NAVIGATION: 'tmp-rollout-saved-insight-refresh-on-navigation', // owner: @thmsobrmlr
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -1,13 +1,16 @@
 import { useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
+import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 
 export function ComputationTimeWithRefresh(): JSX.Element | null {
     const { lastRefresh } = useValues(dataNodeLogic)
 
-    if (!lastRefresh) {
-        return null
-    }
+    usePeriodicRerender(15000)
 
-    return <div className="flex items-center text-muted-alt">Computed {dayjs(lastRefresh).fromNow()}</div>
+    return (
+        <div className="flex items-center text-muted-alt">
+            Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
+        </div>
+    )
 }

--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -1,16 +1,13 @@
 import { useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
-import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 
 export function ComputationTimeWithRefresh(): JSX.Element | null {
     const { lastRefresh } = useValues(dataNodeLogic)
 
-    usePeriodicRerender(15000)
+    if (!lastRefresh) {
+        return null
+    }
 
-    return (
-        <div className="flex items-center text-muted-alt">
-            Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
-        </div>
-    )
+    return <div className="flex items-center text-muted-alt">Computed {dayjs(lastRefresh).fromNow()}</div>
 }

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -1,6 +1,6 @@
 import { ActionsNode, BreakdownFilter, EventsNode, InsightQueryNode, TrendsQuery } from '~/queries/schema'
 import { ActionType, ChartDisplayType, InsightModel, IntervalType } from '~/types'
-import { seriesToActionsAndEvents } from '../InsightQuery/utils/queryNodeToFilter'
+import { queryNodeToFilter, seriesToActionsAndEvents } from '../InsightQuery/utils/queryNodeToFilter'
 import { getEventNamesForAction } from 'lib/utils'
 import {
     isInsightQueryWithBreakdown,
@@ -8,8 +8,7 @@ import {
     isStickinessQuery,
     isTrendsQuery,
 } from '~/queries/utils'
-import { filtersToQueryNode } from '../InsightQuery/utils/filtersToQueryNode'
-import equal from 'fast-deep-equal'
+import { compareFilters } from 'scenes/insights/utils/compareFilters'
 
 export const getAllEventNames = (query: InsightQueryNode, allActions: ActionType[]): string[] => {
     const { actions, events } = seriesToActionsAndEvents((query as TrendsQuery).series || [])
@@ -94,8 +93,10 @@ export const getCachedResults = (
     }
 
     // only set the cached result when the filters match the currently set ones
-    const cachedQueryNode = filtersToQueryNode(cachedInsight.filters)
-    if (!equal(cachedQueryNode, query)) {
+    const cachedFilters = cachedInsight.filters
+    const currentFilters = queryNodeToFilter(query)
+
+    if (!compareFilters(cachedFilters, currentFilters)) {
         return undefined
     }
 

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -118,11 +118,6 @@ export const insightDataLogic = kea<insightDataLogicType>([
                     const savedFilters =
                         savedInsight.filters ||
                         queryNodeToFilter(insightTypeToDefaultQuery[currentFilters.insight || InsightType.TRENDS])
-
-                    // TODO: Ignore filter_test_accounts for now, but should compare against default
-                    delete currentFilters.filter_test_accounts
-                    delete savedFilters.filter_test_accounts
-
                     return !compareFilters(currentFilters, savedFilters)
                 }
             },

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -364,6 +364,9 @@ export const insightLogic = kea<insightLogicType>([
                 loadInsight: () => true,
                 loadInsightSuccess: () => false,
                 loadInsightFailure: () => false,
+                fetchResultFromNumericInsightApi: () => true,
+                fetchResultFromNumericInsightApiSuccess: () => false,
+                fetchResultFromNumericInsightApiFailure: () => false,
             },
         ],
         /*

--- a/frontend/src/scenes/insights/utils/compareFilters.ts
+++ b/frontend/src/scenes/insights/utils/compareFilters.ts
@@ -8,6 +8,14 @@ const clean = (f: Partial<AnyFilterType>): Partial<AnyFilterType> => {
     // remove undefined values, empty array and empty objects
     const cleanedFilters = objectCleanWithEmpty(cleanFilters(f))
 
+    // TODO: Ignore filter_test_accounts for now, but should compare against default
+    delete cleanedFilters.filter_test_accounts
+
+    // sync with DEFAULT_DATE_FROM_DAYS
+    if (!cleanedFilters.date_from) {
+        cleanedFilters.date_from = '-7d'
+    }
+
     cleanedFilters.events = cleanedFilters.events?.map((e) => {
         // event math `total` is the default
         if (e.math === 'total') {

--- a/frontend/src/scenes/insights/utils/compareFilters.ts
+++ b/frontend/src/scenes/insights/utils/compareFilters.ts
@@ -11,12 +11,21 @@ const clean = (f: Partial<AnyFilterType>): Partial<AnyFilterType> => {
     // TODO: Ignore filter_test_accounts for now, but should compare against default
     delete cleanedFilters.filter_test_accounts
 
+    // remove properties related to persons modal
+    delete cleanedFilters.entity_id
+    delete cleanedFilters.entity_type
+    delete cleanedFilters.entity_math
+
     // sync with DEFAULT_DATE_FROM_DAYS
     if (!cleanedFilters.date_from) {
         cleanedFilters.date_from = '-7d'
     }
 
     cleanedFilters.events = cleanedFilters.events?.map((e) => {
+        if (!e.order && (cleanedFilters.events || []).length === 1 && (cleanedFilters.actions || []).length === 0) {
+            e.order = 0
+        }
+
         // event math `total` is the default
         if (e.math === 'total') {
             delete e.math


### PR DESCRIPTION
## Problem

Insight refreshes haven't been working as expected.

## Changes

This PR calls the numeric insight api endpoint with the refresh parameter when an insight without results is encountered on mount i.e. pretty much when navigating to the insight from the saved insights page or a dashboard. This is to bring the behaviour closer to what we perviously had https://github.com/PostHog/posthog/blob/361a2bc1cb48c68f616a455b513089fe66a91f18/frontend/src/scenes/insights/insightLogic.ts#L327-L337.

The numeric insights api is different for the insights list (`?short_id=`) and insights results (`/trends`, `/funnels`, etc.) endpoint, in that it implements a heuristic wether to respond with a cached version or a synchronously updated one. See https://github.com/PostHog/posthog/issues/14178 for details. Long term we should consolidate the differing caching behaviour backend side.

Additional changes necessary to make this work:
- determine wether to use a cached insight based on the `compareFilters` function instead of comparing queries for equality
- correctly handling the default for date_from in this function

## How did you test this code?

Manual testing