### PR TITLE
feat(data-management): event and property definitions

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -140,7 +140,13 @@ export const KEY_MAPPING: KeyMappingInterface = {
         $active_feature_flags: {
             label: 'Active Feature Flags',
             description: 'Keys of the feature flags that were active while this event was sent.',
-            examples: ['beta-feature'],
+            examples: ["['beta-feature']"],
+        },
+        $enabled_feature_flags: {
+            label: 'Enabled Feature Flags',
+            description:
+                'Keys and multivariate values of the feature flags that were active while this event was sent.',
+            examples: ['{"flag": "value"}'],
         },
         $feature_flag_response: {
             label: 'Feature Flag Response',

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -9,11 +9,10 @@ import {
     VerifiedPropertyIcon,
     IconSelectAll,
 } from 'lib/lemon-ui/icons'
-import { KEY_MAPPING } from 'lib/taxonomy'
+import { getKeyMapping, KEY_MAPPING } from 'lib/taxonomy'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { getSingularType } from 'lib/components/DefinitionPopover/utils'
 import clsx from 'clsx'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
@@ -121,15 +120,15 @@ function RawDefinitionHeader({
         innerContent
     )
 
+    const description = definition.description || getKeyMapping(definition.name, 'event')?.description
+
     return (
         <>
             {!hideIcon && icon && <div className="definition-column-name-icon">{icon}</div>}
             {!hideText && (
                 <div className="definition-column-name-content">
                     <div>{linkedInnerContent}</div>
-                    <div className="definition-column-name-content-description">
-                        {definition.description || <i>Add a description for this {getSingularType(group.type)}</i>}
-                    </div>
+                    {description ? <div className="text-xs text-ellipsis">{description}</div> : null}
                 </div>
             )}
         </>

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
@@ -33,6 +33,8 @@
                 display: flex;
                 flex-direction: column;
                 position: relative;
+                min-height: 32px;
+                justify-content: center;
 
                 .definition-column-name-content-title {
                     font-weight: 600;
@@ -49,12 +51,6 @@
                         right: -50px;
                         height: 22px;
                     }
-                }
-
-                .definition-column-name-content-description {
-                    font-size: 13px;
-                    color: var(--muted);
-                    text-overflow: ellipsis;
                 }
             }
         }

--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.scss
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.scss
@@ -28,6 +28,8 @@
                 display: flex;
                 flex-direction: column;
                 position: relative;
+                min-height: 32px;
+                justify-content: center;
 
                 .definition-column-name-content-title {
                     font-weight: 600;
@@ -42,12 +44,6 @@
                         right: -50px;
                         height: 22px;
                     }
-                }
-
-                .definition-column-name-content-description {
-                    font-size: 13px;
-                    color: var(--muted);
-                    text-overflow: ellipsis;
                 }
             }
         }


### PR DESCRIPTION
## Problem

The event and property definitions page is silent (_and_ loud with blablatext) when it comes to PostHog events/properties:

![2023-07-13 00 48 07](https://github.com/PostHog/posthog/assets/53387/a6737266-26fa-4b06-b1a8-9aa99a16af05)


## Changes

![2023-07-13 00 46 23](https://github.com/PostHog/posthog/assets/53387/044f2f02-844a-4bd0-9dce-d7271f0d4577)

## Caveats

The event definitions page is a bit odd. There's something broken with the pagination, and we're using the same list of strings for both event names and properties. However both are old issues I'd prefer to fix in a different PR some other day.

I also don't have time to untangle the entire legacy CSS pattern here. So did the bare minimum :(.

If you have enough access rights / available_features to edit descriptions, then those obviously take priority... but I didn't have that set up for the screencasts.

## How did you test this code?

Visually 👀 

