### PR TITLE
chore(plugin-server): only require postgres for org manager

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -52,6 +52,7 @@ import {
     TeamId,
     TimestampFormat,
 } from '../../types'
+import { fetchOrganization } from '../../worker/ingestion/organization-manager'
 import { fetchTeam, fetchTeamByToken } from '../../worker/ingestion/team-manager'
 import { parseRawClickHouseEvent } from '../event'
 import { instrumentQuery } from '../metrics'
@@ -1300,12 +1301,7 @@ export class DB {
     // Organization
 
     public async fetchOrganization(organizationId: string): Promise<RawOrganization | undefined> {
-        const selectResult = await this.postgresQuery<RawOrganization>(
-            `SELECT * FROM posthog_organization WHERE id = $1`,
-            [organizationId],
-            'fetchOrganization'
-        )
-        return selectResult.rows[0]
+        return await fetchOrganization(this.postgres, organizationId)
     }
 
     // Team

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -161,7 +161,7 @@ export async function createHub(
         serverConfig.PERSON_INFO_CACHE_TTL
     )
     const teamManager = new TeamManager(postgres, serverConfig, statsd)
-    const organizationManager = new OrganizationManager(db, teamManager)
+    const organizationManager = new OrganizationManager(postgres, teamManager)
     const pluginsApiKeyManager = new PluginsApiKeyManager(db)
     const rootAccessManager = new RootAccessManager(db)
     const actionManager = new ActionManager(db, capabilities)

--- a/plugin-server/src/worker/ingestion/organization-manager.ts
+++ b/plugin-server/src/worker/ingestion/organization-manager.ts
@@ -1,5 +1,7 @@
+import { Client, Pool } from 'pg'
+
 import { RawOrganization, Team, TeamId } from '../../types'
-import { DB } from '../../utils/db/db'
+import { postgresQuery } from '../../utils/db/postgres'
 import { timeoutGuard } from '../../utils/db/utils'
 import { getByAge } from '../../utils/utils'
 import { TeamManager } from './team-manager'
@@ -9,13 +11,13 @@ const ONE_DAY = 24 * 60 * 60 * 1000
 type OrganizationCache<T> = Map<RawOrganization['id'], [T, number]>
 
 export class OrganizationManager {
-    db: DB
+    postgres: Client | Pool
     teamManager: TeamManager
     organizationCache: OrganizationCache<RawOrganization | null>
     availableFeaturesCache: Map<TeamId, [Array<string>, number]>
 
-    constructor(db: DB, teamManager: TeamManager) {
-        this.db = db
+    constructor(postgres: Client | Pool, teamManager: TeamManager) {
+        this.postgres = postgres
         this.teamManager = teamManager
         this.organizationCache = new Map()
         this.availableFeaturesCache = new Map()
@@ -29,7 +31,8 @@ export class OrganizationManager {
 
         const timeout = timeoutGuard(`Still running "fetchOrganization". Timeout warning after 30 sec!`)
         try {
-            const organization: RawOrganization | null = (await this.db.fetchOrganization(organizationId)) || null
+            const organization: RawOrganization | null =
+                (await fetchOrganization(this.postgres, organizationId)) || null
             this.organizationCache.set(organizationId, [organization, Date.now()])
             return organization
         } finally {
@@ -61,4 +64,17 @@ export class OrganizationManager {
         this.availableFeaturesCache = new Map()
         this.organizationCache.delete(organizationId)
     }
+}
+
+export async function fetchOrganization(
+    client: Client | Pool,
+    organizationId: string
+): Promise<RawOrganization | undefined> {
+    const selectResult = await postgresQuery<RawOrganization>(
+        client,
+        `SELECT * FROM posthog_organization WHERE id = $1`,
+        [organizationId],
+        'fetchOrganization'
+    )
+    return selectResult.rows[0]
 }

--- a/plugin-server/tests/worker/ingestion/organization-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/organization-manager.test.ts
@@ -15,7 +15,7 @@ describe('OrganizationManager()', () => {
     beforeEach(async () => {
         ;[hub, closeHub] = await createHub()
         await resetTestDatabase()
-        organizationManager = new OrganizationManager(hub.db, hub.teamManager)
+        organizationManager = new OrganizationManager(hub.postgres, hub.teamManager)
     })
     afterEach(async () => {
         await closeHub()
@@ -24,7 +24,7 @@ describe('OrganizationManager()', () => {
     describe('fetchOrganization()', () => {
         it('fetches and caches the team', async () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
-            jest.spyOn(hub.db, 'postgresQuery')
+            jest.spyOn(hub.postgres, 'query')
 
             let organization = await organizationManager.fetchOrganization(commonOrganizationId)
 
@@ -33,19 +33,19 @@ describe('OrganizationManager()', () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:25').getTime())
             await hub.db.postgresQuery("UPDATE posthog_organization SET name = 'Updated Name!'", undefined, 'testTag')
 
-            jest.mocked(hub.db.postgresQuery).mockClear()
+            jest.mocked(hub.postgres.query).mockClear()
 
             organization = await organizationManager.fetchOrganization(commonOrganizationId)
 
             expect(organization!.name).toEqual('TEST ORG')
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
+            expect(hub.postgres.query).toHaveBeenCalledTimes(0)
 
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:36').getTime())
 
             organization = await organizationManager.fetchOrganization(commonOrganizationId)
 
             expect(organization!.name).toEqual('Updated Name!')
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(hub.postgres.query).toHaveBeenCalledTimes(1)
         })
 
         it('returns null when no such team', async () => {


### PR DESCRIPTION
Previously we were passing the kitchen sink into this manager. This
makes it tricky to allow the manager to be used in other contexts.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
