### PR TITLE
chore(plugin-server): disable mmdb if we're not on ingestion

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -54,7 +54,6 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
 
         case PluginServerMode.plugins_async:
             return {
-                mmdb: true,
                 processPluginJobs: true,
                 processAsyncHandlers: true,
                 pluginScheduledTasks: true,
@@ -62,31 +61,26 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             }
         case PluginServerMode.plugins_exports:
             return {
-                mmdb: true,
                 processAsyncHandlers: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.async_onevent:
             return {
-                mmdb: true,
                 processAsyncOnEventHandlers: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.async_webhooks:
             return {
-                mmdb: true,
                 processAsyncWebhooksHandlers: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.jobs:
             return {
-                mmdb: true,
                 processPluginJobs: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.scheduler:
             return {
-                mmdb: true,
                 pluginScheduledTasks: true,
                 ...sharedCapabilities,
             }


### PR DESCRIPTION
We don't use mmdb on other workloads, so we shouldn't be loading it.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
