### PR TITLE
chore: Call out plugin and teamID in pluginconfig logs

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/export-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/export-events.ts
@@ -109,9 +109,11 @@ export function upgradeExportEvents(
 
                     status.info(
                         '🚃',
-                        `Enqueued PluginConfig ${pluginConfig.id} batch ${payload.batchId} for retry #${
-                            payload.retriesPerformedSoFar + 1
-                        } in ${Math.round(nextRetrySeconds)}s`
+                        `Enqueued PluginConfig ${pluginConfig.id} (plugin=${pluginConfig.plugin_id}, team=${
+                            pluginConfig.team_id
+                        }) batch ${payload.batchId} for retry #${payload.retriesPerformedSoFar + 1} in ${Math.round(
+                            nextRetrySeconds
+                        )}s`
                     )
                     hub.statsd?.increment('plugin.export_events.retry_enqueued', {
                         retry: `${payload.retriesPerformedSoFar + 1}`,
@@ -121,7 +123,7 @@ export function upgradeExportEvents(
                 } else {
                     status.info(
                         '☠️',
-                        `Dropped PluginConfig ${pluginConfig.id} batch ${payload.batchId} after retrying ${payload.retriesPerformedSoFar} times`
+                        `Dropped PluginConfig ${pluginConfig.id} (plugin=${pluginConfig.plugin_id}, team=${pluginConfig.team_id}) batch ${payload.batchId} after retrying ${payload.retriesPerformedSoFar} times`
                     )
                     hub.statsd?.increment('plugin.export_events.retry_dropped', {
                         retry: `${payload.retriesPerformedSoFar}`,

--- a/plugin-server/src/worker/vm/upgrades/export-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/export-events.ts
@@ -1,4 +1,5 @@
 import { Plugin, PluginEvent, PluginMeta, ProcessedPluginEvent, RetryError } from '@posthog/plugin-scaffold'
+import { Counter } from 'prom-client'
 
 import { Hub, PluginConfig, PluginConfigVMInternalResponse, PluginTaskType } from '../../../types'
 import { isTestEnv } from '../../../utils/env-utils'
@@ -13,6 +14,12 @@ const EXPORT_BUFFER_BYTES_MAXIMUM = 100 * 1024 * 1024
 const EXPORT_BUFFER_SECONDS_MINIMUM = 1
 const EXPORT_BUFFER_SECONDS_MAXIMUM = 600
 const EXPORT_BUFFER_SECONDS_DEFAULT = isTestEnv() ? 0 : 10
+
+export const appRetriesCounter = new Counter({
+    name: 'export_app_retries',
+    help: 'Count of events retries processing onEvent apps, by team and plugin.',
+    labelNames: ['team_id', 'plugin_id'],
+})
 
 type ExportEventsUpgrade = Plugin<{
     global: {
@@ -120,6 +127,12 @@ export function upgradeExportEvents(
                         plugin: pluginConfig.plugin?.name ?? '?',
                         teamId: pluginConfig.team_id.toString(),
                     })
+                    appRetriesCounter
+                        .labels({
+                            team_id: pluginConfig.team_id,
+                            plugin_id: pluginConfig.plugin_id,
+                        })
+                        .inc()
                 } else {
                     status.info(
                         '☠️',


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We can faster know which plugins are retried from the logs

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
