### PR TITLE
fix: Do retry on CH connection errors

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -286,8 +286,6 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 retry_policy=RetryPolicy(
                     maximum_attempts=6,
                     non_retryable_error_types=[
-                        # If we can't connect to ClickHouse, no point in retrying.
-                        "ConnectionError",
                         # Validation failed, and will keep failing.
                         "ValueError",
                     ],

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -339,9 +339,6 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
                 retry_policy=RetryPolicy(
                     maximum_attempts=3,
                     non_retryable_error_types=[
-                        # If we can't connect to ClickHouse, no point in
-                        # retrying.
-                        "ConnectionError",
                         # Validation failed, and will keep failing.
                         "ValueError",
                     ],


### PR DESCRIPTION
## Problem

ConnectionErrors are actually fairly transient and we should retry on them. I originally imagined ClickHouse going down, but networks failing is a much more common (and easy to recover from) cause.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Remove `ConnectionError` from errors we shouldn't retry on.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
