### PR TITLE
feat: Saving indicator debouncing for slow connections

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
@@ -2,7 +2,7 @@ import { NotebookLogicProps, notebookLogic } from './notebookLogic'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { NotebookSyncStatus } from '~/types'
 import { LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
 import { IconDocumentExpand } from 'lib/lemon-ui/icons'
@@ -35,8 +35,22 @@ const syncStatusMap: Record<NotebookSyncStatus, { content: React.ReactNode; tool
 export const NotebookSyncInfo = (props: NotebookLogicProps): JSX.Element | null => {
     const { syncStatus } = useValues(notebookLogic(props))
     const [shown, setShown] = useState(false)
+    const [debounceTimeout, setDebounceTimeout] = useState<NodeJS.Timeout | null>(null)
+    const [debouncedSyncStatus, setDebouncedSyncStatus] = useState<NotebookSyncStatus | null>(null)
+
+    const clearDebounceTimeout = useCallback(() => {
+        if (debounceTimeout) {
+            clearTimeout(debounceTimeout)
+        }
+    }, [debounceTimeout])
 
     useEffect(() => {
+        clearDebounceTimeout()
+
+        const debounceDelay = syncStatus === 'saving' ? 100 : 0
+        const timeout = setTimeout(() => setDebouncedSyncStatus(syncStatus), debounceDelay)
+        setDebounceTimeout(timeout)
+
         if (syncStatus !== 'synced') {
             return setShown(true)
         }
@@ -46,14 +60,18 @@ export const NotebookSyncInfo = (props: NotebookLogicProps): JSX.Element | null 
         }
 
         const t = setTimeout(() => setShown(false), 3000)
-        return () => clearTimeout(t)
+
+        return () => {
+            clearTimeout(t)
+            clearDebounceTimeout()
+        }
     }, [syncStatus])
 
-    if (!syncStatus) {
+    if (!debouncedSyncStatus) {
         return null
     }
 
-    const content = syncStatusMap[syncStatus]
+    const content = syncStatusMap[debouncedSyncStatus]
 
     return shown ? (
         <Tooltip title={content.tooltip} placement="left">

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -171,7 +171,7 @@ export const notebookLogic = kea<notebookLogicType>([
 
         syncStatus: [
             (s) => [s.notebook, s.notebookLoading, s.localContent, s.isLocalOnly],
-            (notebook, notebookLoading, localContent, isLocalOnly): NotebookSyncStatus | undefined => {
+            (notebook, notebookLoading, localContent, isLocalOnly): NotebookSyncStatus => {
                 if (notebook?.is_template) {
                     return 'synced'
                 }


### PR DESCRIPTION
## Problem

The saving indicator jumps when the network request is too quick
![jumping](https://github.com/PostHog/posthog/assets/6685876/6ed645d0-ea36-4cd9-8efb-f5ccbb8f42c9)

## Changes

Don't see the intermediate state for really quick saves
![new](https://github.com/PostHog/posthog/assets/6685876/c7ce4ba2-774f-471b-ab5b-28187699e5ce)

Slow network requests still show the "Saving" indicator
![slow](https://github.com/PostHog/posthog/assets/6685876/1b1f0ba2-3b59-41f9-a4b0-8850b67b4264)

## How did you test this code?

Manually (with gifs)