### PR TITLE
feat: don't track byte size, it isn't useful enough

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -131,9 +131,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
         // NOTE: 10 minutes
         SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,
-        SESSION_RECORDING_MAX_LINES_PER_FILE: ['dev', 'test'].includes(process.env.NODE_ENV || 'undefined')
-            ? 100 // NOTE: low value in dev or test, so that while testing we flush pretty frequently
-            : 4000, // in production when flushing based on time we primarily see roughly 500 lines per file
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
         SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY: '@posthog/replay/partition-high-water-marks',
         POSTHOG_SESSION_RECORDING_REDIS_HOST: undefined,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -131,9 +131,9 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
         // NOTE: 10 minutes
         SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,
-        SESSION_RECORDING_MAX_BUFFER_SIZE_KB: ['dev', 'test'].includes(process.env.NODE_ENV || 'undefined')
-            ? 1024 // NOTE: ~1MB in dev or test, so that even with gzipped content we still flush pretty frequently
-            : 1024 * 50, // ~50MB after compression in prod
+        SESSION_RECORDING_MAX_LINES_PER_FILE: ['dev', 'test'].includes(process.env.NODE_ENV || 'undefined')
+            ? 100 // NOTE: low value in dev or test, so that while testing we flush pretty frequently
+            : 4000, // in production when flushing based on time we primarily see roughly 500 lines per file
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
         SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY: '@posthog/replay/partition-high-water-marks',
         POSTHOG_SESSION_RECORDING_REDIS_HOST: undefined,

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -124,31 +124,10 @@ export class SessionManager {
         }
 
         await this.addToBuffer(message)
-        await this.flushIfBufferExceedsCapacity()
     }
 
     public get isEmpty(): boolean {
         return this.buffer.count === 0
-    }
-
-    public async flushIfBufferExceedsCapacity(): Promise<void> {
-        if (this.destroying) {
-            return
-        }
-
-        // loosely estimated value, we don't want to flush too often based on size
-        // but tracking the size closely was expensive when looking at time spent in CPU flamegraphs
-        // when flushing based on time we see a mean of 500ish lines per file
-        // although peaks much higher than that
-        if (this.buffer.count > this.serverConfig.SESSION_RECORDING_MAX_LINES_PER_FILE) {
-            status.info('🚽', `blob_ingester_session_manager flushing buffer due to size`, {
-                lines: this.buffer.count,
-                threshold: this.serverConfig.SESSION_RECORDING_MAX_LINES_PER_FILE,
-                ...this.logContext(),
-            })
-            // return the promise and let the caller decide whether to await
-            return this.flush('buffer_size')
-        }
     }
 
     public async flushIfSessionBufferIsOld(referenceNow: number, flushThresholdMillis: number): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -50,10 +50,6 @@ const gaugeSessionsRevoked = new Gauge({
     help: 'A gauge of the number of sessions being revoked when partitions are revoked when a re-balance occurs',
 })
 
-const gaugeBytesBuffered = new Gauge({
-    name: 'recording_blob_ingestion_bytes_buffered',
-    help: 'A gauge of the bytes of data buffered in files. Maybe the consumer needs this much RAM as it might flush many of the files close together and holds them in memory when it does',
-})
 export const gaugeRealtimeSessions = new Gauge({
     name: 'recording_realtime_sessions',
     help: 'Number of real time sessions being handled by this blob ingestion consumer',
@@ -390,12 +386,8 @@ export class SessionRecordingBlobIngester {
         // We trigger the flushes from this level to reduce the number of running timers
         this.flushInterval = setInterval(() => {
             status.info('🚽', `blob_ingester_session_manager flushInterval fired`)
-            // It's unclear what happens if an exception occurs here so, we try catch it just in case
-            let sessionManagerBufferSizes = 0
 
             for (const [key, sessionManager] of this.sessions) {
-                sessionManagerBufferSizes += sessionManager.buffer.size
-
                 // in practice, we will always have a values for latestKafkaMessageTimestamp,
                 const referenceTime = this.partitionNow[sessionManager.partition]
                 if (!referenceTime) {
@@ -428,7 +420,6 @@ export class SessionRecordingBlobIngester {
             }
 
             gaugeSessionsHandled.set(this.sessions.size)
-            gaugeBytesBuffered.set(sessionManagerBufferSizes)
             gaugeRealtimeSessions.set(
                 Array.from(this.sessions.values()).reduce(
                     (acc, sessionManager) => acc + (sessionManager.realtime ? 1 : 0),

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -212,7 +212,6 @@ export interface PluginsServerConfig {
     // local directory might be a volume mount or a directory on disk (e.g. in local dev)
     SESSION_RECORDING_LOCAL_DIRECTORY: string
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
-    SESSION_RECORDING_MAX_LINES_PER_FILE: number
     SESSION_RECORDING_REMOTE_FOLDER: string
     SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY: string
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -212,7 +212,7 @@ export interface PluginsServerConfig {
     // local directory might be a volume mount or a directory on disk (e.g. in local dev)
     SESSION_RECORDING_LOCAL_DIRECTORY: string
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
-    SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number
+    SESSION_RECORDING_MAX_LINES_PER_FILE: number
     SESSION_RECORDING_REMOTE_FOLDER: string
     SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY: string
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -95,7 +95,6 @@ describe('session-manager', () => {
             newestKafkaTimestamp: timestamp,
             file: expect.any(String),
             id: expect.any(String),
-            size: 4139, // The size of the event payload - this may change when test data changes
             offsets: [1],
             createdAt: now(),
             eventsRange: {


### PR DESCRIPTION
## Problem

Looking at flamegraphs of the blob ingester we see `byteLength` in `addToBuffer` taking up significant time.

That is used to track buffer size so we can flush if the buffer gets too bug. In practice we rarely flush based on size. So let's remove it.

## Changes

removes it

## How did you test this code?

checked it still runs locally, opened the PR to see what tests fail 🙈 