### PR TITLE
fix(ui): prevent persons modal overflow

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.scss
@@ -92,6 +92,7 @@
     .LemonModal__container {
         display: flex;
         height: 100%;
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
## Problem

<img width="697" alt="Screenshot 2023-07-05 at 13 17 15" src="https://github.com/PostHog/posthog/assets/1851359/ca32195b-b0ef-4251-a8e1-40887d346275">


## Changes

This PR fixes an overflow issue with the persons modal.

## How did you test this code?

Locally & visual regression tests