### PR TITLE
feat: Break up webhooks from onEvent

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -7,23 +7,83 @@ import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
+// TODO: remove once we've migrated
 export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaJSIngestionConsumer): Promise<void> {
+    const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
+    const event = convertToIngestionEvent(clickHouseEvent)
+
+    await Promise.all([
+        runInstrumentedFunction({
+            server: queue.pluginsServer,
+            event: event,
+            func: () => queue.workerMethods.runAppsOnEventPipeline(event),
+            statsKey: `kafka_queue.process_async_handlers_on_event`,
+            timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
+            teamId: event.teamId,
+        }),
+        runInstrumentedFunction({
+            server: queue.pluginsServer,
+            event: event,
+            func: () => queue.workerMethods.runWebhooksHandlersEventPipeline(event),
+            statsKey: `kafka_queue.process_async_handlers_webhooks`,
+            timeoutMessage: 'After 30 seconds still running runWebhooksHandlersEventPipeline',
+            teamId: event.teamId,
+        }),
+    ])
+}
+
+// TODO: remove once we've migrated
+export async function eachBatchAsyncHandlers(
+    payload: EachBatchPayload,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
+    await eachBatch(payload, queue, eachMessageAsyncHandlers, groupIntoBatches, 'async_handlers')
+}
+
+export async function eachMessageAppsOnEventHandlers(
+    message: KafkaMessage,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
     const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
     const event = convertToIngestionEvent(clickHouseEvent)
 
     await runInstrumentedFunction({
         server: queue.pluginsServer,
         event: event,
-        func: () => queue.workerMethods.runAsyncHandlersEventPipeline(event),
-        statsKey: `kafka_queue.process_async_handlers`,
-        timeoutMessage: 'After 30 seconds still running runAsyncHandlersEventPipeline',
+        func: () => queue.workerMethods.runAppsOnEventPipeline(event),
+        statsKey: `kafka_queue.process_async_handlers_on_event`,
+        timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
         teamId: event.teamId,
     })
 }
 
-export async function eachBatchAsyncHandlers(
+export async function eachMessageWebhooksHandlers(
+    message: KafkaMessage,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
+    const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
+    const event = convertToIngestionEvent(clickHouseEvent)
+
+    await runInstrumentedFunction({
+        server: queue.pluginsServer,
+        event: event,
+        func: () => queue.workerMethods.runWebhooksHandlersEventPipeline(event),
+        statsKey: `kafka_queue.process_async_handlers_webhooks`,
+        timeoutMessage: 'After 30 seconds still running runWebhooksHandlersEventPipeline',
+        teamId: event.teamId,
+    })
+}
+
+export async function eachBatchAppsOnEventHandlers(
     payload: EachBatchPayload,
     queue: KafkaJSIngestionConsumer
 ): Promise<void> {
-    await eachBatch(payload, queue, eachMessageAsyncHandlers, groupIntoBatches, 'async_handlers')
+    await eachBatch(payload, queue, eachMessageAppsOnEventHandlers, groupIntoBatches, 'async_handlers_on_event')
+}
+
+export async function eachBatchWebhooksHandlers(
+    payload: EachBatchPayload,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
+    await eachBatch(payload, queue, eachMessageWebhooksHandlers, groupIntoBatches, 'async_handlers_webhooks')
 }

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -56,10 +56,15 @@ export class KafkaJSIngestionConsumer {
         // references to queue.workerMethods buried deep in the codebase
         // #onestepatatime
         this.workerMethods = {
-            runAsyncHandlersEventPipeline: (event: PostIngestionEvent) => {
+            runAppsOnEventPipeline: (event: PostIngestionEvent) => {
                 this.pluginsServer.lastActivity = new Date().valueOf()
-                this.pluginsServer.lastActivityType = 'runAsyncHandlersEventPipeline'
-                return piscina.run({ task: 'runAsyncHandlersEventPipeline', args: { event } })
+                this.pluginsServer.lastActivityType = 'runAppsOnEventPipeline'
+                return piscina.run({ task: 'runAppsOnEventPipeline', args: { event } })
+            },
+            runWebhooksHandlersEventPipeline: (event: PostIngestionEvent) => {
+                this.pluginsServer.lastActivity = new Date().valueOf()
+                this.pluginsServer.lastActivityType = 'runWebhooksHandlersEventPipeline'
+                return piscina.run({ task: 'runWebhooksHandlersEventPipeline', args: { event } })
             },
             runEventPipeline: (event: PipelineEvent) => {
                 this.pluginsServer.lastActivity = new Date().valueOf()
@@ -217,10 +222,15 @@ export class IngestionConsumer {
         // references to queue.workerMethods buried deep in the codebase
         // #onestepatatime
         this.workerMethods = {
-            runAsyncHandlersEventPipeline: (event: PostIngestionEvent) => {
+            runAppsOnEventPipeline: (event: PostIngestionEvent) => {
                 this.pluginsServer.lastActivity = new Date().valueOf()
-                this.pluginsServer.lastActivityType = 'runAsyncHandlersEventPipeline'
-                return piscina.run({ task: 'runAsyncHandlersEventPipeline', args: { event } })
+                this.pluginsServer.lastActivityType = 'runAppsOnEventPipeline'
+                return piscina.run({ task: 'runAppsOnEventPipeline', args: { event } })
+            },
+            runWebhooksHandlersEventPipeline: (event: PostIngestionEvent) => {
+                this.pluginsServer.lastActivity = new Date().valueOf()
+                this.pluginsServer.lastActivityType = 'runWebhooksHandlersEventPipeline'
+                return piscina.run({ task: 'runWebhooksHandlersEventPipeline', args: { event } })
             },
             runEventPipeline: (event: PipelineEvent) => {
                 this.pluginsServer.lastActivity = new Date().valueOf()

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -24,7 +24,7 @@ import { startAnalyticsEventsIngestionConsumer } from './ingestion-queues/analyt
 import { startAnalyticsEventsIngestionOverflowConsumer } from './ingestion-queues/analytics-events-ingestion-overflow-consumer'
 import { startJobsConsumer } from './ingestion-queues/jobs-consumer'
 import { IngestionConsumer, KafkaJSIngestionConsumer } from './ingestion-queues/kafka-queue'
-import { startOnEventHandlerConsumer } from './ingestion-queues/on-event-handler-consumer'
+import { startAsyncHandlerConsumer } from './ingestion-queues/on-event-handler-consumer'
 import { startScheduledTasksConsumer } from './ingestion-queues/scheduled-tasks-consumer'
 import { SessionRecordingBlobIngester } from './ingestion-queues/session-recording/session-recordings-blob-consumer'
 import { startSessionRecordingEventsConsumer } from './ingestion-queues/session-recording/session-recordings-consumer'
@@ -287,14 +287,16 @@ export async function startPluginsServer(
             })
         }
 
+        // TODO: Add split for webhooks and onEvent
         if (capabilities.processAsyncHandlers) {
             ;[hub, closeHub] = hub ? [hub, closeHub] : await createHub(serverConfig, null, capabilities)
             serverInstance = serverInstance ? serverInstance : { hub }
 
             piscina = piscina ?? (await makePiscina(serverConfig, hub))
-            const { queue: onEventQueue, isHealthy: isOnEventsIngestionHealthy } = await startOnEventHandlerConsumer({
+            const { queue: onEventQueue, isHealthy: isOnEventsIngestionHealthy } = await startAsyncHandlerConsumer({
                 hub: hub,
                 piscina: piscina,
+                kind: 'async',
             })
 
             onEventHandlerConsumer = onEventQueue

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -296,7 +296,6 @@ export async function startPluginsServer(
             const { queue: onEventQueue, isHealthy: isOnEventsIngestionHealthy } = await startAsyncHandlerConsumer({
                 hub: hub,
                 piscina: piscina,
-                kind: 'async',
             })
 
             onEventHandlerConsumer = onEventQueue

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -441,7 +441,8 @@ export interface PluginTask {
 }
 
 export type WorkerMethods = {
-    runAsyncHandlersEventPipeline: (event: PostIngestionEvent) => Promise<void>
+    runAppsOnEventPipeline: (event: PostIngestionEvent) => Promise<void>
+    runWebhooksHandlersEventPipeline: (event: PostIngestionEvent) => Promise<void>
     runEventPipeline: (event: PipelineEvent) => Promise<EventPipelineResult>
 }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
@@ -1,16 +1,10 @@
 import { runInstrumentedFunction } from '../../../main/utils'
-import { Element, PostIngestionEvent } from '../../../types'
+import { PostIngestionEvent } from '../../../types'
 import { convertToProcessedPluginEvent } from '../../../utils/event'
 import { runOnEvent } from '../../plugins/run'
 import { EventPipelineRunner } from './runner'
 
-export async function runAsyncHandlersStep(runner: EventPipelineRunner, event: PostIngestionEvent) {
-    await Promise.all([processOnEvent(runner, event), processWebhooks(runner, event, event.elementsList)])
-
-    return null
-}
-
-async function processOnEvent(runner: EventPipelineRunner, event: PostIngestionEvent) {
+export async function processOnEventStep(runner: EventPipelineRunner, event: PostIngestionEvent) {
     const processedPluginEvent = convertToProcessedPluginEvent(event)
 
     await runInstrumentedFunction({
@@ -21,13 +15,12 @@ async function processOnEvent(runner: EventPipelineRunner, event: PostIngestionE
         timeoutMessage: `After 30 seconds still running onEvent`,
         teamId: event.teamId,
     })
+    return null
 }
 
-async function processWebhooks(
-    runner: EventPipelineRunner,
-    event: PostIngestionEvent,
-    elements: Element[] | undefined
-) {
+export async function processWebhooksStep(runner: EventPipelineRunner, event: PostIngestionEvent) {
+    const elements = event.elementsList
     const actionMatches = await runner.hub.actionMatcher.match(event, elements)
     await runner.hub.hookCannon.findAndFireHooks(event, actionMatches)
+    return null
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -15,7 +15,7 @@ import { pluginsProcessEventStep } from './pluginsProcessEventStep'
 import { populateTeamDataStep } from './populateTeamDataStep'
 import { prepareEventStep } from './prepareEventStep'
 import { processPersonsStep } from './processPersonsStep'
-import { runAsyncHandlersStep } from './runAsyncHandlersStep'
+import { processOnEventStep, processWebhooksStep } from './runAsyncHandlersStep'
 
 const silentFailuresAsyncHandlers = new Counter({
     name: 'async_handlers_silent_failure',
@@ -166,12 +166,32 @@ export class EventPipelineRunner {
         }
     }
 
-    async runAsyncHandlersEventPipeline(event: PostIngestionEvent): Promise<EventPipelineResult> {
+    async runWebhooksEventPipeline(event: PostIngestionEvent): Promise<EventPipelineResult> {
         try {
-            this.hub.statsd?.increment('kafka_queue.event_pipeline.start', { pipeline: 'asyncHandlers' })
-            await this.runStep(runAsyncHandlersStep, [this, event], event.teamId, false)
-            this.hub.statsd?.increment('kafka_queue.async_handlers.processed')
-            return this.registerLastStep('runAsyncHandlersStep', event.teamId, [event])
+            this.hub.statsd?.increment('kafka_queue.event_pipeline.start', { pipeline: 'webhooks' })
+            await this.runStep(processWebhooksStep, [this, event], event.teamId, false)
+            this.hub.statsd?.increment('kafka_queue.webhooks.processed')
+            return this.registerLastStep('processWebhooksStep', event.teamId, [event])
+        } catch (error) {
+            if (error instanceof DependencyUnavailableError) {
+                // If this is an error with a dependency that we control, we want to
+                // ensure that the caller knows that the event was not processed,
+                // for a reason that we control and that is transient.
+                throw error
+            }
+
+            silentFailuresAsyncHandlers.inc()
+
+            return { lastStep: error.step, args: [], error: error.message }
+        }
+    }
+
+    async runAppsOnEventPipeline(event: PostIngestionEvent): Promise<EventPipelineResult> {
+        try {
+            this.hub.statsd?.increment('kafka_queue.event_pipeline.start', { pipeline: 'onEvent' })
+            await this.runStep(processOnEventStep, [this, event], event.teamId, false)
+            this.hub.statsd?.increment('kafka_queue.onevent.processed')
+            return this.registerLastStep('processOnEventStep', event.teamId, [event])
         } catch (error) {
             if (error instanceof DependencyUnavailableError) {
                 // If this is an error with a dependency that we control, we want to
@@ -213,10 +233,13 @@ export class EventPipelineRunner {
                 description: step.name,
             },
             async () => {
-                const timeout = timeoutGuard('Event pipeline step stalled. Timeout warning after 30 sec!', {
-                    step: step.name,
-                    event: JSON.stringify(this.originalEvent),
-                })
+                const timeout = timeoutGuard(
+                    `Event pipeline step stalled. Timeout warning after 30 sec! step=${step.name} team_id=${teamId} distinct_id=${this.originalEvent.distinct_id}`,
+                    {
+                        step: step.name,
+                        event: JSON.stringify(this.originalEvent),
+                    }
+                )
                 try {
                     const result = await step(...args)
                     pipelineStepCompletionCounter.labels(step.name).inc()

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -33,9 +33,13 @@ export const workerTasks: Record<string, TaskRunner> = {
         const runner = new EventPipelineRunner(hub, args.event)
         return await runner.runEventPipeline(args.event)
     },
-    runAsyncHandlersEventPipeline: async (hub, args: { event: PostIngestionEvent }) => {
+    runAppsOnEventPipeline: async (hub, args: { event: PostIngestionEvent }) => {
         const runner = new EventPipelineRunner(hub, convertToProcessedPluginEvent(args.event))
-        return await runner.runAsyncHandlersEventPipeline(args.event)
+        return await runner.runAppsOnEventPipeline(args.event)
+    },
+    runWebhooksHandlersEventPipeline: async (hub, args: { event: PostIngestionEvent }) => {
+        const runner = new EventPipelineRunner(hub, convertToProcessedPluginEvent(args.event))
+        return await runner.runWebhooksEventPipeline(args.event)
     },
     reloadPlugins: async (hub) => {
         await setupPlugins(hub)

--- a/plugin-server/src/worker/worker.ts
+++ b/plugin-server/src/worker/worker.ts
@@ -87,7 +87,11 @@ export const createTaskRunner =
                 return response
             },
             (transactionDuration: number) => {
-                if (task === 'runEventPipeline' || task === 'runAsyncHandlersEventPipeline') {
+                if (
+                    task === 'runEventPipeline' ||
+                    task === 'runWebhooksHandlersEventPipeline' ||
+                    task === 'runAppsOnEventPipeline'
+                ) {
                     return transactionDuration > 0.5 ? 1 : 0.01
                 } else {
                     return 1

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -55,7 +55,8 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
                 db: 'database',
             },
             workerMethods: {
-                runAsyncHandlersEventPipeline: jest.fn(),
+                runAppsOnEventPipeline: jest.fn(),
+                runWebhooksHandlersEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }
@@ -173,7 +174,8 @@ describe('eachBatchLegacyIngestion with overflow reroute', () => {
                 db: 'database',
             },
             workerMethods: {
-                runAsyncHandlersEventPipeline: jest.fn(),
+                runAppsOnEventPipeline: jest.fn(),
+                runWebhooksHandlersEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -56,7 +56,8 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
                 db: 'database',
             },
             workerMethods: {
-                runAsyncHandlersEventPipeline: jest.fn(),
+                runAppsOnEventPipeline: jest.fn(),
+                runWebhooksHandlersEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }
@@ -149,7 +150,8 @@ describe('eachBatchLegacyIngestion with overflow consume', () => {
                 db: 'database',
             },
             workerMethods: {
-                runAsyncHandlersEventPipeline: jest.fn(),
+                runAppsOnEventPipeline: jest.fn(),
+                runWebhooksHandlersEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -1,6 +1,9 @@
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
 import { eachBatch } from '../../../src/main/ingestion-queues/batch-processing/each-batch'
-import { eachBatchAsyncHandlers } from '../../../src/main/ingestion-queues/batch-processing/each-batch-async-handlers'
+import {
+    eachBatchAppsOnEventHandlers,
+    eachBatchWebhooksHandlers,
+} from '../../../src/main/ingestion-queues/batch-processing/each-batch-async-handlers'
 import {
     eachBatchParallelIngestion,
     IngestionOverflowMode,
@@ -123,7 +126,8 @@ describe('eachBatchX', () => {
                 },
             },
             workerMethods: {
-                runAsyncHandlersEventPipeline: jest.fn(),
+                runAppsOnEventPipeline: jest.fn(),
+                runWebhooksHandlersEventPipeline: jest.fn(),
                 runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }
@@ -149,18 +153,35 @@ describe('eachBatchX', () => {
         })
     })
 
-    describe('eachBatchAsyncHandlers', () => {
-        it('calls runAsyncHandlersEventPipeline', async () => {
-            await eachBatchAsyncHandlers(createKafkaJSBatch(clickhouseEvent), queue)
+    describe('eachBatchWebhooksHandlers', () => {
+        it('calls runWebhooksHandlersEventPipeline', async () => {
+            await eachBatchAppsOnEventHandlers(createKafkaJSBatch(clickhouseEvent), queue)
 
-            expect(queue.workerMethods.runAsyncHandlersEventPipeline).toHaveBeenCalledWith({
+            expect(queue.workerMethods.runAppsOnEventPipeline).toHaveBeenCalledWith({
                 ...event,
                 properties: {
                     $ip: '127.0.0.1',
                 },
             })
             expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(
-                'kafka_queue.each_batch_async_handlers',
+                'kafka_queue.each_batch_async_handlers_on_event',
+                expect.any(Date)
+            )
+        })
+    })
+
+    describe('eachBatchWebhooksHandlers', () => {
+        it('calls runWebhooksHandlersEventPipeline', async () => {
+            await eachBatchWebhooksHandlers(createKafkaJSBatch(clickhouseEvent), queue)
+
+            expect(queue.workerMethods.runWebhooksHandlersEventPipeline).toHaveBeenCalledWith({
+                ...event,
+                properties: {
+                    $ip: '127.0.0.1',
+                },
+            })
+            expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(
+                'kafka_queue.each_batch_async_handlers_webhooks',
                 expect.any(Date)
             )
         })

--- a/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
@@ -1,4 +1,4 @@
-// While these test cases focus on runAsyncHandlersEventPipeline, they were
+// While these test cases focus on runAppsOnEventPipeline, they were
 // explicitly intended to test that failures to produce to the `jobs` topic
 // due to availability errors would be bubbled up to the consumer, where we can
 // then make decisions about how to handle this case e.g. here we test that it
@@ -39,8 +39,8 @@ import {
 
 jest.setTimeout(10000)
 
-describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
-    // Tests the failure cases for the workerTasks.runAsyncHandlersEventPipeline
+describe('workerTasks.runAppsOnEventPipeline()', () => {
+    // Tests the failure cases for the workerTasks.runAppsOnEventPipeline
     // task. Note that this equally applies to e.g. runEventPipeline task as
     // well and likely could do with adding additional tests for that.
     //
@@ -120,7 +120,7 @@ describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
 
         await expect(
             piscinaTaskRunner({
-                task: 'runAsyncHandlersEventPipeline',
+                task: 'runAppsOnEventPipeline',
                 args: {
                     event: {
                         distinctId: 'asdf',
@@ -167,12 +167,12 @@ describe('workerTasks.runAsyncHandlersEventPipeline()', () => {
 
         await expect(
             piscinaTaskRunner({
-                task: 'runAsyncHandlersEventPipeline',
+                task: 'runAppsOnEventPipeline',
                 args: { event },
             })
         ).resolves.toEqual({
             args: [expect.objectContaining(event)],
-            lastStep: 'runAsyncHandlersStep',
+            lastStep: 'processOnEventStep',
         })
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
@@ -22,7 +22,10 @@ describe('Event Pipeline integration test', () => {
         const runner = new EventPipelineRunner(hub, event)
         const result = await runner.runEventPipeline(event)
         const postIngestionEvent = convertToIngestionEvent(result.args[0])
-        return runner.runAsyncHandlersEventPipeline(postIngestionEvent)
+        return Promise.all([
+            runner.runAppsOnEventPipeline(postIngestionEvent),
+            runner.runWebhooksEventPipeline(postIngestionEvent),
+        ])
     }
 
     beforeEach(async () => {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
@@ -1,6 +1,9 @@
 import { ISOTimestamp, PostIngestionEvent } from '../../../../src/types'
 import { convertToProcessedPluginEvent } from '../../../../src/utils/event'
-import { runAsyncHandlersStep } from '../../../../src/worker/ingestion/event-pipeline/runAsyncHandlersStep'
+import {
+    processOnEventStep,
+    processWebhooksStep,
+} from '../../../../src/worker/ingestion/event-pipeline/runAsyncHandlersStep'
 import { runOnEvent, runOnSnapshot } from '../../../../src/worker/plugins/run'
 
 jest.mock('../../../../src/worker/plugins/run')
@@ -41,31 +44,22 @@ describe('runAsyncHandlersStep()', () => {
     })
 
     it('stops processing', async () => {
-        const response = await runAsyncHandlersStep(runner, ingestionEvent)
+        const response = await processOnEventStep(runner, ingestionEvent)
 
         expect(response).toEqual(null)
     })
 
     it('does action matching and fires webhooks', async () => {
-        await runAsyncHandlersStep(runner, ingestionEvent)
+        await processWebhooksStep(runner, ingestionEvent)
 
         expect(runner.hub.actionMatcher.match).toHaveBeenCalled()
         expect(runner.hub.hookCannon.findAndFireHooks).toHaveBeenCalledWith(ingestionEvent, ['action1', 'action2'])
     })
 
     it('calls onEvent plugin methods', async () => {
-        await runAsyncHandlersStep(runner, ingestionEvent)
+        await processOnEventStep(runner, ingestionEvent)
 
         expect(runOnEvent).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(ingestionEvent))
         expect(runOnSnapshot).not.toHaveBeenCalled()
-    })
-
-    it('still calls onEvent if actions lookup fails', async () => {
-        const error = new Error('Event matching failed')
-        jest.mocked(runner.hub.actionMatcher.match).mockRejectedValue(error)
-
-        await expect(runAsyncHandlersStep(runner, ingestionEvent)).rejects.toThrow(error)
-
-        expect(runOnEvent).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(ingestionEvent))
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -7,7 +7,7 @@ import { pluginsProcessEventStep } from '../../../../src/worker/ingestion/event-
 import { populateTeamDataStep } from '../../../../src/worker/ingestion/event-pipeline/populateTeamDataStep'
 import { prepareEventStep } from '../../../../src/worker/ingestion/event-pipeline/prepareEventStep'
 import { processPersonsStep } from '../../../../src/worker/ingestion/event-pipeline/processPersonsStep'
-import { runAsyncHandlersStep } from '../../../../src/worker/ingestion/event-pipeline/runAsyncHandlersStep'
+import { processOnEventStep } from '../../../../src/worker/ingestion/event-pipeline/runAsyncHandlersStep'
 import { EventPipelineRunner } from '../../../../src/worker/ingestion/event-pipeline/runner'
 
 jest.mock('../../../../src/worker/ingestion/event-pipeline/populateTeamDataStep')
@@ -103,7 +103,7 @@ describe('EventPipelineRunner', () => {
         ])
         jest.mocked(prepareEventStep).mockResolvedValue(preIngestionEvent)
         jest.mocked(createEventStep).mockResolvedValue([null, Promise.resolve()])
-        jest.mocked(runAsyncHandlersStep).mockResolvedValue(null)
+        jest.mocked(processOnEventStep).mockResolvedValue(null)
     })
 
     describe('runEventPipeline()', () => {
@@ -233,7 +233,7 @@ describe('EventPipelineRunner', () => {
             })
 
             it('does not emit to dead letter queue for runAsyncHandlersStep', async () => {
-                jest.mocked(runAsyncHandlersStep).mockRejectedValue(error)
+                jest.mocked(processOnEventStep).mockRejectedValue(error)
 
                 await runner.runEventPipeline(pipelineEvent)
 
@@ -243,17 +243,17 @@ describe('EventPipelineRunner', () => {
         })
     })
 
-    describe('runAsyncHandlersEventPipeline()', () => {
+    describe('runAppsOnEventPipeline()', () => {
         it('runs remaining steps', async () => {
             jest.mocked(hub.db.fetchPerson).mockResolvedValue('testPerson')
 
-            await runner.runAsyncHandlersEventPipeline({
+            await runner.runAppsOnEventPipeline({
                 ...preIngestionEvent,
                 person_properties: {},
                 person_created_at: '2020-02-23T02:11:00.000Z' as ISOTimestamp,
             })
 
-            expect(runner.steps).toEqual(['runAsyncHandlersStep'])
+            expect(runner.steps).toEqual(['processOnEventStep'])
         })
     })
 })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Async handlers lagging happens occasionally and the problem could be either with webhooks or with exports, separating them out would make debugging and handling easier at the cost of some extra processing and pods. Furthermore webhooks might be much faster or slower to handle compared to exports so the waiting together might not be best

see also https://posthog.slack.com/archives/C0374DA782U/p1688474721871699?thread_ts=1688246723.752029&cid=C0374DA782U

The plan is:
1. ship this (it's a no-op for prod)
2. ship a follow-up PR to add capabilities (this one is too big already) - still a no-op for prod
3. kill current async deployment
4. create 2 new consumers, which we'll call `-apps-on-event` and `-webhooks` respectively & set the kafka offsets for both to match existing async kafka offsets
5. start the 2 separate deployments for onEvent and webhooks respectively

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
