### PR TITLE
feat(data-management): add last seen to event definitions

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -19,6 +19,7 @@ import { urls } from 'scenes/urls'
 import { combineUrl } from 'kea-router'
 import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { TZLabel } from 'lib/components/TZLabel'
 
 const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
     { value: EventDefinitionType.Event, label: 'All events', 'data-attr': 'event-type-option-event' },
@@ -59,6 +60,15 @@ export function EventDefinitionsTable(): JSX.Element {
             className: 'definition-column-name',
             render: function Render(_, definition: EventDefinition) {
                 return <EventDefinitionHeader definition={definition} hideIcon asLink />
+            },
+            sorter: true,
+        },
+        {
+            title: 'Last seen',
+            key: 'last_seen_at',
+            className: 'definition-column-last_seen_at',
+            render: function Render(_, definition: EventDefinition) {
+                return definition.last_seen_at ? <TZLabel time={definition.last_seen_at} /> : null
             },
             sorter: true,
         },

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -74,7 +74,7 @@ class EventDefinitionViewSet(
     filter_backends = [TermSearchFilterBackend]
 
     search_fields = ["name"]
-    ordering_fields = ["name"]
+    ordering_fields = ["name", "last_seen_at"]
 
     def get_queryset(self):
         # `type` = 'all' | 'event' | 'action_event'
@@ -125,8 +125,8 @@ class EventDefinitionViewSet(
             else:
                 order_direction = "ASC"
         else:
-            order = "name"
-            order_direction = "ASC"
+            order = "last_seen_at"
+            order_direction = "DESC"
 
         return order, order_direction
 


### PR DESCRIPTION
## Problem

This looks less than stellar:

<img width="1469" alt="image" src="https://github.com/PostHog/posthog/assets/53387/298af9f9-8967-446d-909a-f23960b97f6b">

## Changes

Adds a "last seen" column and uses that as the default sort order.

<img width="980" alt="image" src="https://github.com/PostHog/posthog/assets/53387/18032d9e-8e41-4c2a-9418-735fca52fd52">

## How did you test this code?

👀 