### PR TITLE
chore(plugin-server): simplify action matcher deps

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -993,23 +993,6 @@ export class DB {
         return insertResult.rows[0]
     }
 
-    public async doesPersonBelongToCohort(cohortId: number, personUuid: string, teamId: number): Promise<boolean> {
-        const psqlResult = await this.postgresQuery(
-            `
-            SELECT count(1) AS count
-            FROM posthog_cohortpeople
-            JOIN posthog_cohort ON (posthog_cohort.id = posthog_cohortpeople.cohort_id)
-            JOIN (SELECT * FROM posthog_person where team_id = $3) AS posthog_person_in_team ON (posthog_cohortpeople.person_id = posthog_person_in_team.id)
-            WHERE cohort_id=$1
-              AND posthog_person_in_team.uuid=$2
-              AND posthog_cohortpeople.version IS NOT DISTINCT FROM posthog_cohort.version
-            `,
-            [cohortId, personUuid, teamId],
-            'doesPersonBelongToCohort'
-        )
-        return psqlResult.rows[0].count > 0
-    }
-
     public async addPersonToCohort(
         cohortId: number,
         personId: Person['id'],

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -213,7 +213,7 @@ export async function createHub(
         rootAccessManager,
         promiseManager,
         actionManager,
-        actionMatcher: new ActionMatcher(db, actionManager, statsd),
+        actionMatcher: new ActionMatcher(postgres, actionManager, statsd),
         conversionBufferEnabledTeams,
     }
 

--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -3,6 +3,7 @@ import { captureException } from '@sentry/node'
 import escapeStringRegexp from 'escape-string-regexp'
 import equal from 'fast-deep-equal'
 import { StatsD } from 'hot-shots'
+import { Client, Pool } from 'pg'
 import RE2 from 're2'
 
 import {
@@ -19,8 +20,8 @@ import {
     PropertyOperator,
     StringMatching,
 } from '../../types'
-import { DB } from '../../utils/db/db'
 import { extractElements } from '../../utils/db/elements-chain'
+import { postgresQuery } from '../../utils/db/postgres'
 import { stringToBoolean } from '../../utils/env-utils'
 import { stringify } from '../../utils/utils'
 import { ActionManager } from './action-manager'
@@ -126,12 +127,12 @@ export function matchString(actual: string, expected: string, matching: StringMa
 }
 
 export class ActionMatcher {
-    private db: DB
+    private postgres: Client | Pool
     private actionManager: ActionManager
     private statsd: StatsD | undefined
 
-    constructor(db: DB, actionManager: ActionManager, statsd?: StatsD) {
-        this.db = db
+    constructor(postgres: Client | Pool, actionManager: ActionManager, statsd?: StatsD) {
+        this.postgres = postgres
         this.actionManager = actionManager
         this.statsd = statsd
     }
@@ -377,7 +378,25 @@ export class ActionMatcher {
         if (isNaN(cohortId)) {
             throw new Error(`Can't match against invalid cohort ID value "${filter.value}!"`)
         }
-        return await this.db.doesPersonBelongToCohort(Number(filter.value), personUuid, teamId)
+        return await this.doesPersonBelongToCohort(Number(filter.value), personUuid, teamId)
+    }
+
+    public async doesPersonBelongToCohort(cohortId: number, personUuid: string, teamId: number): Promise<boolean> {
+        const psqlResult = await postgresQuery(
+            this.postgres,
+            `
+        SELECT count(1) AS count
+        FROM posthog_cohortpeople
+        JOIN posthog_cohort ON (posthog_cohort.id = posthog_cohortpeople.cohort_id)
+        JOIN (SELECT * FROM posthog_person where team_id = $3) AS posthog_person_in_team ON (posthog_cohortpeople.person_id = posthog_person_in_team.id)
+        WHERE cohort_id=$1
+          AND posthog_person_in_team.uuid=$2
+          AND posthog_cohortpeople.version IS NOT DISTINCT FROM posthog_cohort.version
+        `,
+            [cohortId, personUuid, teamId],
+            'doesPersonBelongToCohort'
+        )
+        return psqlResult.rows[0].count > 0
     }
 
     /**

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -1052,19 +1052,25 @@ describe('DB', () => {
             })
             await hub.db.addPersonToCohort(cohort2.id, person.id, cohort.version)
 
-            expect(await hub.db.doesPersonBelongToCohort(cohort.id, person.uuid, person.team_id)).toEqual(false)
+            expect(await hub.actionMatcher.doesPersonBelongToCohort(cohort.id, person.uuid, person.team_id)).toEqual(
+                false
+            )
         })
 
         it('returns true if person belongs to cohort', async () => {
             await hub.db.addPersonToCohort(cohort.id, person.id, cohort.version)
 
-            expect(await hub.db.doesPersonBelongToCohort(cohort.id, person.uuid, person.team_id)).toEqual(true)
+            expect(await hub.actionMatcher.doesPersonBelongToCohort(cohort.id, person.uuid, person.team_id)).toEqual(
+                true
+            )
         })
 
         it('returns false if person does not belong to current version of the cohort', async () => {
             await hub.db.addPersonToCohort(cohort.id, person.id, -1)
 
-            expect(await hub.db.doesPersonBelongToCohort(cohort.id, person.uuid, person.team_id)).toEqual(false)
+            expect(await hub.actionMatcher.doesPersonBelongToCohort(cohort.id, person.uuid, person.team_id)).toEqual(
+                false
+            )
         })
 
         it('handles NULL version cohorts', async () => {
@@ -1074,10 +1080,14 @@ describe('DB', () => {
                 team_id: team.id,
                 version: null,
             })
-            expect(await hub.db.doesPersonBelongToCohort(cohort2.id, person.uuid, person.team_id)).toEqual(false)
+            expect(await hub.actionMatcher.doesPersonBelongToCohort(cohort2.id, person.uuid, person.team_id)).toEqual(
+                false
+            )
 
             await hub.db.addPersonToCohort(cohort2.id, person.id, null)
-            expect(await hub.db.doesPersonBelongToCohort(cohort2.id, person.uuid, person.team_id)).toEqual(true)
+            expect(await hub.actionMatcher.doesPersonBelongToCohort(cohort2.id, person.uuid, person.team_id)).toEqual(
+                true
+            )
         })
     })
 


### PR DESCRIPTION
Specifically this only depends on postgres, so passing in the `DB`
object is unnecessary. This should make refactors easier to e.g. only
load the required dependencies when they are needed.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
