### PR TITLE
chore: bump clickhouse for local dev and ci to 23.6

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -242,7 +242,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.10.10']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:23.4.2.11']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:23.6.1.1524']
                 segment: ['FOSS', 'EE']
                 person-on-events: [false, true]
                 # :NOTE: Keep concurrency and groups in sync

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -28,7 +28,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.4.2.11}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.6.1.1524}
         restart: on-failure
         depends_on:
             - kafka

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -71,7 +71,9 @@ class TestQuotaLimiting(BaseTest):
                     timestamp=now() - relativedelta(hours=1),
                     team=self.team,
                 )
+        import time
 
+        time.sleep(5)
         result = update_all_org_billing_quotas()
         org_id = str(self.organization.id)
         assert result["events"] == {org_id: 1612137599}

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -1,4 +1,6 @@
+import time
 from uuid import uuid4
+
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -71,9 +73,7 @@ class TestQuotaLimiting(BaseTest):
                     timestamp=now() - relativedelta(hours=1),
                     team=self.team,
                 )
-        import time
-
-        time.sleep(5)
+        time.sleep(1)
         result = update_all_org_billing_quotas()
         org_id = str(self.organization.id)
         assert result["events"] == {org_id: 1612137599}


### PR DESCRIPTION
## Problem

Major issue with clickhouse handling changed columns when you have projections - fix is in 23.6. We need to move to 23.6 rapidly

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
