### PR TITLE
fix: Step picker for time-to-convert funnel, fixes #16282

### DIFF
--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
@@ -30,7 +30,11 @@ export function FunnelStepsPicker(): JSX.Element | null {
                           label: `Step ${stepIndex + 1}`,
                           labelInMenu: (
                               <>
-                                  <span>Step ${stepIndex + 1} – </span>
+                                  <span>
+                                      {`Step ${stepIndex + 1}`}
+                                      {filterSteps[stepIndex].name ? ' -' : ''}
+                                      &nbsp;
+                                  </span>
                                   <EntityFilterInfo filter={filterSteps[stepIndex] as EntityFilter} />
                               </>
                           ),


### PR DESCRIPTION
## Problem

See #16282.

## Changes

<img width="682" alt="Screenshot 2023-07-13 at 2 20 19 AM" src="https://github.com/PostHog/posthog/assets/346068/13c9f404-3fcd-411d-9a1c-54ec7f6257a4">
<img width="679" alt="Screenshot 2023-07-13 at 2 20 31 AM" src="https://github.com/PostHog/posthog/assets/346068/10f51a17-e2d1-4a66-98c8-f6ab396674c0">

## How did you test this code?

Several stages were added to the funnel for various types of events. I ensured that the event name showed up in the drop down when applicable and did not show for "All events." I also checked to ensure the spacing after the dash rendered appropriately since using a space alone (e.g. ' - ') was not sufficient.

## I applied to Posthog!

Shameless plug: I applied recently, and I'm on a mission to close as many PRs as feasible until I land an interview.