### PR TITLE
fix: navigate to tab only if it is different

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -323,7 +323,7 @@ export const personsLogic = kea<personsLogicType>({
     urlToAction: ({ actions, values, props }) => ({
         '/person/*': ({ _: rawPersonDistinctId }, { sessionRecordingId }, { activeTab }) => {
             if (props.syncWithUrl) {
-                if (sessionRecordingId) {
+                if (sessionRecordingId && values.activeTab !== PersonsTabType.SESSION_RECORDINGS) {
                     actions.navigateToTab(PersonsTabType.SESSION_RECORDINGS)
                 } else if (activeTab && values.activeTab !== activeTab) {
                     actions.navigateToTab(activeTab as PersonsTabType)


### PR DESCRIPTION
## Problem

Looks like this was introduced in #15936 

See https://posthoghelp.zendesk.com/agent/tickets/3938 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/6403)

clicking on a recording when on the persons page recording tab would change the URL, and include a sessionRecordingId, that would trigger a navigation to the recordings tab which was already open, and then logics would bounce backwards and forwards setting and navigating until stack overflow happened

## Changes

only navigate if not already on the tab

## How did you test this code?

👀 locally
