### PR TITLE
fix(surveys): enable app warning and setup help fixes

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -110,7 +110,7 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                         <LemonBanner type="error">
                             Surveys requires the{' '}
                             <a onClick={() => surveyPlugin?.id && editPlugin(surveyPlugin.id)}>survey app</a> to be
-                            enabled. Enable and save it, and make sure you have the "opt_in_site_apps" setting in your
+                            enabled. You also need to make sure you have the "opt_in_site_apps" setting in your
                             PostHog initialization code.
                         </LemonBanner>
                     )}

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -110,8 +110,8 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                         <LemonBanner type="error">
                             Surveys requires the{' '}
                             <a onClick={() => surveyPlugin?.id && editPlugin(surveyPlugin.id)}>survey app</a> to be
-                            enabled. You also need to make sure you have the "opt_in_site_apps" setting in your
-                            PostHog initialization code.
+                            enabled. You also need to make sure you have the "opt_in_site_apps" setting in your PostHog
+                            initialization code.
                         </LemonBanner>
                     )}
                     <LemonTabs

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -17,9 +17,11 @@ import { SurveyReleaseSummary } from './Survey'
 import { SurveyAppearance } from './SurveyAppearance'
 import { SurveyQuestionType, SurveyType } from '~/types'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
-    const { survey, dataTableQuery, surveyLoading, surveyPlugin, surveyMetricsQueries } = useValues(surveyLogic)
+    const { survey, dataTableQuery, surveyLoading, surveyPlugin, surveyMetricsQueries, showSurveyAppWarning } =
+        useValues(surveyLogic)
     // TODO: survey results logic
     // const { surveyImpressionsCount, surveyStartedCount, surveyCompletedCount } = useValues(surveyResultsLogic)
     const { editingSurvey, updateSurvey, launchSurvey, stopSurvey, archiveSurvey } = useActions(surveyLogic)
@@ -103,6 +105,14 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                             </>
                         }
                     />
+                    {showSurveyAppWarning && (
+                        <LemonBanner type="error">
+                            Surveys requires the{' '}
+                            <a onClick={() => surveyPlugin?.id && editPlugin(surveyPlugin.id)}>survey app</a> to be
+                            enabled. Enable and save it, and make sure you have the "opt_in_site_apps" setting in your
+                            PostHog initialization code.
+                        </LemonBanner>
+                    )}
                     <LemonTabs
                         activeKey={tabKey}
                         onChange={(key) => setTabKey(key)}

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -1,5 +1,5 @@
 import { TZLabel } from '@posthog/apps-common'
-import { LemonButton, LemonDivider, LemonCollapse, LemonCheckbox, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import { useValues, useActions } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -18,6 +18,7 @@ import { SurveyAppearance } from './SurveyAppearance'
 import { SurveyQuestionType, SurveyType } from '~/types'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const { survey, dataTableQuery, surveyLoading, surveyPlugin, surveyMetricsQueries, showSurveyAppWarning } =
@@ -182,54 +183,45 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                             />
                                         </div>
                                         <div className="w-full flex flex-col items-center">
-                                            <LemonCollapse
-                                                className="w-full mb-2"
-                                                panels={[
-                                                    {
-                                                        key: '1',
-                                                        header: 'Survey setup help',
-                                                        content: (
-                                                            <div>
-                                                                <div className="flex flex-col">
-                                                                    <span className="font-medium mb-2">
-                                                                        Option 1: Enable the surveys app (recommended)
-                                                                    </span>
-                                                                    <div className="flex gap-2 items-start">
-                                                                        <LemonCheckbox /> Add the following option to
-                                                                        your PostHog instance:
-                                                                    </div>
-                                                                    <CodeSnippet language={Language.JavaScript} wrap>
-                                                                        {OPT_IN_SNIPPET}
-                                                                    </CodeSnippet>
-                                                                    <div className="flex items-center gap-1">
-                                                                        <LemonCheckbox />{' '}
-                                                                        <LemonButton
-                                                                            onClick={() =>
-                                                                                surveyPlugin?.id &&
-                                                                                editPlugin(surveyPlugin.id)
-                                                                            }
-                                                                        >
-                                                                            Enable and save the surveys app
-                                                                        </LemonButton>
-                                                                    </div>
-                                                                </div>
-                                                                <div className="flex flex-col mt-3">
-                                                                    <span className="font-medium">
-                                                                        Option 2: Create your own custom survey UI with
-                                                                        our headless API
-                                                                    </span>
-                                                                    <Link
-                                                                        to="https://posthog.com/docs/surveys/manual"
-                                                                        target="_blank"
-                                                                    >
-                                                                        See documentation
-                                                                    </Link>
-                                                                </div>
+                                            <div className="border rounded p-4 w-full">
+                                                {survey.type !== SurveyType.API ? (
+                                                    showSurveyAppWarning && (
+                                                        <div className="flex flex-col">
+                                                            <div className="flex gap-2 items-start">
+                                                                1. Add the following option to your PostHog instance:
                                                             </div>
-                                                        ),
-                                                    },
-                                                ]}
-                                            />
+                                                            <CodeSnippet language={Language.JavaScript} wrap>
+                                                                {OPT_IN_SNIPPET}
+                                                            </CodeSnippet>
+                                                            <div className="flex items-center">
+                                                                2.{' '}
+                                                                <LemonButton
+                                                                    onClick={() =>
+                                                                        surveyPlugin?.id && editPlugin(surveyPlugin.id)
+                                                                    }
+                                                                >
+                                                                    Enable and save the surveys app
+                                                                </LemonButton>
+                                                            </div>
+                                                        </div>
+                                                    )
+                                                ) : (
+                                                    <span className="font-medium">
+                                                        See the documentation below on API survey setup.
+                                                    </span>
+                                                )}
+                                                <div>
+                                                    Need more information?{' '}
+                                                    <a
+                                                        data-attr="survey-doc-link"
+                                                        target="_blank"
+                                                        rel="noopener"
+                                                        href="https://posthog.com/docs/surveys/manual"
+                                                    >
+                                                        Check the docs <IconOpenInNew />
+                                                    </a>
+                                                </div>
+                                            </div>
                                             {survey.type !== SurveyType.API ? (
                                                 <div className="mt-6">
                                                     <SurveyAppearance
@@ -243,7 +235,9 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                                     />
                                                 </div>
                                             ) : (
-                                                <SurveyAPIEditor survey={survey} />
+                                                <div className="mt-2">
+                                                    <SurveyAPIEditor survey={survey} />
+                                                </div>
                                             )}
                                         </div>
                                     </div>

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -142,7 +142,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 'reportSurveyViewed',
             ],
         ],
-        values: [pluginsLogic, ['installedPlugins']],
+        values: [pluginsLogic, ['installedPlugins', 'enabledPlugins']],
     })),
     actions({
         editingSurvey: (editing: boolean) => ({ editing }),
@@ -263,6 +263,14 @@ export const surveyLogic = kea<surveyLogicType>([
             (installedPlugins: PluginType[]): PluginType | undefined => {
                 // TODO: add more sturdy check for the survey plugin
                 return installedPlugins.find((plugin) => plugin.name === 'Surveys app')
+            },
+        ],
+        showSurveyAppWarning: [
+            (s) => [s.survey, s.enabledPlugins],
+            (survey: Survey, enabledPlugins: PluginType[]): boolean => {
+                return !!(
+                    survey.type !== SurveyType.API && !enabledPlugins.find((plugin) => plugin.name === 'Surveys app')
+                )
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Non API surveys will literally not work unless the app is enabled and the "opt in site app" setting is present. 

Also no one reads things in a collapse, so updated the setup help info to make it more explicit.

## Changes
Detect if the survey app is not enabled and present a banner to make sure the user sets up the survey properly before they can use it.

<img width="1163" alt="Screen Shot 2023-07-13 at 10 47 32 AM" src="https://github.com/PostHog/posthog/assets/25164963/7f3defd9-07b2-4083-abf9-3fa167aac795">
<img width="1167" alt="Screen Shot 2023-07-13 at 10 47 41 AM" src="https://github.com/PostHog/posthog/assets/25164963/2e0b0786-fbd6-4079-99e8-13fbda2eb015">
<img width="1163" alt="Screen Shot 2023-07-13 at 10 50 57 AM" src="https://github.com/PostHog/posthog/assets/25164963/7a8f59de-1344-4c45-b6f3-5fd84c2ade34">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
