### PR TITLE
fix: delete is sometimes timing out

### DIFF
--- a/.run/Plugin Server.run.xml
+++ b/.run/Plugin Server.run.xml
@@ -12,9 +12,11 @@
       <env name="KAFKA_HOSTS" value="localhost:9092" />
       <env name="OBJECT_STORAGE_ENABLED" value="True" />
       <env name="SESSION_RECORDING_ENABLE_OFFSET_HIGH_WATER_MARK_PROCESSING" value="true" />
+      <env name="SESSION_RECORDING_KAFKA_BATCH_SIZE" value="200" />
       <env name="SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS" value="180" />
       <env name="SESSION_RECORDING_SUMMARY_INGESTION_ENABLED_TEAMS" value="all" />
       <env name="WORKER_CONCURRENCY" value="2" />
+      <env name="SESSION_RECORDING_KAFKA_QUEUE_SIZE" value="600" />
     </envs>
     <method v="2" />
   </configuration>

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/realtime-manager.ts
@@ -1,9 +1,9 @@
 import { captureException } from '@sentry/node'
+import { randomUUID } from 'crypto'
 import { Redis } from 'ioredis'
 import { EventEmitter } from 'node:events'
 import { Counter } from 'prom-client'
 
-import { uuid } from '../../../../../../frontend/src/lib/utils'
 import { PluginsServerConfig, RedisPool } from '../../../../types'
 import { timeoutGuard } from '../../../../utils/db/utils'
 import { status } from '../../../../utils/status'
@@ -169,7 +169,7 @@ export class RealtimeManager extends EventEmitter {
                  *  and let it expire
                  */
                 const pipeline = client.pipeline()
-                const newKey = `expired-${key}-${uuid()}`
+                const newKey = `expired-${key}-${randomUUID()}`
                 pipeline.rename(`${key}`, newKey)
                 // renaming shouldn't affect the existing TTL
                 // but, we set one anyway to be sure

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/realtime-manager.ts
@@ -3,6 +3,7 @@ import { Redis } from 'ioredis'
 import { EventEmitter } from 'node:events'
 import { Counter } from 'prom-client'
 
+import { uuid } from '../../../../../../frontend/src/lib/utils'
 import { PluginsServerConfig, RedisPool } from '../../../../types'
 import { timeoutGuard } from '../../../../utils/db/utils'
 import { status } from '../../../../utils/status'
@@ -152,7 +153,28 @@ export class RealtimeManager extends EventEmitter {
 
         try {
             await this.run(`clearAllMessages ${key} `, async (client) => {
-                return client.del(key)
+                /**
+                 * We could delete the key here but (https://redis.io/commands/del/) del is O(M)
+                 * where M is the number of items in the sorted set, for a large buffer this could be
+                 * a lot of work.
+                 *
+                 * Whereas RENAME (https://redis.io/commands/rename/) is O(1)
+                 * (_almost_ always O(1))
+                 * """
+                 *  If newkey already exists it is overwritten, when this happens RENAME executes an implicit DEL operation,
+                 *  so if the deleted key contains a very big value it may cause high latency
+                 *  even if RENAME itself is usually a constant-time operation.
+                 *  """
+                 *  So, we rename the key to expired-<key>-<uuid>, so that it can't possibly clash
+                 *  and let it expire
+                 */
+                const pipeline = client.pipeline()
+                const newKey = `expired-${key}-${uuid()}`
+                pipeline.rename(`${key}`, newKey)
+                // renaming shouldn't affect the existing TTL
+                // but, we set one anyway to be sure
+                pipeline.expire(newKey, 1)
+                return pipeline.exec()
             })
         } catch (error) {
             captureException(error, { tags: { teamId, sessionId }, extra: { key } })


### PR DESCRIPTION
                /**
                 * We could delete the key here but (https://redis.io/commands/del/) del is O(M)
                 * where M is the number of items in the sorted set, for a large buffer this could be
                 * a lot of work.
                 *
                 * Whereas RENAME (https://redis.io/commands/rename/) is O(1)
                 * (_almost_ always O(1))
                 * """
                 *  If newkey already exists it is overwritten, when this happens RENAME executes an implicit DEL operation,
                 *  so if the deleted key contains a very big value it may cause high latency
                 *  even if RENAME itself is usually a constant-time operation.
                 *  """
                 *  So, we rename the key to expired-<key>-<uuid>, so that it can't possibly clash
                 *  and let it expire
                 */

e.g. https://posthog.sentry.io/issues/4313072916/?query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-blob-ingestion&referrer=issue-stream&statsPeriod=24h&stream_index=4