### PR TITLE
chore(plugin-server): add pluginconfig id to pg queries

### DIFF
--- a/plugin-server/src/worker/vm/extensions/storage.ts
+++ b/plugin-server/src/worker/vm/extensions/storage.ts
@@ -26,7 +26,7 @@ export function createStorage(server: Hub, pluginConfig: PluginConfig): StorageE
                     DO UPDATE SET value = $3
                 `,
                 [pluginConfig.id, key, JSON.stringify(value)],
-                'storageSet'
+                `storageSet(pluginConfig.id=${pluginConfig.id})`
             )
         }
 


### PR DESCRIPTION
This should appear in `pg_stat_activity` and make it easier to debug
queries that are misbehaving. We mainly want to be able to know which
plugin config is causing the issue so we can fix or disable it.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
