### PR TITLE
test(recordings-blob): fix rebalance test

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer-rebalancing.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer-rebalancing.test.ts
@@ -11,7 +11,7 @@ import { createIncomingRecordingMessage } from './fixtures'
 
 function assertIngesterHasExpectedPartitions(ingester: SessionRecordingBlobIngester, expectedPartitions: number[]) {
     const partitions: Set<number> = new Set()
-    ingester.sessions.forEach((session) => {
+    Object.values(ingester.sessions).forEach((session) => {
         partitions.add(session.partition)
     })
     expect(Array.from(partitions)).toEqual(expectedPartitions)


### PR DESCRIPTION
I think maybe `ingester.sessions` changed somewhere along the time,
hopefully this fixes it.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
