### PR TITLE
chore: disconnect consumer on error handling functional_tests

### DIFF
--- a/plugin-server/functional_tests/analytics-ingestion/error-handling.test.ts
+++ b/plugin-server/functional_tests/analytics-ingestion/error-handling.test.ts
@@ -27,6 +27,10 @@ beforeAll(async () => {
     organizationId = await createOrganization()
 })
 
+afterAll(async () => {
+    await dlqConsumer.disconnect()
+})
+
 test.concurrent('consumer handles messages just less than 1MB gracefully', async () => {
     // For this we basically want the plugin-server to try and produce a new
     // message larger than 1MB. We do this by creating a person with a lot of

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -37,7 +37,7 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
-    await Promise.all([await dlqConsumer.disconnect()])
+    await dlqConsumer.disconnect()
 })
 
 test.concurrent(


### PR DESCRIPTION
If we don't we end up with a bunch of errors in the logs about imports
happening after jest tests have finished.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
