### PR TITLE
fix(dashboards): always override insight with dashboard dates

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -842,7 +842,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         response = self.dashboard_api.get_dashboard(dashboard.pk)
         self.assertEqual(
             response["tiles"][0]["insight"]["filters"],
-            {"events": [{"id": "$pageview"}], "insight": "TRENDS", "date_from": "-7d"},
+            {"events": [{"id": "$pageview"}], "insight": "TRENDS", "date_from": "-7d", "date_to": None},
         )
 
     def test_retrieve_dashboard_different_team(self):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -259,29 +259,6 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         self.assertNotEqual(insight_in_isolation["filters_hash"], insight_on_dashboard["filters_hash"])
 
-    def test_get_insight_in_dashboard_context_date_filters(self) -> None:
-        dashboard_id, _ = self.dashboard_api.create_dashboard(
-            {"filters": {"date_from": "-7d"}, "name": "the dashboard"}
-        )
-
-        insight_id, _ = self.dashboard_api.create_insight(
-            {
-                "filters": {"date_from": "2023-06-17", "date_to": "2023-06-25"},
-                "name": "insight",
-                "dashboards": [dashboard_id],
-            }
-        )
-
-        insight_filters_in_isolation = self.dashboard_api.get_insight(insight_id).get("filters")
-        self.assertEqual(insight_filters_in_isolation.get("date_to"), "2023-06-25")
-        self.assertEqual(insight_filters_in_isolation.get("date_from"), "2023-06-17")
-
-        insight_filters_on_dashboard = self.dashboard_api.get_insight(
-            insight_id, query_params={"from_dashboard": dashboard_id}
-        ).get("filters")
-        self.assertEqual(insight_filters_on_dashboard.get("date_to"), None)
-        self.assertEqual(insight_filters_on_dashboard.get("date_from"), "-7d")
-
     def test_get_insight_by_short_id(self) -> None:
         filter_dict = {"events": [{"id": "$pageview"}]}
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -259,6 +259,29 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         self.assertNotEqual(insight_in_isolation["filters_hash"], insight_on_dashboard["filters_hash"])
 
+    def test_get_insight_in_dashboard_context_date_filters(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard(
+            {"filters": {"date_from": "-7d"}, "name": "the dashboard"}
+        )
+
+        insight_id, _ = self.dashboard_api.create_insight(
+            {
+                "filters": {"date_from": "2023-06-17", "date_to": "2023-06-25"},
+                "name": "insight",
+                "dashboards": [dashboard_id],
+            }
+        )
+
+        insight_filters_in_isolation = self.dashboard_api.get_insight(insight_id).get("filters")
+        self.assertEqual(insight_filters_in_isolation.get("date_to"), "2023-06-25")
+        self.assertEqual(insight_filters_in_isolation.get("date_from"), "2023-06-17")
+
+        insight_filters_on_dashboard = self.dashboard_api.get_insight(
+            insight_id, query_params={"from_dashboard": dashboard_id}
+        ).get("filters")
+        self.assertEqual(insight_filters_on_dashboard.get("date_to"), None)
+        self.assertEqual(insight_filters_on_dashboard.get("date_from"), "-7d")
+
     def test_get_insight_by_short_id(self) -> None:
         filter_dict = {"events": [{"id": "$pageview"}]}
 

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -103,15 +103,22 @@ class Insight(models.Model):
         if dashboard and not self.query:
             dashboard_filters = {**dashboard.filters}
             dashboard_properties = dashboard_filters.pop("properties") if dashboard_filters.get("properties") else None
+            insight_date_from = self.filters.get("date_from", None)
+            insight_date_to = self.filters.get("date_to", None)
             dashboard_date_from = dashboard_filters.get("date_from", None)
             dashboard_date_to = dashboard_filters.get("date_to", None)
 
             filters = {
                 **self.filters,
                 **dashboard_filters,
-                "date_from": dashboard_date_from,
-                "date_to": dashboard_date_to,
             }
+
+            if dashboard_date_from is None:
+                filters["date_from"] = insight_date_from
+                filters["date_to"] = insight_date_to
+            else:
+                filters["date_from"] = dashboard_date_from
+                filters["date_to"] = dashboard_date_to
 
             if dashboard_date_from == "all" and filters.get("compare", None) is True:
                 filters["compare"] = None

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -103,20 +103,15 @@ class Insight(models.Model):
         if dashboard and not self.query:
             dashboard_filters = {**dashboard.filters}
             dashboard_properties = dashboard_filters.pop("properties") if dashboard_filters.get("properties") else None
-
-            insight_date_from = self.filters.get("date_from", None)
-            insight_date_to = self.filters.get("date_to", None)
             dashboard_date_from = dashboard_filters.get("date_from", None)
             dashboard_date_to = dashboard_filters.get("date_to", None)
 
             filters = {
                 **self.filters,
                 **dashboard_filters,
-                "date_from": dashboard_date_from or insight_date_from,
+                "date_from": dashboard_date_from,
+                "date_to": dashboard_date_to,
             }
-
-            if dashboard_date_to or insight_date_to:
-                filters["date_to"] = dashboard_date_to or insight_date_to
 
             if dashboard_date_from == "all" and filters.get("compare", None) is True:
                 filters["compare"] = None

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -32,6 +32,8 @@ class TestInsightModel(BaseTest):
         )
 
         assert filters_with_no_dashboard["date_from"] == "-30d"
+        assert filters_with_dashboard_with_no_date_from["date_to"] is None  # can be ignored if None
+        del filters_with_dashboard_with_no_date_from["date_to"]
         assert filters_with_no_dashboard == filters_with_dashboard_with_no_date_from
 
     def test_dashboard_with_date_from_filters_does_override_date_from(self) -> None:
@@ -42,6 +44,16 @@ class TestInsightModel(BaseTest):
         )
 
         assert filters_with_dashboard_with_different_date_from["date_from"] == "-14d"
+
+    def test_dashboard_with_date_from_filters_does_override_date_to(self) -> None:
+        insight = Insight.objects.create(team=self.team, filters={"date_from": "2023-06-17", "date_to": "2023-06-25"})
+
+        filters_with_dashboard_with_different_date_from = insight.dashboard_filters(
+            dashboard=(Dashboard.objects.create(team=self.team, filters={"date_from": "-14d"}))
+        )
+
+        assert filters_with_dashboard_with_different_date_from["date_from"] == "-14d"
+        assert filters_with_dashboard_with_different_date_from["date_to"] is None
 
     def test_dashboard_with_same_date_from_filters_generates_expected_date_from(self) -> None:
         insight = Insight.objects.create(team=self.team, filters={"date_from": "-30d"})


### PR DESCRIPTION
## Problem

See https://posthoghelp.zendesk.com/agent/tickets/3850 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/6749)

## Changes

This PR changes dashboards to always overwrite the date filters, also if they are `None`.

## How did you test this code?

Tried an example locally and added a regression test.