### PR TITLE
chore: disable slack on zapier test

### DIFF
--- a/plugin-server/functional_tests/webhooks.test.ts
+++ b/plugin-server/functional_tests/webhooks.test.ts
@@ -125,12 +125,12 @@ test.concurrent(`webhooks: fires zapier REST webhook`, async () => {
         const action = await createAction(
             {
                 team_id: teamId,
-                name: 'slack',
-                description: 'slack',
+                name: 'zapier',
+                description: 'zapier',
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
                 deleted: false,
-                post_to_slack: true,
+                post_to_slack: false,
                 slack_message_format:
                     '[event.name] with [event.properties.name] was triggered by [person.properties.email]',
                 created_by_id: user.id,
@@ -139,7 +139,7 @@ test.concurrent(`webhooks: fires zapier REST webhook`, async () => {
             },
             [
                 {
-                    name: 'slack',
+                    name: 'zapier',
                     tag_name: 'div',
                     text: 'text',
                     href: null,


### PR DESCRIPTION
There's a race condition in the test in that if we check the request
after slack has fired but before zapier has, we'll get a false negative.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
