### PR TITLE
fix(experiments): Fix loading goal preview and updating metrics

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -107,7 +107,7 @@ export function Experiment(): JSX.Element {
     const [showWarning, setShowWarning] = useState(true)
 
     // insightLogic
-    const logic = insightLogic({ dashboardItemId: EXPERIMENT_INSIGHT_ID, doNotLoad: true })
+    const logic = insightLogic({ dashboardItemId: EXPERIMENT_INSIGHT_ID })
     const { insightProps } = useValues(logic)
 
     // insightDataLogic

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -279,6 +279,8 @@ export const experimentLogic = kea<experimentLogicType>([
                             // These were used to change feature flag targeting, but this is controlled directly
                             // on the feature flag now.
                             filters: {
+                                events: [],
+                                actions: [],
                                 ...values.experiment.filters,
                                 properties: [],
                             },
@@ -339,11 +341,15 @@ export const experimentLogic = kea<experimentLogicType>([
                     aggregationGroupTypeIndex !== undefined
                         ? { math: 'unique_group', math_group_type_index: aggregationGroupTypeIndex }
                         : {}
+                const eventAddition =
+                    filters?.actions || filters?.events
+                        ? {}
+                        : { events: [{ ...getDefaultEvent(), ...groupAggregation }] }
                 newInsightFilters = cleanFilters({
                     insight: InsightType.TRENDS,
                     date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
                     date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                    events: [{ ...getDefaultEvent(), ...groupAggregation }],
+                    ...eventAddition,
                     ...filters,
                 })
             }


### PR DESCRIPTION
## Problem

Supercedes https://github.com/PostHog/posthog/pull/16589

Noticed that updating / editing experiment goals is a bit borked, as when you select an event, and then an action, it duplicates your trend metric.

Fixes that.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
