### PR TITLE
fix: plugin mode string check

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -87,19 +87,12 @@ export enum PluginServerMode {
     recordings_blob_ingestion = 'recordings-blob-ingestion',
 }
 
-export const stringToPluginServerMode: { [key: string]: PluginServerMode } = {
-    ingestion: PluginServerMode.ingestion,
-    'ingestion-overflow': PluginServerMode.ingestion_overflow,
-    async: PluginServerMode.plugins_async,
-    'async-onevent': PluginServerMode.async_onevent,
-    'async-webhooks': PluginServerMode.async_webhooks,
-    exports: PluginServerMode.plugins_exports,
-    jobs: PluginServerMode.jobs,
-    scheduler: PluginServerMode.scheduler,
-    'analytics-ingestion': PluginServerMode.analytics_ingestion,
-    'recordings-ingestion': PluginServerMode.recordings_ingestion,
-    'recordings-blob-ingestion': PluginServerMode.recordings_blob_ingestion,
-}
+export const stringToPluginServerMode = Object.fromEntries(
+    Object.entries(PluginServerMode).map(([key, value]) => [
+        value,
+        PluginServerMode[key as keyof typeof PluginServerMode],
+    ])
+) as Record<string, PluginServerMode>
 
 export interface PluginsServerConfig {
     WORKER_CONCURRENCY: number // number of concurrent worker threads

--- a/plugin-server/tests/main/capabilities.test.ts
+++ b/plugin-server/tests/main/capabilities.test.ts
@@ -1,11 +1,22 @@
 import { GraphileWorker } from '../../src/main/graphile-worker/graphile-worker'
 import { startGraphileWorker } from '../../src/main/graphile-worker/worker-setup'
 import { Hub, LogLevel } from '../../src/types'
+import { PluginServerMode, stringToPluginServerMode } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 import Piscina from '../../src/worker/piscina'
 
 jest.mock('../../src/main/ingestion-queues/kafka-queue')
 jest.mock('../../src/main/graphile-worker/schedule')
+
+describe('stringToPluginServerMode', () => {
+    test('gives the right value for async -> PluginServerMode.plugins_async', () => {
+        expect(stringToPluginServerMode['async']).toEqual(PluginServerMode.plugins_async)
+    })
+
+    test('gives undefined for invalid input', () => {
+        expect(stringToPluginServerMode['invalid']).toEqual(undefined)
+    })
+})
 
 describe('capabilities', () => {
     let hub: Hub


### PR DESCRIPTION
Previously we had to keep these in sync, but now we can just use the
`PluginServerMode` enum directly.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
