### PR TITLE
chore(on-event): add retry topic for on-event handler

### DIFF
--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -6,6 +6,7 @@ const suffix = isTestEnv() ? '_test' : ''
 export const prefix = process.env.KAFKA_PREFIX || ''
 
 export const KAFKA_EVENTS_JSON = `${prefix}clickhouse_events_json${suffix}`
+export const KAFKA_ON_EVENT = `${prefix}on_event${suffix}`
 export const KAFKA_ON_EVENT_RETRIES_1 = `${prefix}on_event_retries_1${suffix}`
 export const KAFKA_ON_EVENT_RETRIES_2 = `${prefix}on_event_retries_2${suffix}`
 export const KAFKA_PERSON = `${prefix}clickhouse_person${suffix}`

--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -6,6 +6,8 @@ const suffix = isTestEnv() ? '_test' : ''
 export const prefix = process.env.KAFKA_PREFIX || ''
 
 export const KAFKA_EVENTS_JSON = `${prefix}clickhouse_events_json${suffix}`
+export const KAFKA_ON_EVENT_RETRIES_1 = `${prefix}on_event_retries_1${suffix}`
+export const KAFKA_ON_EVENT_RETRIES_2 = `${prefix}on_event_retries_2${suffix}`
 export const KAFKA_PERSON = `${prefix}clickhouse_person${suffix}`
 export const KAFKA_PERSON_UNIQUE_ID = `${prefix}clickhouse_person_unique_id${suffix}`
 export const KAFKA_PERSON_DISTINCT_ID = `${prefix}clickhouse_person_distinct_id${suffix}`

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -1,12 +1,12 @@
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
+import { KAFKA_ON_EVENT_RETRIES_1, KAFKA_ON_EVENT_RETRIES_2 } from '../../../config/kafka-topics'
 import { RawClickHouseEvent } from '../../../types'
 import { convertToIngestionEvent } from '../../../utils/event'
 import { groupIntoBatches } from '../../../utils/utils'
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eachBatch } from './each-batch'
-import { KAFKA_ON_EVENT_RETRIES_1, KAFKA_ON_EVENT_RETRIES_2 } from '../../../config/kafka-topics'
 
 // TODO: remove once we've migrated
 export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaJSIngestionConsumer): Promise<void> {
@@ -98,13 +98,14 @@ export async function eachBatchAppsOnEventHandlers(
             payload.pause()
             setTimeout(() => payload.resume(), waitTime)
         }
-
-        await eachBatch(payload, queue, eachMessageAppsOnEventHandlers, groupIntoBatches, 'async_handlers_on_event')
     }
 
-    export async function eachBatchWebhooksHandlers(
-        payload: EachBatchPayload,
-        queue: KafkaJSIngestionConsumer
-    ): Promise<void> {
-        await eachBatch(payload, queue, eachMessageWebhooksHandlers, groupIntoBatches, 'async_handlers_webhooks')
-    }
+    await eachBatch(payload, queue, eachMessageAppsOnEventHandlers, groupIntoBatches, 'async_handlers_on_event')
+}
+
+export async function eachBatchWebhooksHandlers(
+    payload: EachBatchPayload,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
+    await eachBatch(payload, queue, eachMessageWebhooksHandlers, groupIntoBatches, 'async_handlers_webhooks')
+}

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -25,7 +25,7 @@ export class KafkaJSIngestionConsumer {
     public pluginsServer: Hub
     public workerMethods: WorkerMethods
     public consumerReady: boolean
-    public topic: string
+    public topics: string[]
     public consumerGroupId: string
     public eachBatch: KafkaJSBatchFunction
     public consumer: Consumer
@@ -36,13 +36,13 @@ export class KafkaJSIngestionConsumer {
     constructor(
         pluginsServer: Hub,
         piscina: Piscina,
-        topic: string,
+        topics: string[],
         consumerGroupId: string,
         batchHandler: KafkaJSBatchFunction
     ) {
         this.pluginsServer = pluginsServer
         this.kafka = pluginsServer.kafka!
-        this.topic = topic
+        this.topics = topics
         this.consumerGroupId = consumerGroupId
         this.consumer = KafkaJSIngestionConsumer.buildConsumer(
             this.kafka,
@@ -82,7 +82,7 @@ export class KafkaJSIngestionConsumer {
         const timeout = timeoutGuard(
             `Kafka queue is slow to start. Waiting over 1 minute to join the consumer group`,
             {
-                topics: [this.topic],
+                topics: this.topics,
             },
             60000
         )
@@ -174,7 +174,7 @@ export class KafkaJSIngestionConsumer {
         }
         try {
             await this.consumer.disconnect()
-        } catch {}
+        } catch { }
 
         this.consumerReady = false
     }

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -1,6 +1,6 @@
 import * as schedule from 'node-schedule'
 
-import { KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
+import { KAFKA_EVENTS_JSON, KAFKA_ON_EVENT_RETRIES_1, KAFKA_ON_EVENT_RETRIES_2, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
 import { Hub } from '../../types'
 import { status } from '../../utils/status'
 import Piscina from '../../worker/piscina'
@@ -109,7 +109,7 @@ export const buildAsyncIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscin
     return new KafkaJSIngestionConsumer(
         hub,
         piscina,
-        KAFKA_EVENTS_JSON,
+        [KAFKA_EVENTS_JSON],
         `${KAFKA_PREFIX}clickhouse-plugin-server-async`,
         eachBatchAsyncHandlers
     )
@@ -119,7 +119,7 @@ export const buildOnEventIngestionConsumer = ({ hub, piscina }: { hub: Hub; pisc
     return new KafkaJSIngestionConsumer(
         hub,
         piscina,
-        KAFKA_EVENTS_JSON,
+        [KAFKA_EVENTS_JSON, KAFKA_ON_EVENT_RETRIES_1, KAFKA_ON_EVENT_RETRIES_2],
         `${KAFKA_PREFIX}clickhouse-plugin-server-async-onevent`,
         eachBatchAppsOnEventHandlers
     )
@@ -129,7 +129,7 @@ export const buildWebhooksIngestionConsumer = ({ hub, piscina }: { hub: Hub; pis
     return new KafkaJSIngestionConsumer(
         hub,
         piscina,
-        KAFKA_EVENTS_JSON,
+        [KAFKA_EVENTS_JSON],
         `${KAFKA_PREFIX}clickhouse-plugin-server-async-webhooks`,
         eachBatchWebhooksHandlers
     )


### PR DESCRIPTION
We're handling retries in memory at the moment, which means we end up
blocking the consumer loop when this is happening. It is much more
efficient to have a separate topic for retries, which means we can
continue to process events from the main topic without blocking.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
