### PR TITLE
chore: log when OG image not found

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Any, Dict, Optional, cast
 from urllib.parse import urlparse, urlunparse
 
+import structlog
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.timezone import now
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -25,6 +26,8 @@ from posthog.models.user import User
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.user_permissions import UserPermissions
 from posthog.utils import render_template
+
+logger = structlog.get_logger(__name__)
 
 
 def shared_url_as_png(url: str = "") -> str:
@@ -194,6 +197,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
                     "dashboard", "insight", "recording"
                 ).get(access_token=access_token)
             except SharingConfiguration.DoesNotExist:
+                logger.error("SharingConfiguration_access_token_match_not_found", access_token=access_token)
                 raise NotFound()
 
             if sharing_configuration and sharing_configuration.enabled:
@@ -206,6 +210,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
         resource = self.get_object()
 
         if not resource:
+            logger.error("SharingConfiguration_resource_not_found", token=self.request.query_params.get("token"))
             raise NotFound()
 
         embedded = "embedded" in request.GET or "/embedded/" in request.path
@@ -221,6 +226,10 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
             exported_data["accessToken"] = resource.access_token
             exported_asset = self.exported_asset_for_sharing_configuration(resource)
             if not exported_asset:
+                logger.error(
+                    "SharingConfiguration_open_graph_image_asset_not_found",
+                    exported_asset_id=exported_asset.pk if exported_asset else None,
+                )
                 raise NotFound()
             return get_content_response(exported_asset, False)
         elif isinstance(resource, SharingConfiguration):
@@ -297,5 +306,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
             return exported_asset_matches.first()
         else:
             export_asset = export_asset_for_opengraph(resource)
-
+            logger.info(
+                "SharingConfiguration_open_graph_image_asset_created_on_demand", exported_asset_id=export_asset.pk
+            )
             return export_asset

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -128,6 +128,11 @@ def get_content_response(asset: ExportedAsset, download: bool = False):
         content = object_storage.read_bytes(asset.content_location)
 
     if not content:
+        logger.error(
+            "exported_asset.content-missing",
+            exported_asset_id=asset.id,
+            has_content=asset.has_content if asset else False,
+        )
         raise NotFound()
 
     res = HttpResponse(content, content_type=asset.export_format)


### PR DESCRIPTION
## Problem

OG image for a shared insight returns 404, we don't have anything in the logs to investigate

## Changes

add too much logging so we can see what happened and then cut back on the logging

## How did you test this code?

🧠 
