### PR TITLE
fix: exported assets with no content are invalid

### DIFF
--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -128,6 +128,10 @@ def get_content_response(asset: ExportedAsset, download: bool = False):
         content = object_storage.read_bytes(asset.content_location)
 
     if not content:
+        # if we don't have content, the asset is invalid, so, expire it
+        asset.expires_after = now()
+        asset.save()
+
         raise NotFound()
 
     res = HttpResponse(content, content_type=asset.export_format)

--- a/posthog/models/test/test_exported_asset_model.py
+++ b/posthog/models/test/test_exported_asset_model.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timedelta
 
+import pytest
+from dateutil.parser import isoparse
 from freezegun import freeze_time
+from rest_framework.exceptions import NotFound
 
-from posthog.models.exported_asset import ExportedAsset
+from posthog.models.exported_asset import ExportedAsset, get_content_response
 from posthog.test.base import APIBaseTest
 
 
@@ -70,3 +73,21 @@ class TestExportedAssetModel(APIBaseTest):
             asset_that_is_not_expired,
             asset_that_has_no_expiry,
         ]
+
+    @freeze_time("2021-01-01T12:00:00Z")
+    def test_invalid_exported_asset_is_expired_on_access(self) -> None:
+        asset: ExportedAsset = ExportedAsset.objects.create(
+            team=self.team,
+            created_by=self.user,
+            expires_after=datetime.now() + timedelta(seconds=100),
+            # an invalid asset is one that has no local or remote content
+            content=None,
+            content_location=None,
+        )
+
+        assert asset.expires_after != isoparse("2021-01-01T12:00:00Z")
+
+        with pytest.raises(NotFound):
+            get_content_response(asset, False)
+
+        assert asset.expires_after == isoparse("2021-01-01T12:00:00Z")


### PR DESCRIPTION
## Problem

I tried to share an insight and then demo that it would have an open graph image while we were having an outage.

The asset was exported but had no content stored in Postgres or blob storage, so it was invalid and would return 404 on access

## Changes

It would be nicer not to generate the asset in the first place but that's tricky, so let's expire the asset when we try to serve it and discover it is invalid. That way if someone tries to hit the OG image URL twice we'll regenerate it

## How did you test this code?

developer tests