### PR TITLE
fix: editor simplification

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -5,7 +5,7 @@ import StarterKit from '@tiptap/starter-kit'
 import ExtensionPlaceholder from '@tiptap/extension-placeholder'
 import FloatingMenu from '@tiptap/extension-floating-menu'
 import ExtensionDocument from '@tiptap/extension-document'
-import { EditorRange, isCurrentNodeEmpty, shouldShowFloatingMenu } from './utils'
+import { EditorRange, isCurrentNodeEmpty } from './utils'
 
 import { NotebookNodeFlag } from '../Nodes/NotebookNodeFlag'
 import { NotebookNodeQuery } from 'scenes/notebooks/Nodes/NotebookNodeQuery'
@@ -16,7 +16,7 @@ import { NotebookNodePerson } from '../Nodes/NotebookNodePerson'
 import { NotebookNodeLink } from '../Nodes/NotebookNodeLink'
 
 import posthog from 'posthog-js'
-import { SlashCommandsExtension } from './SlashCommands'
+import { FloatingSlashCommands, SlashCommandsExtension } from './SlashCommands'
 import { JSONContent } from './utils'
 import { NotebookEditor } from '~/types'
 
@@ -135,7 +135,6 @@ export function Editor({
             onCreate({
                 getJSON: () => editor.getJSON(),
                 setEditable: (editable: boolean) => editor.setEditable(editable, false),
-                shouldShowFloatingMenu: () => shouldShowFloatingMenu(editor),
                 setContent: (content: JSONContent) => editor.commands.setContent(content, false),
                 hasContent: () => !editor.isEmpty || false,
                 deleteRange: (range: EditorRange) => editor.chain().focus().deleteRange(range),
@@ -148,7 +147,7 @@ export function Editor({
     return (
         <>
             <EditorContent editor={_editor} className="flex flex-col flex-1" />
-            {/* {_editor && <FloatingSlashCommands editor={_editor} />} */}
+            {_editor && <FloatingSlashCommands editor={_editor} />}
         </>
     )
 }

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -1,0 +1,135 @@
+import { useEditor, EditorContent } from '@tiptap/react'
+import { useEffect, useRef } from 'react'
+import StarterKit from '@tiptap/starter-kit'
+import ExtensionPlaceholder from '@tiptap/extension-placeholder'
+import ExtensionDocument from '@tiptap/extension-document'
+import { Editor } from './utils'
+
+import { NotebookNodeFlag } from '../Nodes/NotebookNodeFlag'
+import { NotebookNodeQuery } from 'scenes/notebooks/Nodes/NotebookNodeQuery'
+import { NotebookNodeInsight } from 'scenes/notebooks/Nodes/NotebookNodeInsight'
+import { NotebookNodeRecording } from 'scenes/notebooks/Nodes/NotebookNodeRecording'
+import { NotebookNodePlaylist } from 'scenes/notebooks/Nodes/NotebookNodePlaylist'
+import { NotebookNodePerson } from '../Nodes/NotebookNodePerson'
+import { NotebookNodeLink } from '../Nodes/NotebookNodeLink'
+
+import posthog from 'posthog-js'
+import { SlashCommandsExtension } from './SlashCommands'
+import { JSONContent } from './utils'
+import { NotebookEditor } from '~/types'
+
+const CustomDocument = ExtensionDocument.extend({
+    content: 'heading block*',
+})
+
+export function Editor({
+    initialContent,
+    editable,
+    onCreate,
+    onUpdate,
+    placeholder,
+}: {
+    initialContent: JSONContent
+    editable: boolean
+    onCreate: (editor: NotebookEditor) => void
+    onUpdate: () => void
+    placeholder: ({ node }: { node: any }) => string
+}): JSX.Element {
+    const editorRef = useRef<Editor>()
+
+    const _editor = useEditor({
+        extensions: [
+            CustomDocument,
+            StarterKit.configure({
+                document: false,
+            }),
+            ExtensionPlaceholder.configure({
+                placeholder: placeholder,
+            }),
+            NotebookNodeLink,
+
+            NotebookNodeInsight,
+            NotebookNodeQuery,
+            NotebookNodeRecording,
+            NotebookNodePlaylist,
+            NotebookNodePerson,
+            NotebookNodeFlag,
+            SlashCommandsExtension,
+
+            // Ensure this is last as a fallback for all PostHog links
+            // LinkExtension.configure({}),
+        ],
+        content: initialContent,
+        editorProps: {
+            attributes: {
+                class: 'NotebookEditor',
+            },
+            handleDrop: (view, event, _slice, moved) => {
+                const editor = editorRef.current
+                if (!editor) {
+                    return false
+                }
+
+                if (!moved && event.dataTransfer) {
+                    const text = event.dataTransfer.getData('text/plain')
+                    const node = event.dataTransfer.getData('node')
+                    const properties = event.dataTransfer.getData('properties')
+
+                    if (text.indexOf(window.location.origin) === 0 || node) {
+                        // PostHog link - ensure this gets input as a proper link
+                        const coordinates = view.posAtCoords({ left: event.clientX, top: event.clientY })
+
+                        if (!coordinates) {
+                            return false
+                        }
+
+                        if (node) {
+                            editor
+                                .chain()
+                                .focus()
+                                .setTextSelection(coordinates.pos)
+                                .insertContent({ type: node, attrs: JSON.parse(properties) })
+                                .run()
+
+                            // We report this case, the pasted version is handled by the posthogNodePasteRule
+                            posthog.capture('notebook node dropped', { node_type: node })
+                        } else {
+                            editor?.chain().focus().setTextSelection(coordinates.pos).run()
+                            view.pasteText(text)
+                        }
+
+                        return true
+                    }
+
+                    if (event.dataTransfer.files && event.dataTransfer.files[0]) {
+                        // if dropping external files
+                        const file = event.dataTransfer.files[0] // the dropped file
+
+                        console.log('TODO: Dropped file!', file)
+                        // TODO: Detect if it is an image and add image upload handler
+
+                        return true
+                    }
+                }
+
+                return false
+            },
+        },
+        onCreate: ({ editor }) => {
+            editorRef.current = editor
+            onCreate({
+                getJSON: () => editor.getJSON(),
+                setContent: (content: JSONContent) => editor.commands.setContent(content, false),
+                hasContent: () => !editor.isEmpty || false,
+            })
+        },
+        onUpdate: onUpdate,
+        onDestroy,
+    })
+
+    useEffect(() => {
+        _editor?.setEditable(editable, false)
+    }, [editable, _editor])
+
+    return <EditorContent editor={_editor} className="flex flex-col flex-1" />
+}

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -17,8 +17,7 @@ import { NotebookNodeLink } from '../Nodes/NotebookNodeLink'
 
 import posthog from 'posthog-js'
 import { FloatingSlashCommands, SlashCommandsExtension } from './SlashCommands'
-import { JSONContent } from './utils'
-import { NotebookEditor } from '~/types'
+import { JSONContent, NotebookEditor } from './utils'
 
 const CustomDocument = ExtensionDocument.extend({
     content: 'heading block*',
@@ -136,7 +135,7 @@ export function Editor({
                 getJSON: () => editor.getJSON(),
                 setEditable: (editable: boolean) => editor.setEditable(editable, false),
                 setContent: (content: JSONContent) => editor.commands.setContent(content, false),
-                hasContent: () => !editor.isEmpty || false,
+                isEmpty: () => editor.isEmpty,
                 deleteRange: (range: EditorRange) => editor.chain().focus().deleteRange(range),
             })
         },

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { SCRATCHPAD_NOTEBOOK } from './notebooksListLogic'
-import { FloatingSlashCommands } from './SlashCommands'
 import { NotebookConflictWarning } from './NotebookConflictWarning'
 import { Editor } from './Editor'
 import { NotebookLoadingState } from './NotebookLoadingState'
@@ -23,7 +22,7 @@ const PLACEHOLDER_TITLES = ['Release notes', 'Product roadmap', 'Meeting notes',
 
 export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Element {
     const logic = notebookLogic({ shortId })
-    const { notebook, content, notebookLoading, isEmpty, conflictWarningVisible } = useValues(logic)
+    const { notebook, content, notebookLoading, isEmpty, editor, conflictWarningVisible } = useValues(logic)
     const { setEditor, onEditorUpdate, duplicateNotebook, loadNotebook } = useActions(logic)
     const { isExpanded } = useValues(notebookSettingsLogic)
 
@@ -34,6 +33,12 @@ export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Elem
             loadNotebook()
         }
     }, [])
+
+    useEffect(() => {
+        if (editor) {
+            editor.setEditable(editable)
+        }
+    }, [editable])
 
     // TODO - Render a special state if the notebook is empty
 
@@ -56,8 +61,6 @@ export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Elem
     return (
         <BindLogic logic={notebookLogic} props={{ shortId }}>
             <div className={clsx('Notebook', !isExpanded && 'Notebook--compact')}>
-                <FloatingSlashCommands />
-
                 {notebook.is_template && (
                     <LemonBanner
                         type="info"
@@ -86,7 +89,6 @@ export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Elem
 
                 <Editor
                     initialContent={content}
-                    editable={editable}
                     onCreate={setEditor}
                     onUpdate={onEditorUpdate}
                     placeholder={({ node }: { node: any }) => {

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -10,8 +10,8 @@ import { notebookSettingsLogic } from './notebookSettingsLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { SCRATCHPAD_NOTEBOOK } from './notebooksListLogic'
 import { NotebookConflictWarning } from './NotebookConflictWarning'
-import { Editor } from './Editor'
 import { NotebookLoadingState } from './NotebookLoadingState'
+import { Editor } from './Editor'
 
 export type NotebookProps = {
     shortId: string
@@ -38,7 +38,7 @@ export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Elem
         if (editor) {
             editor.setEditable(editable)
         }
-    }, [editable])
+    }, [editor, editable])
 
     // TODO - Render a special state if the notebook is empty
 

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -1,45 +1,30 @@
-import { useEditor, EditorContent } from '@tiptap/react'
-import StarterKit from '@tiptap/starter-kit'
-import ExtensionDocument from '@tiptap/extension-document'
-import ExtensionPlaceholder from '@tiptap/extension-placeholder'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 import { BindLogic, useActions, useValues } from 'kea'
 import './Notebook.scss'
 
-import { NotebookNodeFlag } from '../Nodes/NotebookNodeFlag'
-import { NotebookNodeQuery } from 'scenes/notebooks/Nodes/NotebookNodeQuery'
-import { NotebookNodeInsight } from 'scenes/notebooks/Nodes/NotebookNodeInsight'
-import { NotebookNodeRecording } from 'scenes/notebooks/Nodes/NotebookNodeRecording'
-import { NotebookNodePlaylist } from 'scenes/notebooks/Nodes/NotebookNodePlaylist'
-import { NotebookNodePerson } from '../Nodes/NotebookNodePerson'
-import { NotebookNodeLink } from '../Nodes/NotebookNodeLink'
 import { sampleOne } from 'lib/utils'
-import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { NotFound } from 'lib/components/NotFound'
 import clsx from 'clsx'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
-import posthog from 'posthog-js'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { SCRATCHPAD_NOTEBOOK } from './notebooksListLogic'
-import { FloatingSlashCommands, SlashCommandsExtension } from './SlashCommands'
+import { FloatingSlashCommands } from './SlashCommands'
 import { NotebookConflictWarning } from './NotebookConflictWarning'
+import { Editor } from './Editor'
+import { NotebookLoadingState } from './NotebookLoadingState'
 
 export type NotebookProps = {
     shortId: string
     editable?: boolean
 }
 
-const CustomDocument = ExtensionDocument.extend({
-    content: 'heading block*',
-})
-
 const PLACEHOLDER_TITLES = ['Release notes', 'Product roadmap', 'Meeting notes', 'Bug analysis']
 
 export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Element {
     const logic = notebookLogic({ shortId })
     const { notebook, content, notebookLoading, isEmpty, conflictWarningVisible } = useValues(logic)
-    const { setEditorRef, onEditorUpdate, duplicateNotebook, loadNotebook } = useActions(logic)
+    const { setEditor, onEditorUpdate, duplicateNotebook, loadNotebook } = useActions(logic)
     const { isExpanded } = useValues(notebookSettingsLogic)
 
     const headingPlaceholder = useMemo(() => sampleOne(PLACEHOLDER_TITLES), [shortId])
@@ -50,173 +35,72 @@ export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Elem
         }
     }, [])
 
-    // Whenever our content changes, we want to ignore the next update (which is caused by the editor itself)
-    const ignoreUpdateRef = useRef(true)
-    useEffect(() => {
-        ignoreUpdateRef.current = true
-    }, [content])
-
-    // NOTE: We shouldn't use this reference as it can be that it is null in many of the contexts
-    const _editor = useEditor({
-        extensions: [
-            CustomDocument,
-            StarterKit.configure({
-                document: false,
-            }),
-            ExtensionPlaceholder.configure({
-                placeholder: ({ node }) => {
-                    if (node.type.name === 'heading' && node.attrs.level === 1) {
-                        return `Untitled - maybe.. "${headingPlaceholder}"`
-                    }
-
-                    if (node.type.name === 'heading') {
-                        return `Heading ${node.attrs.level}`
-                    }
-
-                    return ''
-                },
-            }),
-            NotebookNodeLink,
-
-            NotebookNodeInsight,
-            NotebookNodeQuery,
-            NotebookNodeRecording,
-            NotebookNodePlaylist,
-            NotebookNodePerson,
-            NotebookNodeFlag,
-            SlashCommandsExtension,
-
-            // Ensure this is last as a fallback for all PostHog links
-            // LinkExtension.configure({}),
-        ],
-        content,
-        editorProps: {
-            attributes: {
-                class: 'NotebookEditor',
-            },
-            handleDrop: (view, event, _slice, moved) => {
-                const editor = logic.values.editor // Only for type checking - should never be null
-                if (!editor) {
-                    return false
-                }
-
-                if (!moved && event.dataTransfer) {
-                    const text = event.dataTransfer.getData('text/plain')
-                    const node = event.dataTransfer.getData('node')
-                    const properties = event.dataTransfer.getData('properties')
-
-                    if (text.indexOf(window.location.origin) === 0 || node) {
-                        // PostHog link - ensure this gets input as a proper link
-                        const coordinates = view.posAtCoords({ left: event.clientX, top: event.clientY })
-
-                        if (!coordinates) {
-                            return false
-                        }
-
-                        if (node) {
-                            editor
-                                .chain()
-                                .focus()
-                                .setTextSelection(coordinates.pos)
-                                .insertContent({ type: node, attrs: JSON.parse(properties) })
-                                .run()
-
-                            // We report this case, the pasted version is handled by the posthogNodePasteRule
-                            posthog.capture('notebook node dropped', { node_type: node })
-                        } else {
-                            editor?.chain().focus().setTextSelection(coordinates.pos).run()
-                            view.pasteText(text)
-                        }
-
-                        return true
-                    }
-
-                    if (event.dataTransfer.files && event.dataTransfer.files[0]) {
-                        // if dropping external files
-                        const file = event.dataTransfer.files[0] // the dropped file
-
-                        console.log('TODO: Dropped file!', file)
-                        // TODO: Detect if it is an image and add image upload handler
-
-                        return true
-                    }
-                }
-
-                return false
-            },
-        },
-        onUpdate: ({}) => {
-            if (ignoreUpdateRef.current) {
-                ignoreUpdateRef.current = false
-                return
-            }
-            onEditorUpdate()
-        },
-    })
-
-    useEffect(() => {
-        if (_editor) {
-            setEditorRef(_editor)
-        }
-    }, [_editor])
-
-    useEffect(() => {
-        _editor?.setEditable(editable && !!notebook, false)
-    }, [editable, _editor, notebook])
-
     // TODO - Render a special state if the notebook is empty
+
+    if (conflictWarningVisible) {
+        return <NotebookConflictWarning />
+    } else if (!notebook && notebookLoading) {
+        return <NotebookLoadingState />
+    } else if (!notebook) {
+        return <NotFound object="notebook" />
+    } else if (isEmpty && !editable) {
+        return (
+            <div className="NotebookEditor">
+                <h1>
+                    <i>Untitled</i>
+                </h1>
+            </div>
+        )
+    }
 
     return (
         <BindLogic logic={notebookLogic} props={{ shortId }}>
             <div className={clsx('Notebook', !isExpanded && 'Notebook--compact')}>
                 <FloatingSlashCommands />
-                {conflictWarningVisible ? (
-                    <NotebookConflictWarning />
-                ) : !notebook && notebookLoading ? (
-                    <div className="space-y-4 px-8 py-4">
-                        <LemonSkeleton className="w-1/2 h-8" />
-                        <LemonSkeleton className="w-1/3 h-4" />
-                        <LemonSkeleton className="h-4" />
-                        <LemonSkeleton className="h-4" />
-                    </div>
-                ) : !notebook ? (
-                    <NotFound object="notebook" />
-                ) : isEmpty && !editable ? (
-                    <div className="NotebookEditor">
-                        <h1>
-                            <i>Untitled</i>
-                        </h1>
-                    </div>
-                ) : (
-                    <>
-                        {notebook.is_template && (
-                            <LemonBanner
-                                type="info"
-                                className="my-4"
-                                action={{
-                                    onClick: duplicateNotebook,
-                                    children: 'Create notebook',
-                                }}
-                            >
-                                <b>This is a template.</b> You can create a copy of it to edit and use as your own.
-                            </LemonBanner>
-                        )}
 
-                        {notebook.short_id === SCRATCHPAD_NOTEBOOK.short_id ? (
-                            <LemonBanner
-                                type="info"
-                                action={{
-                                    children: 'Convert to Notebook',
-                                    onClick: duplicateNotebook,
-                                }}
-                            >
-                                This is your scratchpad. It is only visible to you and is persisted only in this
-                                browser. It's a great place to gather ideas before turning into a saved Notebook!
-                            </LemonBanner>
-                        ) : null}
-                        <EditorContent editor={_editor} className="flex flex-col flex-1" />
-                    </>
+                {notebook.is_template && (
+                    <LemonBanner
+                        type="info"
+                        className="my-4"
+                        action={{
+                            onClick: duplicateNotebook,
+                            children: 'Create notebook',
+                        }}
+                    >
+                        <b>This is a template.</b> You can create a copy of it to edit and use as your own.
+                    </LemonBanner>
                 )}
+
+                {notebook.short_id === SCRATCHPAD_NOTEBOOK.short_id ? (
+                    <LemonBanner
+                        type="info"
+                        action={{
+                            children: 'Convert to Notebook',
+                            onClick: duplicateNotebook,
+                        }}
+                    >
+                        This is your scratchpad. It is only visible to you and is persisted only in this browser. It's a
+                        great place to gather ideas before turning into a saved Notebook!
+                    </LemonBanner>
+                ) : null}
+
+                <Editor
+                    initialContent={content}
+                    editable={editable}
+                    onCreate={setEditor}
+                    onUpdate={onEditorUpdate}
+                    placeholder={({ node }: { node: any }) => {
+                        if (node.type.name === 'heading' && node.attrs.level === 1) {
+                            return `Untitled - maybe.. "${headingPlaceholder}"`
+                        }
+
+                        if (node.type.name === 'heading') {
+                            return `Heading ${node.attrs.level}`
+                        }
+
+                        return ''
+                    }}
+                />
             </div>
         </BindLogic>
     )

--- a/frontend/src/scenes/notebooks/Notebook/NotebookLoadingState.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookLoadingState.tsx
@@ -1,0 +1,12 @@
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+
+export function NotebookLoadingState(): JSX.Element {
+    return (
+        <div className="space-y-4 px-8 py-4">
+            <LemonSkeleton className="w-1/2 h-8" />
+            <LemonSkeleton className="w-1/3 h-4" />
+            <LemonSkeleton className="h-4" />
+            <LemonSkeleton className="h-4" />
+        </div>
+    )
+}

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -1,11 +1,11 @@
-import { Extension } from '@tiptap/core'
+import { Editor as TTEditor, Extension } from '@tiptap/core'
 import Suggestion from '@tiptap/suggestion'
 
 import { FloatingMenu, ReactRenderer } from '@tiptap/react'
 import { LemonButton, LemonButtonWithDropdown, LemonDivider } from '@posthog/lemon-ui'
 import { IconCohort, IconPlus, IconQueryEditor, IconRecording, IconTableChart } from 'lib/lemon-ui/icons'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
-import { Editor, EditorCommands, EditorRange } from './utils'
+import { EditorCommands, EditorRange, isCurrentNodeEmpty } from './utils'
 import { NotebookNodeType } from '~/types'
 import { examples } from '~/queries/examples'
 import { Popover } from 'lib/lemon-ui/Popover'
@@ -253,26 +253,24 @@ const SlashCommandsPopover = forwardRef<SlashCommandsRef, SlashCommandsProps>(fu
     )
 })
 
-export function FloatingSlashCommands({ editor }: { editor: Editor }): JSX.Element | null {
-    // const { editor } = useValues(notebookLogic)
+export function FloatingSlashCommands({ editor }: { editor: TTEditor }): JSX.Element | null {
+    const shouldShow = useCallback((): boolean => {
+        if (!editor) {
+            return false
+        }
+        if (editor.view.hasFocus() && editor.isEditable && editor.isActive('paragraph') && isCurrentNodeEmpty(editor)) {
+            return true
+        }
 
-    // const shouldShow = useCallback((): boolean => {
-    //     if (!editor) {
-    //         return false
-    //     }
-    //     if (editor.view.hasFocus() && editor.isEditable && editor.isActive('paragraph') && isCurrentNodeEmpty(editor)) {
-    //         return true
-    //     }
-
-    //     return false
-    // }, [editor])
+        return false
+    }, [editor])
 
     return editor ? (
         <FloatingMenu
             editor={editor}
             tippyOptions={{ duration: 100, placement: 'left' }}
             className="NotebookFloatingButton"
-            // shouldShow={shouldShow(editor)}
+            shouldShow={shouldShow}
         >
             <LemonButtonWithDropdown
                 size="small"

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -1,24 +1,23 @@
-import { ChainedCommands, Editor, Extension, Range } from '@tiptap/core'
+import { Extension } from '@tiptap/core'
 import Suggestion from '@tiptap/suggestion'
 
 import { FloatingMenu, ReactRenderer } from '@tiptap/react'
 import { LemonButton, LemonButtonWithDropdown, LemonDivider } from '@posthog/lemon-ui'
-import { useValues } from 'kea'
-import { notebookLogic } from './notebookLogic'
 import { IconCohort, IconPlus, IconQueryEditor, IconRecording, IconTableChart } from 'lib/lemon-ui/icons'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
-import { isCurrentNodeEmpty } from './utils'
+import { isCurrentNodeEmpty, Editor, EditorCommands, EditorRange } from './utils'
 import { NotebookNodeType } from '~/types'
 import { examples } from '~/queries/examples'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import Fuse from 'fuse.js'
+import { useValues } from 'kea'
+import { notebookLogic } from './notebookLogic'
 
 type SlashCommandsProps = {
-    editor: Editor
     mode: 'slash' | 'add'
     query?: string
-    range?: Range
+    range?: EditorRange
     decorationNode?: any
 }
 
@@ -30,7 +29,7 @@ type SlashCommandsItem = {
     title: string
     search?: string
     icon?: JSX.Element
-    command: (chain: ChainedCommands) => ChainedCommands
+    command: (chain: EditorCommands) => EditorCommands
 }
 
 const TEXT_CONTROLS: SlashCommandsItem[] = [
@@ -40,11 +39,11 @@ const TEXT_CONTROLS: SlashCommandsItem[] = [
     },
     {
         title: 'H2',
-        command: (chain) => chain.toggleHeading({ level: 1 }),
+        command: (chain) => chain.toggleHeading({ level: 2 }),
     },
     {
         title: 'H3',
-        command: (chain) => chain.toggleHeading({ level: 1 }),
+        command: (chain) => chain.toggleHeading({ level: 3 }),
     },
     {
         title: 'B',
@@ -87,9 +86,10 @@ const SLASH_COMMANDS: SlashCommandsItem[] = [
 ]
 
 const SlashCommands = forwardRef<SlashCommandsRef, SlashCommandsProps>(function SlashCommands(
-    { mode, editor, range = { from: 0, to: 0 }, query },
+    { mode, range = { from: 0, to: 0 }, query },
     ref
 ): JSX.Element | null {
+    const { editor } = useValues(notebookLogic)
     // We start with 1 because the first item is the text controls
     const [selectedIndex, setSelectedIndex] = useState(0)
     const [selectedHorizontalIndex, setSelectedHorizontalIndex] = useState(0)
@@ -121,12 +121,14 @@ const SlashCommands = forwardRef<SlashCommandsRef, SlashCommandsProps>(function 
     }, [query])
 
     const onPressEnter = (): void => {
-        const command =
-            selectedIndex === -1
-                ? TEXT_CONTROLS[selectedHorizontalIndex].command
-                : filteredSlashCommands[selectedIndex].command
+        if (!!editor) {
+            const command =
+                selectedIndex === -1
+                    ? TEXT_CONTROLS[selectedHorizontalIndex].command
+                    : filteredSlashCommands[selectedIndex].command
 
-        command(editor.chain().focus().deleteRange(range)).run()
+            command(editor.deleteRange(range)).run()
+        }
     }
     const onPressUp = (): void => {
         setSelectedIndex(Math.max(selectedIndex - 1, -1))
@@ -198,7 +200,7 @@ const SlashCommands = forwardRef<SlashCommandsRef, SlashCommandsProps>(function 
                         status="primary-alt"
                         size="small"
                         active={selectedIndex === -1 && selectedHorizontalIndex === index}
-                        onClick={() => item.command(editor.chain().focus().deleteRange(range)).run()}
+                        onClick={() => item.command(editor.deleteRange(range)).run()}
                     >
                         {item.title}
                     </LemonButton>
@@ -214,7 +216,7 @@ const SlashCommands = forwardRef<SlashCommandsRef, SlashCommandsProps>(function 
                     status="primary-alt"
                     icon={item.icon}
                     active={index === selectedIndex}
-                    onClick={() => item.command(editor.chain().focus().deleteRange(range)).run()}
+                    onClick={() => item.command(editor.deleteRange(range)).run()}
                 >
                     {item.title}
                 </LemonButton>
@@ -251,9 +253,7 @@ const SlashCommandsPopover = forwardRef<SlashCommandsRef, SlashCommandsProps>(fu
     )
 })
 
-export function FloatingSlashCommands(): JSX.Element | null {
-    const { editor } = useValues(notebookLogic)
-
+export function FloatingSlashCommands({ editor }: { editor: Editor }): JSX.Element | null {
     const shouldShow = useCallback((): boolean => {
         if (!editor) {
             return false
@@ -276,7 +276,7 @@ export function FloatingSlashCommands(): JSX.Element | null {
                 size="small"
                 icon={<IconPlus />}
                 dropdown={{
-                    overlay: <SlashCommands mode="add" editor={editor} range={undefined} />,
+                    overlay: <SlashCommands mode="add" range={undefined} />,
                     placement: 'right-start',
                     fallbackPlacements: ['left-start'],
                     actionable: true,

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -5,7 +5,7 @@ import { FloatingMenu, ReactRenderer } from '@tiptap/react'
 import { LemonButton, LemonButtonWithDropdown, LemonDivider } from '@posthog/lemon-ui'
 import { IconCohort, IconPlus, IconQueryEditor, IconRecording, IconTableChart } from 'lib/lemon-ui/icons'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
-import { isCurrentNodeEmpty, Editor, EditorCommands, EditorRange } from './utils'
+import { Editor, EditorCommands, EditorRange } from './utils'
 import { NotebookNodeType } from '~/types'
 import { examples } from '~/queries/examples'
 import { Popover } from 'lib/lemon-ui/Popover'
@@ -254,23 +254,25 @@ const SlashCommandsPopover = forwardRef<SlashCommandsRef, SlashCommandsProps>(fu
 })
 
 export function FloatingSlashCommands({ editor }: { editor: Editor }): JSX.Element | null {
-    const shouldShow = useCallback((): boolean => {
-        if (!editor) {
-            return false
-        }
-        if (editor.view.hasFocus() && editor.isEditable && editor.isActive('paragraph') && isCurrentNodeEmpty(editor)) {
-            return true
-        }
+    // const { editor } = useValues(notebookLogic)
 
-        return false
-    }, [editor])
+    // const shouldShow = useCallback((): boolean => {
+    //     if (!editor) {
+    //         return false
+    //     }
+    //     if (editor.view.hasFocus() && editor.isEditable && editor.isActive('paragraph') && isCurrentNodeEmpty(editor)) {
+    //         return true
+    //     }
+
+    //     return false
+    // }, [editor])
 
     return editor ? (
         <FloatingMenu
             editor={editor}
             tippyOptions={{ duration: 100, placement: 'left' }}
             className="NotebookFloatingButton"
-            shouldShow={shouldShow}
+            // shouldShow={shouldShow(editor)}
         >
             <LemonButtonWithDropdown
                 size="small"

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -182,7 +182,7 @@ export const notebookLogic = kea<notebookLogicType>([
         isEmpty: [
             (s) => [s.editor, s.content],
             (editor: NotebookEditor): boolean => {
-                return editor.hasContent()
+                return editor?.hasContent() || false
             },
         ],
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -2,10 +2,10 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import type { notebookLogicType } from './notebookLogicType'
 import { loaders } from 'kea-loaders'
 import { handleNotebookCreation, notebooksListLogic, SCRATCHPAD_NOTEBOOK } from './notebooksListLogic'
-import { NotebookEditor, NotebookSyncStatus, NotebookType } from '~/types'
+import { NotebookSyncStatus, NotebookType } from '~/types'
 
 // NOTE: Annoyingly, if we import this then kea logic typegen generates two imports and fails so we reimport it from a utils file
-import { JSONContent } from './utils'
+import { JSONContent, NotebookEditor } from './utils'
 import api from 'lib/api'
 import posthog from 'posthog-js'
 import { downloadFile, slugify } from 'lib/utils'
@@ -182,7 +182,7 @@ export const notebookLogic = kea<notebookLogicType>([
         isEmpty: [
             (s) => [s.editor, s.content],
             (editor: NotebookEditor): boolean => {
-                return editor?.hasContent() || false
+                return editor?.isEmpty() || false
             },
         ],
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -2,10 +2,10 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import type { notebookLogicType } from './notebookLogicType'
 import { loaders } from 'kea-loaders'
 import { handleNotebookCreation, notebooksListLogic, SCRATCHPAD_NOTEBOOK } from './notebooksListLogic'
-import { NotebookSyncStatus, NotebookType } from '~/types'
+import { NotebookEditor, NotebookSyncStatus, NotebookType } from '~/types'
 
 // NOTE: Annoyingly, if we import this then kea logic typegen generates two imports and fails so we reimport it from a utils file
-import { JSONContent, Editor } from './utils'
+import { JSONContent } from './utils'
 import api from 'lib/api'
 import posthog from 'posthog-js'
 import { downloadFile, slugify } from 'lib/utils'
@@ -26,7 +26,7 @@ export const notebookLogic = kea<notebookLogicType>([
         actions: [notebooksListLogic, ['receiveNotebookUpdate']],
     }),
     actions({
-        setEditorRef: (editor: Editor) => ({ editor }),
+        setEditor: (editor: NotebookEditor) => ({ editor }),
         onEditorUpdate: true,
         setLocalContent: (jsonContent: JSONContent) => ({ jsonContent }),
         clearLocalContent: true,
@@ -46,9 +46,9 @@ export const notebookLogic = kea<notebookLogicType>([
             },
         ],
         editor: [
-            null as Editor | null,
+            null as NotebookEditor | null,
             {
-                setEditorRef: (_, { editor }) => editor,
+                setEditor: (_, { editor }) => editor,
             },
         ],
         ready: [
@@ -92,7 +92,7 @@ export const notebookLogic = kea<notebookLogicType>([
 
                     if (!values.notebook) {
                         // If this is the first load we need to override the content fully
-                        values.editor?.commands.setContent(response.content)
+                        values.editor?.setContent(response.content)
                     }
 
                     return response
@@ -166,9 +166,9 @@ export const notebookLogic = kea<notebookLogicType>([
         isLocalOnly: [() => [(_, props) => props], (props): boolean => props.shortId === 'scratchpad'],
         content: [
             (s) => [s.notebook, s.localContent],
-            (notebook, localContent): JSONContent | undefined => {
+            (notebook, localContent): JSONContent => {
                 // We use the local content is set otherwise the notebook content
-                return localContent || notebook?.content
+                return localContent || notebook?.content || []
             },
         ],
         title: [
@@ -181,8 +181,8 @@ export const notebookLogic = kea<notebookLogicType>([
 
         isEmpty: [
             (s) => [s.editor, s.content],
-            (editor): boolean => {
-                return editor?.isEmpty ?? false
+            (editor: NotebookEditor): boolean => {
+                return editor.hasContent()
             },
         ],
 

--- a/frontend/src/scenes/notebooks/Notebook/utils.ts
+++ b/frontend/src/scenes/notebooks/Notebook/utils.ts
@@ -1,10 +1,25 @@
 // Helpers for Kea issue with double importing
-import { JSONContent as TTJSONContent, Editor as TTEditor } from '@tiptap/core'
+import {
+    JSONContent as TTJSONContent,
+    Editor as TTEditor,
+    ChainedCommands as EditorCommands,
+    Range as EditorRange,
+} from '@tiptap/core'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface JSONContent extends TTJSONContent {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Editor extends TTEditor {}
+
+export { ChainedCommands as EditorCommands, Range as EditorRange } from '@tiptap/core'
+
+export interface NotebookEditor {
+    getJSON: () => JSONContent
+    setEditable: (editable: boolean) => void
+    setContent: (content: JSONContent) => void
+    hasContent: () => boolean
+    deleteRange: (range: EditorRange) => EditorCommands
+}
 
 // Loosely based on https://github.com/ueberdosis/tiptap/blob/develop/packages/extension-floating-menu/src/floating-menu-plugin.ts#LL38C3-L55C4
 export const isCurrentNodeEmpty = (editor: Editor): boolean => {

--- a/frontend/src/scenes/notebooks/Notebook/utils.ts
+++ b/frontend/src/scenes/notebooks/Notebook/utils.ts
@@ -9,7 +9,6 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface JSONContent extends TTJSONContent {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Editor extends TTEditor {}
 
 export { ChainedCommands as EditorCommands, Range as EditorRange } from '@tiptap/core'
 
@@ -21,8 +20,22 @@ export interface NotebookEditor {
     deleteRange: (range: EditorRange) => EditorCommands
 }
 
+export const shouldShowFloatingMenu = (editor: TTEditor): boolean => {
+    if (
+        !editor ||
+        !editor.view.hasFocus() ||
+        !editor.isEditable ||
+        !editor.isActive('paragraph') ||
+        !isCurrentNodeEmpty(editor)
+    ) {
+        return false
+    }
+
+    return true
+}
+
 // Loosely based on https://github.com/ueberdosis/tiptap/blob/develop/packages/extension-floating-menu/src/floating-menu-plugin.ts#LL38C3-L55C4
-export const isCurrentNodeEmpty = (editor: Editor): boolean => {
+export const isCurrentNodeEmpty = (editor: TTEditor): boolean => {
     const selection = editor.state.selection
     const { $anchor, empty } = selection
     const isEmptyTextBlock = $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !$anchor.parent.textContent

--- a/frontend/src/scenes/notebooks/Notebook/utils.ts
+++ b/frontend/src/scenes/notebooks/Notebook/utils.ts
@@ -16,7 +16,7 @@ export interface NotebookEditor {
     getJSON: () => JSONContent
     setEditable: (editable: boolean) => void
     setContent: (content: JSONContent) => void
-    hasContent: () => boolean
+    isEmpty: () => boolean
     deleteRange: (range: EditorRange) => EditorCommands
 }
 

--- a/frontend/src/scenes/notebooks/Notebook/utils.ts
+++ b/frontend/src/scenes/notebooks/Notebook/utils.ts
@@ -20,20 +20,6 @@ export interface NotebookEditor {
     deleteRange: (range: EditorRange) => EditorCommands
 }
 
-export const shouldShowFloatingMenu = (editor: TTEditor): boolean => {
-    if (
-        !editor ||
-        !editor.view.hasFocus() ||
-        !editor.isEditable ||
-        !editor.isActive('paragraph') ||
-        !isCurrentNodeEmpty(editor)
-    ) {
-        return false
-    }
-
-    return true
-}
-
 // Loosely based on https://github.com/ueberdosis/tiptap/blob/develop/packages/extension-floating-menu/src/floating-menu-plugin.ts#LL38C3-L55C4
 export const isCurrentNodeEmpty = (editor: TTEditor): boolean => {
     const selection = editor.state.selection

--- a/frontend/src/scenes/notebooks/NotebookSidebarPlaceholder.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSidebarPlaceholder.tsx
@@ -1,0 +1,25 @@
+import { LemonButton } from '@posthog/lemon-ui'
+import { useActions } from 'kea'
+import { notebookSidebarLogic } from './Notebook/notebookSidebarLogic'
+import { IconArrowRight } from 'lib/lemon-ui/icons'
+
+export function NotebookSidebarPlaceholder(): JSX.Element {
+    const { setNotebookSideBarShown } = useActions(notebookSidebarLogic)
+
+    return (
+        <div className="flex flex-col justify-center items-center h-full text-muted-alt mx-10">
+            <h2 className="text-muted-alt">
+                This Notebook is open in the sidebar <IconArrowRight />
+            </h2>
+
+            <p>
+                You can navigate around PostHog and <b>drag and drop</b> thing into it. Or you can close the sidebar and
+                it will be full screen here instead.
+            </p>
+
+            <LemonButton type="secondary" onClick={() => setNotebookSideBarShown(false)}>
+                Open it here instead
+            </LemonButton>
+        </div>
+    )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -27,7 +27,7 @@ import { LogicWrapper } from 'kea'
 import { AggregationAxisFormat } from 'scenes/insights/aggregationAxisFormat'
 import { Layout } from 'react-grid-layout'
 import { DatabaseSchemaQueryResponseField, InsightQueryNode, Node, QueryContext } from './queries/schema'
-import { JSONContent, EditorCommands, EditorRange } from 'scenes/notebooks/Notebook/utils'
+import { JSONContent } from 'scenes/notebooks/Notebook/utils'
 
 export type Optional<T, K extends string | number | symbol> = Omit<T, K> & { [K in keyof T]?: T[K] }
 
@@ -2980,14 +2980,6 @@ export enum NotebookNodeType {
 }
 
 export type NotebookSyncStatus = 'synced' | 'saving' | 'unsaved' | 'local'
-
-export interface NotebookEditor {
-    getJSON: () => JSONContent
-    setEditable: (editable: boolean) => void
-    setContent: (content: JSONContent) => void
-    hasContent: () => boolean
-    deleteRange: (range: EditorRange) => EditorCommands
-}
 
 export interface DataWarehouseCredential {
     access_key: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -27,7 +27,7 @@ import { LogicWrapper } from 'kea'
 import { AggregationAxisFormat } from 'scenes/insights/aggregationAxisFormat'
 import { Layout } from 'react-grid-layout'
 import { DatabaseSchemaQueryResponseField, InsightQueryNode, Node, QueryContext } from './queries/schema'
-import { JSONContent } from 'scenes/notebooks/Notebook/utils'
+import { JSONContent, EditorCommands, EditorRange } from 'scenes/notebooks/Notebook/utils'
 
 export type Optional<T, K extends string | number | symbol> = Omit<T, K> & { [K in keyof T]?: T[K] }
 
@@ -2983,8 +2983,10 @@ export type NotebookSyncStatus = 'synced' | 'saving' | 'unsaved' | 'local'
 
 export interface NotebookEditor {
     getJSON: () => JSONContent
+    setEditable: (editable: boolean) => void
     setContent: (content: JSONContent) => void
     hasContent: () => boolean
+    deleteRange: (range: EditorRange) => EditorCommands
 }
 
 export interface DataWarehouseCredential {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2981,6 +2981,12 @@ export enum NotebookNodeType {
 
 export type NotebookSyncStatus = 'synced' | 'saving' | 'unsaved' | 'local'
 
+export interface NotebookEditor {
+    getJSON: () => JSONContent
+    setContent: (content: JSONContent) => void
+    hasContent: () => boolean
+}
+
 export interface DataWarehouseCredential {
     access_key: string
     access_secret: string

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "@testing-library/dom": ">=7.21.4",
         "@tiptap/core": "2.0.3",
         "@tiptap/extension-document": "2.0.3",
+        "@tiptap/extension-floating-menu": "^2.0.3",
         "@tiptap/extension-link": "2.0.3",
         "@tiptap/extension-placeholder": "2.0.3",
         "@tiptap/pm": "2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   '@tiptap/extension-document':
     specifier: 2.0.3
     version: 2.0.3(@tiptap/core@2.0.3)
+  '@tiptap/extension-floating-menu':
+    specifier: ^2.0.3
+    version: 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
   '@tiptap/extension-link':
     specifier: 2.0.3
     version: 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
@@ -13330,7 +13333,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}


### PR DESCRIPTION
## Problem

Towards https://github.com/PostHog/posthog/issues/15680

The were some autosave issues with the existing implementation of the editor

## Changes

- Abstract all TipTap specific code to a separate `Editor` component
- Expose a limited interface to the `editor` that can be referenced from different components
- Componentize some smaller UI pieces 

## How did you test this code?

There should be no changes in functionality. Tested that everything still works locally