### PR TITLE
fix: toolbar API calls

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -35,7 +35,13 @@ describe('API helper', () => {
 
             expect(fakeFetch).toHaveBeenCalledWith(
                 '/api/projects/2/events?properties=%5B%7B%22key%22%3A%22something%22%2C%22value%22%3A%22is_set%22%2C%22operator%22%3A%22is_set%22%2C%22type%22%3A%22event%22%7D%5D&limit=10&orderBy=%5B%22-timestamp%22%5D',
-                { signal: undefined, headers: { 'X-POSTHOG-SESSION-ID': 'fake-session-id' } }
+                {
+                    signal: undefined,
+                    headers: {
+                        // TODO: get_session_id isn't safe in the toolbar, needs fixing in posthog-js
+                        // 'X-POSTHOG-SESSION-ID': 'fake-session-id'
+                    },
+                }
             )
         })
     })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1429,11 +1429,11 @@ const api = {
         let response
         const startTime = new Date().getTime()
         try {
-            const sessionId = posthog.get_session_id()
             response = await fetch(url, {
                 signal: options?.signal,
                 headers: {
-                    'X-POSTHOG-SESSION-ID': sessionId,
+                    // TODO: get_session_id isn't safe in the toolbar, needs fixing in posthog-js
+                    // 'X-POSTHOG-SESSION-ID': posthog.get_session_id(),
                 },
             })
         } catch (e) {
@@ -1458,7 +1458,8 @@ const api = {
             headers: {
                 ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
                 'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
-                'X-POSTHOG-SESSION-ID': posthog.get_session_id(),
+                // TODO: get_session_id isn't safe in the toolbar, needs fixing in posthog-js
+                // 'X-POSTHOG-SESSION-ID': posthog.get_session_id(),
             },
             body: isFormData ? data : JSON.stringify(data),
             signal: options?.signal,
@@ -1490,7 +1491,8 @@ const api = {
             headers: {
                 ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
                 'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
-                'X-POSTHOG-SESSION-ID': posthog.get_session_id(),
+                // TODO: get_session_id isn't safe in the toolbar, needs fixing in posthog-js
+                // 'X-POSTHOG-SESSION-ID': posthog.get_session_id(),
             },
             body: data ? (isFormData ? data : JSON.stringify(data)) : undefined,
             signal: options?.signal,
@@ -1516,6 +1518,7 @@ const api = {
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
+                // TODO: get_session_id isn't safe in the toolbar, needs fixing in posthog-js
                 // 'X-POSTHOG-SESSION-ID': posthog.get_session_id(),
             },
         })


### PR DESCRIPTION
## Problem

Adding session id into the headers isn't safe in the toolbar

## Changes

Let's turn it off until we fix posthog-js

## How did you test this code?

see: https://posthog.slack.com/archives/C0460HY55M0/p1689324410304429