### PR TITLE
fix(hogql): restrict identifier characters

### DIFF
--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -34,6 +34,8 @@ def escape_param_clickhouse(value: str) -> str:
 def escape_hogql_identifier(identifier: str | int) -> str:
     if isinstance(identifier, int):  # In HogQL we allow integers as identifiers to access array elements
         return str(identifier)
+    if "%" in identifier:
+        raise HogQLException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
     # HogQL allows dollars in the identifier.
     if re.match(
         r"^[A-Za-z_$][A-Za-z0-9_$]*$", identifier
@@ -44,6 +46,8 @@ def escape_hogql_identifier(identifier: str | int) -> str:
 
 # Copied from clickhouse_driver.util.escape, adapted from single quotes to backquotes.
 def escape_clickhouse_identifier(identifier: str) -> str:
+    if "%" in identifier:
+        raise HogQLException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
     if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", identifier):
         return identifier
     return "`%s`" % "".join(backquote_escape_chars_map.get(c, c) for c in identifier)

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1,9 +1,9 @@
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, date
 from difflib import get_close_matches
 from typing import List, Literal, Optional, Union, cast
-
+from uuid import UUID
 
 from posthog.hogql import ast
 from posthog.hogql.base import AST
@@ -35,6 +35,7 @@ from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
 from posthog.hogql.transforms.property_types import resolve_property_types
 from posthog.hogql.visitor import Visitor
 from posthog.models.property import PropertyName, TableColumn
+from posthog.models.utils import UUIDT
 from posthog.utils import PersonOnEventsMode
 
 
@@ -422,13 +423,29 @@ class _Printer(Visitor):
             raise HogQLException(f"Unknown CompareOperationOp: {type(node.op).__name__}")
 
     def visit_constant(self, node: ast.Constant):
-        if self.dialect == "clickhouse" and (
-            isinstance(node.value, str) or isinstance(node.value, list) or isinstance(node.value, tuple)
-        ):
-            # inline the string in hogql, but use %(hogql_val_0)s in clickhouse
-            return self.context.add_value(node.value)
-        else:
+        if self.dialect == "hogql":
+            # Inline everything in HogQL
             return self._print_escaped_string(node.value)
+        elif (
+            node.value is None
+            or isinstance(node.value, bool)
+            or isinstance(node.value, int)
+            or isinstance(node.value, float)
+            or isinstance(node.value, UUID)
+            or isinstance(node.value, UUIDT)
+            or isinstance(node.value, datetime)
+            or isinstance(node.value, date)
+        ):
+            # Inline some permitted types in ClickHouse
+            value = self._print_escaped_string(node.value)
+            if "%" in value:
+                # We don't know if this will be passed on as part of a legacy ClickHouse query or not.
+                # Ban % to be on the safe side. Who knows how it can end up in a UUID or datetime for example.
+                raise HogQLException(f"Invalid character '%' in constant: {value}")
+            return value
+        else:
+            # Strings, lists, tuples, and any other random datatype printed in ClickHouse.
+            return self.context.add_value(node.value)
 
     def visit_field(self, node: ast.Field):
         if node.type is None:
@@ -793,19 +810,17 @@ class _Printer(Visitor):
         return None
 
     def _print_identifier(self, name: str) -> str:
-        if "%" in name:
-            raise HogQLException(f"Invalid identifier {name}. Identifiers cannot contain the '%' character.")
         if self.dialect == "clickhouse":
             return escape_clickhouse_identifier(name)
         return escape_hogql_identifier(name)
 
     def _print_hogql_identifier_or_index(self, name: str | int) -> str:
-        # Regular identifiers can't start with a number. Print digit strings as-is for unesacped tuple access.
+        # Regular identifiers can't start with a number. Print digit strings as-is for unescaped tuple access.
         if isinstance(name, int) and str(name).isdigit():
             return str(name)
         return escape_hogql_identifier(name)
 
-    def _print_escaped_string(self, name: float | int | str | list | tuple | datetime) -> str:
+    def _print_escaped_string(self, name: float | int | str | list | tuple | datetime | date) -> str:
         if self.dialect == "clickhouse":
             return escape_clickhouse_string(name, timezone=self._get_timezone())
         return escape_hogql_string(name, timezone=self._get_timezone())

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -793,6 +793,8 @@ class _Printer(Visitor):
         return None
 
     def _print_identifier(self, name: str) -> str:
+        if "%" in name:
+            raise HogQLException(f"Invalid identifier {name}. Identifiers cannot contain the '%' character.")
         if self.dialect == "clickhouse":
             return escape_clickhouse_identifier(name)
         return escape_hogql_identifier(name)

--- a/posthog/hogql/test/test_escape_sql.py
+++ b/posthog/hogql/test/test_escape_sql.py
@@ -133,7 +133,7 @@ class TestPrintString(BaseTest):
 
     def test_escape_clickhouse_string_errors(self):
         # This test is a stopgap. Think long and hard before adding support for printing dicts or objects.
-        # Make sure string escapign happens at the right level, and % is tested through and through.
+        # Make sure string escaping happens at the right level, and % is tested through and through.
         with self.assertRaises(HogQLException) as context:
             escape_clickhouse_string({"a": 1, "b": 2})  # type: ignore
         self.assertTrue("SQLValueEscaper has no method visit_dict" in str(context.exception))

--- a/posthog/hogql/test/test_escape_sql.py
+++ b/posthog/hogql/test/test_escape_sql.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from posthog.hogql.errors import HogQLException
 from posthog.hogql.escape_sql import (
     escape_hogql_identifier,
     escape_clickhouse_string,
@@ -20,7 +21,7 @@ class TestPrintString(BaseTest):
         self.assertEqual(escape_hogql_identifier("a b c"), "`a b c`")
         self.assertEqual(escape_hogql_identifier("a.b.c"), "`a.b.c`")
         self.assertEqual(escape_hogql_identifier("a-b-c"), "`a-b-c`")
-        self.assertEqual(escape_hogql_identifier("a#$%#"), "`a#$%#`")
+        self.assertEqual(escape_hogql_identifier("a#$#"), "`a#$#`")
         self.assertEqual(escape_hogql_identifier("back`tick"), "`back\\`tick`")
         self.assertEqual(escape_hogql_identifier("single'quote"), "`single'quote`")
         self.assertEqual(escape_hogql_identifier('double"quote'), '`double"quote`')
@@ -38,7 +39,7 @@ class TestPrintString(BaseTest):
         self.assertEqual(escape_clickhouse_identifier("a b c"), "`a b c`")
         self.assertEqual(escape_clickhouse_identifier("a.b.c"), "`a.b.c`")
         self.assertEqual(escape_clickhouse_identifier("a-b-c"), "`a-b-c`")
-        self.assertEqual(escape_clickhouse_identifier("a#$%#"), "`a#$%#`")
+        self.assertEqual(escape_clickhouse_identifier("a#$#"), "`a#$#`")
         self.assertEqual(escape_clickhouse_identifier("back`tick"), "`back\\`tick`")
         self.assertEqual(escape_clickhouse_identifier("single'quote"), "`single'quote`")
         self.assertEqual(escape_clickhouse_identifier('double"quote'), '`double"quote`')
@@ -113,3 +114,26 @@ class TestPrintString(BaseTest):
         self.assertEqual(escape_hogql_string(float("-123.123")), "-123.123")
         self.assertEqual(escape_hogql_string(float("0.000000000000000001")), "1e-18")
         self.assertEqual(escape_hogql_string(float("234732482374928374923")), "2.3473248237492837e+20")
+
+    def test_escape_hogql_identifier_errors(self):
+        with self.assertRaises(HogQLException) as context:
+            escape_hogql_identifier("with % percent")
+        self.assertTrue(
+            'The HogQL identifier "with % percent" is not permitted as it contains the "%" character'
+            in str(context.exception)
+        )
+
+    def test_escape_clickhouse_identifier_errors(self):
+        with self.assertRaises(HogQLException) as context:
+            escape_clickhouse_identifier("with % percent")
+        self.assertTrue(
+            'The HogQL identifier "with % percent" is not permitted as it contains the "%" character'
+            in str(context.exception)
+        )
+
+    def test_escape_clickhouse_string_errors(self):
+        # This test is a stopgap. Think long and hard before adding support for printing dicts or objects.
+        # Make sure string escapign happens at the right level, and % is tested through and through.
+        with self.assertRaises(HogQLException) as context:
+            escape_clickhouse_string({"a": 1, "b": 2})  # type: ignore
+        self.assertTrue("SQLValueEscaper has no method visit_dict" in str(context.exception))

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -264,7 +264,9 @@ class TestPrinter(BaseTest):
         self._assert_expr_error("person.chipotle", "Field not found: chipotle")
         self._assert_expr_error("properties.0", "SQL indexes start from one, not from zero. E.g: array[1]")
         self._assert_expr_error("properties.id.0", "SQL indexes start from one, not from zero. E.g: array[1]")
-        self._assert_expr_error("event as `as%d`", "Alias \"as%d\" contains unsupported character '%'")
+        self._assert_expr_error(
+            "event as `as%d`", 'The HogQL identifier "as%d" is not permitted as it contains the "%" character'
+        )
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_expr_parse_errors_poe_on(self):


### PR DESCRIPTION
## Problem

There's a character can cause trouble when printed as part of a query where it shouldn't be

## Changes

Increases the paranoia level by explicitly checking for it.

## How did you test this code?

Added tests