### PR TITLE
refactor: Account for duplicates in CH for BatchExports

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -322,7 +322,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_client, bucket_name):
-    """Test the full S3 workflow targetting a MinIO bucket.
+    """Test that S3 Export Workflow end-to-end by using a local MinIO bucket instead of S3.
 
     The workflow should update the batch export run status to completed and produce the expected
     records to the MinIO bucket.

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -1071,3 +1071,135 @@ async def test_s3_export_workflow_continues_on_multiple_json_decode_error(client
 
     duplicate_events = [event for event in events if not should_fail(event)]
     assert_events_in_s3(s3_client, bucket_name, prefix, events + duplicate_events)
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_s3_export_workflow_with_minio_bucket_produces_no_duplicates(client: HttpClient, s3_client, bucket_name):
+    """Test that S3 Export Workflow end-to-end by using a local MinIO bucket instead of S3.
+
+    In this particular instance of the test, we assert no duplicates are exported to S3.
+    """
+    ch_client = ClickHouseClient(
+        url=settings.CLICKHOUSE_HTTP_URL,
+        user=settings.CLICKHOUSE_USER,
+        password=settings.CLICKHOUSE_PASSWORD,
+        database=settings.CLICKHOUSE_DATABASE,
+    )
+
+    prefix = f"posthog-events-{str(uuid4())}"
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": bucket_name,
+            "region": "us-east-1",
+            "prefix": prefix,
+            "batch_window_size": 3600,
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = await acreate_organization("test")
+    team = await acreate_team(organization=organization)
+    batch_export = await acreate_batch_export(
+        team_id=team.pk,
+        name=batch_export_data["name"],
+        destination_data=batch_export_data["destination"],
+        interval=batch_export_data["interval"],
+    )
+
+    duplicate_id = str(uuid4())
+    duplicate_distinct_id = str(uuid4())
+    duplicate_person_id = str(uuid4())
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": "test",
+            "timestamp": "2023-04-25 13:30:00.000000",
+            "created_at": "2023-04-25 13:30:00.000000",
+            "inserted_at": f"2023-04-25 13:30:00.000000",
+            "_timestamp": "2023-04-25 13:30:00",
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team.pk,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "distinct_id": str(uuid4()),
+            "elements_chain": "this is a comman, separated, list, of css selectors(?)",
+        },
+        {
+            "uuid": duplicate_id,
+            "event": "test",
+            "timestamp": "2023-04-25 14:29:00.000000",
+            "created_at": "2023-04-25 14:29:00.000000",
+            "inserted_at": f"2023-04-25 14:29:00.000000",
+            "_timestamp": "2023-04-25 14:29:00",
+            "person_id": duplicate_person_id,
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team.pk,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "distinct_id": duplicate_distinct_id,
+            "elements_chain": "this is a comman, separated, list, of css selectors(?)",
+        },
+    ]
+    events_with_duplicates = events + [
+        {
+            "uuid": duplicate_id,
+            "event": "test",
+            "timestamp": "2023-04-25 14:29:00.000000",
+            "created_at": "2023-04-25 14:29:00.000000",
+            "inserted_at": f"2023-04-25 14:29:00.000000",
+            "_timestamp": "2023-04-25 14:29:00",
+            "person_id": duplicate_person_id,
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team.pk,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "distinct_id": duplicate_distinct_id,
+            "elements_chain": "this is a comman, separated, list, of css selectors(?)",
+        }
+    ]
+
+    # Insert some data into the `sharded_events` table.
+    await insert_events(
+        client=ch_client,
+        events=events_with_duplicates,
+    )
+
+    workflow_id = str(uuid4())
+    inputs = S3BatchExportInputs(
+        team_id=team.pk,
+        batch_export_id=str(batch_export.id),
+        data_interval_end="2023-04-25 14:30:00.000000",
+        **batch_export.destination.config,
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[S3BatchExportWorkflow],
+            activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+                await activity_environment.client.execute_workflow(
+                    S3BatchExportWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+
+        runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+        assert len(runs) == 1
+
+        run = runs[0]
+        assert run.status == "Completed"
+
+    assert_events_in_s3(s3_client, bucket_name, prefix, events)

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -22,7 +22,7 @@ SELECT_QUERY_TEMPLATE = Template(
 )
 
 
-async def get_rows_count(client, team_id: int, interval_start: str, interval_end: str):
+async def get_rows_count(client, team_id: int, interval_start: str, interval_end: str) -> int:
     data_interval_start_ch = datetime.fromisoformat(interval_start).strftime("%Y-%m-%d %H:%M:%S")
     data_interval_end_ch = datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
     query = SELECT_QUERY_TEMPLATE.substitute(

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -25,7 +25,9 @@ SELECT_QUERY_TEMPLATE = Template(
 async def get_rows_count(client, team_id: int, interval_start: str, interval_end: str):
     data_interval_start_ch = datetime.fromisoformat(interval_start).strftime("%Y-%m-%d %H:%M:%S")
     data_interval_end_ch = datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
-    query = SELECT_QUERY_TEMPLATE.substitute(fields="count(*) as count", order_by="", format="")
+    query = SELECT_QUERY_TEMPLATE.substitute(
+        fields="count(DISTINCT event, cityHash64(distinct_id), cityHash64(uuid)) as count", order_by="", format=""
+    )
     count = await client.read_query(
         query,
         query_parameters={
@@ -48,6 +50,7 @@ def get_results_iterator(
     data_interval_end_ch = datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
     query = SELECT_QUERY_TEMPLATE.substitute(
         fields="""
+                    DISTINCT ON (event, cityHash64(distinct_id), cityHash64(uuid))
                     toString(uuid) as uuid,
                     timestamp,
                     inserted_at,


### PR DESCRIPTION
## Problem

Duplicates are asynchronously handled by ClickHouse. This means that a BatchExport is not guaranteed to be de-duplicated. BatchExports run with at least once semantics, so we expect duplicates to happen. However, we can sacrifice some performance to ensure no duplicates in each batch by modifying the query with a `DISTINCT ON` clause.


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Added a `DISTINCT ON` clause to the exports query to deduplicate.

I also had to fix a unit test:

For some reason, one of the unit tests wasn't working properly (`test_s3_export_workflow_with_minio_bucket`):
* The timestamp bounds were set in such a way no events would ever be selected.
* The MinIO bucket credentials were not being passed to the workflow inputs.
* The bucket name was not correct.

I do not understand how this test worked and didn't fail before. This is unrelated to the previous commit changes.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added unit tests for de-duplication (both unit and testing the s3 workflow for duplicates).
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
