### PR TITLE
feat: Use aiochclient speedups

### DIFF
--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -1,6 +1,6 @@
 # name: TestCohort.test_async_deletion_of_cohort
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -10,7 +10,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.1
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -114,7 +114,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.2
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -124,7 +124,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.3
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2
@@ -134,7 +134,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.4
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -144,7 +144,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.5
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -178,7 +178,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.6
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -188,7 +188,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.7
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:103 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 # - `pip-compile --rebuild requirements.in`
 # - `pip-compile --rebuild requirements-dev.in`
 #
-aiochclient[aiohttp]>=2.4.0
+aiochclient[aiohttp-speedups]>=2.4.0
 antlr4-python3-runtime==4.13.0
 amqp==2.6.0
 boto3==1.26.66

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,10 @@
 #
 #    pip-compile requirements.in
 #
-aiochclient[aiohttp]==2.4.0
+aiochclient[aiohttp-speedups]==2.4.0
     # via -r requirements.in
+aiodns==3.0.0
+    # via aiochclient
 aiohttp==3.8.4
     # via
     #   aiochclient
@@ -53,6 +55,8 @@ botocore==1.29.66
     #   s3transfer
 botocore-stubs==1.29.130
     # via boto3-stubs
+cchardet==2.1.7
+    # via aiochclient
 celery==4.4.7
     # via
     #   -r requirements.in
@@ -68,6 +72,7 @@ certifi==2019.11.28
 cffi==1.14.5
     # via
     #   cryptography
+    #   pycares
     #   snowflake-connector-python
 chardet==5.1.0
     # via prance
@@ -76,6 +81,8 @@ charset-normalizer==2.1.0
     #   aiohttp
     #   requests
     #   snowflake-connector-python
+ciso8601==2.3.0
+    # via aiochclient
 clickhouse-driver==0.2.4
     # via
     #   -r requirements.in
@@ -285,6 +292,8 @@ psycopg2-binary==2.8.6
     # via -r requirements.in
 ptyprocess==0.6.0
     # via pexpect
+pycares==4.3.0
+    # via aiodns
 pycparser==2.20
     # via cffi
 pycryptodomex==3.18.0


### PR DESCRIPTION
## Problem

Relatively light weight speedups can hopefully help when parsing query results. Using Cython and uvloop is recommended to gain more speed, but those are heavier dependencies, so let's go in steps.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Install `aiochclient` with `[aiohttp-speedups]`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
