### PR TITLE
fix: Bump max_execution_time in batch exports

### DIFF
--- a/posthog/temporal/workflows/clickhouse.py
+++ b/posthog/temporal/workflows/clickhouse.py
@@ -45,6 +45,8 @@ async def get_client():
                 user=settings.CLICKHOUSE_USER,
                 password=settings.CLICKHOUSE_PASSWORD,
                 database=settings.CLICKHOUSE_DATABASE,
+                # TODO: make this a setting.
+                max_execution_time=1200,
             )
             yield client
             await client.close()

--- a/posthog/temporal/workflows/clickhouse.py
+++ b/posthog/temporal/workflows/clickhouse.py
@@ -46,7 +46,7 @@ async def get_client():
                 password=settings.CLICKHOUSE_PASSWORD,
                 database=settings.CLICKHOUSE_DATABASE,
                 # TODO: make this a setting.
-                max_execution_time=1200,
+                max_execution_time=0,
             )
             yield client
             await client.close()


### PR DESCRIPTION
## Problem

We are going to the offline cluster, so let's be more generous with our `max_execution_time`.

TODO: make it a setting.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
