### PR TITLE
fix(insights): cohorts can only be made from persons

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -195,14 +195,16 @@ export function PersonsModal({
                     <LemonButton type="secondary" onClick={closeModal}>
                         Close
                     </LemonButton>
-                    <LemonButton
-                        onClick={() => setIsCohortModalOpen(true)}
-                        type="primary"
-                        data-attr="person-modal-save-as-cohort"
-                        disabled={!actors.length}
-                    >
-                        Save as cohort
-                    </LemonButton>
+                    {actors && actors.length > 0 && !isGroupType(actors[0]) && (
+                        <LemonButton
+                            onClick={() => setIsCohortModalOpen(true)}
+                            type="primary"
+                            data-attr="person-modal-save-as-cohort"
+                            disabled={!actors.length}
+                        >
+                            Save as cohort
+                        </LemonButton>
+                    )}
                 </LemonModal.Footer>
             </LemonModal>
             <SaveCohortModal


### PR DESCRIPTION
## Problem

Cohorts contain people. It makes sense to create a cohort from the persons modal:

<img width="612" alt="image" src="https://github.com/PostHog/posthog/assets/53387/b3e36880-f723-4c53-ab39-8a0b3fe8f4a4">

This persons modal can also show groups. Cohorts can't be created from groups, yet the button was there.

## Changes

Removes the cohort button from group modals:

<img width="652" alt="image" src="https://github.com/PostHog/posthog/assets/53387/de3ed2e2-317b-46c0-a87b-b35f8e6b516a">


## How did you test this code?

👀 