### PR TITLE
fix: Do not timeout on CH reads in batch exports

### DIFF
--- a/posthog/temporal/workflows/clickhouse.py
+++ b/posthog/temporal/workflows/clickhouse.py
@@ -1,7 +1,8 @@
-from aiochclient import ChClient
-from aiohttp import ClientSession, TCPConnector
-from django.conf import settings
 from contextlib import asynccontextmanager
+
+from aiochclient import ChClient
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
+from django.conf import settings
 
 
 @asynccontextmanager
@@ -35,8 +36,9 @@ async def get_client():
     #        ssl_context.load_verify_locations(settings.CLICKHOUSE_CA)
     #    elif ssl_context.verify_mode is ssl.CERT_REQUIRED:
     #        ssl_context.load_default_certs(ssl.Purpose.SERVER_AUTH)
+    timeout = ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
     with TCPConnector(verify_ssl=False) as connector:
-        async with ClientSession(connector=connector) as session:
+        async with ClientSession(connector=connector, timeout=timeout) as session:
             client = ChClient(
                 session,
                 url=settings.CLICKHOUSE_HTTP_URL,


### PR DESCRIPTION
## Problem

aiohttp has a default timeout of 5 minutes. Export runs can take longer than that.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

For now, do not timeout. Eventually, we can handle timeouts in Temporal

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
