### PR TITLE
fix(replay): no quotes because they're added for you

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
@@ -44,8 +44,8 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                                 -- we don't really care about the absolute value, 
                                 -- but we do care about whether timezones have an odd impact
                                 -- so, we extend the range by a day on each side so that timezones don't cause issues
-                                AND timestamp >= '${dayjs(oldestTimestamp).subtract(1, 'day')}'
-                                AND timestamp <= '${dayjs(newestTimestamp).add(1, 'day')}'
+                                AND timestamp >= ${dayjs(oldestTimestamp).subtract(1, 'day')}
+                                AND timestamp <= ${dayjs(newestTimestamp).add(1, 'day')}
                                 GROUP BY session_id`,
                     }
 


### PR DESCRIPTION
## Problem

#16393 broke the session properties query because there were quotes and we added quotes. Everyone knows quotes on quotes is too many quotes

See customer report here https://posthog.slack.com/archives/C04J1TJ11UZ/p1688747606840759