### PR TITLE
feat: make flush threshold disk space aware

### DIFF
--- a/cdp/Dockerfile
+++ b/cdp/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
 # Install SQLx CLI.
 RUN cargo install --version 0.6.3 sqlx-cli --no-default-features --features native-tls,postgres
 
-FROM node:18.12.1-bullseye-slim AS cdp-build
+FROM node:18.16.1-bullseye-slim AS cdp-build
 
 WORKDIR /code
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -57,7 +57,7 @@ RUN rm -rf node_modules && \
     rm -rf /tmp/pnpm-store
 
 # Build the final image.
-FROM node:18.12.1-bullseye-slim
+FROM node:18.16.1-bullseye-slim
 
 WORKDIR /code
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/cdp/package.json
+++ b/cdp/package.json
@@ -23,7 +23,7 @@
         "@types/koa-bodyparser": "^4.3.10",
         "@types/koa-pino-logger": "^3.0.1",
         "@types/koa-router": "^7.4.4",
-        "@types/node": "^18.15.11",
+        "@types/node": "^18.16.1",
         "@types/pg": "^8.6.6",
         "jest": "^29.5.0",
         "nodemon": "^2.0.22",

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -101,7 +101,7 @@
         "@types/jsonwebtoken": "^8.5.5",
         "@types/long": "4.x.x",
         "@types/luxon": "^1.27.0",
-        "@types/node": "^16.0.0",
+        "@types/node": "^18.16.1",
         "@types/node-fetch": "^2.5.10",
         "@types/node-schedule": "^2.1.0",
         "@types/pg": "^8.6.0",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 patchedDependencies:
   pg@8.10.0:
@@ -201,8 +205,8 @@ devDependencies:
     specifier: ^1.27.0
     version: 1.27.1
   '@types/node':
-    specifier: ^16.0.0
-    version: 16.18.25
+    specifier: ^18.16.1
+    version: 18.16.1
   '@types/node-fetch':
     specifier: ^2.5.10
     version: 2.6.3
@@ -268,7 +272,7 @@ devDependencies:
     version: 7.0.0(eslint@8.39.0)
   jest:
     specifier: ^28.1.1
-    version: 28.1.3(@types/node@16.18.25)(ts-node@10.9.1)
+    version: 28.1.3(@types/node@18.16.1)(ts-node@10.9.1)
   nodemon:
     specifier: ^2.0.22
     version: 2.0.22
@@ -283,7 +287,7 @@ devDependencies:
     version: 2.8.8
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@swc/core@1.3.55)(@types/node@16.18.25)(typescript@4.9.5)
+    version: 10.9.1(@swc/core@1.3.55)(@types/node@18.16.1)(typescript@4.9.5)
   typescript:
     specifier: ^4.7.4
     version: 4.9.5
@@ -3164,7 +3168,7 @@ packages:
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.6
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: false
 
   /@grpc/proto-loader@0.7.6:
@@ -3218,7 +3222,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -3239,14 +3243,14 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@16.18.25)(ts-node@10.9.1)
+      jest-config: 28.1.3(@types/node@18.16.1)(ts-node@10.9.1)
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -3281,7 +3285,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       jest-mock: 28.1.3
     dev: true
 
@@ -3308,7 +3312,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       jest-message-util: 28.1.3
       jest-mock: 28.1.3
       jest-util: 28.1.3
@@ -3340,7 +3344,7 @@ packages:
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -3428,7 +3432,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -3440,7 +3444,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -3912,7 +3916,7 @@ packages:
   /@types/adm-zip@0.4.34:
     resolution: {integrity: sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
   /@types/babel__core@7.20.0:
@@ -3965,7 +3969,7 @@ packages:
   /@types/duplexify@3.6.1:
     resolution: {integrity: sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: false
 
   /@types/faker@5.5.9:
@@ -3983,19 +3987,19 @@ packages:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: false
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
   /@types/ioredis@4.28.10:
     resolution: {integrity: sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -4032,7 +4036,7 @@ packages:
   /@types/jsonwebtoken@8.5.9:
     resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
   /@types/linkify-it@3.0.2:
@@ -4072,17 +4076,17 @@ packages:
   /@types/node-fetch@2.6.3:
     resolution: {integrity: sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       form-data: 3.0.1
 
   /@types/node-schedule@2.1.0:
     resolution: {integrity: sha512-NiTwl8YN3v/1YCKrDFSmCTkVxFDylueEqsOFdgF+vPsm+AlyJKGAo5yzX1FiOxPsZiN6/r8gJitYx2EaSuBmmg==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
-  /@types/node@16.18.25:
-    resolution: {integrity: sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==}
+  /@types/node@18.16.1:
+    resolution: {integrity: sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==}
 
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
@@ -4091,7 +4095,7 @@ packages:
   /@types/pg@8.6.6:
     resolution: {integrity: sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       pg-protocol: 1.6.0
       pg-types: 2.2.0
 
@@ -4102,7 +4106,7 @@ packages:
   /@types/redis@2.8.32:
     resolution: {integrity: sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
   /@types/redlock@4.0.4:
@@ -4117,7 +4121,7 @@ packages:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: false
 
   /@types/semver@7.3.13:
@@ -4127,7 +4131,7 @@ packages:
   /@types/snowflake-sdk@1.6.12:
     resolution: {integrity: sha512-Ndz6x750TkuvHvdRBH8Cb7T8et2anyyY1j8kFChJ+s8FtURNRKut7DWaq9YdseKXZvqwA3ZYZxKaQRwtSq67eg==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       generic-pool: 3.9.0
     dev: true
 
@@ -4138,7 +4142,7 @@ packages:
   /@types/tar-stream@2.2.2:
     resolution: {integrity: sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
   /@types/triple-beam@1.3.2:
@@ -4148,7 +4152,7 @@ packages:
   /@types/tunnel@0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: false
 
   /@types/uuid@8.3.4:
@@ -7678,7 +7682,7 @@ packages:
       '@jest/expect': 28.1.3
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -7697,7 +7701,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@28.1.3(@types/node@16.18.25)(ts-node@10.9.1):
+  /jest-cli@28.1.3(@types/node@18.16.1)(ts-node@10.9.1):
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -7714,7 +7718,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 28.1.3(@types/node@16.18.25)(ts-node@10.9.1)
+      jest-config: 28.1.3(@types/node@18.16.1)(ts-node@10.9.1)
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -7725,7 +7729,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@28.1.3(@types/node@16.18.25)(ts-node@10.9.1):
+  /jest-config@28.1.3(@types/node@18.16.1)(ts-node@10.9.1):
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -7740,7 +7744,7 @@ packages:
       '@babel/core': 7.21.4
       '@jest/test-sequencer': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       babel-jest: 28.1.3(@babel/core@7.21.4)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -7760,7 +7764,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.55)(@types/node@16.18.25)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.3.55)(@types/node@18.16.1)(typescript@4.9.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7800,7 +7804,7 @@ packages:
       '@jest/environment': 28.1.3
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       jest-mock: 28.1.3
       jest-util: 28.1.3
     dev: true
@@ -7816,7 +7820,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7867,7 +7871,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@28.1.3):
@@ -7921,7 +7925,7 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.11
@@ -8007,7 +8011,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -8032,7 +8036,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -8044,12 +8048,12 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@28.1.3(@types/node@16.18.25)(ts-node@10.9.1):
+  /jest@28.1.3(@types/node@18.16.1)(ts-node@10.9.1):
     resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -8062,7 +8066,7 @@ packages:
       '@jest/core': 28.1.3(ts-node@10.9.1)
       '@jest/types': 28.1.3
       import-local: 3.1.0
-      jest-cli: 28.1.3(@types/node@16.18.25)(ts-node@10.9.1)
+      jest-cli: 28.1.3(@types/node@18.16.1)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -9659,7 +9663,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       long: 5.2.3
     dev: false
 
@@ -10628,7 +10632,7 @@ packages:
       tap-parser: 11.0.2
       tap-yaml: 1.0.2
       tcompare: 5.0.7
-      ts-node: 10.9.1(@swc/core@1.3.55)(@types/node@16.18.25)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.3.55)(@types/node@18.16.1)(typescript@4.9.5)
       typescript: 4.9.5
       which: 2.0.2
     transitivePeerDependencies:
@@ -10834,7 +10838,7 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
-  /ts-node@10.9.1(@swc/core@1.3.55)(@types/node@16.18.25)(typescript@4.9.5):
+  /ts-node@10.9.1(@swc/core@1.3.55)(@types/node@18.16.1)(typescript@4.9.5):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10854,7 +10858,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 16.18.25
+      '@types/node': 18.16.1
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/disk-aware-threshold.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/disk-aware-threshold.ts
@@ -1,0 +1,56 @@
+import { statfs } from 'fs/promises'
+
+import { status } from '../../../../utils/status'
+
+/**
+ * If the underlying disk is filling up we can flush early.
+ *
+ * We don't need to check disk space every time we want to choose a threshold, so we check it every minute.
+ */
+export class DiskSpaceAwareThreshold {
+    private readonly sessionRecordingLocalDirectory: string
+    private availableSpaceInMB: number | null = null
+
+    constructor(sessionRecordingLocalDirectory: string) {
+        this.sessionRecordingLocalDirectory = sessionRecordingLocalDirectory
+
+        setInterval(async () => {
+            try {
+                const stats = await statfs(this.sessionRecordingLocalDirectory)
+                const availableSpace = stats.bavail * stats.bsize
+                this.availableSpaceInMB = availableSpace / 1_000_000
+            } catch (e) {
+                status.error('🔭', 'DiskSpaceAwareLimits failed to check disk space', e)
+            }
+        }, 60_000)
+    }
+
+    public adjustThreshold(currentThresholdMillis: number): number {
+        let proposedThreshold = currentThresholdMillis
+
+        if (this.availableSpaceInMB !== null) {
+            try {
+                // the disk has 50GB to start with
+                if (this.availableSpaceInMB < 5_000) {
+                    proposedThreshold = 0
+                } else if (this.availableSpaceInMB < 10_000) {
+                    proposedThreshold = currentThresholdMillis * 0.5
+                } else if (this.availableSpaceInMB < 20_000) {
+                    proposedThreshold = currentThresholdMillis * 0.7
+                }
+
+                if (proposedThreshold !== currentThresholdMillis) {
+                    status.info('🔭', 'DiskSpaceAwareThreshold adjusted threshold', {
+                        startingThreshold: currentThresholdMillis,
+                        adjustedThreshold: proposedThreshold,
+                        availableSpaceInMB: this.availableSpaceInMB,
+                    })
+                }
+            } catch (e) {
+                status.error('🔭', 'DiskSpaceAwareLimits failed to check disk space', e)
+            }
+        }
+
+        return proposedThreshold
+    }
+}

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/disk-aware-threshold.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/disk-aware-threshold.test.ts
@@ -1,0 +1,57 @@
+import { statfs } from 'fs/promises'
+
+import { DiskSpaceAwareThreshold } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/disk-aware-threshold'
+
+jest.mock('fs/promises', () => ({
+    statfs: jest.fn(),
+}))
+
+const mockStatFsResult = (availableSpaceInMB: number) => ({
+    bavail: (availableSpaceInMB * 1_000_000) / 4096,
+    bsize: 4096,
+})
+
+describe('DiskSpaceAwareThreshold', () => {
+    let diskSpaceAwareThreshold: DiskSpaceAwareThreshold
+    const sessionRecordingLocalDirectory = '/tmp'
+
+    beforeEach(() => {
+        ;(statfs as jest.Mock).mockReset()
+        jest.useFakeTimers({ legacyFakeTimers: true })
+    })
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers()
+        jest.useRealTimers()
+    })
+
+    describe('flush interval', () => {
+        it('updates flush int1erval based on qavailable disk space', () => {
+            ;(statfs as jest.Mock).mockResolvedValue(mockStatFsResult(20_000))
+            diskSpaceAwareThreshold = new DiskSpaceAwareThreshold(sessionRecordingLocalDirectory)
+            jest.advanceTimersByTime(60_001)
+            expect(diskSpaceAwareThreshold.adjustThreshold(1000)).toBe(1000)
+        })
+
+        it('updates flush int1erval based on available disk space', () => {
+            ;(statfs as jest.Mock).mockResolvedValue(mockStatFsResult(19_999))
+            diskSpaceAwareThreshold = new DiskSpaceAwareThreshold(sessionRecordingLocalDirectory)
+            jest.advanceTimersByTime(60_001)
+            expect(diskSpaceAwareThreshold.adjustThreshold(1000)).toBe(700)
+        })
+
+        it('updates flush interval based on available disk space', () => {
+            ;(statfs as jest.Mock).mockResolvedValue(mockStatFsResult(9_999))
+            diskSpaceAwareThreshold = new DiskSpaceAwareThreshold(sessionRecordingLocalDirectory)
+            jest.advanceTimersByTime(60_001)
+            expect(diskSpaceAwareThreshold.adjustThreshold(1000)).toBe(500)
+        })
+
+        it('2', () => {
+            ;(statfs as jest.Mock).mockResolvedValue(mockStatFsResult(4_999))
+            diskSpaceAwareThreshold = new DiskSpaceAwareThreshold(sessionRecordingLocalDirectory)
+            jest.advanceTimersByTime(60_001)
+            expect(diskSpaceAwareThreshold.adjustThreshold(1000)).toBe(0)
+        })
+    })
+})

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -3,6 +3,7 @@ import { createReadStream, createWriteStream } from 'fs'
 import { DateTime, Settings } from 'luxon'
 
 import { defaultConfig } from '../../../../../src/config/config'
+import { DiskSpaceAwareThreshold } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/disk-aware-threshold'
 import { SessionManager } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/session-manager'
 import { now } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/utils'
 import { createIncomingRecordingMessage } from '../fixtures'
@@ -72,6 +73,11 @@ describe('session-manager', () => {
             defaultConfig,
             mockS3Client,
             mockRealtimeManager,
+            {
+                adjustThreshold(currentThresholdMillis: number): number {
+                    return currentThresholdMillis
+                },
+            } as DiskSpaceAwareThreshold,
             1,
             'session_id_1',
             1,

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -18,7 +18,7 @@
 #
 # ---------------------------------------------------------
 #
-FROM node:18.12.1-bullseye-slim AS frontend-build
+FROM node:18.16.1-bullseye-slim AS frontend-build
 WORKDIR /code
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -37,7 +37,7 @@ RUN pnpm build
 #
 # ---------------------------------------------------------
 #
-FROM node:18.12.1-bullseye-slim AS plugin-server-build
+FROM node:18.16.1-bullseye-slim AS plugin-server-build
 WORKDIR /code/plugin-server
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
## Problem

If the blob ingester disk starts to fill up, then it should flush the data it has

## Changes

We have to upgrade past node 18.15.0 to get access to `statsfs` to check disk space

It's probably cheap to check disk, but also won't change much, so this presents a single instance to all session managers that decides whether to amend a threshold passed to it based on the current disk space.

## How did you test this code?

developer tests and checking things still run locally and this code is called