### PR TITLE
fix: Blob ingester file deletion logic

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -2,7 +2,7 @@ import { Upload } from '@aws-sdk/lib-storage'
 import { captureException, captureMessage } from '@sentry/node'
 import { randomUUID } from 'crypto'
 import { createReadStream, createWriteStream, WriteStream } from 'fs'
-import { readFile, unlink } from 'fs/promises'
+import { readFile, stat, unlink } from 'fs/promises'
 import { DateTime } from 'luxon'
 import path from 'path'
 import { Counter, Gauge } from 'prom-client'
@@ -113,7 +113,7 @@ export class SessionManager {
     }
 
     public get isEmpty(): boolean {
-        return this.buffer.count === 0
+        return !this.buffer.count && !this.flushBuffer?.count
     }
 
     public async flushIfSessionBufferIsOld(referenceNow: number, flushThresholdMillis: number): Promise<void> {
@@ -196,23 +196,28 @@ export class SessionManager {
             const timeRange = `${firstTimestamp}-${lastTimestamp}`
             const dataKey = `${baseKey}/data/${timeRange}`
 
-            await new Promise<void>((resolve) => {
+            await new Promise<void>((resolve, reject) => {
                 // We need to safely end the file before reading from it
                 fileStream.end(async () => {
-                    const fileStream = createReadStream(file).pipe(zlib.createGzip())
+                    try {
+                        const fileStream = createReadStream(file).pipe(zlib.createGzip())
 
-                    this.inProgressUpload = new Upload({
-                        client: this.s3Client,
-                        params: {
-                            Bucket: this.serverConfig.OBJECT_STORAGE_BUCKET,
-                            Key: dataKey,
-                            Body: fileStream,
-                        },
-                    })
+                        this.inProgressUpload = new Upload({
+                            client: this.s3Client,
+                            params: {
+                                Bucket: this.serverConfig.OBJECT_STORAGE_BUCKET,
+                                Key: dataKey,
+                                Body: fileStream,
+                            },
+                        })
 
-                    await this.inProgressUpload.done()
-                    fileStream.close()
-                    resolve()
+                        await this.inProgressUpload.done()
+                        fileStream.close(() => {
+                            resolve()
+                        })
+                    } catch (error) {
+                        reject(error)
+                    }
                 })
             })
 
@@ -384,11 +389,16 @@ export class SessionManager {
     }
 
     private async destroyBuffer(buffer: SessionBuffer): Promise<void> {
-        buffer.fileStream.destroy()
-        await unlink(buffer.file).catch((error) => {
-            status.error('🧨', 'blob_ingester_session_manager failed to unlink buffer file', {
-                ...this.logContext(),
-                error,
+        await new Promise<void>((resolve) => {
+            buffer.fileStream.close(async () => {
+                try {
+                    await stat(buffer.file)
+                    await unlink(buffer.file)
+                } catch (error) {
+                    // Indicates the file was already deleted (i.e. if there was never any data in the buffer)
+                }
+
+                resolve()
             })
         })
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -212,9 +212,8 @@ export class SessionManager {
                         })
 
                         await this.inProgressUpload.done()
-                        fileStream.close(() => {
-                            resolve()
-                        })
+                        fileStream.close()
+                        resolve()
                     } catch (error) {
                         reject(error)
                     }

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -20,8 +20,8 @@ jest.mock('fs', () => {
             return {
                 write: jest.fn(),
                 pipe: () => ({ close: jest.fn() }),
+                close: jest.fn((cb) => cb?.()),
                 end: jest.fn((cb) => cb?.()),
-                destroy: jest.fn((cb) => cb?.()),
             }
         }),
     }
@@ -30,6 +30,7 @@ jest.mock('fs', () => {
 jest.mock('@aws-sdk/lib-storage', () => {
     const mockUpload = jest.fn().mockImplementation(() => {
         return {
+            abort: jest.fn().mockResolvedValue(undefined),
             done: jest.fn().mockResolvedValue(undefined),
         }
     })
@@ -245,7 +246,7 @@ describe('session-manager', () => {
 
         expect(sessionManager.flushBuffer).toEqual(undefined)
         expect(mockFinish).toBeCalledTimes(1)
-        expect(fileStream.destroy).toBeCalledTimes(1)
+        expect(fileStream.close).toBeCalledTimes(1)
     })
 
     it('flushes messages and whilst collecting new ones', async () => {


### PR DESCRIPTION
## Problem

Due to some confusion with streams we aren't deleting things the right way. If a stream is closed before anything is written to it then there is no file to be deleted.

Also we weren't checking the flushBuffer when determining if a SessionManager was empty or not, leading to premature deletion.

## Changes

* Fixes these

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
