### PR TITLE
fix(webhooks): split by dot

### DIFF
--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -215,7 +215,7 @@ export function getFormattedMessage(
         const markdownValues: string[] = []
 
         for (const token of tokens) {
-            const tokenParts = token.match(/\$\w+|\$\$\w+|\w+/g) || []
+            const tokenParts = token.split('.') || []
 
             const [value, markdownValue] = getValueOfToken(action, event, team, siteUrl, webhookType, tokenParts)
             values.push(value)

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -417,7 +417,9 @@ describe('hooks', () => {
                 WebhookType.Slack
             )
             expect(text).toBe('2 from Chrome on Pricing page with undefined, yes sir')
-            expect(markdown).toBe('<https://localhost:8000/person/2|2> from Chrome on Pricing page with undefined')
+            expect(markdown).toBe(
+                '<https://localhost:8000/person/2|2> from Chrome on Pricing page with undefined, yes sir'
+            )
         })
 
         test('default format', () => {

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -406,7 +406,7 @@ describe('hooks', () => {
                 id: 1,
                 name: 'action1',
                 slack_message_format:
-                    '[user.name] from [user.browser] on [event.properties.page_title] page with [event.properties.fruit]',
+                    '[user.name] from [user.browser] on [event.properties.page_title] page with [event.properties.fruit], [event.properties.with space]',
             } as Action
 
             const [text, markdown] = getFormattedMessage(
@@ -416,7 +416,7 @@ describe('hooks', () => {
                 'https://localhost:8000',
                 WebhookType.Slack
             )
-            expect(text).toBe('2 from Chrome on Pricing page with undefined')
+            expect(text).toBe('2 from Chrome on Pricing page with undefined, yes sir')
             expect(markdown).toBe('<https://localhost:8000/person/2|2> from Chrome on Pricing page with undefined')
         })
 

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -397,7 +397,7 @@ describe('hooks', () => {
     describe('getFormattedMessage', () => {
         const event = {
             distinctId: '2',
-            properties: { $browser: 'Chrome', page_title: 'Pricing' },
+            properties: { $browser: 'Chrome', page_title: 'Pricing', 'with space': 'yes sir' },
         } as unknown as PostIngestionEvent
         const team = { person_display_name_properties: null } as Team
 


### PR DESCRIPTION
## Problem

If you had a property with a space in the key, you couldn't use it in webhooks.

## Changes

Now you can. Introduces a simple `[person.properties.Onboarding Problem]` syntax. Previously the regex split by words, which doesn't make much sense in this context.

## How did you test this code?

Wrote a test, and used webhook.site as well

<img width="655" alt="image" src="https://github.com/PostHog/posthog/assets/53387/14824ce6-827d-45ff-88b1-0493ecdd2ade">

<img width="444" alt="image" src="https://github.com/PostHog/posthog/assets/53387/2e7bd445-636b-4b12-b25e-359569bfcd5e">
