### PR TITLE
fix(experiments): Don't accidentally show the editor

### DIFF
--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -70,7 +70,7 @@ export function Query(props: QueryProps): JSX.Element | null {
     } else if (isSavedInsightNode(query)) {
         component = <SavedInsight query={query} context={queryContext} />
     } else if (isInsightVizNode(query)) {
-        component = <InsightViz query={query} setQuery={setQuery} context={queryContext} />
+        component = <InsightViz query={query} setQuery={setQuery} context={queryContext} readOnly={readOnly} />
     } else if (isTimeToSeeDataSessionsNode(query)) {
         component = <TimeToSeeData query={query} cachedResults={props.cachedResults} />
     }

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -24,11 +24,12 @@ type InsightVizProps = {
     query: InsightVizNode
     setQuery?: (node: InsightVizNode) => void
     context?: QueryContext
+    readOnly?: boolean
 }
 
 let uniqueNode = 0
 
-export function InsightViz({ query, setQuery, context }: InsightVizProps): JSX.Element {
+export function InsightViz({ query, setQuery, context, readOnly }: InsightVizProps): JSX.Element {
     const [key] = useState(() => `InsightViz.${uniqueNode++}`)
     const insightProps: InsightLogicProps = context?.insightProps || { dashboardItemId: `new-AdHoc.${key}` }
     const dataNodeLogicProps: DataNodeLogicProps = {
@@ -60,11 +61,13 @@ export function InsightViz({ query, setQuery, context }: InsightVizProps): JSX.E
                         'insight-wrapper--singlecolumn': isFunnels,
                     })}
                 >
-                    <EditorFilters
-                        query={query.source}
-                        setQuery={setQuerySource}
-                        showing={insightMode === ItemMode.Edit}
-                    />
+                    {!readOnly && (
+                        <EditorFilters
+                            query={query.source}
+                            setQuery={setQuerySource}
+                            showing={insightMode === ItemMode.Edit}
+                        />
+                    )}
 
                     <div className="insights-container" data-attr="insight-view">
                         <InsightContainer

--- a/frontend/src/scenes/feedback/inAppFeedbackLogic.ts
+++ b/frontend/src/scenes/feedback/inAppFeedbackLogic.ts
@@ -1,4 +1,4 @@
-import { EventsQuery } from '../../queries/schema'
+import { EventsQuery, InsightVizNode } from '../../queries/schema'
 import { actions, afterMount, kea, path, reducers } from 'kea'
 import { DataTableNode, Node, NodeKind, QuerySchema, TrendsQuery } from '~/queries/schema'
 
@@ -43,6 +43,11 @@ const DEFAULT_TREND_QUERY: TrendsQuery = {
     },
 }
 
+const DEFAULT_TREND_INSIGHT_VIZ_NODE: InsightVizNode = {
+    kind: NodeKind.InsightVizNode,
+    source: DEFAULT_TREND_QUERY,
+}
+
 export const inAppFeedbackLogic = kea<inAppFeedbackLogicType>([
     path(['scenes', 'feedback', 'inAppFeedbackLogic']),
     actions({
@@ -70,28 +75,31 @@ export const inAppFeedbackLogic = kea<inAppFeedbackLogicType>([
             },
         ],
         trendQuery: [
-            DEFAULT_TREND_QUERY as TrendsQuery,
+            DEFAULT_TREND_INSIGHT_VIZ_NODE as InsightVizNode,
             {
                 setDataTableQuery: (_, { query }) => {
                     if (query.kind === NodeKind.DataTableNode) {
                         const dataTableQuery = query as DataTableNode
                         const source = dataTableQuery.source as EventsQuery
                         return {
-                            ...DEFAULT_TREND_QUERY,
-                            series: [
-                                {
-                                    kind: NodeKind.EventsNode,
-                                    event: source.event,
-                                    name: source.event ?? undefined,
+                            ...DEFAULT_TREND_INSIGHT_VIZ_NODE,
+                            source: {
+                                ...DEFAULT_TREND_QUERY,
+                                series: [
+                                    {
+                                        kind: NodeKind.EventsNode,
+                                        event: source.event,
+                                        name: source.event ?? undefined,
+                                    },
+                                ],
+                                dateRange: {
+                                    date_from: source.after,
+                                    date_to: source.before,
                                 },
-                            ],
-                            dateRange: {
-                                date_from: source.after,
-                                date_to: source.before,
                             },
                         }
                     } else {
-                        return DEFAULT_TREND_QUERY
+                        return DEFAULT_TREND_INSIGHT_VIZ_NODE
                     }
                 },
             },


### PR DESCRIPTION
## Problem

Noticed that sometimes (I can't reliably reproduce) the insight editor filters show up in an experiment when they shouldn't.

I suspect this happens because: 

```
    const { insightMode } = useValues(insightSceneLogic)
```

insightSceneLogic is not keyed, shared across all insights, so the value probably carries over from an edit screen on an existing insight.

So, whenever readOnly is set on a query, this PR updates to never show editor filters. This seems a lot more safe than trying to walk through all possible spaghetti connections between logics to make sure insightMode is never in Edit mode when viewing a readOnly query.

---

Also updates the existing readOnly query for InAppFeedback which I noticed broke when we split out InsightViz 

<img width="1240" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/847d7e24-b45b-4a24-afd4-57d477afa70c">

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
