### PR TITLE
chore: add more logging usage report and delay by an hour

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -83,7 +83,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
     )
 
     # Send all instance usage to the Billing service
-    sender.add_periodic_task(crontab(hour=0, minute=0), send_org_usage_reports.s(), name="send instance usage report")
+    sender.add_periodic_task(crontab(hour=1, minute=0), send_org_usage_reports.s(), name="send instance usage report")
     # Update local usage info for rate limiting purposes - offset by 30 minutes to not clash with the above
     sender.add_periodic_task(crontab(hour="*", minute=30), update_quota_limiting.s(), name="update quota limiting")
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -679,6 +679,7 @@ def send_all_org_usage_reports(
     org_reports: Dict[str, OrgReport] = {}
 
     print("Generating reports for teams...")  # noqa T201
+    time_now = datetime.now()
     for team in teams:
         team_report = UsageReportCounters(
             event_count_lifetime=find_count_for_team_in_rows(team.id, all_data["teams_with_event_count_lifetime"]),
@@ -767,10 +768,13 @@ def send_all_org_usage_reports(
                         field.name,
                         getattr(org_report, field.name) + getattr(team_report, field.name),
                     )
+    time_since = datetime.now() - time_now
+    print(f"Generating reports for teams took {time_since.total_seconds()} seconds.")  # noqa T201
 
     all_reports = []
 
     print("Sending usage reports to PostHog and Billing...")  # noqa T201
+    time_now = datetime.now()
     for org_report in org_reports.values():
         org_id = org_report.organization_id
 
@@ -795,4 +799,6 @@ def send_all_org_usage_reports(
         # Then capture the events to Billing
         if has_non_zero_usage(full_report):
             send_report_to_billing_service.delay(org_id, full_report_dict)
+    time_since = datetime.now() - time_now
+    print(f"Sending usage reports to PostHog and Billing took {time_since.total_seconds()} seconds.")  # noqa T201
     return all_reports

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -516,7 +516,7 @@ def has_non_zero_usage(report: FullUsageReport) -> bool:
     )
 
 
-@app.task(ignore_result=True, retries=3)
+@app.task(ignore_result=True, retries=6)
 def send_all_org_usage_reports(
     dry_run: bool = False,
     at: Optional[str] = None,
@@ -678,6 +678,7 @@ def send_all_org_usage_reports(
 
     org_reports: Dict[str, OrgReport] = {}
 
+    print("Generating reports for teams...")  # noqa T201
     for team in teams:
         team_report = UsageReportCounters(
             event_count_lifetime=find_count_for_team_in_rows(team.id, all_data["teams_with_event_count_lifetime"]),
@@ -769,6 +770,7 @@ def send_all_org_usage_reports(
 
     all_reports = []
 
+    print("Sending usage reports to PostHog and Billing...")  # noqa T201
     for org_report in org_reports.values():
         org_id = org_report.organization_id
 


### PR DESCRIPTION
## Problem

The nightly usage report task is consistently failing and I don't want to have to babysit it while I am out of town.

A couple theories about why it might be happening are:
1. Some query that is taking too long.
    - We added query timing decorator and, while some of them take a while, they almost never fail when I run them manually. Also, the ones that take longest are the events ones _plus_ one of the hogql ones, which I will look more into, though I still feel like the fact that they never fail when I run them manually is weird.
2. Something is happening with Clickhouse at the same time this is trying to run, which is causing issues
    - No idea what this could be, but I figure we can try delaying this cron for an hour and see if that helps? Not ideal but might work as a short-term solution, we will see.
3. Some other part of the function that generates the reports is taking too long or failing.
    - There are two other parts of this script and I'm not sure which take longest, so added some very basic timing on those, not broken down by team but just for the entire thing. There's probably a much better way to do this.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

See above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
