### PR TITLE
chore: Run tests on Postgres 15

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -7,7 +7,7 @@
 
 services:
     db:
-        image: postgres:12-alpine
+        image: postgres:15-alpine
         restart: on-failure
         environment:
             POSTGRES_USER: posthog

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -277,3 +277,5 @@ def healthcheck_middleware(get_response: Callable[[HttpRequest], HttpResponse]):
         return get_response(request)
 
     return middleware
+
+#Trigger tests on PG15

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -16,7 +16,7 @@
 # endpoints are for a very specific purpose and we want to make sure that any
 # changes to them are deliberate, as otherwise we could introduce unexpected
 # behaviour in deployments.
-#Trigger tests on PG15
+# Trigger tests on PG15
 
 from typing import Callable, Dict, List, Literal, cast, get_args
 

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -16,6 +16,7 @@
 # endpoints are for a very specific purpose and we want to make sure that any
 # changes to them are deliberate, as otherwise we could introduce unexpected
 # behaviour in deployments.
+#Trigger tests on PG15
 
 from typing import Callable, Dict, List, Literal, cast, get_args
 
@@ -278,4 +279,3 @@ def healthcheck_middleware(get_response: Callable[[HttpRequest], HttpResponse]):
 
     return middleware
 
-#Trigger tests on PG15

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -16,7 +16,6 @@
 # endpoints are for a very specific purpose and we want to make sure that any
 # changes to them are deliberate, as otherwise we could introduce unexpected
 # behaviour in deployments.
-# Trigger tests on PG15
 
 from typing import Callable, Dict, List, Literal, cast, get_args
 

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -37,6 +37,7 @@ def pushed_metrics_registry(job_name: str):
 
     NOTE: only use to expose gauges, for use cases where one value per
     region makes sense (e.g. instance metrics computed by celery jobs).
+    dummy commit
     """
 
     registry = CollectorRegistry()


### PR DESCRIPTION
## Problem

PG 11 will have end of support from AWS we need to upgrade 

## Changes

Change tests to use `postgres15-alpine`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
