### PR TITLE
fix: Increase number of retries to bump timeout

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -284,7 +284,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 insert_inputs,
                 start_to_close_timeout=dt.timedelta(minutes=10),
                 retry_policy=RetryPolicy(
-                    maximum_attempts=3,
+                    maximum_attempts=6,
                     non_retryable_error_types=[
                         # If we can't connect to ClickHouse, no point in retrying.
                         "ConnectionError",


### PR DESCRIPTION
## Problem

Some exports are taking longer than 30 minutes to finish... I assume due to the size of the dataset. I'm confident we can bring the time down, as we are leaving a lot of performance gains on the table. However, while I investigate further how to mitigate this, let's bump the timeout and get the backfills done.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Bump number of retries from 3 to 6, effectively doubling the timeout.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
