### PR TITLE
fix: Resume iterator on JSONDecodeError for BatchExports

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -8,20 +8,20 @@ from uuid import uuid4
 import boto3
 import pytest
 from aiochclient import ChClient
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.test import Client as HttpClient
 from django.test import override_settings
 from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
 from ee.clickhouse.materialized_columns.columns import materialize
-
-from asgiref.sync import sync_to_async
-
 from posthog.api.test.test_organization import acreate_organization
 from posthog.api.test.test_team import acreate_team
 from posthog.batch_exports.service import acreate_batch_export, afetch_batch_export_runs
 from posthog.temporal.workflows.base import create_export_run, update_export_run_status
+from posthog.temporal.workflows.batch_exports import get_results_iterator
 from posthog.temporal.workflows.s3_batch_export import (
     S3BatchExportInputs,
     S3BatchExportWorkflow,
@@ -133,6 +133,36 @@ def s3_client(bucket_name):
 def amaterialize(table: Literal["events", "person", "groups"], column: str):
     """Materialize a column in a table."""
     return materialize(table, column)
+
+
+def assert_events_in_s3(s3_client, bucket_name, key_prefix, events):
+    """Assert provided events written to JSON in key_prefix in S3 bucket_name."""
+    # List the objects in the bucket with the prefix.
+    objects = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=key_prefix)
+
+    # Check that there is only one object.
+    assert len(objects.get("Contents", [])) == 1
+
+    # Get the object.
+    key = objects["Contents"][0].get("Key")
+    assert key
+    object = s3_client.get_object(Bucket=bucket_name, Key=key)
+    data = object["Body"].read()
+
+    # Check that the data is correct.
+    json_data = [json.loads(line) for line in data.decode("utf-8").split("\n") if line]
+    # Pull out the fields we inserted only
+
+    json_data.sort(key=lambda x: x["timestamp"])
+
+    # Remove team_id, _timestamp from events
+    expected_events = [{k: v for k, v in event.items() if k not in ["team_id", "_timestamp"]} for event in events]
+    expected_events.sort(key=lambda x: x["timestamp"])
+
+    # First check one event, the first one, so that we can get a nice diff if
+    # the included data is different.
+    assert json_data[0] == expected_events[0]
+    assert json_data == expected_events
 
 
 @pytest.mark.django_db
@@ -310,7 +340,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_client):
+async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_client, bucket_name):
     """
     Test that the whole workflow not just the activity works. It should update
     the batch export run status to completed, as well as updating the record
@@ -323,15 +353,16 @@ async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_clien
         database=settings.CLICKHOUSE_DATABASE,
     )
 
+    prefix = f"posthog-events-{str(uuid4())}"
     destination_data = {
         "type": "S3",
         "config": {
-            "bucket_name": "my-production-s3-bucket",
+            "bucket_name": bucket_name,
             "region": "us-east-1",
-            "prefix": "posthog-events/",
+            "prefix": prefix,
             "batch_window_size": 3600,
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
         },
     }
 
@@ -354,9 +385,9 @@ async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_clien
         {
             "uuid": str(uuid4()),
             "event": "test",
-            "timestamp": "2023-04-20 14:30:00.000000",
-            "created_at": "2023-04-20 14:30:00.000000",
-            "_timestamp": "2023-04-20 14:30:00",
+            "timestamp": "2023-04-25 13:30:00.000000",
+            "created_at": "2023-04-25 13:30:00.000000",
+            "_timestamp": "2023-04-25 13:30:00",
             "person_id": str(uuid4()),
             "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
             "team_id": team.pk,
@@ -367,9 +398,9 @@ async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_clien
         {
             "uuid": str(uuid4()),
             "event": "test",
-            "timestamp": "2023-04-25 14:30:00.000000",
-            "created_at": "2023-04-25 14:30:00.000000",
-            "_timestamp": "2023-04-25 14:30:00",
+            "timestamp": "2023-04-25 14:29:00.000000",
+            "created_at": "2023-04-25 14:29:00.000000",
+            "_timestamp": "2023-04-25 14:29:00",
             "person_id": str(uuid4()),
             "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
             "team_id": team.pk,
@@ -410,8 +441,139 @@ async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_clien
                     retry_policy=RetryPolicy(maximum_attempts=1),
                 )
 
-        runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
-        assert len(runs) == 1
+    runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+    assert len(runs) == 1
 
-        run = runs[0]
-        assert run.status == "Completed"
+    run = runs[0]
+    assert run.status == "Completed"
+
+    assert_events_in_s3(s3_client, bucket_name, prefix, events)
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_s3_export_workflow_continues_on_json_decode_error(client: HttpClient, s3_client, bucket_name):
+    """Test that S3 Export Workflow end-to-end by using a local MinIO bucket instead of S3.
+
+    In this particular case, we should be handling JSONDecodeErrors produced by attempting to parse
+    ClickHouse error strings.
+    """
+    ch_client = ChClient(
+        url=settings.CLICKHOUSE_HTTP_URL,
+        user=settings.CLICKHOUSE_USER,
+        password=settings.CLICKHOUSE_PASSWORD,
+        database=settings.CLICKHOUSE_DATABASE,
+    )
+
+    prefix = f"posthog-events-{str(uuid4())}"
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": bucket_name,
+            "region": "us-east-1",
+            "prefix": prefix,
+            "batch_window_size": 3600,
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = await acreate_organization("test")
+    team = await acreate_team(organization=organization)
+    batch_export = await acreate_batch_export(
+        team_id=team.pk,
+        name=batch_export_data["name"],
+        destination_data=batch_export_data["destination"],
+        interval=batch_export_data["interval"],
+    )
+
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": "test",
+            "timestamp": "2023-04-25 13:30:00.000000",
+            "created_at": "2023-04-25 13:30:00.000000",
+            "_timestamp": "2023-04-25 13:30:00",
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team.pk,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "distinct_id": str(uuid4()),
+            "elements_chain": "this is a comman, separated, list, of css selectors(?)",
+        },
+        {
+            "uuid": str(uuid4()),
+            "event": "test",
+            "timestamp": "2023-04-25 14:29:00.000000",
+            "created_at": "2023-04-25 14:29:00.000000",
+            "_timestamp": "2023-04-25 14:29:00",
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team.pk,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "distinct_id": str(uuid4()),
+            "elements_chain": "this is a comman, separated, list, of css selectors(?)",
+        },
+    ]
+
+    # Insert some data into the `sharded_events` table.
+    await insert_events(
+        client=ch_client,
+        events=events,
+    )
+
+    workflow_id = str(uuid4())
+    inputs = S3BatchExportInputs(
+        team_id=team.pk,
+        batch_export_id=str(batch_export.id),
+        data_interval_end="2023-04-25 14:30:00.000000",
+        **batch_export.destination.config,
+    )
+    error_raised = False
+
+    async def fake_get_results_iterator(*args, **kwargs):
+        nonlocal error_raised
+
+        async for result in get_results_iterator(*args, **kwargs):
+            if error_raised is False:
+                error_raised = True
+                raise json.JSONDecodeError("Test error", "A ClickHouse error message\n", 0)
+
+            yield result
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[S3BatchExportWorkflow],
+            activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+                with mock.patch(
+                    "posthog.temporal.workflows.s3_batch_export.get_results_iterator",
+                    side_effect=fake_get_results_iterator,
+                ):
+                    await activity_environment.client.execute_workflow(
+                        S3BatchExportWorkflow.run,
+                        inputs,
+                        id=workflow_id,
+                        task_queue=settings.TEMPORAL_TASK_QUEUE,
+                        retry_policy=RetryPolicy(maximum_attempts=1),
+                    )
+
+    assert error_raised is True
+
+    runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+    assert len(runs) == 1
+
+    run = runs[0]
+    assert run.status == "Completed"
+
+    assert_events_in_s3(s3_client, bucket_name, prefix, events)

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -559,7 +559,7 @@ async def test_s3_export_workflow_continues_on_json_decode_error(client: HttpCli
                 with mock.patch(
                     "posthog.temporal.workflows.s3_batch_export.get_results_iterator",
                     side_effect=fake_get_results_iterator,
-                ):
+                ) as mocked_iterator:
                     await activity_environment.client.execute_workflow(
                         S3BatchExportWorkflow.run,
                         inputs,
@@ -567,6 +567,24 @@ async def test_s3_export_workflow_continues_on_json_decode_error(client: HttpCli
                         task_queue=settings.TEMPORAL_TASK_QUEUE,
                         retry_policy=RetryPolicy(maximum_attempts=1),
                     )
+
+    assert mocked_iterator.call_count == 2  # An extra call for the error
+    mocked_iterator.assert_has_calls(
+        [
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25T13:30:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25T13:30:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+        ]
+    )
 
     assert error_raised is True
 
@@ -577,3 +595,165 @@ async def test_s3_export_workflow_continues_on_json_decode_error(client: HttpCli
     assert run.status == "Completed"
 
     assert_events_in_s3(s3_client, bucket_name, prefix, events)
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_s3_export_workflow_continues_on_multiple_json_decode_error(client: HttpClient, s3_client, bucket_name):
+    """Test that S3 Export Workflow end-to-end by using a local MinIO bucket instead of S3.
+
+    In this particular case, we should be handling JSONDecodeErrors produced by attempting to parse
+    ClickHouse error strings.
+    """
+    ch_client = ChClient(
+        url=settings.CLICKHOUSE_HTTP_URL,
+        user=settings.CLICKHOUSE_USER,
+        password=settings.CLICKHOUSE_PASSWORD,
+        database=settings.CLICKHOUSE_DATABASE,
+    )
+
+    prefix = f"posthog-events-{str(uuid4())}"
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": bucket_name,
+            "region": "us-east-1",
+            "prefix": prefix,
+            "batch_window_size": 3600,
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = await acreate_organization("test")
+    team = await acreate_team(organization=organization)
+    batch_export = await acreate_batch_export(
+        team_id=team.pk,
+        name=batch_export_data["name"],
+        destination_data=batch_export_data["destination"],
+        interval=batch_export_data["interval"],
+    )
+
+    # Produce a list of 10 events.
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": str(i),
+            "timestamp": f"2023-04-25 13:3{i}:00.000000",
+            "created_at": f"2023-04-25 13:3{i}:00.000000",
+            "_timestamp": f"2023-04-25 13:3{i}:00",
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team.pk,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "distinct_id": str(uuid4()),
+            "elements_chain": "this is a comman, separated, list, of css selectors(?)",
+        }
+        for i in range(10)
+    ]
+
+    # Insert some data into the `sharded_events` table.
+    await insert_events(
+        client=ch_client,
+        events=events,
+    )
+
+    workflow_id = str(uuid4())
+    inputs = S3BatchExportInputs(
+        team_id=team.pk,
+        batch_export_id=str(batch_export.id),
+        data_interval_end="2023-04-25 14:30:00.000000",
+        **batch_export.destination.config,
+    )
+
+    failed_events = set()
+
+    def should_fail(event):
+        return bool(int(event["event"]) % 2)
+
+    async def fake_get_results_iterator(*args, **kwargs):
+        async for result in get_results_iterator(*args, **kwargs):
+            if result["event"] not in failed_events and should_fail(result):
+                # Will raise an exception every other row.
+                failed_events.add(result["event"])  # Otherwise we infinite loop
+                raise json.JSONDecodeError("Test error", "A ClickHouse error message\n", 0)
+
+            yield result
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[S3BatchExportWorkflow],
+            activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+                with mock.patch(
+                    "posthog.temporal.workflows.s3_batch_export.get_results_iterator",
+                    side_effect=fake_get_results_iterator,
+                ) as mocked_iterator:
+                    await activity_environment.client.execute_workflow(
+                        S3BatchExportWorkflow.run,
+                        inputs,
+                        id=workflow_id,
+                        task_queue=settings.TEMPORAL_TASK_QUEUE,
+                        retry_policy=RetryPolicy(maximum_attempts=1),
+                    )
+
+    assert mocked_iterator.call_count == 6  # 5 failures so 5 extra calls
+    mocked_iterator.assert_has_calls(  # The first call + we resume on all the even dates.
+        [
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25T13:30:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25 13:30:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25 13:32:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25 13:34:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25 13:36:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+            mock.call(
+                client=mock.ANY,
+                interval_start="2023-04-25 13:38:00",
+                interval_end="2023-04-25T14:30:00",
+                team_id=team.pk,
+            ),
+        ]
+    )
+
+    runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+    assert len(runs) == 1
+
+    run = runs[0]
+    assert run.status == "Completed"
+
+    duplicate_events = [event for event in events if not should_fail(event)]
+    assert_events_in_s3(s3_client, bucket_name, prefix, events + duplicate_events)

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -1,10 +1,8 @@
 import json
+from datetime import datetime
 from string import Template
 
 from aiochclient import ChClient
-
-from datetime import datetime
-
 
 SELECT_QUERY_TEMPLATE = Template(
     """
@@ -51,6 +49,7 @@ async def get_results_iterator(client: ChClient, team_id: int, interval_start: s
             fields="""
                     uuid,
                     timestamp,
+                    _timestamp,
                     created_at,
                     event,
                     properties,

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -17,6 +17,7 @@ SELECT_QUERY_TEMPLATE = Template(
         AND _timestamp >= toDateTime({data_interval_start}, 'UTC')
         AND _timestamp < toDateTime({data_interval_end}, 'UTC')
         AND team_id = {team_id}
+    $order_by
     """
 )
 
@@ -26,7 +27,7 @@ async def get_rows_count(client: ChClient, team_id: int, interval_start: str, in
     data_interval_end_ch = datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
 
     row = await client.fetchrow(
-        SELECT_QUERY_TEMPLATE.substitute(fields="count(*) as count"),
+        SELECT_QUERY_TEMPLATE.substitute(fields="count(*) as count", order_by=""),
         params={
             "team_id": team_id,
             "data_interval_start": data_interval_start_ch,
@@ -59,7 +60,8 @@ async def get_results_iterator(client: ChClient, team_id: int, interval_start: s
                     person_properties,
                     -- Autocapture fields
                     elements_chain
-                """
+            """,
+            order_by="ORDER BY _timestamp",
         ),
         json=True,
         params={

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -106,6 +106,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
         # when it reaches 50MB in size.
         parts: List[CompletedPartTypeDef] = []
         part_number = 1
+
         results_iterator = get_results_iterator(
             client=client,
             team_id=inputs.team_id,

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -113,12 +113,34 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
             interval_end=inputs.data_interval_end,
         )
 
+        result = None
+
         with tempfile.NamedTemporaryFile() as local_results_file:
             while True:
                 try:
                     result = await results_iterator.__anext__()
                 except StopAsyncIteration:
                     break
+                except json.JSONDecodeError:
+                    # This is raised by aiochclient as we try to decode an error message from ClickHouse.
+                    # So far, this error message only indicated that we were too slow consuming rows.
+                    # So, we can resume from the last result.
+                    if result is None:
+                        # We failed right at the beginning
+                        new_interval_start = None
+                    else:
+                        new_interval_start = result.get("_timestamp", None)
+
+                    if not isinstance(new_interval_start, str):
+                        new_interval_start = inputs.data_interval_start
+
+                    results_iterator = get_results_iterator(
+                        client=client,
+                        team_id=inputs.team_id,
+                        interval_start=new_interval_start,  # This means we'll generate at least one duplicate.
+                        interval_end=inputs.data_interval_end,
+                    )
+                    continue
 
                 if not result:
                     break

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -122,6 +122,9 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
                 except StopAsyncIteration:
                     break
                 except json.JSONDecodeError:
+                    activity.logger.info(
+                        "Failed to decode a JSON value while iterating, potentially due to a ClickHouse error"
+                    )
                     # This is raised by aiochclient as we try to decode an error message from ClickHouse.
                     # So far, this error message only indicated that we were too slow consuming rows.
                     # So, we can resume from the last result.

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -115,7 +115,6 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
         )
 
         result = None
-
         with tempfile.NamedTemporaryFile() as local_results_file:
             while True:
                 try:
@@ -150,7 +149,9 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
                     break
 
                 # Write the results to a local file
-                local_results_file.write(json.dumps(result).encode("utf-8"))
+                local_results_file.write(
+                    json.dumps({k: v for k, v in result.items() if k != "_timestamp"}).encode("utf-8")
+                )
                 local_results_file.write("\n".encode("utf-8"))
 
                 # Write results to S3 when the file reaches 50MB and reset the

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -180,20 +180,47 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                 interval_start=inputs.data_interval_start,
                 interval_end=inputs.data_interval_end,
             )
-
+            result = None
             local_results_file = tempfile.NamedTemporaryFile(suffix=".jsonl")
             try:
                 while True:
                     try:
                         result = await results_iterator.__anext__()
+
                     except StopAsyncIteration:
                         break
+
+                    except json.JSONDecodeError:
+                        activity.logger.info(
+                            "Failed to decode a JSON value while iterating, potentially due to a ClickHouse error"
+                        )
+                        # This is raised by aiochclient as we try to decode an error message from ClickHouse.
+                        # So far, this error message only indicated that we were too slow consuming rows.
+                        # So, we can resume from the last result.
+                        if result is None:
+                            # We failed right at the beginning
+                            new_interval_start = None
+                        else:
+                            new_interval_start = result.get("_timestamp", None)
+
+                        if not isinstance(new_interval_start, str):
+                            new_interval_start = inputs.data_interval_start
+
+                        results_iterator = get_results_iterator(
+                            client=client,
+                            team_id=inputs.team_id,
+                            interval_start=new_interval_start,  # This means we'll generate at least one duplicate.
+                            interval_end=inputs.data_interval_end,
+                        )
+                        continue
 
                     if not result:
                         break
 
                     # Write the results to a local file
-                    local_results_file.write(json.dumps(result).encode("utf-8"))
+                    local_results_file.write(
+                        json.dumps({k: v for k, v in result.items() if k != "_timestamp"}).encode("utf-8")
+                    )
                     local_results_file.write("\n".encode("utf-8"))
 
                     # Write results to Snowflake when the file reaches 50MB and

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -412,66 +412,63 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging
-  'SELECT 1'
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.1
   '
   
   SET LOCAL statement_timeout = 2
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.1
+  '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.2
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.3
   '
-  
-  SET LOCAL statement_timeout = 2
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.4
-  '
   WITH target_person_ids AS
     (SELECT team_id,
             person_id
@@ -514,13 +511,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.4
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.6
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.5
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -528,6 +525,20 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.6
+  '
+  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
+         "posthog_featureflaghashkeyoverride"."hash_key",
+         "posthog_featureflaghashkeyoverride"."person_id"
+  FROM "posthog_featureflaghashkeyoverride"
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
+                                                              2,
+                                                              3,
+                                                              4,
+                                                              5 /* ... */)
+         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.7

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -412,62 +412,65 @@
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging
-  '
-  
-  SET LOCAL statement_timeout = 2
-  '
+  'SELECT 1'
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.1
   '
-  WITH target_person_ids AS
-    (SELECT team_id,
-            person_id
-     FROM posthog_persondistinctid
-     WHERE team_id = 2
-       AND distinct_id IN ('other_id',
-                           'example_id') ),
-       existing_overrides AS
-    (SELECT team_id,
-            person_id,
-            feature_flag_key,
-            hash_key
-     FROM posthog_featureflaghashkeyoverride
-     WHERE team_id = 2
-       AND person_id IN
-         (SELECT person_id
-          FROM target_person_ids) ),
-       flags_to_override AS
-    (SELECT key
-     FROM posthog_featureflag
-     WHERE team_id = 2
-       AND ensure_experience_continuity = TRUE
-       AND active = TRUE
-       AND deleted = FALSE
-       AND key NOT IN
-         (SELECT feature_flag_key
-          FROM existing_overrides) )
-  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-  SELECT team_id,
-         person_id,
-         key,
-         'example_id'
-  FROM flags_to_override,
-       target_person_ids
-  WHERE
-    EXISTS
-      (SELECT 1
-       FROM posthog_person
-       WHERE id = person_id
-         AND team_id = 2) ON CONFLICT DO NOTHING
+  
+  SET LOCAL statement_timeout = 2
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.2
   '
+  WITH target_person_ids AS
+    (SELECT team_id,
+            person_id
+     FROM posthog_persondistinctid
+     WHERE team_id = 2
+       AND distinct_id IN ('other_id',
+                           'example_id') ),
+       existing_overrides AS
+    (SELECT team_id,
+            person_id,
+            feature_flag_key,
+            hash_key
+     FROM posthog_featureflaghashkeyoverride
+     WHERE team_id = 2
+       AND person_id IN
+         (SELECT person_id
+          FROM target_person_ids) ),
+       flags_to_override AS
+    (SELECT key
+     FROM posthog_featureflag
+     WHERE team_id = 2
+       AND ensure_experience_continuity = TRUE
+       AND active = TRUE
+       AND deleted = FALSE
+       AND key NOT IN
+         (SELECT feature_flag_key
+          FROM existing_overrides) )
+  INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+  SELECT team_id,
+         person_id,
+         key,
+         'example_id'
+  FROM flags_to_override,
+       target_person_ids
+  WHERE
+    EXISTS
+      (SELECT 1
+       FROM posthog_person
+       WHERE id = person_id
+         AND team_id = 2) ON CONFLICT DO NOTHING
+  '
+---
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.3
+  '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.3
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.4
   '
   WITH target_person_ids AS
     (SELECT team_id,
@@ -511,13 +514,13 @@
          AND team_id = 2) ON CONFLICT DO NOTHING
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.4
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.5
   '
   
   SET LOCAL statement_timeout = 2
   '
 ---
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.5
+# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.6
   '
   SELECT "posthog_persondistinctid"."person_id",
          "posthog_persondistinctid"."distinct_id"
@@ -525,20 +528,6 @@
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('other_id',
                                                       'example_id')
          AND "posthog_persondistinctid"."team_id" = 2)
-  '
----
-# name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.6
-  '
-  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
-         "posthog_featureflaghashkeyoverride"."hash_key",
-         "posthog_featureflaghashkeyoverride"."person_id"
-  FROM "posthog_featureflaghashkeyoverride"
-  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
-                                                              2,
-                                                              3,
-                                                              4,
-                                                              5 /* ... */)
-         AND "posthog_featureflaghashkeyoverride"."team_id" = 2)
   '
 ---
 # name: TestHashKeyOverridesRaceConditions.test_hash_key_overrides_with_simulated_race_conditions_on_person_merging.7


### PR DESCRIPTION
## Problem

BatchExports are too slow (not the query itself, but everything that happens after), we already addressed this partially by sending queries to the offline cluster in #16470. Let's be sure we are addressing the issue by explicitly handling it, at least in S3.

I'm not a fan of how big this loop is growing: I was working on refactoring it in #16445, but this is more urgent.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Catch `JSONDecodeError` and reset the iterator when it happens.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
