### PR TITLE
feat: allow disabling high water mark processing

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -35,7 +35,6 @@ env:
     OBJECT_STORAGE_BUCKET: 'posthog'
     # set the max buffer size small enough that the functional tests behave the same in CI as when running locally
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: 1024
-    SESSION_RECORDING_BLOB_PROCESSING_TEAMS: 'all'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.run/Plugin Server.run.xml
+++ b/.run/Plugin Server.run.xml
@@ -11,10 +11,10 @@
       <env name="DATABASE_URL" value="postgres://posthog:posthog@localhost:5432/posthog" />
       <env name="KAFKA_HOSTS" value="localhost:9092" />
       <env name="OBJECT_STORAGE_ENABLED" value="True" />
-      <env name="SESSION_RECORDING_BLOB_PROCESSING_TEAMS" value="all" />
+      <env name="SESSION_RECORDING_ENABLE_OFFSET_HIGH_WATER_MARK_PROCESSING" value="true" />
+      <env name="SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS" value="180" />
       <env name="SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS" value="all" />
       <env name="WORKER_CONCURRENCY" value="2" />
-      <env name="SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS" value="180" />
     </envs>
     <method v="2" />
   </configuration>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,8 +44,7 @@
                 "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
                 "KAFKA_HOSTS": "localhost:9092",
                 "WORKER_CONCURRENCY": "2",
-                "OBJECT_STORAGE_ENABLED": "True",
-                "SESSION_RECORDING_BLOB_PROCESSING_TEAMS": "all"
+                "OBJECT_STORAGE_ENABLED": "True"
             }
         },
         {

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -121,9 +121,12 @@ export function getDefaultConfig(): PluginsServerConfig {
         USE_KAFKA_FOR_SCHEDULED_TASKS: true,
         CLOUD_DEPLOYMENT: 'default', // Used as a Sentry tag
 
+        // this defaults to true, but is used to disable for testing in production
+        SESSION_RECORDING_ENABLE_OFFSET_HIGH_WATER_MARK_PROCESSING: true,
+
         SESSION_RECORDING_KAFKA_HOSTS: undefined,
         SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL: undefined,
-        SESSION_RECORDING_BLOB_PROCESSING_TEAMS: '', // TODO: Change this to 'all' when we release it fully
+
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
         // NOTE: 10 minutes
         SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -202,7 +202,7 @@ export class SessionOffsetHighWaterMark {
 
 /**
  * To test if the offset high-water mark functionality is introducing playback errors
- * here's a version that does nothing tht can be swapped in
+ * here's a version that does nothing that can be swapped in
  */
 export class NullSessionOffsetHighWaterMark extends SessionOffsetHighWaterMark {
     getWatermarkFor(_tp: TopicPartition): Record<string, number> {

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -199,3 +199,34 @@ export class SessionOffsetHighWaterMark {
         delete this.topicPartitionWaterMarks[`${tp.topic}-${tp.partition}`]
     }
 }
+
+/**
+ * To test if the offset high-water mark functionality is introducing playback errors
+ * here's a version that does nothing tht can be swapped in
+ */
+export class NullSessionOffsetHighWaterMark extends SessionOffsetHighWaterMark {
+    getWatermarkFor(_tp: TopicPartition): Record<string, number> {
+        return {}
+    }
+
+    async add(_tp: TopicPartition, _sessionId: string, _offset: number): Promise<void> {
+        return Promise.resolve()
+    }
+
+    async getAll(_tp: TopicPartition): Promise<Record<string, number> | null> {
+        return Promise.resolve(null)
+    }
+
+    async onCommit(_tp: TopicPartition, _offset: number): Promise<Record<string, number> | null> {
+        return Promise.resolve(null)
+    }
+
+    async isBelowHighWaterMark(_tp: TopicPartition, _sessionId: string, _offset: number): Promise<boolean> {
+        // always return false so that we never drop messages
+        return Promise.resolve(false)
+    }
+
+    revoke(_tp: TopicPartition) {
+        return
+    }
+}

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -23,7 +23,10 @@ import { ObjectStorage } from '../../services/object_storage'
 import { eventDroppedCounter } from '../metrics'
 import { RealtimeManager } from './blob-ingester/realtime-manager'
 import { SessionManager } from './blob-ingester/session-manager'
-import { SessionOffsetHighWaterMark } from './blob-ingester/session-offset-high-water-mark'
+import {
+    NullSessionOffsetHighWaterMark,
+    SessionOffsetHighWaterMark,
+} from './blob-ingester/session-offset-high-water-mark'
 import { IncomingRecordingMessage } from './blob-ingester/types'
 import { now } from './blob-ingester/utils'
 
@@ -81,7 +84,6 @@ export class SessionRecordingBlobIngester {
     batchConsumer?: BatchConsumer
     producer?: RdKafkaProducer
     flushInterval: NodeJS.Timer | null = null
-    enabledTeams: number[] | null
     // the time at the most recent message of a particular partition
     partitionNow: Record<number, number | null> = {}
 
@@ -91,16 +93,17 @@ export class SessionRecordingBlobIngester {
         private objectStorage: ObjectStorage,
         private redisPool: RedisPool
     ) {
-        const enabledTeamsString = this.serverConfig.SESSION_RECORDING_BLOB_PROCESSING_TEAMS
-        this.enabledTeams =
-            enabledTeamsString === 'all' ? null : enabledTeamsString.split(',').filter(Boolean).map(parseInt)
-
         this.realtimeManager = new RealtimeManager(this.redisPool, this.serverConfig)
 
-        this.sessionOffsetHighWaterMark = new SessionOffsetHighWaterMark(
-            this.redisPool,
-            serverConfig.SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY
-        )
+        this.sessionOffsetHighWaterMark = this.serverConfig.SESSION_RECORDING_ENABLE_OFFSET_HIGH_WATER_MARK_PROCESSING
+            ? new SessionOffsetHighWaterMark(this.redisPool, serverConfig.SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY)
+            : // this receives a redis pool but doesn't use it,
+              // it is simpler to override the original like this, but will also let us see if
+              // the redis pool is contributing to RAM troubles
+              new NullSessionOffsetHighWaterMark(
+                  this.redisPool,
+                  serverConfig.SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY
+              )
     }
 
     public async consume(event: IncomingRecordingMessage, sentrySpan?: Sentry.Span): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -104,6 +104,10 @@ export class SessionRecordingBlobIngester {
     }
 
     public async consume(event: IncomingRecordingMessage, sentrySpan?: Sentry.Span): Promise<void> {
+        // we have to reset this counter once we're consuming messages since then we know we're not re-balancing
+        // otherwise the consumer continues to report however many sessions were revoked at the last re-balance forever
+        gaugeSessionsRevoked.set(0)
+
         const { team_id, session_id } = event
         const key = `${team_id}-${session_id}`
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -191,13 +191,14 @@ export interface PluginsServerConfig {
     EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: number
     CLOUD_DEPLOYMENT: string
 
-    SESSION_RECORDING_BLOB_PROCESSING_TEAMS: string
+    SESSION_RECORDING_ENABLE_OFFSET_HIGH_WATER_MARK_PROCESSING: boolean
     // local directory might be a volume mount or a directory on disk (e.g. in local dev)
     SESSION_RECORDING_LOCAL_DIRECTORY: string
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number
     SESSION_RECORDING_REMOTE_FOLDER: string
     SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY: string
+
     // Dedicated infra values
     SESSION_RECORDING_KAFKA_HOSTS: string | undefined
     SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL: KafkaSecurityProtocol | undefined


### PR DESCRIPTION
## Problem

We're not able to play back all of the recordings captured by the blob ingester, the offset high water mark processing is new and if it isn't working correctly would lead to us skipping data we should not have

## Changes

* Allow us to set an environment variable that uses a no-op high-water mark processor
* sneaks in removal of the no-longer-used SESSION_RECORDING_BLOB_PROCESSING_TEAMS env var

## How did you test this code?

checked it still runs locally