### PR TITLE
fix(decide): Ensure erroneous user input can't switch the db off

### DIFF
--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -718,9 +718,8 @@ def handle_feature_flag_exception(err: Exception, log_message: str = ""):
     if reason == "unknown":
         capture_exception(err)
 
-    # Whenever error occurs, by default assume the database connection is lost.
-    # We'll recover after the next healthcheck.
-    postgres_healthcheck.set_connection(False)
+    if isinstance(err, DatabaseError):
+        postgres_healthcheck.set_connection(False)
 
 
 def parse_exception_for_error_message(err: Exception):


### PR DESCRIPTION
Noticed that some errors occur purely because of user input.

We don't want to, by default, set the database healthcheck off in these cases

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
