### PR TITLE
feat(insights): move refresh button out of menu

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -153,6 +153,7 @@ export const FEATURE_FLAGS = {
     SHOW_PRODUCT_INTRO_EXISTING_PRODUCTS: 'show-product-intro-existing-products', // owner: @raquelmsmith
     SESSION_RECORDING_SHOW_CONSOLE_LOGS_FILTER: 'session-recording-show-console-logs-filter', // owner: #team-monitoring
     ARTIFICIAL_HOG: 'artificial-hog', // owner: @Twixes
+    REFRESH_BUTTON_ON_INSIGHT: 'refresh-button-on-insight', // owner: @thmsobrmlr
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -1,16 +1,38 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
+
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
+import { Link } from '@posthog/lemon-ui'
 
 export function ComputationTimeWithRefresh(): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const showRefreshOnInsight = !!featureFlags[FEATURE_FLAGS.REFRESH_BUTTON_ON_INSIGHT]
+
     const { lastRefresh } = useValues(dataNodeLogic)
 
-    usePeriodicRerender(15000)
+    const { insightProps } = useValues(insightLogic)
+    const { getInsightRefreshButtonDisabledReason } = useValues(insightDataLogic(insightProps))
+    const { loadData } = useActions(insightDataLogic(insightProps))
+
+    usePeriodicRerender(15000) // Re-render every 15 seconds for up-to-date `insightRefreshButtonDisabledReason`
 
     return (
         <div className="flex items-center text-muted-alt">
             Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
+            {showRefreshOnInsight && (
+                <>
+                    <span className="px-1">•</span>
+                    <Link disabledReason={getInsightRefreshButtonDisabledReason()} onClick={() => loadData(true)}>
+                        Refresh
+                    </Link>
+                </>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -44,8 +44,13 @@ import { isInsightVizNode } from '~/queries/utils'
 import { posthog } from 'posthog-js'
 import { summarizeInsight } from 'scenes/insights/summarizeInsight'
 import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const showRefreshInMenu = !featureFlags[FEATURE_FLAGS.REFRESH_BUTTON_ON_INSIGHT]
+
     // insightSceneLogic
     const { insightMode, subscriptionId } = useValues(insightSceneLogic)
     const { setInsightMode } = useActions(insightSceneLogic)
@@ -143,37 +148,45 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                     <div className="flex justify-between items-center gap-2">
                         {!hasDashboardItemId ? (
                             <>
-                                <More
-                                    overlay={
-                                        <>
-                                            <LemonButton
-                                                status="stealth"
-                                                onClick={() => loadData(true)}
-                                                fullWidth
-                                                data-attr="refresh-insight-from-insight-view"
-                                                disabledReason={insightRefreshButtonDisabledReason}
-                                            >
-                                                Refresh
-                                            </LemonButton>
-                                        </>
-                                    }
-                                />
-                                <LemonDivider vertical />
+                                {showRefreshInMenu ? (
+                                    <>
+                                        <More
+                                            overlay={
+                                                <>
+                                                    <LemonButton
+                                                        status="stealth"
+                                                        onClick={() => loadData(true)}
+                                                        fullWidth
+                                                        data-attr="refresh-insight-from-insight-view"
+                                                        disabledReason={insightRefreshButtonDisabledReason}
+                                                    >
+                                                        Refresh
+                                                    </LemonButton>
+                                                </>
+                                            }
+                                        />
+                                        <LemonDivider vertical />
+                                    </>
+                                ) : (
+                                    <></>
+                                )}
                             </>
                         ) : (
                             <>
                                 <More
                                     overlay={
                                         <>
-                                            <LemonButton
-                                                status="stealth"
-                                                onClick={() => loadData(true)}
-                                                fullWidth
-                                                data-attr="refresh-insight-from-insight-view"
-                                                disabledReason={insightRefreshButtonDisabledReason}
-                                            >
-                                                Refresh
-                                            </LemonButton>
+                                            {showRefreshInMenu && (
+                                                <LemonButton
+                                                    status="stealth"
+                                                    onClick={() => loadData(true)}
+                                                    fullWidth
+                                                    data-attr="refresh-insight-from-insight-view"
+                                                    disabledReason={insightRefreshButtonDisabledReason}
+                                                >
+                                                    Refresh
+                                                </LemonButton>
+                                            )}
                                             <LemonButton
                                                 status="stealth"
                                                 onClick={() => duplicateInsight(insight as InsightModel, true)}


### PR DESCRIPTION
## Problem

People haven't been able to find the refresh button, see https://posthog.slack.com/archives/C0368RPHLQH/p1688032364866089. 

We're working on refreshing insights pro-actively on navigation as well: https://github.com/PostHog/posthog/pull/16310.

## Changes

This PR moves the Refresh button out of the menu in a Lemon-compliant way, undoing the changes from https://github.com/PostHog/posthog/pull/14444/files#diff-e7b6aa1aa6b3902abd099b901426b9752d198f1f3a1c77e06acf5bc1b4ec4ce1. Added a feature flag to not overload ourselves, just in case.

## How did you test this code?

Manual testing