### PR TITLE
feat: add the referral field to the social signup form

### DIFF
--- a/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
+++ b/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
@@ -7,10 +7,12 @@ import { useActions, useValues } from 'kea'
 import { confirmOrganizationLogic } from './confirmOrganizationLogic'
 import { Field } from 'lib/forms/Field'
 import { AnimatedCollapsible } from 'lib/components/AnimatedCollapsible'
-import { urls } from 'scenes/urls'
 import { Form } from 'kea-forms'
 import { BridgePage } from 'lib/components/BridgePage/BridgePage'
 import SignupRoleSelect from 'lib/components/SignupRoleSelect'
+import SignupReferralSourceSelect from 'lib/components/SignupReferralSourceSelect'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export const scene: SceneExport = {
     component: ConfirmOrganization,
@@ -20,6 +22,7 @@ export const scene: SceneExport = {
 export function ConfirmOrganization(): JSX.Element {
     const { isConfirmOrganizationSubmitting, email, showNewOrgWarning } = useValues(confirmOrganizationLogic)
     const { setShowNewOrgWarning } = useActions(confirmOrganizationLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <BridgePage view="org-creation-confirmation" hedgehog>
@@ -77,6 +80,20 @@ export function ConfirmOrganization(): JSX.Element {
                 </Field>
 
                 <SignupRoleSelect />
+                {featureFlags[FEATURE_FLAGS.REFERRAL_SOURCE_SELECT] === 'test' ? (
+                    <SignupReferralSourceSelect />
+                ) : (
+                    <>
+                        <Field name="referral_source" label="Where did you hear about us?" showOptional>
+                            <LemonInput
+                                className="ph-ignore-input"
+                                data-attr="signup-referral-source"
+                                placeholder=""
+                                disabled={isConfirmOrganizationSubmitting}
+                            />
+                        </Field>
+                    </>
+                )}
 
                 <LemonButton
                     htmlType="submit"
@@ -86,16 +103,6 @@ export function ConfirmOrganization(): JSX.Element {
                     loading={isConfirmOrganizationSubmitting}
                 >
                     Create organization
-                </LemonButton>
-
-                <LemonButton
-                    fullWidth
-                    center
-                    type="secondary"
-                    disabled={isConfirmOrganizationSubmitting}
-                    to={urls.signup()}
-                >
-                    Cancel
                 </LemonButton>
             </Form>
 


### PR DESCRIPTION
## Problem

The referral source field did not exist on the social signup organization creation form. Could help explain why this field has lower response rates than the role select.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds the field, as well as the currently running experiment on the field (input -> select). Also gets rid of the cancel button on the form because it takes up space and feels unnecessary.

![image](https://github.com/PostHog/posthog/assets/18598166/e91d1ecf-b85b-4583-bca1-5a0355bdd881)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
