### PR TITLE
chore(instrumentation): bump log levels for cohorts and event volume

### DIFF
--- a/posthog/models/async_deletion/delete.py
+++ b/posthog/models/async_deletion/delete.py
@@ -39,7 +39,7 @@ class AsyncDeletionProcess(ABC):
 
         if len(to_verify) > 0:
             AsyncDeletion.objects.filter(pk__in=[row.pk for row in to_verify]).update(delete_verified_at=timezone.now())
-            logger.info(
+            logger.warn(
                 "Updated `delete_verified_at` for AsyncDeletion",
                 {"count": len(to_verify), "team_ids": list(set(row.team_id for row in to_verify))},
             )

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -13,7 +13,7 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
             logger.debug("No AsyncDeletion for cohorts to perform")
             return
 
-        logger.info(
+        logger.warn(
             "Starting AsyncDeletion on `cohortpeople` table in ClickHouse",
             {"count": len(deletions), "team_ids": list(set(row.team_id for row in deletions))},
         )

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -10,7 +10,7 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
 
     def process(self, deletions: List[AsyncDeletion]):
         if len(deletions) == 0:
-            logger.debug("No AsyncDeletion for cohorts to perform")
+            logger.warn("No AsyncDeletion for cohorts to perform")
             return
 
         logger.warn(

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -194,7 +194,7 @@ class Cohort(models.Model):
     def calculate_people_ch(self, pending_version):
         from posthog.models.cohort.util import recalculate_cohortpeople
 
-        logger.info("cohort_calculation_started", id=self.pk, current_version=self.version, new_version=pending_version)
+        logger.warn("cohort_calculation_started", id=self.pk, current_version=self.version, new_version=pending_version)
         start_time = time.monotonic()
 
         try:
@@ -223,7 +223,7 @@ class Cohort(models.Model):
         )
         self.refresh_from_db()
 
-        logger.info(
+        logger.warn(
             "cohort_calculation_completed",
             id=self.pk,
             version=pending_version,

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -254,7 +254,7 @@ def recalculate_cohortpeople(cohort: Cohort, pending_version: int) -> Optional[i
     before_count = get_cohort_size(cohort)
 
     if before_count:
-        logger.info(
+        logger.warn(
             "Recalculating cohortpeople starting", team_id=cohort.team_id, cohort_id=cohort.pk, size_before=before_count
         )
 
@@ -275,7 +275,7 @@ def recalculate_cohortpeople(cohort: Cohort, pending_version: int) -> Optional[i
     count = get_cohort_size(cohort, override_version=pending_version)
 
     if count is not None and before_count is not None:
-        logger.info(
+        logger.warn(
             "Recalculating cohortpeople done",
             team_id=cohort.team_id,
             cohort_id=cohort.pk,

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -59,7 +59,7 @@ def calculate_cohort_from_list(cohort_id: int, items: List[str]) -> None:
     cohort = Cohort.objects.get(pk=cohort_id)
 
     cohort.insert_users_by_list(items)
-    logger.info("Calculating cohort {} from CSV took {:.2f} seconds".format(cohort.pk, (time.time() - start_time)))
+    logger.warn("Calculating cohort {} from CSV took {:.2f} seconds".format(cohort.pk, (time.time() - start_time)))
 
 
 @shared_task(ignore_result=True, max_retries=1)

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -131,7 +131,7 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
 
         for series_event in insight_series_events:
             if series_event not in event_definitions:
-                logger.info(
+                logger.warn(
                     "calculate_event_property_usage_for_team.insight_uses_event_with_no_definition",
                     team=team_id,
                     event_id=series_event,
@@ -145,7 +145,7 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
             count_for_property = counted_properties[counted_property]
 
             if property_name not in property_definitions:
-                logger.info(
+                logger.warn(
                     "calculate_event_property_usage_for_team.insight_uses_property_with_no_definition",
                     team=team_id,
                     property=property_name,
@@ -159,7 +159,7 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
         events_volume = _get_events_volume(team_id, since)
         for event, (volume, last_seen_at) in events_volume.items():
             if event not in event_definitions:
-                logger.info(
+                logger.warn(
                     "calculate_event_property_usage_for_team.event_volume_found_for_event_with_no_definition",
                     team_id=team_id,
                     event_name=event,
@@ -282,7 +282,7 @@ def _get_insight_query_usage(team_id: int, since: datetime) -> Tuple[List[str], 
     for id, item_filters in insight_filters:
         try:
             if item_filters is None:
-                logger.info(
+                logger.warn(
                     "calculate_event_property_usage_for_team.insight_has_no_filters",
                     team=team_id,
                     insight_id=id,


### PR DESCRIPTION
## Problem

We have a persistent issue with insights returning empty results. Investigation led to a cohort subquery, where a cohort version with empty data is used. We want to know why a version for an empty cohort would be used.

Secondly, we recurringly run into issues with the 30-day event volume calculation.

Unfortunately info level logs from these tasks are not present in Loki, but warn level are. Why? [Who knows](https://posthog.slack.com/archives/C045QJCUGQ4/p1688644965217499).

## Changes

This PR bumps the log level for the relevant tasks to warn, so that we can use Loki for digging deeper.

## How did you test this code?

No testing