### PR TITLE
Revert "chore(plugin-server): we split onevent and webhooks consumers"

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -11,6 +11,37 @@ import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
+// TODO: remove once we've migrated
+export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaJSIngestionConsumer): Promise<void> {
+    const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
+    const event = convertToIngestionEvent(clickHouseEvent)
+
+    await Promise.all([
+        runInstrumentedFunction({
+            event: event,
+            func: () => queue.workerMethods.runAppsOnEventPipeline(event),
+            statsKey: `kafka_queue.process_async_handlers_on_event`,
+            timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
+            teamId: event.teamId,
+        }),
+        runInstrumentedFunction({
+            event: event,
+            func: () => runWebhooks(queue.pluginsServer, event),
+            statsKey: `kafka_queue.process_async_handlers_webhooks`,
+            timeoutMessage: 'After 30 seconds still running runWebhooksHandlersEventPipeline',
+            teamId: event.teamId,
+        }),
+    ])
+}
+
+// TODO: remove once we've migrated
+export async function eachBatchAsyncHandlers(
+    payload: EachBatchPayload,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
+    await eachBatch(payload, queue, eachMessageAsyncHandlers, groupIntoBatches, 'async_handlers')
+}
+
 export async function eachMessageAppsOnEventHandlers(
     message: KafkaMessage,
     queue: KafkaJSIngestionConsumer

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -5,8 +5,43 @@ import { KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from '../../config/kafka-to
 import { Hub } from '../../types'
 import { status } from '../../utils/status'
 import Piscina from '../../worker/piscina'
-import { eachBatchAppsOnEventHandlers, eachBatchWebhooksHandlers } from './batch-processing/each-batch-async-handlers'
+import {
+    eachBatchAppsOnEventHandlers,
+    eachBatchAsyncHandlers,
+    eachBatchWebhooksHandlers,
+} from './batch-processing/each-batch-async-handlers'
 import { KafkaJSIngestionConsumer } from './kafka-queue'
+
+export const startAsyncHandlerConsumer = async ({
+    hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
+    piscina,
+}: {
+    hub: Hub
+    piscina: Piscina
+}) => {
+    /*
+        Consumes analytics events from the Kafka topic `clickhouse_events_json`
+        and processes any onEvent plugin handlers configured for the team. This
+        also includes `exportEvents` handlers defined in plugins as these are
+        also handled via modifying `onEvent` to call `exportEvents`.
+
+        At the moment this is just a wrapper around `IngestionConsumer`. We may
+        want to further remove that abstraction in the future.
+    */
+    status.info('🔁', `Starting async handler consumer`)
+
+    const queue = buildAsyncIngestionConsumer({ hub, piscina })
+
+    await queue.start()
+
+    schedule.scheduleJob('0 * * * * *', async () => {
+        await queue.emitConsumerGroupMetrics()
+    })
+
+    const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
+
+    return { queue, isHealthy: () => isHealthy() }
+}
 
 export const startAsyncOnEventHandlerConsumer = async ({
     hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
@@ -68,6 +103,17 @@ export const startAsyncWebhooksHandlerConsumer = async ({
     const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
 
     return { queue, isHealthy: () => isHealthy() }
+}
+
+// TODO: remove once we've migrated
+export const buildAsyncIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {
+    return new KafkaJSIngestionConsumer(
+        hub,
+        piscina,
+        KAFKA_EVENTS_JSON,
+        `${KAFKA_PREFIX}clickhouse-plugin-server-async`,
+        eachBatchAsyncHandlers
+    )
 }
 
 export const buildOnEventIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -26,6 +26,7 @@ import { startAnalyticsEventsIngestionOverflowConsumer } from './ingestion-queue
 import { startJobsConsumer } from './ingestion-queues/jobs-consumer'
 import { IngestionConsumer, KafkaJSIngestionConsumer } from './ingestion-queues/kafka-queue'
 import {
+    startAsyncHandlerConsumer,
     startAsyncOnEventHandlerConsumer,
     startAsyncWebhooksHandlerConsumer,
 } from './ingestion-queues/on-event-handler-consumer'
@@ -310,6 +311,21 @@ export async function startPluginsServer(
             })
         }
 
+        // TODO: remove once onevent and webhooks split is fully out
+        if (capabilities.processAsyncHandlers) {
+            ;[hub, closeHub] = hub ? [hub, closeHub] : await createHub(serverConfig, null, capabilities)
+            serverInstance = serverInstance ? serverInstance : { hub }
+
+            piscina = piscina ?? (await makePiscina(serverConfig, hub))
+            const { queue: onEventQueue, isHealthy: isOnEventsIngestionHealthy } = await startAsyncHandlerConsumer({
+                hub: hub,
+                piscina: piscina,
+            })
+
+            onEventHandlerConsumer = onEventQueue
+
+            healthChecks['on-event-ingestion'] = isOnEventsIngestionHealthy
+        }
         if (capabilities.processAsyncOnEventHandlers) {
             if (capabilities.processAsyncHandlers) {
                 throw Error('async and onEvent together are not allowed - would export twice')
@@ -328,7 +344,6 @@ export async function startPluginsServer(
 
             healthChecks['on-event-ingestion'] = isOnEventsIngestionHealthy
         }
-
         if (capabilities.processAsyncWebhooksHandlers) {
             if (capabilities.processAsyncHandlers) {
                 throw Error('async and webhooks together are not allowed - would send twice')
@@ -348,6 +363,7 @@ export async function startPluginsServer(
             healthChecks['webhooks-ingestion'] = isWebhooksIngestionHealthy
         }
 
+        // If we have
         if (hub && serverInstance) {
             pubSub = new PubSub(hub, {
                 [hub.PLUGINS_RELOAD_PUBSUB_CHANNEL]: async () => {

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType, PostIngestionEvent } from '../types'
+import { Action, EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType, PostIngestionEvent, Team } from '../types'
 import { convertToProcessedPluginEvent } from '../utils/event'
 import { EventPipelineRunner } from './ingestion/event-pipeline/runner'
 import { loadSchedule } from './plugins/loadSchedule'
@@ -42,6 +42,15 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     reloadSchedule: async (hub) => {
         await loadSchedule(hub)
+    },
+    reloadAllActions: async (hub) => {
+        return await hub.actionManager.reloadAllActions()
+    },
+    reloadAction: async (hub, args: { teamId: Team['id']; actionId: Action['id'] }) => {
+        return await hub.actionManager.reloadAction(args.teamId, args.actionId)
+    },
+    dropAction: (hub, args: { teamId: Team['id']; actionId: Action['id'] }) => {
+        return hub.actionManager.dropAction(args.teamId, args.actionId)
     },
     teardownPlugins: async (hub) => {
         await teardownPlugins(hub)


### PR DESCRIPTION
That wasn't meant to merge, not all tests were passing 🤔 

Reverts PostHog/posthog#16509