### PR TITLE
fix(insights): refetch stale saved insights

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -59,10 +59,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         ) {
             actions.loadData()
         }
-        if (
-            props.cachedResults &&
-            (!values.response || (oldProps.cachedResults && !equal(props.cachedResults, oldProps.cachedResults)))
-        ) {
+        if (props.cachedResults && !values.response) {
             actions.setResponse(props.cachedResults)
         }
     }),

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -21,12 +21,13 @@ import { isInsightQueryNode, isEventsQuery, isPersonsNode } from '~/queries/util
 import { subscriptions } from 'kea-subscriptions'
 import { objectsEqual, shouldCancelQuery, uuid } from 'lib/utils'
 import clsx from 'clsx'
-import api, { ApiMethodOptions } from 'lib/api'
+import api, { ApiMethodOptions, getJSONOrThrow } from 'lib/api'
 import { removeExpressionComment } from '~/queries/nodes/DataTable/utils'
 import { userLogic } from 'scenes/userLogic'
 import { UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES } from 'scenes/insights/insightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import equal from 'fast-deep-equal'
+import { filtersToQueryNode } from '../InsightQuery/utils/filtersToQueryNode'
 
 export interface DataNodeLogicProps {
     key: string
@@ -49,7 +50,13 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         if (props.query?.kind && oldProps.query?.kind && props.query.kind !== oldProps.query.kind) {
             actions.clearResponse()
         }
-        if (props.query?.kind && !objectsEqual(props.query, oldProps.query) && !props.cachedResults) {
+        if (
+            props.query?.kind &&
+            !objectsEqual(props.query, oldProps.query) &&
+            (!props.cachedResults ||
+                (isInsightQueryNode(props.query) &&
+                    (props.cachedResults['result'] === null || props.cachedResults['result'] === undefined)))
+        ) {
             actions.loadData()
         }
         if (
@@ -79,6 +86,18 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 setResponse: (response) => response,
                 clearResponse: () => null,
                 loadData: async ({ refresh, queryId }, breakpoint) => {
+                    if (
+                        isInsightQueryNode(props.query) &&
+                        props.cachedResults &&
+                        props.cachedResults['id'] &&
+                        props.cachedResults['filters'] &&
+                        equal(props.query, filtersToQueryNode(props.cachedResults['filters']))
+                    ) {
+                        const url = `api/projects/${values.currentTeamId}/insights/${props.cachedResults['id']}?refresh=true`
+                        const fetchResponse = await api.getResponse(url)
+                        return await getJSONOrThrow(fetchResponse)
+                    }
+
                     if (props.cachedResults && !refresh) {
                         return props.cachedResults
                     }

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -84,12 +84,7 @@ export const getCachedResults = (
     cachedInsight: Partial<InsightModel> | undefined | null,
     query: InsightQueryNode
 ): Partial<InsightModel> | undefined => {
-    if (
-        !cachedInsight ||
-        cachedInsight.result === null ||
-        cachedInsight.result === undefined ||
-        cachedInsight.filters === undefined
-    ) {
+    if (!cachedInsight || cachedInsight.filters === undefined) {
         return undefined
     }
 


### PR DESCRIPTION
## Problem

Before the migration to data exploration we have been refreshing saved insights like this https://github.com/PostHog/posthog/blob/361a2bc1cb48c68f616a455b513089fe66a91f18/frontend/src/scenes/insights/insightLogic.ts#L327-L337

Note: The remark about refreshing the insights' cache key does not seem valid to me any more, as the current mechanism seems to simply lookup a hashed version of filters from Redis.

## Changes

This PR re-implements the same behaviour for data exploration. And while this brings the new behaviour in line with the old, I don't think we've arrived at the final solution yet. Instead we should make [the heuristics](https://github.com/PostHog/posthog/blob/bbb7ed9968e1c495d59da923ee8a85bbf8466f75/posthog/api/insight.py#L507-L516) ([PR](https://github.com/PostHog/posthog/pull/14178)) for refreshing independent of a saved insight (i.e. they should work for new insights as well).

## How did you test this code?

Navigating around locally
