### PR TITLE
fix: Route queries to offline cluster for batch exports

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 from typing import List
 from urllib.parse import urlparse
 
@@ -7,7 +7,7 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 
 from posthog.settings.base_variables import DEBUG, IS_COLLECT_STATIC, TEST
-from posthog.settings.utils import get_from_env, str_to_bool, get_list
+from posthog.settings.utils import get_from_env, get_list, str_to_bool
 
 # See https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS
 DISABLE_SERVER_SIDE_CURSORS = get_from_env("USING_PGBOUNCER", False, type_cast=str_to_bool)
@@ -157,6 +157,14 @@ if CLICKHOUSE_SECURE:
     _clickhouse_http_port = "8443"
 
 CLICKHOUSE_HTTP_URL = f"{_clickhouse_http_protocol}{CLICKHOUSE_HOST}:{_clickhouse_http_port}/"
+
+if TEST or DEBUG:
+    # When testing, there is no offline cluster.
+    CLICKHOUSE_OFFLINE_HTTP_URL = CLICKHOUSE_HTTP_URL
+else:
+    CLICKHOUSE_OFFLINE_HTTP_URL = (
+        f"{_clickhouse_http_protocol}{CLICKHOUSE_OFFLINE_CLUSTER_HOST}:{_clickhouse_http_port}/"
+    )
 
 READONLY_CLICKHOUSE_USER = os.getenv("READONLY_CLICKHOUSE_USER", None)
 READONLY_CLICKHOUSE_PASSWORD = os.getenv("READONLY_CLICKHOUSE_PASSWORD", None)

--- a/posthog/temporal/workflows/clickhouse.py
+++ b/posthog/temporal/workflows/clickhouse.py
@@ -41,7 +41,7 @@ async def get_client():
         async with ClientSession(connector=connector, timeout=timeout) as session:
             client = ChClient(
                 session,
-                url=settings.CLICKHOUSE_HTTP_URL,
+                url=settings.CLICKHOUSE_OFFLINE_HTTP_URL,
                 user=settings.CLICKHOUSE_USER,
                 password=settings.CLICKHOUSE_PASSWORD,
                 database=settings.CLICKHOUSE_DATABASE,


### PR DESCRIPTION
## Problem

Queries are barely timing out (120-130 segs vs 120 max). Let's go to offline cluster for a larger timeout.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
