### PR TITLE
fix(dashboards): use fresh results after filter change

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -40,6 +40,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
             // TODO: need to pass empty query here, as otherwise dataNodeLogic will throw
             dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
             [
+                'response as insightData',
                 'dataLoading as insightDataLoading',
                 'responseErrorObject as insightDataError',
                 'getInsightRefreshButtonDisabledReason',
@@ -52,7 +53,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
             ['setInsight', 'loadInsightSuccess', 'saveInsight as insightLogicSaveInsight'],
             // TODO: need to pass empty query here, as otherwise dataNodeLogic will throw
             dataNodeLogic({ key: insightVizDataNodeKey(props), query: {} as DataNode }),
-            ['loadData'],
+            ['loadData', 'setResponse as setInsightDataResponse'],
         ],
         logic: [insightDataTimingLogic(props)],
     })),
@@ -130,11 +131,15 @@ export const insightDataLogic = kea<insightDataLogicType>([
     }),
 
     listeners(({ actions, values }) => ({
-        setInsight: ({ insight: { filters, query }, options: { overrideFilter } }) => {
+        setInsight: ({ insight: { filters, query, result }, options: { overrideFilter } }) => {
             if (overrideFilter && query == null) {
                 actions.setQuery(queryFromFilters(cleanFilters(filters || {})))
             } else if (query) {
                 actions.setQuery(query)
+            }
+
+            if (result) {
+                actions.setInsightDataResponse({ ...values.insightData, result })
             }
         },
         loadInsightSuccess: ({ insight }) => {

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -281,7 +281,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                 updatedInsight.filters = queryNodeToFilter(values.query.source)
                 updatedInsight.query = undefined
 
-                actions.setInsight(updatedInsight, {})
+                // actions.setInsight(updatedInsight, {})
             }
         },
     })),


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/16558

## Changes

DO NOT MERGE

This seems to be caused by a stale response in dataNodeLogic, setting the response in the setInsight listener of insightDataLogic solves this. The fix causes an infinite loop due to a subscription on response in insightVizDataLogic however. The subscription can be removed once all insights are converted.

## How did you test this code?

See issue above for repro.