### PR TITLE
fix(decide): Prevent erroneous input from failing healthcheck

### DIFF
--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -448,6 +448,10 @@ class FeatureFlagMatcher:
                         assert len(group_query) == 1, f"Expected 1 group query result, got {len(group_query)}"
                         all_conditions = {**all_conditions, **group_query[0]}
                 return all_conditions
+        except ValueError as e:
+            # Usually when a user somehow manages to create an invalid filter, usually via API.
+            # In this case, don't put db down, just skip the flag.
+            raise e
         except Exception as e:
             self.failed_to_fetch_conditions = True
             raise e


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/4298160152/?project=1899813&referrer=regression_activity-email -> noticed a user somehow managed to create an invalid flag, which is causing issues as it can incorrectly fail the healthcheck.

This ensures that doesn't happen.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
