### PR TITLE
fix: Update tests to use new number of retries

### DIFF
--- a/plugin-server/tests/utils/retries.test.ts
+++ b/plugin-server/tests/utils/retries.test.ts
@@ -134,7 +134,7 @@ describe('runRetriableFunction', () => {
         )
     })
 
-    it('catches RetryError error and retries up to 5 times', async () => {
+    it('catches RetryError error and retries up to 3 times', async () => {
         const tryFn = jest.fn().mockImplementation(() => {
             throw new RetryError()
         })
@@ -163,16 +163,14 @@ describe('runRetriableFunction', () => {
 
         jest.runAllTimers()
 
-        await expect(promise).resolves.toEqual(5)
-        expect(tryFn).toHaveBeenCalledTimes(5)
+        await expect(promise).resolves.toEqual(3)
+        expect(tryFn).toHaveBeenCalledTimes(3)
         expect(catchFn).toHaveBeenCalledTimes(1)
         expect(catchFn).toHaveBeenCalledWith(expect.any(RetryError))
         expect(finallyFn).toHaveBeenCalledTimes(1)
-        expect(setTimeout).toHaveBeenCalledTimes(4)
-        expect(setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), 5_000)
-        expect(setTimeout).toHaveBeenNthCalledWith(2, expect.any(Function), 10_000)
-        expect(setTimeout).toHaveBeenNthCalledWith(3, expect.any(Function), 20_000)
-        expect(setTimeout).toHaveBeenNthCalledWith(4, expect.any(Function), 40_000)
+        expect(setTimeout).toHaveBeenCalledTimes(2)
+        expect(setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), 3_000)
+        expect(setTimeout).toHaveBeenNthCalledWith(2, expect.any(Function), 6_000)
         expect(mockHub.appMetrics.queueError).toHaveBeenCalledWith(
             {
                 ...appMetric,
@@ -222,8 +220,8 @@ describe('runRetriableFunction', () => {
         expect(catchFn).toHaveBeenCalledTimes(0)
         expect(finallyFn).toHaveBeenCalledTimes(1)
         expect(setTimeout).toHaveBeenCalledTimes(2)
-        expect(setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), 5_000)
-        expect(setTimeout).toHaveBeenNthCalledWith(2, expect.any(Function), 10_000)
+        expect(setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), 3_000)
+        expect(setTimeout).toHaveBeenNthCalledWith(2, expect.any(Function), 6_000)
         expect(mockHub.appMetrics.queueMetric).toHaveBeenCalledWith({
             ...appMetric,
             successes: 0,


### PR DESCRIPTION
## Problem

PR https://github.com/PostHog/posthog/pull/16312 reduced the number of retries to 3 instead of 5, but didn't update any tests before merging. A couple of retries tests are now failing in `master` and all other branches.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adjust tests to use new number of retries.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
