### PR TITLE
fix(experiments): Remove refresh from experiment last computation

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -1,18 +1,15 @@
 import { useActions, useValues } from 'kea'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 import { Link } from '@posthog/lemon-ui'
 
-export function ComputationTimeWithRefresh(): JSX.Element | null {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const showRefreshOnInsight = !!featureFlags[FEATURE_FLAGS.REFRESH_BUTTON_ON_INSIGHT]
+export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?: boolean }): JSX.Element | null {
+    const showRefreshOnInsight = !disableRefresh
 
     const { lastRefresh } = useValues(dataNodeLogic)
 

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -51,6 +51,7 @@ export function InsightContainer({
     disableTable,
     disableCorrelationTable,
     disableLastComputation,
+    disableLastComputationRefresh,
     disableLegendButton,
     insightMode,
     context,
@@ -59,6 +60,7 @@ export function InsightContainer({
     disableTable?: boolean
     disableCorrelationTable?: boolean
     disableLastComputation?: boolean
+    disableLastComputationRefresh?: boolean
     disableLegendButton?: boolean
     insightMode?: ItemMode
     context?: QueryContext
@@ -213,7 +215,9 @@ export function InsightContainer({
                         {/*Don't add more than two columns in this row.*/}
                         {(!disableLastComputation || !!samplingFactor) && (
                             <div className="flex items-center">
-                                {!disableLastComputation && <ComputationTimeWithRefresh />}
+                                {!disableLastComputation && (
+                                    <ComputationTimeWithRefresh disableRefresh={disableLastComputationRefresh} />
+                                )}
                                 {!!samplingFactor ? (
                                     <span className="text-muted-alt">
                                         {!disableLastComputation && <span className="mx-1">•</span>}

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -7,6 +7,8 @@ import { isFunnelsQuery } from '~/queries/utils'
 
 import { dataNodeLogic, DataNodeLogicProps } from '../DataNode/dataNodeLogic'
 import { InsightQueryNode, InsightVizNode, QueryContext } from '../../schema'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { InsightContainer } from './InsightContainer'
 import { EditorFilters } from './EditorFilters'
@@ -39,6 +41,7 @@ export function InsightViz({ query, setQuery, context, readOnly }: InsightVizPro
     }
 
     const { insightMode } = useValues(insightSceneLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const isFunnels = isFunnelsQuery(query.source)
 
@@ -52,6 +55,11 @@ export function InsightViz({ query, setQuery, context, readOnly }: InsightVizPro
     const disableCorrelationTable = query.showCorrelationTable ? !query.showCorrelationTable : !showIfFull
     const disableLastComputation = query.showLastComputation ? !query.showLastComputation : !showIfFull
     const disableLegendButton = query.showLegendButton ? !query.showLegendButton : !showIfFull
+
+    const disableLastComputationRefresh =
+        query.showLastComputationRefresh !== undefined
+            ? !query.showLastComputationRefresh
+            : !featureFlags[FEATURE_FLAGS.REFRESH_BUTTON_ON_INSIGHT]
 
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
@@ -77,6 +85,7 @@ export function InsightViz({ query, setQuery, context, readOnly }: InsightVizPro
                             disableTable={disableTable}
                             disableCorrelationTable={disableCorrelationTable}
                             disableLastComputation={disableLastComputation}
+                            disableLastComputationRefresh={disableLastComputationRefresh}
                             disableLegendButton={disableLegendButton}
                         />
                     </div>

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1274,6 +1274,9 @@
                 "showLastComputation": {
                     "type": "boolean"
                 },
+                "showLastComputationRefresh": {
+                    "type": "boolean"
+                },
                 "showLegendButton": {
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -331,6 +331,7 @@ export interface InsightVizNode extends Node {
     showTable?: boolean
     showCorrelationTable?: boolean
     showLastComputation?: boolean
+    showLastComputationRefresh?: boolean
     showLegendButton?: boolean
 }
 

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1010,6 +1010,7 @@ export function Experiment(): JSX.Element {
                                         showTable: true,
                                         showLegendButton: false,
                                         showLastComputation: true,
+                                        showLastComputationRefresh: false,
                                     }}
                                     context={{
                                         insightProps: {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1145,6 +1145,7 @@ class InsightVizNode(BaseModel):
     showCorrelationTable: Optional[bool] = None
     showHeader: Optional[bool] = None
     showLastComputation: Optional[bool] = None
+    showLastComputationRefresh: Optional[bool] = None
     showLegendButton: Optional[bool] = None
     showTable: Optional[bool] = None
     source: Union[TrendsQuery, FunnelsQuery, RetentionQuery, PathsQuery, StickinessQuery, LifecycleQuery]


### PR DESCRIPTION
## Problem

We don't want the insight refresh button inline on experiments. It has its own logic to refresh insights (after using the appropriate filters).

This PR makes the refresh option in `ComputationTimeWithRefresh` optional.

I moved the flag to the top level as well, which should make the code less confusing with this additional option

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Run locally, see refresh show up on insights, but not on experiments.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
