### PR TITLE
fix(hogql): Fix issue with handling properties in `EventsQuery`

### DIFF
--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -31,7 +31,9 @@ def escape_param_clickhouse(value: str) -> str:
 
 
 # Copied from clickhouse_driver.util.escape, adapted from single quotes to backquotes. Added a $.
-def escape_hogql_identifier(identifier: str) -> str:
+def escape_hogql_identifier(identifier: str | int) -> str:
+    if isinstance(identifier, int):
+        return str(identifier)
     # HogQL allows dollars in the identifier.
     if re.match(
         r"^[A-Za-z_$][A-Za-z0-9_$]*$", identifier

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -32,7 +32,7 @@ def escape_param_clickhouse(value: str) -> str:
 
 # Copied from clickhouse_driver.util.escape, adapted from single quotes to backquotes. Added a $.
 def escape_hogql_identifier(identifier: str | int) -> str:
-    if isinstance(identifier, int):
+    if isinstance(identifier, int):  # In HogQL we allow integers as identifiers to access array elements
         return str(identifier)
     # HogQL allows dollars in the identifier.
     if re.match(

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -121,6 +121,8 @@ class PropertySwapper(CloningVisitor):
         return node
 
     def _add_notice(self, node: ast.Field, message: str):
+        if node.start is None or node.end is None:
+            return  # Don't add notices for nodes without location (e.g. from EventsQuery JSON)
         # Only highlight the last part of the chain
         start = max(node.start, node.end - len(escape_hogql_identifier(node.chain[-1])))
         self.context.notices.append(


### PR DESCRIPTION
## Problem

We aren't able to process some `EventsQuery` queries since #16154 due to accidentally trying to use `None` for arithmetic in specific cases involving properties. See [Sentry issue](https://posthog.sentry.io/issues/4282605063/).

## Changes

This fixes the problem.

## How did you test this code?

Added a test.