### PR TITLE
fix: no empty message after API error

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -58,6 +58,8 @@ export function RecordingsLists({
         pinnedRecordingsResponseLoading,
         totalFiltersCount,
         listingVersion,
+        sessionRecordingsAPIErrored,
+        pinnedRecordingsAPIErrored,
     } = useValues(logic)
     const { setSelectedRecordingId, setFilters, maybeLoadSessionRecordings, setShowFilters, resetFilters } =
         useActions(logic)
@@ -103,6 +105,11 @@ export function RecordingsLists({
                             </>
                         }
                         activeRecordingId={activeSessionRecording?.id}
+                        empty={
+                            pinnedRecordingsAPIErrored ? (
+                                <LemonBanner type="error">Error while trying to load pinned recordings.</LemonBanner>
+                            ) : undefined
+                        }
                     />
                 ) : null}
 
@@ -200,24 +207,28 @@ export function RecordingsLists({
                     loading={sessionRecordingsResponseLoading}
                     loadingSkeletonCount={RECORDINGS_LIMIT}
                     empty={
-                        <div className={'flex flex-col items-center space-y-2'}>
-                            <span>No matching recordings found</span>
-                            {filters.date_from === DEFAULT_RECORDING_FILTERS.date_from && (
-                                <>
-                                    <LemonButton
-                                        type={'secondary'}
-                                        data-attr={'expand-replay-listing-from-default-seven-days-to-twenty-one'}
-                                        onClick={() => {
-                                            setFilters({
-                                                date_from: '-21d',
-                                            })
-                                        }}
-                                    >
-                                        Search over the last 21 days
-                                    </LemonButton>
-                                </>
-                            )}
-                        </div>
+                        sessionRecordingsAPIErrored ? (
+                            <LemonBanner type="error">Error while trying to load recordings.</LemonBanner>
+                        ) : (
+                            <div className={'flex flex-col items-center space-y-2'}>
+                                <span>No matching recordings found</span>
+                                {filters.date_from === DEFAULT_RECORDING_FILTERS.date_from && (
+                                    <>
+                                        <LemonButton
+                                            type={'secondary'}
+                                            data-attr={'expand-replay-listing-from-default-seven-days-to-twenty-one'}
+                                            onClick={() => {
+                                                setFilters({
+                                                    date_from: '-21d',
+                                                })
+                                            }}
+                                        >
+                                            Search over the last 21 days
+                                        </LemonButton>
+                                    </>
+                                )}
+                            </div>
+                        )
                     }
                     activeRecordingId={activeSessionRecording?.id}
                     onScrollToEnd={() => maybeLoadSessionRecordings('older')}

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.test.ts
@@ -52,6 +52,14 @@ describe('sessionRecordingsListLogic', () => {
                     .toDispatchActionsInAnyOrder(['loadSessionRecordings', 'loadSessionRecordingsSuccess'])
                     .toMatchValues({ shouldShowEmptyState: true })
             })
+
+            it('is false after API call error', async () => {
+                await expectLogic(logic, () => {
+                    // load is called on mount
+                    // logic.actions.loadSessionRecordings()
+                    logic.actions.loadSessionRecordingsFailure('abc')
+                }).toMatchValues({ shouldShowEmptyState: false })
+            })
         })
     })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -282,6 +282,26 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
                 setSelectedRecordingId: (_, { id }) => id ?? null,
             },
         ],
+        sessionRecordingsAPIErrored: [
+            false,
+            {
+                loadSessionRecordingsFailure: () => true,
+                loadSessionRecordingSuccess: () => false,
+                setFilters: () => false,
+                loadNext: () => false,
+                loadPrev: () => false,
+            },
+        ],
+        pinnedRecordingsAPIErrored: [
+            false,
+            {
+                loadPinnedRecordingsFailure: () => true,
+                loadPinnedRecordingsSuccess: () => false,
+                setFilters: () => false,
+                loadNext: () => false,
+                loadPrev: () => false,
+            },
+        ],
     })),
     listeners(({ props, actions, values }) => ({
         loadAllRecordings: () => {
@@ -330,9 +350,27 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
     })),
     selectors({
         shouldShowEmptyState: [
-            (s) => [s.sessionRecordings, s.customFilters, s.sessionRecordingsResponseLoading],
-            (sessionRecordings, customFilters, sessionRecordingsResponseLoading): boolean => {
-                return !sessionRecordingsResponseLoading && sessionRecordings.length === 0 && !customFilters
+            (s) => [
+                s.sessionRecordings,
+                s.customFilters,
+                s.sessionRecordingsResponseLoading,
+                s.sessionRecordingsAPIErrored,
+                s.pinnedRecordingsAPIErrored,
+            ],
+            (
+                sessionRecordings,
+                customFilters,
+                sessionRecordingsResponseLoading,
+                sessionRecordingsAPIErrored,
+                pinnedRecordingsAPIErrored
+            ): boolean => {
+                return (
+                    !sessionRecordingsAPIErrored &&
+                    !pinnedRecordingsAPIErrored &&
+                    !sessionRecordingsResponseLoading &&
+                    sessionRecordings.length === 0 &&
+                    !customFilters
+                )
             },
         ],
 

--- a/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylistsEmptyState.tsx
+++ b/frontend/src/scenes/session-recordings/saved-playlists/SavedSessionRecordingPlaylistsEmptyState.tsx
@@ -5,12 +5,15 @@ import { useActions, useValues } from 'kea'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { savedSessionRecordingPlaylistsLogic } from './savedSessionRecordingPlaylistsLogic'
 import { AvailableFeature, ReplayTabs } from '~/types'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 
 export function SavedSessionRecordingPlaylistsEmptyState(): JSX.Element {
     const { guardAvailableFeature } = useActions(sceneLogic)
     const playlistsLogic = savedSessionRecordingPlaylistsLogic({ tab: ReplayTabs.Recent })
-    const { playlists } = useValues(playlistsLogic)
-    return (
+    const { playlists, loadPlaylistsFailed } = useValues(playlistsLogic)
+    return loadPlaylistsFailed ? (
+        <LemonBanner type="error">Error while trying to load playlist.</LemonBanner>
+    ) : (
         <div className="flex items-center justify-center">
             <div className="max-w-lg mt-12 flex flex-col items-center">
                 <h2 className="text-xl">There are no playlists that match these filters</h2>

--- a/frontend/src/scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic.ts
+++ b/frontend/src/scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic.ts
@@ -74,6 +74,14 @@ export const savedSessionRecordingPlaylistsLogic = kea<savedSessionRecordingPlay
                     }),
             },
         ],
+        loadPlaylistsFailed: [
+            false,
+            {
+                loadPlaylists: () => false,
+                loadPlaylistsSuccess: () => false,
+                loadPlaylistsFailure: () => true,
+            },
+        ],
     })),
     loaders(({ values, actions }) => ({
         playlists: {


### PR DESCRIPTION
## Problem

While trying to figure out this user report https://posthoghelp.zendesk.com/agent/tickets/4096 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7153)

I noticed that if the API call fails we show an empty state in the list panel, which makes people think they are at fault when they're not

## Changes

Show an error if there's an error

<img width="1269" alt="Screenshot 2023-07-08 at 08 53 39" src="https://github.com/PostHog/posthog/assets/984817/f64581ed-a822-4a7c-920e-8ef0dd514325">

<img width="710" alt="Screenshot 2023-07-08 at 09 07 23" src="https://github.com/PostHog/posthog/assets/984817/665b429a-d018-48e9-8434-8d003e495120">


## How did you test this code?

👀 locally