### PR TITLE
feat: Add list nodes for timestamped comments

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -92,6 +92,8 @@ export function NodeWrapper({
                                     'font-semibold': selected,
                                 }
                             )}
+                            contentEditable={false}
+                            draggable={true}
                             data-drag-handle
                         >
                             <div className="shrink-0">

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -1,5 +1,5 @@
 import { mergeAttributes, Node, NodeViewProps } from '@tiptap/core'
-import { ReactNodeViewRenderer } from '@tiptap/react'
+import { NodeViewContent, ReactNodeViewRenderer } from '@tiptap/react'
 import {
     SessionRecordingPlayer,
     SessionRecordingPlayerProps,
@@ -30,6 +30,7 @@ const Component = (props: NodeViewProps): JSX.Element => {
             <div style={{ height: HEIGHT }}>
                 <SessionRecordingPlayer {...recordingLogicProps} />
             </div>
+            <NodeViewContent />
         </NodeWrapper>
     )
 }
@@ -39,6 +40,7 @@ export const NotebookNodeRecording = Node.create({
     group: 'block',
     atom: true,
     draggable: true,
+    content: 'inline*',
 
     addAttributes() {
         return {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -77,6 +77,20 @@ export const NotebookNodeRecording = Node.create({
                 getAttributes: (match) => {
                     return { id: match[1] }
                 },
+                getDeafultContent: (attrs) => {
+                    return [
+                        {
+                            type: NotebookNodeType.TimestampList,
+                            content: [
+                                {
+                                    type: NotebookNodeType.TimestampItem,
+                                    attrs: { sessionRecordingId: attrs.id },
+                                    content: [{ type: 'paragraph' }],
+                                },
+                            ],
+                        },
+                    ]
+                },
             }),
         ]
     },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -27,10 +27,12 @@ const Component = (props: NodeViewProps): JSX.Element => {
             href={urls.replaySingle(recordingLogicProps.sessionRecordingId)}
             heightEstimate={HEIGHT}
         >
-            <div style={{ height: HEIGHT }}>
-                <SessionRecordingPlayer {...recordingLogicProps} />
+            <div className="space-y-2">
+                <div style={{ height: HEIGHT }} contentEditable={false}>
+                    <SessionRecordingPlayer {...recordingLogicProps} />
+                </div>
+                <NodeViewContent />
             </div>
-            <NodeViewContent />
         </NodeWrapper>
     )
 }
@@ -40,7 +42,8 @@ export const NotebookNodeRecording = Node.create({
     group: 'block',
     atom: true,
     draggable: true,
-    content: 'inline*',
+    content: NotebookNodeType.TimestampList,
+    isolating: true,
 
     addAttributes() {
         return {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampItem.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampItem.tsx
@@ -37,7 +37,7 @@ const Component = (props: NodeViewProps): JSX.Element => {
     return (
         <NodeViewWrapper>
             <li data-type={props.node.type.name} className="flex space-x-2">
-                <span>{formatTimestamp(timestamp || currentTimestamp)}</span>
+                <span className="text-muted">{formatTimestamp(timestamp || currentTimestamp)}</span>
                 <NodeViewContent />
             </li>
         </NodeViewWrapper>

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampItem.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampItem.tsx
@@ -1,0 +1,85 @@
+import { mergeAttributes, Node, NodeViewProps, wrappingInputRule } from '@tiptap/pm/commands'
+import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import { dayjs } from 'lib/dayjs'
+import { useValues } from 'kea'
+import {
+    sessionRecordingPlayerLogic,
+    SessionRecordingPlayerLogicProps,
+} from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+import { NotebookNodeType } from '~/types'
+
+const Component = (props: NodeViewProps): JSX.Element => {
+    const timestamp = props.node.attrs.timestamp
+
+    const id = 'TODO: get recording id from parent node'
+    const recordingLogicProps: SessionRecordingPlayerLogicProps = {
+        sessionRecordingId: id,
+        playerKey: `notebook-${id}`,
+    }
+
+    const { currentTimestamp } = useValues(sessionRecordingPlayerLogic(recordingLogicProps))
+
+    // const resetTimestamp = (): void => {
+    //     props.updateAttributes({ timestamp: null })
+    // }
+
+    // const setTimestamp = (): void => {
+    //     props.updateAttributes({ timestamp: currentTimestamp })
+    // }
+
+    return (
+        <NodeViewWrapper>
+            <li data-type={props.node.type.name} className="flex space-x-2">
+                <span>{formatTimestamp(timestamp || currentTimestamp)}</span>
+                <NodeViewContent />
+            </li>
+        </NodeViewWrapper>
+    )
+}
+
+function formatTimestamp(timestamp: number | undefined): string {
+    return dayjs
+        .duration(timestamp || 0, 'milliseconds')
+        .format('HH:mm:ss')
+        .replace(/^00:/, '')
+        .trim()
+}
+
+export const NotebookNodeTimestampItem = Node.create({
+    name: NotebookNodeType.TimestampItem,
+    defining: true,
+    content: 'paragraph+',
+
+    addAttributes() {
+        return {
+            timestamp: { default: null },
+        }
+    },
+
+    parseHTML() {
+        return [{ tag: `li[data-type="${this.name}"]` }]
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ['li', mergeAttributes(HTMLAttributes, { 'data-type': this.name })]
+    },
+
+    addKeyboardShortcuts() {
+        return {
+            Enter: () => this.editor.commands.splitListItem(this.name),
+        }
+    },
+
+    addNodeView() {
+        return ReactNodeViewRenderer(Component)
+    },
+
+    addInputRules() {
+        return [
+            wrappingInputRule({
+                find: /^\s*(\[([( |x])?\])\s$/,
+                type: this.type,
+            }),
+        ]
+    },
+})

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampItem.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampItem.tsx
@@ -1,5 +1,12 @@
-import { mergeAttributes, Node, NodeViewProps, wrappingInputRule } from '@tiptap/pm/commands'
-import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import {
+    Node,
+    NodeViewContent,
+    NodeViewProps,
+    NodeViewWrapper,
+    ReactNodeViewRenderer,
+    mergeAttributes,
+    wrappingInputRule,
+} from '@tiptap/react'
 import { dayjs } from 'lib/dayjs'
 import { useValues } from 'kea'
 import {
@@ -47,21 +54,21 @@ function formatTimestamp(timestamp: number | undefined): string {
 
 export const NotebookNodeTimestampItem = Node.create({
     name: NotebookNodeType.TimestampItem,
-    defining: true,
     content: 'paragraph+',
+    defining: true,
 
     addAttributes() {
         return {
-            timestamp: { default: null },
+            timestamp: { default: null, keepOnSplit: false },
         }
     },
 
     parseHTML() {
-        return [{ tag: `li[data-type="${this.name}"]` }]
+        return [{ tag: `li[data-type="${this.name}"]`, priority: 51 }]
     },
 
     renderHTML({ HTMLAttributes }) {
-        return ['li', mergeAttributes(HTMLAttributes, { 'data-type': this.name })]
+        return ['li', mergeAttributes(HTMLAttributes, { 'data-type': this.name }), 0]
     },
 
     addKeyboardShortcuts() {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampList.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampList.tsx
@@ -1,31 +1,26 @@
-import { mergeAttributes, Node, NodeViewProps } from '@tiptap/core'
-import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import { mergeAttributes, Node } from '@tiptap/core'
 import { NotebookNodeType } from '~/types'
-
-const Component = (props: NodeViewProps): JSX.Element => {
-    return (
-        <NodeViewWrapper>
-            <ul data-type={props.node.type.name}>
-                <NodeViewContent />
-            </ul>
-        </NodeViewWrapper>
-    )
-}
 
 export const NotebookNodeTimestampList = Node.create({
     name: NotebookNodeType.TimestampList,
-    group: 'block',
-    content: `${NotebookNodeType.TimestampItem}+`,
+    group: 'block list',
+
+    addOptions() {
+        return {
+            itemTypeName: NotebookNodeType.TimestampItem,
+            HTMLAttributes: {},
+        }
+    },
+
+    content() {
+        return `${this.options.itemTypeName}+`
+    },
 
     parseHTML() {
-        return [{ tag: `ul[data-type="${this.name}"]` }]
+        return [{ tag: `ul[data-type="${this.name}"]`, priority: 51 }]
     },
 
     renderHTML({ HTMLAttributes }) {
-        return ['ul', mergeAttributes(HTMLAttributes, { 'data-type': this.name })]
-    },
-
-    addNodeView() {
-        return ReactNodeViewRenderer(Component)
+        return ['ul', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { 'data-type': this.name }), 0]
     },
 })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampList.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeTimestampList.tsx
@@ -1,0 +1,31 @@
+import { mergeAttributes, Node, NodeViewProps } from '@tiptap/core'
+import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import { NotebookNodeType } from '~/types'
+
+const Component = (props: NodeViewProps): JSX.Element => {
+    return (
+        <NodeViewWrapper>
+            <ul data-type={props.node.type.name}>
+                <NodeViewContent />
+            </ul>
+        </NodeViewWrapper>
+    )
+}
+
+export const NotebookNodeTimestampList = Node.create({
+    name: NotebookNodeType.TimestampList,
+    group: 'block',
+    content: `${NotebookNodeType.TimestampItem}+`,
+
+    parseHTML() {
+        return [{ tag: `ul[data-type="${this.name}"]` }]
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ['ul', mergeAttributes(HTMLAttributes, { 'data-type': this.name })]
+    },
+
+    addNodeView() {
+        return ReactNodeViewRenderer(Component)
+    },
+})

--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -35,7 +35,7 @@ export function posthogNodePasteRule(options: {
     find: string
     type: NodeType
     getAttributes: (match: ExtendedRegExpMatchArray) => Record<string, any>
-    getDeafultContent: (attrs: Record<string, any>) => JSONContent['content']
+    getDeafultContent?: (attrs: Record<string, any>) => JSONContent['content']
 }): PasteRule {
     return nodePasteRule({
         find: createUrlRegex(options.find),
@@ -45,7 +45,11 @@ export function posthogNodePasteRule(options: {
             posthog.capture('notebook node pasted', { node_type: options.type.name })
             return attrs
         },
-        getDeafultContent: (attrs) => options.getDeafultContent(attrs),
+        getDeafultContent: (attrs) => {
+            if (options.getDeafultContent) {
+                return options.getDeafultContent(attrs)
+            }
+        },
     })
 }
 

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -143,7 +143,6 @@ export function Editor({
             })
         },
         onUpdate: onUpdate,
-        onDestroy: () => {},
     })
 
     return (

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -18,6 +18,8 @@ import { NotebookNodeLink } from '../Nodes/NotebookNodeLink'
 import posthog from 'posthog-js'
 import { FloatingSlashCommands, SlashCommandsExtension } from './SlashCommands'
 import { JSONContent, NotebookEditor } from './utils'
+import { NotebookNodeTimestampList } from '../Nodes/NotebookNodeTimestampList'
+import { NotebookNodeTimestampItem } from '../Nodes/NotebookNodeTimestampItem'
 
 const CustomDocument = ExtensionDocument.extend({
     content: 'heading block*',
@@ -64,7 +66,8 @@ export function Editor({
                 },
             }),
             NotebookNodeLink,
-
+            NotebookNodeTimestampList,
+            NotebookNodeTimestampItem,
             NotebookNodeInsight,
             NotebookNodeQuery,
             NotebookNodeRecording,

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -45,6 +45,10 @@
             list-style: initial;
         }
 
+        ul li[data-type='phTimestampItem'] p {
+            margin-bottom: 0;
+        }
+
         > pre {
             background-color: rgba(0, 0, 0, 0.05);
             border-radius: var(--radius);

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -49,6 +49,14 @@
             margin-bottom: 0;
         }
 
+        ul li[data-type='phTimestampItem'].empty::after {
+            color: #adb5bd;
+            content: 'Add a comment...';
+            float: left;
+            height: 0;
+            pointer-events: none;
+        }
+
         > pre {
             background-color: rgba(0, 0, 0, 0.05);
             border-radius: var(--radius);
@@ -82,6 +90,27 @@
     // antd makes it invisible otherwise
     span::selection {
         color: var(--primary);
+    }
+
+    [contenteditable='false']::selection {
+        color: inherit;
+        background: transparent;
+    }
+
+    [contenteditable='false'] {
+        span::selection {
+            color: inherit;
+            background: transparent;
+        }
+    }
+
+    .NotebookNode--selected {
+        // overriding ::selection is necessary here because
+        // antd makes it invisible otherwise
+        span::selection,
+        p::selection {
+            color: inherit;
+        }
     }
 }
 

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -12,8 +12,6 @@ import { SCRATCHPAD_NOTEBOOK } from './notebooksListLogic'
 import { NotebookConflictWarning } from './NotebookConflictWarning'
 import { NotebookLoadingState } from './NotebookLoadingState'
 import { Editor } from './Editor'
-import { LemonButton } from '@posthog/lemon-ui'
-import { NotebookNodeType } from '~/types'
 
 export type NotebookProps = {
     shortId: string
@@ -62,31 +60,6 @@ export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Elem
 
     return (
         <BindLogic logic={notebookLogic} props={{ shortId }}>
-            <LemonButton
-                onClick={() => {
-                    editor?.setContent([
-                        {
-                            type: 'ph-recording',
-                            attrs: {
-                                id: '1894ad0c17d11ba930-0f0f8f5e6e66cd-1b525634-1fa400-1894ad0c17d11ba930',
-                            },
-                            content: [
-                                {
-                                    type: NotebookNodeType.TimestampList,
-                                    content: [
-                                        {
-                                            type: NotebookNodeType.TimestampItem,
-                                            content: [{ type: 'paragraph' }],
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    ])
-                }}
-            >
-                Reset content
-            </LemonButton>
             <div className={clsx('Notebook', !isExpanded && 'Notebook--compact')}>
                 {notebook.is_template && (
                     <LemonBanner

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -12,6 +12,8 @@ import { SCRATCHPAD_NOTEBOOK } from './notebooksListLogic'
 import { NotebookConflictWarning } from './NotebookConflictWarning'
 import { NotebookLoadingState } from './NotebookLoadingState'
 import { Editor } from './Editor'
+import { LemonButton } from '@posthog/lemon-ui'
+import { NotebookNodeType } from '~/types'
 
 export type NotebookProps = {
     shortId: string
@@ -60,6 +62,31 @@ export function Notebook({ shortId, editable = false }: NotebookProps): JSX.Elem
 
     return (
         <BindLogic logic={notebookLogic} props={{ shortId }}>
+            <LemonButton
+                onClick={() => {
+                    editor?.setContent([
+                        {
+                            type: 'ph-recording',
+                            attrs: {
+                                id: '1894ad0c17d11ba930-0f0f8f5e6e66cd-1b525634-1fa400-1894ad0c17d11ba930',
+                            },
+                            content: [
+                                {
+                                    type: NotebookNodeType.TimestampList,
+                                    content: [
+                                        {
+                                            type: NotebookNodeType.TimestampItem,
+                                            content: [{ type: 'paragraph' }],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ])
+                }}
+            >
+                Reset content
+            </LemonButton>
             <div className={clsx('Notebook', !isExpanded && 'Notebook--compact')}>
                 {notebook.is_template && (
                     <LemonBanner

--- a/frontend/src/scenes/notebooks/Notebook/utils.ts
+++ b/frontend/src/scenes/notebooks/Notebook/utils.ts
@@ -25,11 +25,12 @@ export interface NotebookEditor {
 // Loosely based on https://github.com/ueberdosis/tiptap/blob/develop/packages/extension-floating-menu/src/floating-menu-plugin.ts#LL38C3-L55C4
 export const isCurrentNodeEmpty = (editor: TTEditor): boolean => {
     const selection = editor.state.selection
+    const isRootDepth = selection.$anchor.depth === 1
     const { $anchor, empty } = selection
     const isEmptyTextBlock =
         $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !textContent($anchor.parent)
 
-    if (empty && isEmptyTextBlock) {
+    if (isRootDepth && empty && isEmptyTextBlock) {
         return true
     }
 

--- a/frontend/src/scenes/notebooks/Notebook/utils.ts
+++ b/frontend/src/scenes/notebooks/Notebook/utils.ts
@@ -37,7 +37,11 @@ export const isCurrentNodeEmpty = (editor: TTEditor): boolean => {
     return false
 }
 
-export const textContent = (node: any): string => {
+export const hasContent = (node: any): boolean => {
+    return !!textContent(node)
+}
+
+const textContent = (node: any): string => {
     return getText(node, {
         blockSeparator: ' ',
         textSerializers: {

--- a/frontend/src/scenes/notebooks/Notebook/utils.ts
+++ b/frontend/src/scenes/notebooks/Notebook/utils.ts
@@ -36,7 +36,7 @@ export const isCurrentNodeEmpty = (editor: TTEditor): boolean => {
     return false
 }
 
-const textContent = (node: any): string => {
+export const textContent = (node: any): string => {
     return getText(node, {
         blockSeparator: ' ',
         textSerializers: {

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -136,6 +136,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         <BindLogic logic={sessionRecordingPlayerLogic} props={logicProps}>
             <DraggableToNotebook
                 href={urls.replaySingle(logicProps.sessionRecordingId)}
+                properties={{ id: logicProps.sessionRecordingId }}
                 className="h-full w-full"
                 noOverflow
             >

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2975,6 +2975,8 @@ export enum NotebookNodeType {
     Insight = 'ph-insight',
     Query = 'ph-query',
     Recording = 'ph-recording',
+    TimestampList = 'phTimestampList',
+    TimestampItem = 'phTimestampItem',
     RecordingPlaylist = 'ph-recording-playlist',
     FeatureFlag = 'ph-feature-flag',
     Person = 'ph-person',


### PR DESCRIPTION
## Problem

Towards https://github.com/PostHog/posthog/issues/15680

We don't currently support any type of comments in recordings

## Changes

- Allow the session recording node to render content
- Make list & item types for a new "timestamp" node type

## How did you test this code?

Doesn't actually add any new functionality. Simply adds new node types. Will implement comments using these nodes in a future PR
