### PR TITLE
chore: add breadcrumbs to sentry

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
@@ -1,5 +1,7 @@
+import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
 import { Consumer } from 'kafkajs'
+import { KafkaConsumer } from 'node-rdkafka-acosom'
 
 import { Hub } from '../../types'
 
@@ -39,6 +41,83 @@ export function addMetricsEventListeners(consumer: Consumer, statsd: StatsD | un
 
     consumer.on(consumer.events.REQUEST_QUEUE_SIZE, ({ payload }) => {
         latestRequestQueueSize = payload.queueSize
+    })
+}
+
+export function addSentryBreadcrumbsEventListeners(consumer: KafkaConsumer): void {
+    /** these events are a string literal union and, they're not exported so, we can't enumerate them
+     *  type KafkaClientEvents = 'disconnected' | 'ready' | 'connection.failure' | 'event.error' | 'event.stats' | 'event.log' | 'event.event' | 'event.throttle';
+     *  type KafkaConsumerEvents = 'data' | 'partition.eof' | 'rebalance' | 'rebalance.error' | 'subscribed' | 'unsubscribed' | 'unsubscribe' | 'offset.commit' | KafkaClientEvents;
+     *
+     *  some of them happen very frequently so, we don't want to capture them as breadcrumbs
+     *  and the way the library is written if we listen to individual events then we get typed args we can capture
+     *  with the breadcrumb
+     */
+
+    consumer.on('disconnected', (metrics) => {
+        Sentry.addBreadcrumb({
+            category: 'kafka_lifecycle',
+            message: 'disconnected',
+            level: 'info',
+            data: {
+                metrics,
+            },
+        })
+    })
+
+    consumer.on('connection.failure', (error) => {
+        Sentry.addBreadcrumb({
+            category: 'kafka_lifecycle',
+            message: 'connection.failure',
+            level: 'info',
+            data: {
+                error,
+            },
+        })
+    })
+
+    consumer.on('event.throttle', (eventData) => {
+        Sentry.addBreadcrumb({
+            category: 'kafka_lifecycle',
+            message: 'event.throttle',
+            level: 'info',
+            data: {
+                eventData,
+            },
+        })
+    })
+
+    consumer.on('rebalance', (error) => {
+        Sentry.addBreadcrumb({
+            category: 'kafka_lifecycle',
+            message: 'rebalance',
+            level: 'info',
+            data: {
+                error,
+            },
+        })
+    })
+
+    consumer.on('rebalance.error', (error) => {
+        Sentry.addBreadcrumb({
+            category: 'kafka_lifecycle',
+            message: 'rebalance.error',
+            level: 'info',
+            data: {
+                error,
+            },
+        })
+    })
+
+    consumer.on('partition.eof', (topicPartitionOffset) => {
+        Sentry.addBreadcrumb({
+            category: 'kafka_lifecycle',
+            message: 'partition.eof',
+            level: 'info',
+            data: {
+                topicPartitionOffset,
+            },
+        })
     })
 }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -22,6 +22,7 @@ import { BackgroundRefresher } from '../../../utils/background-refresher'
 import { status } from '../../../utils/status'
 import { fetchTeamTokensWithRecordings } from '../../../worker/ingestion/team-manager'
 import { ObjectStorage } from '../../services/object_storage'
+import { addSentryBreadcrumbsEventListeners } from '../kafka-metrics'
 import { eventDroppedCounter } from '../metrics'
 import { RealtimeManager } from './blob-ingester/realtime-manager'
 import { SessionManager } from './blob-ingester/session-manager'
@@ -346,6 +347,7 @@ export class SessionRecordingBlobIngester {
                 return await this.handleEachBatch(messages)
             },
         })
+        addSentryBreadcrumbsEventListeners(this.batchConsumer.consumer)
 
         this.batchConsumer.consumer.on('rebalance', async (err, topicPartitions) => {
             /**


### PR DESCRIPTION
## Problem

I'm often looking at a blob ingester error report in Sentry and the only information we get is a bunch of S3 uploads in the breadcrumbs

## Changes

Adds some breadcrumbs based on Kafka consumer lifecycle

## How did you test this code?

🙈 it still runs locally