### PR TITLE
refactor(event-usage): remove some unused actions

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -225,7 +225,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         values: [preflightLogic, ['realm'], userLogic, ['user']],
     },
     actions: {
+        // persons related
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
+        reportPersonsModalViewed: (params: any) => ({
+            params,
+        }),
+        reportCohortCreatedFromPersonsModal: (filters: Partial<FilterType>) => ({ filters }),
+        // insights
         reportInsightCreated: (insightType: InsightType | null) => ({ insightType }),
         reportInsightSaved: (filters: Partial<FilterType>, isNewInsight: boolean) => ({ filters, isNewInsight }),
         reportInsightViewed: (
@@ -247,18 +253,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             changedFilters,
             isUsingSessionAnalysis,
         }),
-        reportPersonsModalViewed: (params: any) => ({
-            params,
-        }),
-        reportCohortCreatedFromPersonsModal: (filters: Partial<FilterType>) => ({ filters }),
-        reportBookmarkletDragged: true,
-        reportProjectCreationSubmitted: (projectCount: number, nameLength: number) => ({ projectCount, nameLength }),
-        reportProjectNoticeDismissed: (key: string) => ({ key }),
-        reportBulkInviteAttempted: (inviteesCount: number, namesCount: number) => ({ inviteesCount, namesCount }),
-        reportInviteAttempted: (nameProvided: boolean, instanceEmailAvailable: boolean) => ({
-            nameProvided,
-            instanceEmailAvailable,
-        }),
         reportFunnelCalculated: (
             eventCount: number,
             actionCount: number,
@@ -274,7 +268,48 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             success,
             error,
         }),
+        // insight filters
         reportFunnelStepReordered: true,
+        reportInsightFilterRemoved: (index: number) => ({ index }),
+        reportInsightFilterAdded: (newLength: number, source: GraphSeriesAddedSource) => ({ newLength, source }),
+        reportInsightFilterSet: (
+            filters: Array<{
+                id: string | number | null
+                type?: EntityType
+            }>
+        ) => ({ filters }),
+        reportEntityFilterVisibilitySet: (index: number, visible: boolean) => ({ index, visible }),
+        reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
+        reportPropertyGroupFilterAdded: true,
+        reportChangeOuterPropertyGroupFiltersType: (type: FilterLogicalOperator, groupsLength: number) => ({
+            type,
+            groupsLength,
+        }),
+        reportChangeInnerPropertyGroupFiltersType: (type: FilterLogicalOperator, filtersLength: number) => ({
+            type,
+            filtersLength,
+        }),
+        // insight funnel correlation
+        reportCorrelationViewed: (filters: Partial<FilterType>, delay?: number, propertiesTable?: boolean) => ({
+            filters,
+            delay, // Number of delayed seconds to report event (useful to measure insights where users don't navigate immediately away)
+            propertiesTable,
+        }),
+        reportCorrelationInteraction: (
+            correlationType: FunnelCorrelation['result_type'],
+            action: string,
+            props?: Record<string, any>
+        ) => ({ correlationType, action, props }),
+        reportCorrelationAnalysisFeedback: (rating: number) => ({ rating }),
+        reportCorrelationAnalysisDetailedFeedback: (rating: number, comments: string) => ({ rating, comments }),
+        reportBookmarkletDragged: true,
+        reportProjectCreationSubmitted: (projectCount: number, nameLength: number) => ({ projectCount, nameLength }),
+        reportProjectNoticeDismissed: (key: string) => ({ key }),
+        reportBulkInviteAttempted: (inviteesCount: number, namesCount: number) => ({ inviteesCount, namesCount }),
+        reportInviteAttempted: (nameProvided: boolean, instanceEmailAvailable: boolean) => ({
+            nameProvided,
+            instanceEmailAvailable,
+        }),
         reportPersonPropertyUpdated: (
             action: 'added' | 'updated' | 'removed',
             totalProperties: number,
@@ -315,20 +350,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             device_timezone?: string | null
         ) => ({ component, project_timezone, device_timezone }),
         reportTestAccountFiltersUpdated: (filters: Record<string, any>[]) => ({ filters }),
-        reportInsightFilterRemoved: (index: number) => ({ index }),
-        reportInsightFilterAdded: (newLength: number, source: GraphSeriesAddedSource) => ({ newLength, source }),
-        reportInsightFilterSet: (
-            filters: Array<{
-                id: string | number | null
-                type?: EntityType
-            }>
-        ) => ({ filters }),
-        reportEntityFilterVisibilitySet: (index: number, visible: boolean) => ({ index, visible }),
         reportPropertySelectOpened: true,
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: true,
         reportRemovedInsightFromDashboard: true,
-        reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
         reportSavedInsightTabChanged: (tab: string) => ({ tab }),
         reportSavedInsightFilterUsed: (filterKeys: string[]) => ({ filterKeys }),
         reportSavedInsightLayoutChanged: (layout: string) => ({ layout }),
@@ -343,18 +368,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         ) => ({ playerData, durations, type, delay, loadedFromBlobStorage }),
         reportHelpButtonViewed: true,
         reportHelpButtonUsed: (help_type: HelpType) => ({ help_type }),
-        reportCorrelationViewed: (filters: Partial<FilterType>, delay?: number, propertiesTable?: boolean) => ({
-            filters,
-            delay, // Number of delayed seconds to report event (useful to measure insights where users don't navigate immediately away)
-            propertiesTable,
-        }),
-        reportCorrelationInteraction: (
-            correlationType: FunnelCorrelation['result_type'],
-            action: string,
-            props?: Record<string, any>
-        ) => ({ correlationType, action, props }),
-        reportCorrelationAnalysisFeedback: (rating: number) => ({ rating }),
-        reportCorrelationAnalysisDetailedFeedback: (rating: number, comments: string) => ({ rating, comments }),
         reportRecordingsListFetched: (loadTime: number, listingVersion: '1' | '2' | '3') => ({
             loadTime,
             listingVersion,
@@ -396,15 +409,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             endDate,
             duration,
             significant,
-        }),
-        reportPropertyGroupFilterAdded: true,
-        reportChangeOuterPropertyGroupFiltersType: (type: FilterLogicalOperator, groupsLength: number) => ({
-            type,
-            groupsLength,
-        }),
-        reportChangeInnerPropertyGroupFiltersType: (type: FilterLogicalOperator, filtersLength: number) => ({
-            type,
-            filtersLength,
         }),
         reportPrimaryDashboardModalOpened: true,
         reportPrimaryDashboardChanged: true,

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -530,32 +530,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportInsightRefreshTime: async ({ loadingMilliseconds, insightShortId }) => {
             posthog.capture('insight refresh time', { loadingMilliseconds, insightShortId })
         },
-        reportEventsTablePollingReactedToPageVisibility: async ({ pageIsVisible }) => {
-            posthog.capture(`events table polling ${pageIsVisible ? 'resumed' : 'paused'}`, { pageIsVisible })
-        },
-        reportAnnotationViewed: async ({ annotations }, breakpoint) => {
-            if (!annotations) {
-                // If value is `null` the component has been unmounted, don't report
-                return
-            }
-
-            await breakpoint(500) // Debounce calls to make sure we don't report accidentally hovering over an annotation.
-
-            for (const annotation of annotations) {
-                /* Report one event per annotation */
-                const properties = {
-                    total_items_count: annotations.length,
-                    content_length: annotation.content?.length || 0,
-                    scope: annotation.scope,
-                    deleted: annotation.deleted,
-                    created_by_me: annotation.created_by && annotation.created_by?.uuid === userLogic.values.user?.uuid,
-                    creation_type: annotation.creation_type,
-                    created_at: annotation.created_at,
-                    updated_at: annotation.updated_at,
-                }
-                posthog.capture('annotation viewed', properties)
-            }
-        },
         reportPersonDetailViewed: async (
             {
                 person,
@@ -723,11 +697,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             await breakpoint(500)
             posthog.capture('bookmarklet drag start')
         },
-        reportIngestionBookmarkletCollapsible: async ({ activePanels }, breakpoint) => {
-            breakpoint(500)
-            const action = activePanels.includes('bookmarklet') ? 'shown' : 'hidden'
-            posthog.capture(`ingestion bookmarklet panel ${action}`)
-        },
         reportProjectCreationSubmitted: async ({
             projectCount,
             nameLength,
@@ -743,10 +712,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportProjectNoticeDismissed: async ({ key }) => {
             // ProjectNotice was previously called DemoWarning
             posthog.capture('demo warning dismissed', { warning_key: key })
-        },
-        reportOnboardingStepTriggered: async ({ stepKey, extraArgs }) => {
-            // Fired after the user attempts to start an onboarding step (e.g. clicking on create project)
-            posthog.capture('onboarding step triggered', { step: stepKey, ...extraArgs })
         },
         reportBulkInviteAttempted: async ({
             inviteesCount,
@@ -811,11 +776,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportDashboardPinToggled: async (payload) => {
             posthog.capture(`dashboard pin toggled`, payload)
         },
-        reportDashboardDropdownNavigation: async () => {
-            /* Triggered when a user navigates using the dropdown in the header.
-             */
-            posthog.capture(`dashboard dropdown navigated`)
-        },
         reportDashboardFrontEndUpdate: async ({ attribute, originalLength, newLength }) => {
             posthog.capture(`dashboard frontend updated`, {
                 attribute,
@@ -844,38 +804,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportIngestionLandingSeen: async () => {
             posthog.capture('ingestion landing seen')
         },
-        reportProjectHomeItemClicked: async ({ module, item, extraProps }) => {
-            const defaultProps = { module, item }
-            const eventProps = extraProps ? { ...defaultProps, ...extraProps } : defaultProps
-            posthog.capture('project home item clicked', eventProps)
-        },
-        reportProjectHomeSeen: async ({ teamHasData }) => {
-            posthog.capture('project home seen', { team_has_data: teamHasData })
-        },
 
-        reportInsightHistoryItemClicked: async ({ itemType, displayLocation }) => {
-            posthog.capture('insight history item clicked', { item_type: itemType, display_location: displayLocation })
-            if (displayLocation === 'project home') {
-                // Special case to help w/ project home reporting.
-                posthog.capture('project home item clicked', {
-                    module: 'insights',
-                    item: 'recent_analysis',
-                    item_type: itemType,
-                    display_location: displayLocation,
-                })
-            }
-        },
-
-        reportEventSearched: async ({ searchTerm, extraProps }) => {
-            // This event is only captured on PostHog Cloud
-            if (values.realm === 'cloud') {
-                // Triggered when a search is executed for an action/event (mainly for use on insights)
-                posthog.capture('event searched', { searchTerm, ...extraProps })
-            }
-        },
-        reportInsightFilterUpdated: async ({ type, index, name }) => {
-            posthog.capture('filter updated', { type, index, name })
-        },
         reportInsightFilterRemoved: async ({ index }) => {
             posthog.capture('local filter removed', { index })
         },
@@ -900,14 +829,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportRemovedInsightFromDashboard: async () => {
             posthog.capture('removed insight from dashboard')
         },
-        reportInsightsTabReset: async () => {
-            posthog.capture('insights tab reset')
-        },
         reportInsightsTableCalcToggled: async (payload) => {
             posthog.capture('insights table calc toggled', payload)
-        },
-        reportInsightShortUrlVisited: (props) => {
-            posthog.capture('insight short url visited', props)
         },
         reportSavedInsightFilterUsed: ({ filterKeys }) => {
             posthog.capture('saved insights list page filter used', { filter_keys: filterKeys })
@@ -939,9 +862,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
                 loadedFromBlobStorage,
             }
             posthog.capture(`recording ${type}`, payload)
-        },
-        reportPersonMerged: (props) => {
-            posthog.capture('merge person completed', props)
         },
         reportPersonSplit: (props) => {
             posthog.capture('split person started', props)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -4,7 +4,6 @@ import posthog from 'posthog-js'
 import { userLogic } from 'scenes/userLogic'
 import type { eventUsageLogicType } from './eventUsageLogicType'
 import {
-    AnnotationType,
     FilterType,
     DashboardType,
     PersonType,
@@ -226,8 +225,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         values: [preflightLogic, ['realm'], userLogic, ['user']],
     },
     actions: {
-        reportEventsTablePollingReactedToPageVisibility: (pageIsVisible: boolean) => ({ pageIsVisible }),
-        reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
         reportInsightCreated: (insightType: InsightType | null) => ({ insightType }),
         reportInsightSaved: (filters: Partial<FilterType>, isNewInsight: boolean) => ({ filters, isNewInsight }),
@@ -255,13 +252,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         }),
         reportCohortCreatedFromPersonsModal: (filters: Partial<FilterType>) => ({ filters }),
         reportBookmarkletDragged: true,
-        reportIngestionBookmarkletCollapsible: (activePanels: string[]) => ({ activePanels }),
         reportProjectCreationSubmitted: (projectCount: number, nameLength: number) => ({ projectCount, nameLength }),
         reportProjectNoticeDismissed: (key: string) => ({ key }),
-        reportOnboardingStepTriggered: (stepKey: string, extraArgs: Record<string, string | number | boolean>) => ({
-            stepKey,
-            extraArgs,
-        }),
         reportBulkInviteAttempted: (inviteesCount: number, namesCount: number) => ({ inviteesCount, namesCount }),
         reportInviteAttempted: (nameProvided: boolean, instanceEmailAvailable: boolean) => ({
             nameProvided,
@@ -309,7 +301,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             pinned,
             source,
         }),
-        reportDashboardDropdownNavigation: true,
         reportDashboardFrontEndUpdate: (
             attribute: 'name' | 'description' | 'tags',
             originalLength: number,
@@ -324,21 +315,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             device_timezone?: string | null
         ) => ({ component, project_timezone, device_timezone }),
         reportTestAccountFiltersUpdated: (filters: Record<string, any>[]) => ({ filters }),
-        reportProjectHomeItemClicked: (
-            module: string,
-            item: string,
-            extraProps?: Record<string, string | boolean | number | undefined>
-        ) => ({ module, item, extraProps }),
-        reportProjectHomeSeen: (teamHasData: boolean) => ({ teamHasData }),
-        reportInsightHistoryItemClicked: (itemType: string, displayLocation?: string) => ({
-            itemType,
-            displayLocation,
-        }),
-        reportEventSearched: (searchTerm: string, extraProps?: Record<string, number>) => ({
-            searchTerm,
-            extraProps,
-        }),
-        reportInsightFilterUpdated: (index: number, name: string | null, type?: EntityType) => ({ type, index, name }),
         reportInsightFilterRemoved: (index: number) => ({ index }),
         reportInsightFilterAdded: (newLength: number, source: GraphSeriesAddedSource) => ({ newLength, source }),
         reportInsightFilterSet: (
@@ -352,14 +328,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: true,
         reportRemovedInsightFromDashboard: true,
-        reportInsightsTabReset: true,
         reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
-        reportInsightShortUrlVisited: (valid: boolean, insight: InsightType | null) => ({ valid, insight }),
         reportSavedInsightTabChanged: (tab: string) => ({ tab }),
         reportSavedInsightFilterUsed: (filterKeys: string[]) => ({ filterKeys }),
         reportSavedInsightLayoutChanged: (layout: string) => ({ layout }),
         reportSavedInsightNewInsightClicked: (insightType: string) => ({ insightType }),
-        reportPersonMerged: (merge_count: number) => ({ merge_count }),
         reportPersonSplit: (merge_count: number) => ({ merge_count }),
         reportRecording: (
             playerData: SessionPlayerData,
@@ -368,7 +341,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             delay?: number,
             loadedFromBlobStorage?: boolean
         ) => ({ playerData, durations, type, delay, loadedFromBlobStorage }),
-        reportRecordingScrollTo: (rowIndex: number) => ({ rowIndex }),
         reportHelpButtonViewed: true,
         reportHelpButtonUsed: (help_type: HelpType) => ({ help_type }),
         reportCorrelationViewed: (filters: Partial<FilterType>, delay?: number, propertiesTable?: boolean) => ({


### PR DESCRIPTION
## Problem

It's hard to keep track of the events implemented for insights.

## Changes

This, admittedly nit-picky, PR:
- removes a couple of unused event
- re-orders the events so that those related to insights and insight filters are in order

## How did you test this code?

CI run