### PR TITLE
fix(insights): property key was cut off

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -230,7 +230,6 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             const start = performance.now()
 
             await breakpoint(300)
-            const key = propertyKey.split('__')[0]
             actions.setOptionsLoading(propertyKey)
             actions.abortAnyRunningQuery()
 
@@ -246,7 +245,12 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
 
             const propValues: PropValue[] = await api.get(
                 endpoint ||
-                    'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '') + eventParams,
+                    'api/' +
+                        type +
+                        '/values/?key=' +
+                        encodeURIComponent(propertyKey) +
+                        (newInput ? '&value=' + encodeURIComponent(newInput) : '') +
+                        eventParams,
                 methodOptions
             )
             breakpoint()


### PR DESCRIPTION
## Problem

I couldn't figure out why we were cutting this off. This was causing value autocomplete to fail for elements like `key__nested_key`, like created by the property flattener plugin.

Zendesk: https://posthoghelp.zendesk.com/agent/tickets/4276 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7188)

## Changes

Removes this `__` split, and adds some URL encoding just in case.

## How did you test this code?

Nothing was broken when testing locally in the interface, but I don't know what this old '__' split was trying to achieve. I think it had something to do with old property operators 🤔 