### PR TITLE
ci: deploy master tag on all regions

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -152,6 +152,6 @@ jobs:
                   # to avoid checksum mismatch on multiple platforms.
                   message: |
                       {
-                        "image_tag": "latest",
+                        "image_tag": "master",
                         "context": ${{ toJson(github) }}
                       }


### PR DESCRIPTION
## Problem

We are transitioning our cloud regions from the custom `posthog-cloud:latest` image to `posthog-cloud:master`, that is basically just the vanilla `posthog/posthog`.

## Changes

- Trigger the deploy pipeline with the `master` tag, so that the vanilla image is always used. It's already the case on dev and prod-us through a manual override, this will align prod-eu too.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
