### PR TITLE
feat: Add logs and metrics around promise manager

### DIFF
--- a/plugin-server/src/utils/retries.ts
+++ b/plugin-server/src/utils/retries.ts
@@ -115,7 +115,7 @@ function iterateRetryLoop(retriableFunctionPayload: RetriableFunctionPayload, at
                                 .catch(reject)
                         }, nextRetryMs)
                     )
-                    hub.promiseManager.trackPromise(nextIterationPromise)
+                    hub.promiseManager.trackPromise(nextIterationPromise, 'retries')
                     await hub.promiseManager.awaitPromisesIfNeeded()
                 } else {
                     await catchFn?.(error)

--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -134,7 +134,7 @@ export class AppMetrics {
 
         if (this.timer === null) {
             this.timer = setTimeout(() => {
-                this.hub.promiseManager.trackPromise(this.flush())
+                this.hub.promiseManager.trackPromise(this.flush(), 'app metrics')
                 this.timer = null
             }, this.flushFrequencyMs)
         }

--- a/plugin-server/src/worker/ingestion/utils.ts
+++ b/plugin-server/src/worker/ingestion/utils.ts
@@ -76,6 +76,7 @@ export function captureIngestionWarning(db: DB, teamId: TeamId, type: string, de
                     }),
                 },
             ],
-        })
+        }),
+        'ingestion_warning'
     )
 }

--- a/plugin-server/src/worker/vm/promise-manager.ts
+++ b/plugin-server/src/worker/vm/promise-manager.ts
@@ -1,6 +1,7 @@
 import { StatsD } from 'hot-shots'
 
 import { PluginsServerConfig } from '../../types'
+import { status } from '../../utils/status'
 
 export class PromiseManager {
     pendingPromises: Set<Promise<any>>
@@ -13,22 +14,29 @@ export class PromiseManager {
         this.statsd = statsd
     }
 
-    public trackPromise(promise: Promise<any>): void {
+    public trackPromise(promise: Promise<any>, key: string): void {
         if (typeof promise === 'undefined') {
             return
         }
 
+        status.info('🤝', `Tracking promise ${key}`)
+        this.statsd?.increment(`worker_promise_manager_promise_start`, { key })
         this.pendingPromises.add(promise)
 
         promise.finally(() => {
             this.pendingPromises.delete(promise)
         })
+        status.info('✅', `Tracking promise finished ${key}`)
+        this.statsd?.increment(`worker_promise_manager_promise_end`, { key })
     }
 
     public async awaitPromisesIfNeeded(): Promise<void> {
+        const startTime = performance.now()
         while (this.pendingPromises.size > this.config.MAX_PENDING_PROMISES_PER_WORKER) {
+            status.info('🤝', `looping in awaitPromise since ${startTime} count = ${this.pendingPromises.size}`)
             await Promise.race(this.pendingPromises)
             this.statsd?.increment('worker_promise_manager_promises_awaited')
         }
+        status.info('🕐', `Finished awaiting promises ${performance.now() - startTime}`)
     }
 }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -186,7 +186,8 @@ export function addHistoricalEventsExportCapabilityV2(
         Object.keys(JOB_SPEC.payload!).length
     ) {
         hub.promiseManager.trackPromise(
-            hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, JOB_SPEC)
+            hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, JOB_SPEC),
+            'exports v2 addOrUpdatePublicJob'
         )
     }
     const oldRunEveryMinute = tasks.schedule.runEveryMinute
@@ -783,7 +784,8 @@ export function addHistoricalEventsExportCapabilityV2(
                 type: PluginLogEntryType.Log,
                 instanceId: hub.instanceId,
                 ...overrides,
-            })
+            }),
+            'exports v2 - createLog'
         )
     }
 

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -62,7 +62,8 @@ export function addHistoricalEventsExportCapability(
         Object.keys(JOB_SPEC.payload!).length
     ) {
         hub.promiseManager.trackPromise(
-            hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, JOB_SPEC)
+            hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, JOB_SPEC),
+            'exports addOrUpdatePublicJob'
         )
     }
 
@@ -364,7 +365,8 @@ export function addHistoricalEventsExportCapability(
                 source: PluginLogEntrySource.System,
                 type: type,
                 instanceId: hub.instanceId,
-            })
+            }),
+            'exports createLog'
         )
     }
 }

--- a/plugin-server/src/worker/vm/upgrades/utils/export-events-buffer.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/export-events-buffer.ts
@@ -53,7 +53,10 @@ export class ExportEventsBuffer {
         this.buffer = []
         this.points = 0
 
-        this.hub.promiseManager.trackPromise(this._flush(oldBuffer, oldPoints, new Date()))
+        this.hub.promiseManager.trackPromise(
+            this._flush(oldBuffer, oldPoints, new Date()),
+            'ExportEventsBuffer flush logs'
+        )
         await this.hub.promiseManager.awaitPromisesIfNeeded()
     }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Consumer gets stuck for exports and restart helps. Looking at the metrics we're waiting a lot more on promise manager
[graph](https://metrics.posthog.com/explore?orgId=1&left=%7B%22datasource%22:%22InfluxDB%22,%22queries%22:%5B%7B%22refId%22:%22C%22,%22policy%22:%22default%22,%22resultFormat%22:%22table%22,%22orderByTime%22:%22ASC%22,%22tags%22:%5B%5D,%22groupBy%22:%5B%7B%22type%22:%22time%22,%22params%22:%5B%22$__interval%22%5D%7D,%7B%22type%22:%22fill%22,%22params%22:%5B%22null%22%5D%7D%5D,%22select%22:%5B%5B%7B%22type%22:%22field%22,%22params%22:%5B%22value%22%5D%7D,%7B%22type%22:%22mean%22,%22params%22:%5B%5D%7D%5D%5D,%22measurement%22:%22plugin-server_worker_promise_manager_promises_awaited%22%7D%5D,%22range%22:%7B%22from%22:%221688209076042%22,%22to%22:%221688246273308%22%7D%7D) when we started lagging

related: https://posthog.slack.com/archives/C0374DA782U/p1688246723752029

## Changes

Adding log lines and metrics to be able to figure out which promises we are waiting on when we get stuck vs normal situation

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
