### PR TITLE
fix: catch if cannot acquire redis

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -53,6 +53,11 @@ export class SessionOffsetHighWaterMark {
                 // invalid JSON
                 return null
             } else {
+                captureException(error, {
+                    tags: {
+                        description,
+                    },
+                })
                 throw error
             }
         } finally {


### PR DESCRIPTION
## Problem

blob ingester in EU is in a crash loop, it might be this redis error or that might be a red herring

see https://posthog.sentry.io/issues/4277773562/?project=6423401&query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-blob-ingestion&referrer=issue-stream&statsPeriod=1h&stream_index=1

## Changes

catch the redis error and report it to Sentry neatly

## How did you test this code?

🙈 