### PR TITLE
fix(experiments): Disallow changing variant names

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -889,6 +889,12 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                                 autoCapitalize="off"
                                                 autoCorrect="off"
                                                 spellCheck={false}
+                                                disabled={
+                                                    !!(
+                                                        featureFlag.experiment_set &&
+                                                        featureFlag.experiment_set?.length > 0
+                                                    )
+                                                }
                                             />
                                         </Field>
                                     </Col>
@@ -973,7 +979,7 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                             icon={<IconPlus />}
                             disabledReason={
                                 featureFlag.experiment_set && featureFlag.experiment_set?.length > 0
-                                    ? 'Cannot add variants to a feature flag that is part of an experiment'
+                                    ? 'Cannot add variants to a feature flag that is part of an experiment. To update variants, create a new experiment.'
                                     : undefined
                             }
                             tooltipPlacement="topLeft"


### PR DESCRIPTION
## Problem

It's possible to wiggle around the experiment restriction by going directly to the flag. This stops it.

<img width="1197" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/0767bffb-f0c5-4f05-b2f9-4edb04c34e35">

Fixes https://posthoghelp.zendesk.com/agent/tickets/3990 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/6675)
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
