### PR TITLE
chore: ensure historical data tokens not overflowed

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -536,7 +536,11 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
 
     candidate_partition_key = f"{token}:{distinct_id}"
 
-    if distinct_id.lower() not in LIKELY_ANONYMOUS_IDS and is_randomly_partitioned(candidate_partition_key) is False:
+    if (
+        distinct_id.lower() not in LIKELY_ANONYMOUS_IDS
+        and is_randomly_partitioned(candidate_partition_key) is False
+        or token in settings.TOKENS_HISTORICAL_DATA
+    ):
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
 
     return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)


### PR DESCRIPTION
We want to ensure that data for the historical data is not sent to the
overflow, otherwise this will break in order processing.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
