### PR TITLE
fix(insights): prevent menu close for hogql custom option

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -69,6 +69,7 @@ export interface LemonMenuProps
             | 'maxContentWidth'
             | 'visible'
             | 'onVisibilityChange'
+            | 'closeOnClickInside'
             | 'closeParentPopoverOnClickInside'
             | 'className'
         >,
@@ -233,7 +234,10 @@ interface LemonMenuItemButtonProps {
 
 const LemonMenuItemButton: FunctionComponent<LemonMenuItemButtonProps & React.RefAttributes<HTMLButtonElement>> =
     React.forwardRef(
-        ({ item: { label, items, keyboardShortcut, ...buttonProps }, size, tooltipPlacement }, ref): JSX.Element => {
+        (
+            { item: { label, items, keyboardShortcut, custom, ...buttonProps }, size, tooltipPlacement },
+            ref
+        ): JSX.Element => {
             const Label = typeof label === 'function' ? label : null
             const button = Label ? (
                 <Label key="x" />
@@ -263,7 +267,8 @@ const LemonMenuItemButton: FunctionComponent<LemonMenuItemButtonProps & React.Re
                     tooltipPlacement={tooltipPlacement}
                     placement="right-start"
                     actionable
-                    closeParentPopoverOnClickInside
+                    closeOnClickInside={custom ? false : true}
+                    closeParentPopoverOnClickInside={custom ? false : true}
                 >
                     {button}
                 </LemonMenu>

--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -18,6 +18,8 @@ export interface LemonMenuItemBase
         'icon' | 'sideIcon' | 'disabledReason' | 'tooltip' | 'active' | 'status' | 'data-attr'
     > {
     label: string | JSX.Element
+    /** True if the item is a custom element. */
+    custom?: boolean
 }
 export interface LemonMenuItemNode extends LemonMenuItemBase {
     items: (LemonMenuItemLeaf | false | null)[]
@@ -48,6 +50,8 @@ export interface LemonMenuItemCustom {
     active?: never
     items?: never
     keyboardShortcut?: never
+    /** True if the item is a custom element. */
+    custom?: boolean
 }
 export type LemonMenuItem = LemonMenuItemLeaf | LemonMenuItemCustom | LemonMenuItemNode
 

--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -212,6 +212,7 @@ function convertToMenuSingle<T>(
             ...node,
             active: doOptionsContainActiveValue(childOptions, activeValue),
             items,
+            custom: doOptionsContainCustomControl(childOptions),
         } as LemonMenuItemNode
     } else {
         acc.push(option)
@@ -259,6 +260,19 @@ function doOptionsContainActiveValue<T>(options: LemonSelectOptions<T>, activeVa
                 return true
             }
         } else if (option.value === activeValue) {
+            return true
+        }
+    }
+    return false
+}
+
+function doOptionsContainCustomControl<T>(options: LemonSelectOptions<T>): boolean {
+    for (const option of options) {
+        if ('options' in option) {
+            if (doOptionsContainCustomControl(option.options)) {
+                return true
+            }
+        } else if (typeof option.labelInMenu === 'function') {
             return true
         }
     }


### PR DESCRIPTION
## Problem

The aggregation select for HogQL doesn't work as the menu immediately closes on any click.

## Changes

@Twixes suggested to not close the menu for any custom option, since they likely are always going to be similar to this case, so that's what's implemented here.

UX wise it might make sense to close the menu when a valid HogQL option was selected (unsure as one might want to continue editing 🤔 ). This doesn't seem straight-forward though and since this fixes the original issue I'd like to move forward.

## How did you test this code?

Tested the aggregation select and other selects with custom options e.g. and/or filter.