### PR TITLE
chore: switch back to sync commit and gauge actual offset committed

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -535,14 +535,14 @@ export class SessionRecordingBlobIngester {
         void this.sessionOffsetHighWaterMark.onCommit({ topic, partition }, highestOffsetToCommit)
 
         try {
-            this.batchConsumer?.consumer.commit({
+            this.batchConsumer?.consumer.commitSync({
                 topic,
                 partition,
                 // see https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html for example
                 // for some reason you commit the next offset you expect to read and not the one you actually have
                 offset: highestOffsetToCommit + 1,
             })
-            gaugeOffsetCommitted.inc({ partition })
+            gaugeOffsetCommitted.set({ partition }, highestOffsetToCommit)
         } catch (e) {
             gaugeOffsetCommitFailed.inc({ partition })
             captureException(e, {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
@@ -34,7 +34,7 @@ jest.mock('../../../../src/kafka/batch-consumer', () => {
                 stop: jest.fn(),
                 consumer: {
                     on: jest.fn(),
-                    commit: mockCommit,
+                    commitSync: mockCommit,
                 },
             })
         ),


### PR DESCRIPTION
lifts just the offset commit and gauge out of https://github.com/PostHog/posthog/pull/16521