### PR TITLE
chore(data-warehouse): make sure to send exceptions to sentry

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -32,6 +32,8 @@ from posthog.rate_limit import TeamRateThrottle
 from posthog.schema import EventsQuery, HogQLQuery, RecentPerformancePageViewNode, HogQLMetadata
 from posthog.utils import relative_date_parse
 
+from sentry_sdk import capture_exception
+
 import re
 
 
@@ -119,6 +121,7 @@ class QueryViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             raise ValidationError(str(e), e.code_name)
         except Exception as e:
             self.handle_column_ch_error(e)
+            capture_exception(e)
             raise e
 
     def handle_column_ch_error(self, error):


### PR DESCRIPTION
## Problem

- sentry not getting hogql errors

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- make sure capture_exception is called

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
