### PR TITLE
fix: Removed some high cardinality counters

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/realtime-manager.ts
@@ -1,7 +1,6 @@
 import { captureException } from '@sentry/node'
 import { Redis } from 'ioredis'
 import { EventEmitter } from 'node:events'
-import { Counter } from 'prom-client'
 
 import { PluginsServerConfig, RedisPool } from '../../../../types'
 import { timeoutGuard } from '../../../../utils/db/utils'
@@ -9,12 +8,6 @@ import { status } from '../../../../utils/status'
 import { createRedis } from '../../../../utils/utils'
 import { IncomingRecordingMessage } from './types'
 import { convertToPersistedMessage } from './utils'
-
-export const counterRealtimeSnapshotSubscriptionFinished = new Counter({
-    name: 'realtime_snapshots_subscription_finished_counter',
-    help: 'Indicates that this consumer finished providing realtime snapshots for a session',
-    labelNames: ['team_id'],
-})
 
 const Keys = {
     snapshots(teamId: number, suffix: string): string {
@@ -50,8 +43,6 @@ export class RealtimeManager extends EventEmitter {
 
         return () => {
             this.off(`subscription::${teamId}::${sessionId}`, cb)
-            status.info('🔌', 'RealtimeManager unsubscribed from realtime snapshots', { teamId, sessionId })
-            counterRealtimeSnapshotSubscriptionFinished.inc({ team_id: teamId.toString() })
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -16,12 +16,6 @@ import { RealtimeManager } from './realtime-manager'
 import { IncomingRecordingMessage } from './types'
 import { convertToPersistedMessage, now } from './utils'
 
-export const counterRealtimeSnapshotSubscriptionStarted = new Counter({
-    name: 'realtime_snapshots_subscription_started_counter',
-    help: 'Indicates that this consumer received a request to subscribe to provide realtime snapshots for a session',
-    labelNames: ['team_id'],
-})
-
 export const counterS3FilesWritten = new Counter({
     name: 'recording_s3_files_written',
     help: 'A single file flushed to S3',
@@ -81,11 +75,6 @@ export class SessionManager {
         void realtimeManager.clearAllMessages(this.teamId, this.sessionId)
 
         this.unsubscribe = realtimeManager.onSubscriptionEvent(this.teamId, this.sessionId, () => {
-            status.info('🔌', 'blob_ingester_session_manager RealtimeManager subscribed to realtime snapshots', {
-                teamId,
-                sessionId,
-            })
-            counterRealtimeSnapshotSubscriptionStarted.inc({ team_id: teamId.toString() })
             void this.startRealtime()
         })
     }


### PR DESCRIPTION
## Problem

We were using them to validate the real time manager but given that every session subscribes and unsubscribes, we weren't really learning anything from them

## Changes
* Removes them


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
