### PR TITLE
chore(plugin-server): we split onevent and webhooks consumers

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -11,37 +11,6 @@ import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
-// TODO: remove once we've migrated
-export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaJSIngestionConsumer): Promise<void> {
-    const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
-    const event = convertToIngestionEvent(clickHouseEvent)
-
-    await Promise.all([
-        runInstrumentedFunction({
-            event: event,
-            func: () => queue.workerMethods.runAppsOnEventPipeline(event),
-            statsKey: `kafka_queue.process_async_handlers_on_event`,
-            timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
-            teamId: event.teamId,
-        }),
-        runInstrumentedFunction({
-            event: event,
-            func: () => runWebhooks(queue.pluginsServer, event),
-            statsKey: `kafka_queue.process_async_handlers_webhooks`,
-            timeoutMessage: 'After 30 seconds still running runWebhooksHandlersEventPipeline',
-            teamId: event.teamId,
-        }),
-    ])
-}
-
-// TODO: remove once we've migrated
-export async function eachBatchAsyncHandlers(
-    payload: EachBatchPayload,
-    queue: KafkaJSIngestionConsumer
-): Promise<void> {
-    await eachBatch(payload, queue, eachMessageAsyncHandlers, groupIntoBatches, 'async_handlers')
-}
-
 export async function eachMessageAppsOnEventHandlers(
     message: KafkaMessage,
     queue: KafkaJSIngestionConsumer

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -5,43 +5,8 @@ import { KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from '../../config/kafka-to
 import { Hub } from '../../types'
 import { status } from '../../utils/status'
 import Piscina from '../../worker/piscina'
-import {
-    eachBatchAppsOnEventHandlers,
-    eachBatchAsyncHandlers,
-    eachBatchWebhooksHandlers,
-} from './batch-processing/each-batch-async-handlers'
+import { eachBatchAppsOnEventHandlers, eachBatchWebhooksHandlers } from './batch-processing/each-batch-async-handlers'
 import { KafkaJSIngestionConsumer } from './kafka-queue'
-
-export const startAsyncHandlerConsumer = async ({
-    hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
-    piscina,
-}: {
-    hub: Hub
-    piscina: Piscina
-}) => {
-    /*
-        Consumes analytics events from the Kafka topic `clickhouse_events_json`
-        and processes any onEvent plugin handlers configured for the team. This
-        also includes `exportEvents` handlers defined in plugins as these are
-        also handled via modifying `onEvent` to call `exportEvents`.
-
-        At the moment this is just a wrapper around `IngestionConsumer`. We may
-        want to further remove that abstraction in the future.
-    */
-    status.info('🔁', `Starting async handler consumer`)
-
-    const queue = buildAsyncIngestionConsumer({ hub, piscina })
-
-    await queue.start()
-
-    schedule.scheduleJob('0 * * * * *', async () => {
-        await queue.emitConsumerGroupMetrics()
-    })
-
-    const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
-
-    return { queue, isHealthy: () => isHealthy() }
-}
 
 export const startAsyncOnEventHandlerConsumer = async ({
     hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
@@ -103,17 +68,6 @@ export const startAsyncWebhooksHandlerConsumer = async ({
     const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
 
     return { queue, isHealthy: () => isHealthy() }
-}
-
-// TODO: remove once we've migrated
-export const buildAsyncIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {
-    return new KafkaJSIngestionConsumer(
-        hub,
-        piscina,
-        KAFKA_EVENTS_JSON,
-        `${KAFKA_PREFIX}clickhouse-plugin-server-async`,
-        eachBatchAsyncHandlers
-    )
 }
 
 export const buildOnEventIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { Action, EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType, PostIngestionEvent, Team } from '../types'
+import { EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType, PostIngestionEvent } from '../types'
 import { convertToProcessedPluginEvent } from '../utils/event'
 import { EventPipelineRunner } from './ingestion/event-pipeline/runner'
 import { loadSchedule } from './plugins/loadSchedule'
@@ -42,15 +42,6 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     reloadSchedule: async (hub) => {
         await loadSchedule(hub)
-    },
-    reloadAllActions: async (hub) => {
-        return await hub.actionManager.reloadAllActions()
-    },
-    reloadAction: async (hub, args: { teamId: Team['id']; actionId: Action['id'] }) => {
-        return await hub.actionManager.reloadAction(args.teamId, args.actionId)
-    },
-    dropAction: (hub, args: { teamId: Team['id']; actionId: Action['id'] }) => {
-        return hub.actionManager.dropAction(args.teamId, args.actionId)
     },
     teardownPlugins: async (hub) => {
         await teardownPlugins(hub)


### PR DESCRIPTION
Now we don't need the async consumer anymore, so we can remove it.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
