### PR TITLE
chore: better buckets for kafka batch size

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -78,7 +78,7 @@ const gaugeOffsetCommitFailed = new Gauge({
 const histogramKafkaBatchSize = new Histogram({
     name: 'recording_blob_ingestion_kafka_batch_size',
     help: 'The size of the batches we are receiving from Kafka',
-    buckets: [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, Infinity],
+    buckets: [0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, Infinity],
 })
 
 const counterKafkaMessageReceived = new Counter({


### PR DESCRIPTION
the kafka batch size doesn't vary much, have better buckets