### PR TITLE
chore: add term signal handler to temporal worker

### DIFF
--- a/posthog/temporal/worker.py
+++ b/posthog/temporal/worker.py
@@ -20,7 +20,7 @@ async def start_worker(host, port, namespace, task_queue, server_root_ca_cert=No
     )
 
     # catch the TERM signal, and stop the worker gracefully
-    # https://docs.temporal.io/docs/python/worker/#graceful-shutdown
+    # https://github.com/temporalio/sdk-python#worker-shutdown
     async def signal_handler(sig, frame):
         await worker.shutdown()
         sys.exit(0)

--- a/posthog/temporal/worker.py
+++ b/posthog/temporal/worker.py
@@ -1,11 +1,11 @@
+import signal
+import sys
 from datetime import timedelta
+
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.client import connect
 from posthog.temporal.workflows import ACTIVITIES, WORKFLOWS
-
-import signal
-import sys
 
 
 async def start_worker(host, port, namespace, task_queue, server_root_ca_cert=None, client_cert=None, client_key=None):

--- a/posthog/temporal/worker.py
+++ b/posthog/temporal/worker.py
@@ -1,11 +1,14 @@
+from datetime import timedelta
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.client import connect
 from posthog.temporal.workflows import ACTIVITIES, WORKFLOWS
 
+import signal
+import sys
+
 
 async def start_worker(host, port, namespace, task_queue, server_root_ca_cert=None, client_cert=None, client_key=None):
-
     client = await connect(host, port, namespace, server_root_ca_cert, client_cert, client_key)
     worker = Worker(
         client,
@@ -13,5 +16,15 @@ async def start_worker(host, port, namespace, task_queue, server_root_ca_cert=No
         workflows=WORKFLOWS,
         activities=ACTIVITIES,
         workflow_runner=UnsandboxedWorkflowRunner(),
+        graceful_shutdown_timeout=timedelta(minutes=5),
     )
+
+    # catch the TERM signal, and stop the worker gracefully
+    # https://docs.temporal.io/docs/python/worker/#graceful-shutdown
+    async def signal_handler(sig, frame):
+        await worker.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, signal_handler)
+
     await worker.run()


### PR DESCRIPTION
At the moment it seems that the temporal worker is immediately
terminated when the pod is shut down. This is not ideal as it
means that any in-flight workflows are not given a chance to complete.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
