### PR TITLE
chore: Remove forum option from app

### DIFF
--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -7,7 +7,6 @@ import {
     IconArrowDropDown,
     IconArticle,
     IconHelpOutline,
-    IconQuestionAnswer,
     IconMessages,
     IconFlare,
     IconLive,
@@ -117,16 +116,6 @@ export function HelpButton({
                     },
                     showSupportOptions && {
                         items: [
-                            {
-                                label: 'Ask on the forum',
-                                icon: <IconQuestionAnswer />,
-                                onClick: () => {
-                                    reportHelpButtonUsed(HelpType.Slack)
-                                    hideHelp()
-                                },
-                                to: `https://posthog.com/questions${HELP_UTM_TAGS}`,
-                                targetBlank: true,
-                            },
                             {
                                 label: 'Report a bug',
                                 icon: <IconBugReport />,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Users are getting confused, if they are in the app already we really want them to use the in-app zendesk ticket creation option, so we get all the links and we can ask / share private info.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
