### PR TITLE
chore: make health check method not depend on ingestion queue

### DIFF
--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-consumer.ts
@@ -130,7 +130,7 @@ const startLegacyAnalyticsEventsIngestionConsumer = async ({
     // Subscribe to the heatbeat event to track when the consumer has last
     // successfully consumed a message. This is used to determine if the
     // consumer is healthy.
-    const isHealthy = makeHealthCheck(queue)
+    const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
 
     return { queue, isHealthy }
 }


### PR DESCRIPTION
This allows us to not make an ingestion queue, and thus not have to also
depend on the Hub that is required by the ingestion queue class.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
