### PR TITLE
chore(plugin-server): we split onevent and webhooks consumers

### DIFF
--- a/plugin-server/functional_tests/exports-v2.test.ts
+++ b/plugin-server/functional_tests/exports-v2.test.ts
@@ -241,7 +241,7 @@ test.concurrent('consumer updates timestamp exported to prometheus', async () =>
     const metricBefore = await getMetric({
         name: 'latest_processed_timestamp_ms',
         type: 'GAUGE',
-        labels: { topic: 'clickhouse_events_json', partition: '0', groupId: 'async_handlers' },
+        labels: { topic: 'clickhouse_events_json', partition: '0', groupId: 'async_handlers_on_event' },
     })
 
     await capture({
@@ -260,7 +260,7 @@ test.concurrent('consumer updates timestamp exported to prometheus', async () =>
         const metricAfter = await getMetric({
             name: 'latest_processed_timestamp_ms',
             type: 'GAUGE',
-            labels: { topic: 'clickhouse_events_json', partition: '0', groupId: 'async_handlers' },
+            labels: { topic: 'clickhouse_events_json', partition: '0', groupId: 'async_handlers_on_event' },
         })
         expect(metricAfter).toBeGreaterThan(metricBefore)
         expect(metricAfter).toBeLessThan(Date.now()) // Make sure, e.g. we're not setting micro seconds

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -59,11 +59,6 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 sessionRecordingBlobIngestion: true,
                 ...sharedCapabilities,
             }
-        case PluginServerMode.plugins_exports:
-            return {
-                processAsyncHandlers: true,
-                ...sharedCapabilities,
-            }
         case PluginServerMode.async_onevent:
             return {
                 processAsyncOnEventHandlers: true,

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -16,7 +16,8 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 ingestionHistorical: true,
                 pluginScheduledTasks: true,
                 processPluginJobs: true,
-                processAsyncHandlers: true,
+                processAsyncOnEventHandlers: true,
+                processAsyncWebhooksHandlers: true,
                 sessionRecordingIngestion: true,
                 sessionRecordingBlobIngestion: true,
                 ...sharedCapabilities,
@@ -56,14 +57,6 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case PluginServerMode.recordings_blob_ingestion:
             return {
                 sessionRecordingBlobIngestion: true,
-                ...sharedCapabilities,
-            }
-
-        case PluginServerMode.plugins_async:
-            return {
-                processPluginJobs: true,
-                processAsyncHandlers: true,
-                pluginScheduledTasks: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.plugins_exports:

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -11,37 +11,6 @@ import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
-// TODO: remove once we've migrated
-export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaJSIngestionConsumer): Promise<void> {
-    const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
-    const event = convertToIngestionEvent(clickHouseEvent)
-
-    await Promise.all([
-        runInstrumentedFunction({
-            event: event,
-            func: () => queue.workerMethods.runAppsOnEventPipeline(event),
-            statsKey: `kafka_queue.process_async_handlers_on_event`,
-            timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
-            teamId: event.teamId,
-        }),
-        runInstrumentedFunction({
-            event: event,
-            func: () => runWebhooks(queue.pluginsServer, event),
-            statsKey: `kafka_queue.process_async_handlers_webhooks`,
-            timeoutMessage: 'After 30 seconds still running runWebhooksHandlersEventPipeline',
-            teamId: event.teamId,
-        }),
-    ])
-}
-
-// TODO: remove once we've migrated
-export async function eachBatchAsyncHandlers(
-    payload: EachBatchPayload,
-    queue: KafkaJSIngestionConsumer
-): Promise<void> {
-    await eachBatch(payload, queue, eachMessageAsyncHandlers, groupIntoBatches, 'async_handlers')
-}
-
 export async function eachMessageAppsOnEventHandlers(
     message: KafkaMessage,
     queue: KafkaJSIngestionConsumer

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -5,43 +5,8 @@ import { KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from '../../config/kafka-to
 import { Hub } from '../../types'
 import { status } from '../../utils/status'
 import Piscina from '../../worker/piscina'
-import {
-    eachBatchAppsOnEventHandlers,
-    eachBatchAsyncHandlers,
-    eachBatchWebhooksHandlers,
-} from './batch-processing/each-batch-async-handlers'
+import { eachBatchAppsOnEventHandlers, eachBatchWebhooksHandlers } from './batch-processing/each-batch-async-handlers'
 import { KafkaJSIngestionConsumer } from './kafka-queue'
-
-export const startAsyncHandlerConsumer = async ({
-    hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
-    piscina,
-}: {
-    hub: Hub
-    piscina: Piscina
-}) => {
-    /*
-        Consumes analytics events from the Kafka topic `clickhouse_events_json`
-        and processes any onEvent plugin handlers configured for the team. This
-        also includes `exportEvents` handlers defined in plugins as these are
-        also handled via modifying `onEvent` to call `exportEvents`.
-
-        At the moment this is just a wrapper around `IngestionConsumer`. We may
-        want to further remove that abstraction in the future.
-    */
-    status.info('🔁', `Starting async handler consumer`)
-
-    const queue = buildAsyncIngestionConsumer({ hub, piscina })
-
-    await queue.start()
-
-    schedule.scheduleJob('0 * * * * *', async () => {
-        await queue.emitConsumerGroupMetrics()
-    })
-
-    const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
-
-    return { queue, isHealthy: () => isHealthy() }
-}
 
 export const startAsyncOnEventHandlerConsumer = async ({
     hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
@@ -103,17 +68,6 @@ export const startAsyncWebhooksHandlerConsumer = async ({
     const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
 
     return { queue, isHealthy: () => isHealthy() }
-}
-
-// TODO: remove once we've migrated
-export const buildAsyncIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {
-    return new KafkaJSIngestionConsumer(
-        hub,
-        piscina,
-        KAFKA_EVENTS_JSON,
-        `${KAFKA_PREFIX}clickhouse-plugin-server-async`,
-        eachBatchAsyncHandlers
-    )
 }
 
 export const buildOnEventIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -78,7 +78,6 @@ export enum PluginServerMode {
     ingestion_historical = 'ingestion-historical',
     async_onevent = 'async-onevent',
     async_webhooks = 'async-webhooks',
-    plugins_exports = 'exports', // TODO: remove once onevent and webhooks split is out
     jobs = 'jobs',
     scheduler = 'scheduler',
     analytics_ingestion = 'analytics-ingestion',
@@ -266,7 +265,6 @@ export interface PluginServerCapabilities {
     ingestionHistorical?: boolean
     pluginScheduledTasks?: boolean
     processPluginJobs?: boolean
-    processAsyncHandlers?: boolean
     processAsyncOnEventHandlers?: boolean
     processAsyncWebhooksHandlers?: boolean
     sessionRecordingIngestion?: boolean

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -76,7 +76,6 @@ export enum PluginServerMode {
     ingestion = 'ingestion',
     ingestion_overflow = 'ingestion-overflow',
     ingestion_historical = 'ingestion-historical',
-    plugins_async = 'async',
     async_onevent = 'async-onevent',
     async_webhooks = 'async-webhooks',
     plugins_exports = 'exports', // TODO: remove once onevent and webhooks split is out

--- a/plugin-server/src/worker/ingestion/action-manager.ts
+++ b/plugin-server/src/worker/ingestion/action-manager.ts
@@ -68,7 +68,7 @@ export class ActionManager {
     }
 
     public dropAction(teamId: Team['id'], actionId: Action['id']): void {
-        if (!this.capabilities.processAsyncHandlers && !this.capabilities.processAsyncWebhooksHandlers) {
+        if (!this.capabilities.processAsyncWebhooksHandlers) {
             return
         }
 

--- a/plugin-server/src/worker/ingestion/action-manager.ts
+++ b/plugin-server/src/worker/ingestion/action-manager.ts
@@ -33,14 +33,14 @@ export class ActionManager {
     }
 
     public async reloadAllActions(): Promise<void> {
-        if (this.capabilities.processAsyncHandlers || this.capabilities.processAsyncWebhooksHandlers) {
+        if (this.capabilities.processAsyncWebhooksHandlers) {
             this.actionCache = await fetchAllActionsGroupedByTeam(this.postgres)
             status.info('🍿', 'Fetched all actions from DB anew')
         }
     }
 
     public async reloadAction(teamId: Team['id'], actionId: Action['id']): Promise<void> {
-        if (!this.capabilities.processAsyncHandlers && !this.capabilities.processAsyncWebhooksHandlers) {
+        if (!this.capabilities.processAsyncWebhooksHandlers) {
             return
         }
 

--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -141,7 +141,6 @@ export class ActionMatcher {
     public async match(event: PostIngestionEvent, elements?: Element[]): Promise<Action[]> {
         const matchingStart = new Date()
         const teamActions: Action[] = Object.values(this.actionManager.getTeamActions(event.teamId))
-        console.error(teamActions)
         if (!elements) {
             const rawElements: Record<string, any>[] | undefined = event.properties?.['$elements']
             elements = rawElements ? extractElements(rawElements) : []

--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -141,6 +141,7 @@ export class ActionMatcher {
     public async match(event: PostIngestionEvent, elements?: Element[]): Promise<Action[]> {
         const matchingStart = new Date()
         const teamActions: Action[] = Object.values(this.actionManager.getTeamActions(event.teamId))
+        console.error(teamActions)
         if (!elements) {
             const rawElements: Record<string, any>[] | undefined = event.properties?.['$elements']
             elements = rawElements ? extractElements(rawElements) : []

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { Action, EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType, PostIngestionEvent, Team } from '../types'
+import { EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType, PostIngestionEvent } from '../types'
 import { convertToProcessedPluginEvent } from '../utils/event'
 import { EventPipelineRunner } from './ingestion/event-pipeline/runner'
 import { loadSchedule } from './plugins/loadSchedule'
@@ -42,15 +42,6 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     reloadSchedule: async (hub) => {
         await loadSchedule(hub)
-    },
-    reloadAllActions: async (hub) => {
-        return await hub.actionManager.reloadAllActions()
-    },
-    reloadAction: async (hub, args: { teamId: Team['id']; actionId: Action['id'] }) => {
-        return await hub.actionManager.reloadAction(args.teamId, args.actionId)
-    },
-    dropAction: (hub, args: { teamId: Team['id']; actionId: Action['id'] }) => {
-        return hub.actionManager.dropAction(args.teamId, args.actionId)
     },
     teardownPlugins: async (hub) => {
         await teardownPlugins(hub)

--- a/plugin-server/src/worker/vm/capabilities.ts
+++ b/plugin-server/src/worker/vm/capabilities.ts
@@ -44,7 +44,7 @@ function shouldSetupPlugin(serverCapability: keyof PluginServerCapabilities, plu
     if (serverCapability === 'processPluginJobs') {
         return (pluginCapabilities.jobs || []).length > 0
     }
-    if (serverCapability === 'processAsyncHandlers' || serverCapability === 'processAsyncOnEventHandlers') {
+    if (serverCapability === 'processAsyncOnEventHandlers') {
         return pluginCapabilities.methods?.some((method) => ['onSnapshot', 'onEvent', 'exportEvents'].includes(method))
     }
 

--- a/plugin-server/tests/worker/capabilities.test.ts
+++ b/plugin-server/tests/worker/capabilities.test.ts
@@ -81,7 +81,7 @@ describe('capabilities', () => {
                 const shouldSetupPlugin = shouldSetupPluginInServer(
                     {
                         ingestion: true,
-                        processAsyncHandlers: true,
+                        processAsyncOnEventHandlers: true,
                         processPluginJobs: true,
                         pluginScheduledTasks: true,
                     },
@@ -140,20 +140,23 @@ describe('capabilities', () => {
             })
         })
 
-        describe('processAsyncHandlers', () => {
+        describe('processAsyncOnEventHandlers', () => {
             it.each(['onEvent', 'onSnapshot', 'exportEvents'])(
-                'returns true if plugin has %s and the server has processAsyncHandlers capability',
+                'returns true if plugin has %s and the server has processAsyncOnEventHandlers capability',
                 (method) => {
                     const shouldSetupPlugin = shouldSetupPluginInServer(
-                        { processAsyncHandlers: true },
+                        { processAsyncOnEventHandlers: true },
                         { methods: [method] }
                     )
                     expect(shouldSetupPlugin).toEqual(true)
                 }
             )
 
-            it('returns false if plugin has none of onEvent, onSnapshot, or exportEvents and the server has only processAsyncHandlers capability', () => {
-                const shouldSetupPlugin = shouldSetupPluginInServer({ processAsyncHandlers: true }, { methods: [] })
+            it('returns false if plugin has none of onEvent, onSnapshot, or exportEvents and the server has only processAsyncOnEventHandlers capability', () => {
+                const shouldSetupPlugin = shouldSetupPluginInServer(
+                    { processAsyncOnEventHandlers: true },
+                    { methods: [] }
+                )
                 expect(shouldSetupPlugin).toEqual(false)
             })
 


### PR DESCRIPTION
This is a revert of a revert, as the auto-merge prematurely merged the original PR in! 

We don't need the async handler consumer now, as this is split into onevent and webhooks now.

Reverts PostHog/posthog#16510