### PR TITLE
chore(data-warehouse): Put s3table queries into cte so joins work

### DIFF
--- a/posthog/hogql/database/test/tables.py
+++ b/posthog/hogql/database/test/tables.py
@@ -2,9 +2,9 @@ from posthog.hogql.database.models import DateDatabaseField, IntegerDatabaseFiel
 from posthog.hogql.database.s3_table import S3Table
 
 
-def create_aapl_stock_s3_table() -> S3Table:
+def create_aapl_stock_s3_table(name="aapl_stock") -> S3Table:
     return S3Table(
-        name="aapl_stock",
+        name=name,
         url="https://s3.eu-west-3.amazonaws.com/datasets-documentation/aapl_stock.csv",
         format="CSVWithNames",
         fields={

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -41,7 +41,8 @@ class TestDatabase(BaseTest):
             "select * from whatever",
             team=self.team,
         )
+
         self.assertEqual(
             response.clickhouse,
-            f"SELECT whatever.id FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_3)s, %(hogql_val_4)s, %(hogql_val_1)s, %(hogql_val_2)s) AS whatever LIMIT 100 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=True",
+            f"WITH whatever AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_3)s, %(hogql_val_4)s, %(hogql_val_1)s, %(hogql_val_2)s)) SELECT whatever.id FROM whatever LIMIT 100 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=True",
         )

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -10,6 +10,7 @@ class TestS3Table(BaseTest):
     def _init_database(self):
         self.database = create_hogql_database(self.team.pk)
         self.database.aapl_stock = create_aapl_stock_s3_table()
+        self.database.aapl_stock_2 = create_aapl_stock_s3_table(name="aapl_stock_2")
         self.context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=self.database)
 
     def _select(self, query: str, dialect: str = "clickhouse") -> str:
@@ -39,4 +40,70 @@ class TestS3Table(BaseTest):
         self.assertEqual(
             clickhouse,
             "WITH a AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s)) SELECT a.High, a.Low FROM aapl_stock AS a LIMIT 10",
+        )
+
+    def test_s3_table_select_join(self):
+        self._init_database()
+
+        hogql = self._select(
+            query="SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN aapl_stock_2 ON aapl_stock.High = aapl_stock_2.High LIMIT 10",
+            dialect="hogql",
+        )
+        self.assertEqual(
+            hogql,
+            "SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN aapl_stock_2 ON equals(aapl_stock.High, aapl_stock_2.High) LIMIT 10",
+        )
+
+        clickhouse = self._select(
+            query="SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN aapl_stock_2 ON aapl_stock.High = aapl_stock_2.High LIMIT 10",
+            dialect="clickhouse",
+        )
+
+        self.assertEqual(
+            clickhouse,
+            "WITH aapl_stock AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s)), aapl_stock_2 AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_3)s, %(hogql_val_4)s)) SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN aapl_stock_2 ON equals(aapl_stock.High, aapl_stock_2.High) LIMIT 10",
+        )
+
+    def test_s3_table_select_join_with_alias(self):
+        self._init_database()
+
+        hogql = self._select(
+            query="SELECT a.High, a.Low FROM aapl_stock AS a JOIN aapl_stock AS b ON a.High = b.High LIMIT 10",
+            dialect="hogql",
+        )
+        self.assertEqual(
+            hogql, "SELECT a.High, a.Low FROM aapl_stock AS a JOIN aapl_stock AS b ON equals(a.High, b.High) LIMIT 10"
+        )
+
+        clickhouse = self._select(
+            query="SELECT a.High, a.Low FROM aapl_stock AS a JOIN aapl_stock AS b ON a.High = b.High LIMIT 10",
+            dialect="clickhouse",
+        )
+
+        self.assertEqual(
+            clickhouse,
+            "WITH a AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s)), b AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_3)s, %(hogql_val_4)s)) SELECT a.High, a.Low FROM aapl_stock AS a JOIN aapl_stock AS b ON equals(a.High, b.High) LIMIT 10",
+        )
+
+    def test_s3_table_select_and_non_s3_join(self):
+        self._init_database()
+
+        hogql = self._select(
+            query="SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN events ON aapl_stock.High = events.event LIMIT 10",
+            dialect="hogql",
+        )
+        self.assertEqual(
+            hogql,
+            "SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN events ON equals(aapl_stock.High, events.event) LIMIT 10",
+        )
+
+        clickhouse = self._select(
+            query="SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN events ON aapl_stock.High = events.event LIMIT 10",
+            dialect="clickhouse",
+        )
+
+        self.maxDiff = None
+        self.assertEqual(
+            clickhouse,
+            f"WITH aapl_stock AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s)) SELECT aapl_stock.High, aapl_stock.Low FROM aapl_stock JOIN events ON equals(aapl_stock.High, events.event) WHERE equals(events.team_id, {self.team.pk}) LIMIT 10",
         )

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -22,9 +22,10 @@ class TestS3Table(BaseTest):
         self.assertEqual(hogql, "SELECT Date, Open, High, Low, Close, Volume, OpenInt FROM aapl_stock LIMIT 10")
 
         clickhouse = self._select(query="SELECT * FROM aapl_stock LIMIT 10", dialect="clickhouse")
+
         self.assertEqual(
             clickhouse,
-            "SELECT aapl_stock.Date, aapl_stock.Open, aapl_stock.High, aapl_stock.Low, aapl_stock.Close, aapl_stock.Volume, aapl_stock.OpenInt FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s) AS aapl_stock LIMIT 10",
+            "WITH aapl_stock AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s)) SELECT aapl_stock.Date, aapl_stock.Open, aapl_stock.High, aapl_stock.Low, aapl_stock.Close, aapl_stock.Volume, aapl_stock.OpenInt FROM aapl_stock LIMIT 10",
         )
 
     def test_s3_table_select_with_alias(self):
@@ -34,7 +35,8 @@ class TestS3Table(BaseTest):
         self.assertEqual(hogql, "SELECT High, Low FROM aapl_stock AS a LIMIT 10")
 
         clickhouse = self._select(query="SELECT High, Low FROM aapl_stock AS a LIMIT 10", dialect="clickhouse")
+
         self.assertEqual(
             clickhouse,
-            "SELECT a.High, a.Low FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s) AS a LIMIT 10",
+            "WITH a AS (SELECT * FROM s3Cluster('posthog', %(hogql_val_0)s, %(hogql_val_1)s)) SELECT a.High, a.Low FROM aapl_stock AS a LIMIT 10",
         )


### PR DESCRIPTION
## Problem

- joins don't work with s3 tables. When directly joining, the s3tables, incorrect columns will be queried due to implementation

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- CTEs resolve this issue
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
