### PR TITLE
fix: forgotten webhooks consumer split part

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -86,6 +86,7 @@ export async function startPluginsServer(
     let analyticsEventsIngestionConsumer: KafkaJSIngestionConsumer | IngestionConsumer | undefined
     let analyticsEventsIngestionOverflowConsumer: KafkaJSIngestionConsumer | IngestionConsumer | undefined
     let onEventHandlerConsumer: KafkaJSIngestionConsumer | undefined
+    let webhooksHandlerConsumer: KafkaJSIngestionConsumer | undefined
 
     // Kafka consumer. Handles events that we couldn't find an existing person
     // to associate. The buffer handles delaying the ingestion of these events
@@ -131,6 +132,7 @@ export async function startPluginsServer(
             analyticsEventsIngestionConsumer?.stop(),
             analyticsEventsIngestionOverflowConsumer?.stop(),
             onEventHandlerConsumer?.stop(),
+            webhooksHandlerConsumer?.stop(),
             bufferConsumer?.disconnect(),
             jobsConsumer?.disconnect(),
             stopSessionRecordingEventsConsumer?.(),
@@ -332,13 +334,13 @@ export async function startPluginsServer(
             serverInstance = serverInstance ? serverInstance : { hub }
 
             piscina = piscina ?? (await makePiscina(serverConfig, hub))
-            const { queue: onEventQueue, isHealthy: isWebhooksIngestionHealthy } =
+            const { queue: webhooksQueue, isHealthy: isWebhooksIngestionHealthy } =
                 await startAsyncWebhooksHandlerConsumer({
                     hub: hub,
                     piscina: piscina,
                 })
 
-            onEventHandlerConsumer = onEventQueue
+            webhooksHandlerConsumer = webhooksQueue
 
             healthChecks['webhooks-ingestion'] = isWebhooksIngestionHealthy
         }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This isn't broken per say as we weren't going to run onevent and webhooks in the same pod, but makes things more explicit

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
