### PR TITLE
feat: Add BatchExport log storage in CH via Kafka

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -133,6 +133,7 @@ batch_exports_router = projects_router.register(
     r"batch_exports", batch_exports.BatchExportViewSet, "batch_exports", ["team_id"]
 )
 batch_exports_router.register(r"runs", batch_exports.BatchExportRunViewSet, "runs", ["team_id", "batch_export_id"])
+batch_exports_router.register(r"logs", batch_exports.BatchExportRunViewSet, "logs", ["team_id", "batch_export_id"])
 
 projects_router.register(r"warehouse_table", table.TableViewSet, "warehouse_api", ["team_id"])
 

--- a/posthog/api/test/batch_exports/operations.py
+++ b/posthog/api/test/batch_exports/operations.py
@@ -76,6 +76,16 @@ def list_batch_exports_ok(client: TestClient, team_id: int):
     return response.json()
 
 
+def list_batch_exports_logs(client: TestClient, team_id: int, batch_export_id: str):
+    return client.get(f"/api/projects/{team_id}/batch_exports/{batch_export_id}/logs")
+
+
+def list_batch_exports_logs_ok(client: TestClient, team_id: int, batch_export_id: str):
+    response = list_batch_exports_logs(client, team_id, batch_export_id)
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    return response.json()
+
+
 def backfill_batch_export(client: TestClient, team_id: int, batch_export_id: str, start_at: str, end_at: str):
     return client.post(
         f"/api/projects/{team_id}/batch_exports/{batch_export_id}/backfill",

--- a/posthog/api/test/batch_exports/test_logs.py
+++ b/posthog/api/test/batch_exports/test_logs.py
@@ -1,0 +1,54 @@
+import pytest
+from django.test.client import Client as HttpClient
+from rest_framework import status
+
+from posthog.api.test.batch_exports.conftest import start_test_worker
+from posthog.api.test.batch_exports.operations import (
+    create_batch_export_ok,
+    list_batch_exports_logs,
+)
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+from posthog.api.test.test_user import create_user
+from posthog.temporal.client import sync_connect
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+def test_can_get_export_logs_for_your_organizations(client: HttpClient):
+    temporal = sync_connect()
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "batch_window_size": 3600,
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        response = create_batch_export_ok(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+
+        response = list_batch_exports_logs(client, team.pk, response["id"])
+        assert response.status_code == status.HTTP_200_OK, response.json()

--- a/posthog/clickhouse/batch_exports_logs.py
+++ b/posthog/clickhouse/batch_exports_logs.py
@@ -1,0 +1,67 @@
+from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, kafka_engine, ttl_period
+from posthog.clickhouse.table_engines import ReplacingMergeTree
+from posthog.kafka_client.topics import KAFKA_BATCH_EXPORTS_LOGS
+from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
+
+BATCH_EXPORTS_LOGS_TABLE = "batch_exports_logs"
+BATCH_EXPORTS_LOGS_TTL_WEEKS = 1
+
+BATCH_EXPORTS_LOGS_TABLE_BASE_SQL = """
+CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
+(
+    id UUID,
+    team_id Int64,
+    batch_export_id UUID,
+    data_interval_end DateTime64(6, 'UTC'),
+    level VARCHAR,
+    type VARCHAR,
+    message VARCHAR,
+    timestamp DateTime64(6, 'UTC')
+    {extra_fields}
+) ENGINE = {engine}
+"""
+
+BATCH_EXPORTS_LOGS_TABLE_ENGINE = lambda: ReplacingMergeTree(BATCH_EXPORTS_LOGS_TABLE, ver="_timestamp")
+BATCH_EXPORTS_LOGS_TABLE_SQL = lambda: (
+    BATCH_EXPORTS_LOGS_TABLE_BASE_SQL
+    + """ORDER BY (team_id, batch_export_id, data_interval_end, timestamp)
+{ttl_period}
+SETTINGS index_granularity=512
+"""
+).format(
+    table_name=BATCH_EXPORTS_LOGS_TABLE,
+    cluster=CLICKHOUSE_CLUSTER,
+    extra_fields=KAFKA_COLUMNS,
+    engine=BATCH_EXPORTS_LOGS_TABLE_ENGINE(),
+    ttl_period=ttl_period("timestamp", BATCH_EXPORTS_LOGS_TTL_WEEKS),
+)
+
+KAFKA_BATCH_EXPORTS_LOGS_TABLE_SQL = lambda: BATCH_EXPORTS_LOGS_TABLE_BASE_SQL.format(
+    table_name="kafka_" + BATCH_EXPORTS_LOGS_TABLE,
+    cluster=CLICKHOUSE_CLUSTER,
+    engine=kafka_engine(topic=KAFKA_BATCH_EXPORTS_LOGS),
+    extra_fields="",
+)
+
+BATCH_EXPORTS_LOGS_TABLE_MV_SQL = """
+CREATE MATERIALIZED VIEW IF NOT EXISTS {table_name}_mv ON CLUSTER '{cluster}'
+TO {database}.{table_name}
+AS SELECT
+id,
+team_id,
+batch_export_id,
+data_interval_end,
+type,
+level,
+message,
+timestamp,
+_timestamp,
+_offset
+FROM {database}.kafka_{table_name}
+""".format(
+    table_name=BATCH_EXPORTS_LOGS_TABLE, cluster=CLICKHOUSE_CLUSTER, database=CLICKHOUSE_DATABASE
+)
+
+TRUNCATE_BATCH_EXPORTS_LOGS_TABLE_SQL = (
+    f"TRUNCATE TABLE IF EXISTS {BATCH_EXPORTS_LOGS_TABLE} ON CLUSTER '{CLICKHOUSE_CLUSTER}'"
+)

--- a/posthog/clickhouse/migrations/0046_batch_exports_logs.py
+++ b/posthog/clickhouse/migrations/0046_batch_exports_logs.py
@@ -1,0 +1,12 @@
+from posthog.clickhouse.batch_exports_logs import (
+    BATCH_EXPORTS_LOGS_TABLE_MV_SQL,
+    BATCH_EXPORTS_LOGS_TABLE_SQL,
+    KAFKA_BATCH_EXPORTS_LOGS_TABLE_SQL,
+)
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = [
+    run_sql_with_exceptions(BATCH_EXPORTS_LOGS_TABLE_SQL()),
+    run_sql_with_exceptions(KAFKA_BATCH_EXPORTS_LOGS_TABLE_SQL()),
+    run_sql_with_exceptions(BATCH_EXPORTS_LOGS_TABLE_MV_SQL),
+]

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -3,16 +3,20 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import kafka.errors
+from django.conf import settings
 from kafka import KafkaConsumer as KC
 from kafka import KafkaProducer as KP
-from kafka.producer.future import FutureProduceResult, FutureRecordMetadata, RecordMetadata
+from kafka.producer.future import (
+    FutureProduceResult,
+    FutureRecordMetadata,
+    RecordMetadata,
+)
 from kafka.structs import TopicPartition
 from statshog.defaults.django import statsd
 from structlog import get_logger
-from django.conf import settings
+
 from posthog.client import sync_execute
 from posthog.kafka_client import helper
-
 from posthog.utils import SingletonDecorator
 
 KAFKA_PRODUCER_RETRIES = 5

--- a/posthog/kafka_client/topics.py
+++ b/posthog/kafka_client/topics.py
@@ -2,6 +2,7 @@
 
 from posthog.settings.data_stores import KAFKA_PREFIX, SUFFIX
 
+KAFKA_BATCH_EXPORTS_LOGS = f"{KAFKA_PREFIX}batch_exports_logs{SUFFIX}"
 KAFKA_EVENTS_JSON = f"{KAFKA_PREFIX}clickhouse_events_json{SUFFIX}"
 KAFKA_EVENTS_PLUGIN_INGESTION = f"{KAFKA_PREFIX}events_plugin_ingestion{SUFFIX}"
 KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW = f"{KAFKA_PREFIX}events_plugin_ingestion_overflow{SUFFIX}"

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -8,16 +8,15 @@ from uuid import uuid4
 import boto3
 import pytest
 from aiochclient import ChClient
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.test import Client as HttpClient
 from django.test import override_settings
 from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
 from ee.clickhouse.materialized_columns.columns import materialize
-
-from asgiref.sync import sync_to_async
-
 from posthog.api.test.test_organization import acreate_organization
 from posthog.api.test.test_team import acreate_team
 from posthog.batch_exports.service import acreate_batch_export, afetch_batch_export_runs
@@ -267,6 +266,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
         region="us-east-1",
         prefix=prefix,
         team_id=team_id,
+        batch_export_id="1234-1234",
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         aws_access_key_id="object_storage_root_user",


### PR DESCRIPTION
## Problem

We wish to expose status logs from BatchExports so that users can track the progress of their exports, and potentially address any errors. Although there is an existing `plugin_log_entries` table, after discussing it with the team, we decided against using it for these reasons:

*  BatchExports uses UUIDs for its id fields, which we cannot store in `int64` fields like `plugin_id` and `plugin_config_id`.
* Even if we were to store the id in `instance_id` (which is a UUID), we would need to set `plugin_id` and `plugin_config_id` to something that indicates this is an export to avoid leaking logs. This would be too confusing and bug-prone.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Adds a new CH table, `batch_exports_logs` and associated MV to ingest from Kafka.
* Adds a new Kafka topic for batch export logs.
* Produces Temporal logs to Kafka, so workflow writers can just call `activity.logger` or `workflow.logger` as normal after calling a setup function.
* Adds a ViewSet to query logs from CH.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
