### PR TITLE
fix: Noisy error todo with unlinking files

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -390,7 +390,6 @@ export class SessionManager {
                 ...this.logContext(),
                 error,
             })
-            captureException(error, { tags: this.logContext() })
         })
     }
 }


### PR DESCRIPTION
## Problem

We added a sentry catch for an exception but its one we don't actually care about so remove it.

## Changes

* Remove the noisy error

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
