### PR TITLE
feat: better open graph

### DIFF
--- a/frontend/src/exporter/index.html
+++ b/frontend/src/exporter/index.html
@@ -12,8 +12,11 @@
     {% include "head.html" %}
       {% if add_og_tags %}
           <meta property="og:title" content="{{ asset_title }}">
+          <meta property="og:description" content="{{ asset_description }}">
           <meta property="og:url" content="{{ request.build_absolute_uri }}">
           <meta property="og:image" content="{{ request.build_absolute_uri }}.png">
+          <meta property="og:image:alt" content="A screenshot of the PostHog asset">
+          <meta name="twitter:card" content="summary_large_image">
       {% endif %}
   </head>
   <body>

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -62,7 +62,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
 
         instance: ExportedAsset = super().create(validated_data)
 
-        self.generate_export_sync(instance)
+        self.generate_export_sync(instance, 0.01)
 
         instance.refresh_from_db()
 
@@ -136,10 +136,10 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         return instance
 
     @staticmethod
-    def generate_export_sync(instance: ExportedAsset) -> None:
+    def generate_export_sync(instance: ExportedAsset, timeout: float = 10) -> None:
         task = exporter.export_asset.delay(instance.id)
         try:
-            task.get(timeout=10)
+            task.get(timeout)
             instance.refresh_from_db()
         except celery.exceptions.TimeoutError:
             # If the rendering times out - fine, the frontend will poll instead for the response

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -139,7 +139,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
     def generate_export_sync(instance: ExportedAsset, timeout: float = 10) -> None:
         task = exporter.export_asset.delay(instance.id)
         try:
-            task.get(timeout)
+            task.get(timeout=timeout)
             instance.refresh_from_db()
         except celery.exceptions.TimeoutError:
             # If the rendering times out - fine, the frontend will poll instead for the response

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -200,15 +200,18 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
             exported_data["type"] = "image"
 
         add_og_tags = resource.insight or resource.dashboard
+        asset_description = ""
 
         if resource.insight and not resource.insight.deleted:
             # Both insight AND dashboard can be set. If both it is assumed we should render that
             context["dashboard"] = resource.dashboard
             asset_title = resource.insight.name or resource.insight.derived_name
+            asset_description = resource.insight.description or "A shared PostHog insight"
             insight_data = InsightSerializer(resource.insight, many=False, context=context).data
             exported_data.update({"insight": insight_data})
         elif resource.dashboard and not resource.dashboard.deleted:
             asset_title = resource.dashboard.name
+            asset_description = resource.dashboard.description or "A shared PostHog dashboard"
             dashboard_data = DashboardSerializer(resource.dashboard, context=context).data
             # We don't want the dashboard to be accidentally loaded via the shared endpoint
             exported_data.update({"dashboard": dashboard_data})
@@ -240,6 +243,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
             context={
                 "exported_data": json.dumps(exported_data, cls=DjangoJSONEncoder),
                 "asset_title": asset_title,
+                "asset_description": asset_description,
                 "add_og_tags": add_og_tags,
             },
             team_for_public_context=resource.team,

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -31,7 +31,8 @@ class TestSharing(APIBaseTest):
         )
 
     @freeze_time("2022-01-01")
-    def test_gets_sharing_config(self):
+    @patch("posthog.api.exports.exporter.export_asset.delay")
+    def test_gets_sharing_config(self, patched_exporter_task: Mock):
         assert SharingConfiguration.objects.count() == 0
 
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing")
@@ -41,7 +42,8 @@ class TestSharing(APIBaseTest):
         assert data == {"access_token": data["access_token"], "created_at": None, "enabled": False}
 
     @freeze_time("2022-01-01")
-    def test_does_not_change_token_when_toggling_enabled_state(self):
+    @patch("posthog.api.exports.exporter.export_asset.delay")
+    def test_does_not_change_token_when_toggling_enabled_state(self, patched_exporter_task: Mock):
         assert SharingConfiguration.objects.count() == 0
         response = self.client.patch(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing", {"enabled": True}
@@ -64,7 +66,8 @@ class TestSharing(APIBaseTest):
             "enabled": False,
         }
 
-    def test_can_edit_enabled_state(self):
+    @patch("posthog.api.exports.exporter.export_asset.delay")
+    def test_can_edit_enabled_state(self, patched_exporter_task: Mock):
         response = self.client.patch(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing", {"enabled": True}
         )
@@ -76,7 +79,19 @@ class TestSharing(APIBaseTest):
 
         assert response.json()["is_shared"]
 
-    def test_should_update_to_match_existing_dashboard_sharing_token(self):
+    @patch("posthog.api.exports.exporter.export_asset.delay")
+    def test_exports_image_when_sharing(self, patched_exporter_task: Mock):
+        assert ExportedAsset.objects.count() == 0
+
+        self.client.patch(f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing", {"enabled": True})
+
+        assert ExportedAsset.objects.count() == 1
+        asset = ExportedAsset.objects.first()
+        assert asset is not None
+        assert asset.export_format == "image/png"
+
+    @patch("posthog.api.exports.exporter.export_asset.delay")
+    def test_should_update_to_match_existing_dashboard_sharing_token(self, patched_exporter_task: Mock):
         dashboard = Dashboard.objects.create(team=self.team, name="example dashboard", created_by=self.user)
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard.id}/sharing")
         initial_token = response.json()["access_token"]
@@ -101,7 +116,8 @@ class TestSharing(APIBaseTest):
         assert data["access_token"] == "my_test_token"
         assert data["enabled"]
 
-    def test_should_not_be_affected_by_collaboration_rules(self):
+    @patch("posthog.api.exports.exporter.export_asset.delay")
+    def test_should_not_be_affected_by_collaboration_rules(self, _patched_exporter_task: Mock):
         other_user = User.objects.create_and_join(self.organization, "a@x.com", None)
         dashboard = Dashboard.objects.create(
             team=self.team,
@@ -116,7 +132,8 @@ class TestSharing(APIBaseTest):
 
         assert response.status_code == 200
 
-    def test_should_not_get_deleted_item(self):
+    @patch("posthog.api.exports.exporter.export_asset.delay")
+    def test_should_not_get_deleted_item(self, _patched_exporter_task: Mock):
         dashboard = Dashboard.objects.create(
             team=self.team, name="example dashboard", created_by=self.user, share_token="my_test_token", is_shared=True
         )
@@ -135,10 +152,11 @@ class TestSharing(APIBaseTest):
             "/shared_dashboard/something.png?token=my_test_token",
         ]
     )
+    @patch("posthog.api.exports.exporter.export_asset.delay")
     @patch("posthog.models.exported_asset.object_storage.read_bytes")
     @patch("posthog.api.sharing.asset_for_token")
     def test_can_get_shared_dashboard_asset_with_no_content_but_content_location(
-        self, url: str, patched_asset_for_token, patched_object_storage
+        self, url: str, patched_asset_for_token, patched_object_storage, _patched_exporter_task: Mock
     ) -> None:
         asset = ExportedAsset.objects.create(
             team_id=self.team.id,
@@ -166,21 +184,14 @@ class TestSharing(APIBaseTest):
 
         target = self.insight if type == "insights" else self.dashboard
 
+        self._setup_patched_exporter(patched_exporter_task)
+
+        assert ExportedAsset.objects.count() == 0
+
         share_response = self.client.patch(
             f"/api/projects/{self.team.id}/{type}/{target.pk}/sharing", {"enabled": True}
         )
         access_token = share_response.json()["access_token"]
-
-        def add_content_location_on_task_run(*args, **kwargs):
-            asset = ExportedAsset.objects.get(team_id=self.team.id)
-            asset.content_location = "some object url"
-            asset.save()
-
-            return MagicMock()
-
-        patched_exporter_task.side_effect = add_content_location_on_task_run
-
-        assert ExportedAsset.objects.count() == 0
 
         item_opengraph_image = self.client.get("/shared/" + access_token + ".png")
 
@@ -197,6 +208,8 @@ class TestSharing(APIBaseTest):
     ) -> None:
         patched_object_storage.return_value = b"the image bytes"
 
+        self._setup_patched_exporter(patched_exporter_task)
+
         target = self.insight if type == "insights" else self.dashboard
 
         share_response = self.client.patch(
@@ -204,24 +217,28 @@ class TestSharing(APIBaseTest):
         )
         access_token = share_response.json()["access_token"]
 
-        ExportedAsset.objects.create(
-            team_id=self.team.id,
-            export_format=ExportedAsset.ExportFormat.PNG,
-            content=None,
-            content_location="existing object url",
-            insight=self.insight if type == "insights" else None,
-            dashboard=self.dashboard if type == "dashboards" else None,
-        )
-        assert ExportedAsset.objects.count() == 1
+        # generation was called when sharing was enabled
+        patched_exporter_task.reset_mock()
 
         item_opengraph_image = self.client.get("/shared/" + access_token + ".png")
 
+        # and not again on loading the image
         patched_exporter_task.assert_not_called()
 
         assert ExportedAsset.objects.count() == 1
         assert item_opengraph_image.status_code == 200
         assert item_opengraph_image.headers["Content-Type"] == "image/png"
         assert item_opengraph_image.content == b"the image bytes"
+
+    def _setup_patched_exporter(self, patched_exporter_task):
+        def add_content_location_on_task_run(*args, **kwargs):
+            asset = ExportedAsset.objects.get(team_id=self.team.id)
+            asset.content_location = "some object url"
+            asset.save()
+
+            return MagicMock()
+
+        patched_exporter_task.side_effect = add_content_location_on_task_run
 
     @parameterized.expand(["insights", "dashboards"])
     @patch("posthog.models.exported_asset.object_storage.read_bytes")
@@ -233,42 +250,29 @@ class TestSharing(APIBaseTest):
 
         target = self.insight if type == "insights" else self.dashboard
 
-        share_response = self.client.patch(
-            f"/api/projects/{self.team.id}/{type}/{target.pk}/sharing", {"enabled": True}
-        )
-        access_token = share_response.json()["access_token"]
-
         # the existing asset is stale because it is more than 3 hours old
         time_in_the_past = now() - timedelta(hours=4)
-        asset = ExportedAsset.objects.create(
-            team_id=self.team.id,
-            export_format=ExportedAsset.ExportFormat.PNG,
-            content=None,
-            content_location="existing object url",
-            insight=self.insight if type == "insights" else None,
-            dashboard=self.dashboard if type == "dashboards" else None,
-        )
-        asset.created_at = time_in_the_past
-        asset.save()
+        with freeze_time(time_in_the_past):
+            share_response = self.client.patch(
+                f"/api/projects/{self.team.id}/{type}/{target.pk}/sharing", {"enabled": True}
+            )
 
-        def add_content_location_on_task_run(*args, **kwargs):
-            asset = ExportedAsset.objects.get(team_id=self.team.id)
-            asset.content_location = "some object url"
-            asset.save()
+        access_token = share_response.json()["access_token"]
 
-            return MagicMock()
+        assert ExportedAsset.objects.count() == 1
+        original_asset = ExportedAsset.objects.first()
 
-        patched_exporter_task.side_effect = add_content_location_on_task_run
+        self._setup_patched_exporter(patched_exporter_task)
 
         assert ExportedAsset.objects.count() == 1
 
         item_opengraph_image = self.client.get("/shared/" + access_token + ".png")
+        assert item_opengraph_image.status_code == 200
+        assert item_opengraph_image.headers["Content-Type"] == "image/png"
+        assert item_opengraph_image.content == b"the image bytes"
 
         assert ExportedAsset.objects.count() == 1
         final_asset = ExportedAsset.objects.first()
         assert final_asset is not None
-        assert final_asset.id != asset.id
-
-        assert item_opengraph_image.status_code == 200
-        assert item_opengraph_image.headers["Content-Type"] == "image/png"
-        assert item_opengraph_image.content == b"the image bytes"
+        assert original_asset is not None
+        assert final_asset.id != original_asset.id


### PR DESCRIPTION
## Problem

OG sharing only worked in Facebook. So early 2000s

## Changes

* Adds more open graph tags
* creates exported asset on sharing


There's a long delay on sharing in the gif, I changed the timeout but then didn't re-record

![2023-06-30 15 47 43](https://github.com/PostHog/posthog/assets/984817/b14e380c-60e5-415e-9bbe-40cd80c63d49)


## How did you test this code?

👀 locally