### PR TITLE
chore: Remove options to start historical exports

### DIFF
--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -5,7 +5,6 @@ import { HistoricalExport } from './HistoricalExport'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Progress } from 'antd'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { PluginJobModal } from 'scenes/plugins/edit/interface-jobs/PluginJobConfiguration'
 import { useEffect } from 'react'
 
@@ -14,7 +13,7 @@ const RELOAD_HISTORICAL_EXPORTS_FREQUENCY_MS = 20000
 export function HistoricalExportsTab(): JSX.Element {
     const { historicalExports, historicalExportsLoading, pluginConfig, interfaceJobsProps, hasRunningExports } =
         useValues(appMetricsSceneLogic)
-    const { openHistoricalExportModal, loadHistoricalExports } = useActions(appMetricsSceneLogic)
+    const { loadHistoricalExports } = useActions(appMetricsSceneLogic)
 
     useEffect(() => {
         let timer: NodeJS.Timeout | undefined
@@ -34,12 +33,6 @@ export function HistoricalExportsTab(): JSX.Element {
 
     return (
         <div className="space-y-2">
-            <div className="flex items-center justify-end">
-                <LemonButton type="primary" onClick={openHistoricalExportModal} disabled={!interfaceJobsProps}>
-                    Start new export
-                </LemonButton>
-            </div>
-
             <LemonTable
                 dataSource={historicalExports}
                 loading={historicalExportsLoading}
@@ -93,11 +86,6 @@ export function HistoricalExportsTab(): JSX.Element {
                 emptyState={
                     <div className="">
                         <b>Nothing has been exported yet!</b>
-                        {interfaceJobsProps && (
-                            <p className="m-0">
-                                Use "Start new export" button above to export historical data in a given time range.
-                            </p>
-                        )}
                     </div>
                 }
             />

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -1,4 +1,5 @@
 import { LemonTag } from '@posthog/lemon-ui'
+import { Link } from 'lib/lemon-ui/Link'
 import { useValues } from 'kea'
 import { useMemo } from 'react'
 import { JobSpec } from '~/types'
@@ -56,14 +57,23 @@ export function PluginJobOptions({
 
             {jobs.map((jobName) => (
                 <div key={jobName}>
-                    {jobName.includes('Export historical events') ? <i>Export historical events</i> : <i>{jobName}</i>}
-                    <PluginJobConfiguration
-                        jobName={jobName}
-                        jobSpec={publicJobs[jobName]}
-                        pluginConfigId={pluginConfigId}
-                        pluginId={pluginId}
-                        onSubmit={onSubmit}
-                    />
+                    {jobName.includes('Export historical events') ? (
+                        <i>
+                            Currently unavailable, see{' '}
+                            <Link to="https://github.com/PostHog/posthog/issues/15997">GitHub issue</Link>
+                        </i>
+                    ) : (
+                        <>
+                            <i>{jobName}</i>
+                            <PluginJobConfiguration
+                                jobName={jobName}
+                                jobSpec={publicJobs[jobName]}
+                                pluginConfigId={pluginConfigId}
+                                pluginId={pluginId}
+                                onSubmit={onSubmit}
+                            />
+                        </>
+                    )}
                 </div>
             ))}
         </>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The legacy historical exports aren't reliable it's better for everyone if users don't trigger these and rather wait for the new batch exports to be out

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
