### PR TITLE
chore: call stop and disconnect on webhooks consumer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -112,7 +112,21 @@ export const startAsyncWebhooksHandlerConsumer = async ({
 
     const isHealthy = makeHealthCheck(consumer, serverConfig.KAFKA_CONSUMPTION_SESSION_TIMEOUT_MS)
 
-    return { consumer, isHealthy }
+    return {
+        stop: async () => {
+            try {
+                await consumer.stop()
+            } catch (e) {
+                status.error('🚨', 'Error stopping consumer', e)
+            }
+            try {
+                await consumer.disconnect()
+            } catch (e) {
+                status.error('🚨', 'Error disconnecting consumer', e)
+            }
+        },
+        isHealthy,
+    }
 }
 
 export const buildOnEventIngestionConsumer = ({ hub, piscina }: { hub: Hub; piscina: Piscina }) => {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -88,7 +88,7 @@ export async function startPluginsServer(
     let analyticsEventsIngestionOverflowConsumer: KafkaJSIngestionConsumer | IngestionConsumer | undefined
     let analyticsEventsIngestionHistoricalConsumer: KafkaJSIngestionConsumer | IngestionConsumer | undefined
     let onEventHandlerConsumer: KafkaJSIngestionConsumer | undefined
-    let webhooksHandlerConsumer: Consumer | undefined
+    let stopWebhooksHandlerConsumer: () => Promise<void> | undefined
 
     // Kafka consumer. Handles events that we couldn't find an existing person
     // to associate. The buffer handles delaying the ingestion of these events
@@ -135,7 +135,7 @@ export async function startPluginsServer(
             analyticsEventsIngestionOverflowConsumer?.stop(),
             analyticsEventsIngestionHistoricalConsumer?.stop(),
             onEventHandlerConsumer?.stop(),
-            webhooksHandlerConsumer?.stop(),
+            stopWebhooksHandlerConsumer?.(),
             bufferConsumer?.disconnect(),
             jobsConsumer?.disconnect(),
             stopSessionRecordingEventsConsumer?.(),
@@ -336,7 +336,7 @@ export async function startPluginsServer(
             const teamManager = hub?.teamManager ?? new TeamManager(postgres, serverConfig, statsd)
             const organizationManager = hub?.organizationManager ?? new OrganizationManager(postgres, teamManager)
 
-            const { consumer: webhooksConsumer, isHealthy: isWebhooksIngestionHealthy } =
+            const { stop: webhooksStopConsumer, isHealthy: isWebhooksIngestionHealthy } =
                 await startAsyncWebhooksHandlerConsumer({
                     postgres: postgres,
                     kafka: kafka,
@@ -346,7 +346,7 @@ export async function startPluginsServer(
                     statsd: statsd,
                 })
 
-            webhooksHandlerConsumer = webhooksConsumer
+            stopWebhooksHandlerConsumer = webhooksStopConsumer
 
             healthChecks['webhooks-ingestion'] = isWebhooksIngestionHealthy
         }


### PR DESCRIPTION
We were previously just calling stop, but I _think_ we need to call
disconnect as well such that e.g. the consumer event handlers are
called, and we clear the status interval timer.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
