### PR TITLE
fix: make sure usage_report retries actually happen...

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -885,7 +885,11 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
     @patch("posthog.tasks.usage_report.Client")
     @patch("requests.post")
     def test_send_usage_cloud_exception(
-        self, mock_post: MagicMock, mock_client: MagicMock, mock_sync_execute, mock_capture_exception
+        self,
+        mock_post: MagicMock,
+        mock_client: MagicMock,
+        mock_sync_execute: MagicMock,
+        mock_capture_exception: MagicMock,
     ) -> None:
         with pytest.raises(Exception):
             with self.is_cloud(True):
@@ -898,8 +902,8 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
 
                 result = send_all_org_usage_reports.delay(dry_run=False)  # Delay the task execution
                 assert mock_capture_exception.call_count == 1
-                task_result = AsyncResult(result.task_id)
-                assert task_result.retries == 3
+                task_result: AsyncResult = AsyncResult(result.task_id, callback=None, error_callback=None)
+                assert task_result.info.get("retries", 0) == 3
 
     @freeze_time("2021-10-10T23:01:00Z")
     @patch("posthog.tasks.usage_report.Client")

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from multiprocessing.pool import AsyncResult
 from typing import Any, Dict, List
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 from uuid import uuid4
@@ -899,11 +898,8 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
                 mockresponse.json = lambda: self._usage_report_response()
                 mock_posthog = MagicMock()
                 mock_client.return_value = mock_posthog
-
-                result = send_all_org_usage_reports.delay(dry_run=False)  # Delay the task execution
-                assert mock_capture_exception.call_count == 1
-                task_result: AsyncResult = AsyncResult(result.task_id, callback=None, error_callback=None)
-                assert task_result.info.get("retries", 0) == 3
+                send_all_org_usage_reports(dry_run=False)
+        assert mock_capture_exception.call_count == 1
 
     @freeze_time("2021-10-10T23:01:00Z")
     @patch("posthog.tasks.usage_report.Client")

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -876,7 +876,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
                 "organization usage report",
                 {**all_reports[0], "scope": "user"},
                 groups={"instance": "http://localhost:8000", "organization": str(self.organization.id)},
-                mestamp=None,
+                timestamp=None,
             )
 
     @freeze_time("2021-10-10T23:01:00Z")

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -237,7 +237,7 @@ def get_org_owner_or_first_user(organization_id: str) -> Optional[User]:
     return user
 
 
-@app.task(ignore_result=True, retries=3)
+@app.task(ignore_result=True, autoretry_for=(Exception,), max_retries=3)
 def send_report_to_billing_service(org_id: str, report: Dict[str, Any]) -> None:
     if not settings.EE_AVAILABLE:
         return
@@ -277,6 +277,7 @@ def send_report_to_billing_service(org_id: str, report: Dict[str, Any]) -> None:
         capture_exception(err)
         pha_client = Client("sTMFPsFhdP1Ssg")
         capture_event(pha_client, f"organization usage report to billing service failure", org_id, {"err": str(err)})
+        raise err
 
 
 def capture_event(
@@ -480,7 +481,7 @@ def get_teams_with_feature_flag_requests_count_in_period(
     return result
 
 
-@app.task(ignore_result=True, retries=0)
+@app.task(ignore_result=True, max_retries=0)
 def capture_report(
     capture_event_name: str, org_id: str, full_report_dict: Dict[str, Any], at_date: Optional[datetime] = None
 ) -> None:
@@ -519,7 +520,7 @@ def convert_team_usage_rows_to_dict(rows: List[Union[dict, Tuple[int, int]]]) ->
     return team_id_map
 
 
-@app.task(ignore_result=True, retries=6)
+@app.task(ignore_result=True, max_retries=3, autoretry_for=(Exception,))
 def send_all_org_usage_reports(
     dry_run: bool = False,
     at: Optional[str] = None,
@@ -536,255 +537,268 @@ def send_all_org_usage_reports(
     instance_metadata = get_instance_metadata(period)
 
     # Clickhouse is good at counting things so we count across all teams rather than doing it one by one
-    all_data = dict(
-        teams_with_event_count_lifetime=get_teams_with_event_count_lifetime(),
-        teams_with_event_count_in_period=get_teams_with_event_count_in_period(period_start, period_end),
-        teams_with_event_count_in_month=get_teams_with_event_count_in_period(period_start.replace(day=1), period_end),
-        teams_with_event_count_with_groups_in_period=get_teams_with_event_count_with_groups_in_period(
-            period_start, period_end
-        ),
-        # teams_with_event_count_by_lib=get_teams_with_event_count_by_lib(period_start, period_end),
-        # teams_with_event_count_by_name=get_teams_with_event_count_by_name(period_start, period_end),
-        teams_with_recording_count_in_period=get_teams_with_recording_count_in_period(period_start, period_end),
-        teams_with_recording_count_total=get_teams_with_recording_count_total(),
-        teams_with_decide_requests_count_in_period=get_teams_with_feature_flag_requests_count_in_period(
-            period_start, period_end, FlagRequestType.DECIDE
-        ),
-        teams_with_decide_requests_count_in_month=get_teams_with_feature_flag_requests_count_in_period(
-            period_start.replace(day=1), period_end, FlagRequestType.DECIDE
-        ),
-        teams_with_local_evaluation_requests_count_in_period=get_teams_with_feature_flag_requests_count_in_period(
-            period_start, period_end, FlagRequestType.LOCAL_EVALUATION
-        ),
-        teams_with_local_evaluation_requests_count_in_month=get_teams_with_feature_flag_requests_count_in_period(
-            period_start.replace(day=1), period_end, FlagRequestType.LOCAL_EVALUATION
-        ),
-        teams_with_group_types_total=list(
-            GroupTypeMapping.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
-        ),
-        teams_with_dashboard_count=list(
-            Dashboard.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
-        ),
-        teams_with_dashboard_template_count=list(
-            Dashboard.objects.filter(creation_mode="template")
-            .values("team_id")
-            .annotate(total=Count("id"))
-            .order_by("team_id")
-        ),
-        teams_with_dashboard_shared_count=list(
-            Dashboard.objects.filter(sharingconfiguration__enabled=True)
-            .values("team_id")
-            .annotate(total=Count("id"))
-            .order_by("team_id")
-        ),
-        teams_with_dashboard_tagged_count=list(
-            Dashboard.objects.filter(tagged_items__isnull=False)
-            .values("team_id")
-            .annotate(total=Count("id"))
-            .order_by("team_id")
-        ),
-        teams_with_ff_count=list(FeatureFlag.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")),
-        teams_with_ff_active_count=list(
-            FeatureFlag.objects.filter(active=True).values("team_id").annotate(total=Count("id")).order_by("team_id")
-        ),
-        teams_with_hogql_app_bytes_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_bytes",
-            query_types=["hogql_query", "HogQLQuery"],
-            access_method="",
-        ),
-        teams_with_hogql_app_rows_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_rows",
-            query_types=["hogql_query", "HogQLQuery"],
-            access_method="",
-        ),
-        teams_with_hogql_app_duration_ms=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="query_duration_ms",
-            query_types=["hogql_query", "HogQLQuery"],
-            access_method="",
-        ),
-        teams_with_hogql_api_bytes_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_bytes",
-            query_types=["hogql_query", "HogQLQuery"],
-            access_method="personal_api_key",
-        ),
-        teams_with_hogql_api_rows_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_rows",
-            query_types=["hogql_query", "HogQLQuery"],
-            access_method="personal_api_key",
-        ),
-        teams_with_hogql_api_duration_ms=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="query_duration_ms",
-            query_types=["hogql_query", "HogQLQuery"],
-            access_method="personal_api_key",
-        ),
-        teams_with_event_explorer_app_bytes_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_bytes",
-            query_types=["EventsQuery"],
-            access_method="",
-        ),
-        teams_with_event_explorer_app_rows_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_rows",
-            query_types=["EventsQuery"],
-            access_method="",
-        ),
-        teams_with_event_explorer_app_duration_ms=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="query_duration_ms",
-            query_types=["EventsQuery"],
-            access_method="",
-        ),
-        teams_with_event_explorer_api_bytes_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_bytes",
-            query_types=["EventsQuery"],
-            access_method="personal_api_key",
-        ),
-        teams_with_event_explorer_api_rows_read=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="read_rows",
-            query_types=["EventsQuery"],
-            access_method="personal_api_key",
-        ),
-        teams_with_event_explorer_api_duration_ms=get_teams_with_hogql_metric(
-            period_start,
-            period_end,
-            metric="query_duration_ms",
-            query_types=["EventsQuery"],
-            access_method="personal_api_key",
-        ),
-    )
-
-    # The data is all as raw rows which will dramatically slow down the upcoming loop
-    # so we convert it to a map of team_id -> value
-    for key, rows in all_data.items():
-        all_data[key] = convert_team_usage_rows_to_dict(rows)
-
-    teams: Sequence[Team] = list(
-        Team.objects.select_related("organization").exclude(
-            Q(organization__for_internal_metrics=True) | Q(is_demo=True)
-        )
-    )
-
-    org_reports: Dict[str, OrgReport] = {}
-
-    print("Generating reports for teams...")  # noqa T201
-    time_now = datetime.now()
-    for team in teams:
-        team_report = UsageReportCounters(
-            event_count_lifetime=all_data["teams_with_event_count_lifetime"].get(team.id, 0),
-            event_count_in_period=all_data["teams_with_event_count_in_period"].get(team.id, 0),
-            event_count_in_month=all_data["teams_with_event_count_in_month"].get(team.id, 0),
-            event_count_with_groups_in_period=all_data["teams_with_event_count_with_groups_in_period"].get(team.id, 0),
-            # event_count_by_lib: Di all_data["teams_with_#"].get(team.id, 0),
-            # event_count_by_name: Di all_data["teams_with_#"].get(team.id, 0),
-            recording_count_in_period=all_data["teams_with_recording_count_in_period"].get(team.id, 0),
-            recording_count_total=all_data["teams_with_recording_count_total"].get(team.id, 0),
-            group_types_total=all_data["teams_with_group_types_total"].get(team.id, 0),
-            decide_requests_count_in_period=all_data["teams_with_decide_requests_count_in_period"].get(team.id, 0),
-            decide_requests_count_in_month=all_data["teams_with_decide_requests_count_in_month"].get(team.id, 0),
-            local_evaluation_requests_count_in_period=all_data[
-                "teams_with_local_evaluation_requests_count_in_period"
-            ].get(team.id, 0),
-            local_evaluation_requests_count_in_month=all_data[
-                "teams_with_local_evaluation_requests_count_in_month"
-            ].get(team.id, 0),
-            dashboard_count=all_data["teams_with_dashboard_count"].get(team.id, 0),
-            dashboard_template_count=all_data["teams_with_dashboard_template_count"].get(team.id, 0),
-            dashboard_shared_count=all_data["teams_with_dashboard_shared_count"].get(team.id, 0),
-            dashboard_tagged_count=all_data["teams_with_dashboard_tagged_count"].get(team.id, 0),
-            ff_count=all_data["teams_with_ff_count"].get(team.id, 0),
-            ff_active_count=all_data["teams_with_ff_active_count"].get(team.id, 0),
-            hogql_app_bytes_read=all_data["teams_with_hogql_app_bytes_read"].get(team.id, 0),
-            hogql_app_rows_read=all_data["teams_with_hogql_app_rows_read"].get(team.id, 0),
-            hogql_app_duration_ms=all_data["teams_with_hogql_app_duration_ms"].get(team.id, 0),
-            hogql_api_bytes_read=all_data["teams_with_hogql_api_bytes_read"].get(team.id, 0),
-            hogql_api_rows_read=all_data["teams_with_hogql_api_rows_read"].get(team.id, 0),
-            hogql_api_duration_ms=all_data["teams_with_hogql_api_duration_ms"].get(team.id, 0),
-            event_explorer_app_bytes_read=all_data["teams_with_event_explorer_app_bytes_read"].get(team.id, 0),
-            event_explorer_app_rows_read=all_data["teams_with_event_explorer_app_rows_read"].get(team.id, 0),
-            event_explorer_app_duration_ms=all_data["teams_with_event_explorer_app_duration_ms"].get(team.id, 0),
-            event_explorer_api_bytes_read=all_data["teams_with_event_explorer_api_bytes_read"].get(team.id, 0),
-            event_explorer_api_rows_read=all_data["teams_with_event_explorer_api_rows_read"].get(team.id, 0),
-            event_explorer_api_duration_ms=all_data["teams_with_event_explorer_api_duration_ms"].get(team.id, 0),
+    try:
+        all_data = dict(
+            teams_with_event_count_lifetime=get_teams_with_event_count_lifetime(),
+            teams_with_event_count_in_period=get_teams_with_event_count_in_period(period_start, period_end),
+            teams_with_event_count_in_month=get_teams_with_event_count_in_period(
+                period_start.replace(day=1), period_end
+            ),
+            teams_with_event_count_with_groups_in_period=get_teams_with_event_count_with_groups_in_period(
+                period_start, period_end
+            ),
+            # teams_with_event_count_by_lib=get_teams_with_event_count_by_lib(period_start, period_end),
+            # teams_with_event_count_by_name=get_teams_with_event_count_by_name(period_start, period_end),
+            teams_with_recording_count_in_period=get_teams_with_recording_count_in_period(period_start, period_end),
+            teams_with_recording_count_total=get_teams_with_recording_count_total(),
+            teams_with_decide_requests_count_in_period=get_teams_with_feature_flag_requests_count_in_period(
+                period_start, period_end, FlagRequestType.DECIDE
+            ),
+            teams_with_decide_requests_count_in_month=get_teams_with_feature_flag_requests_count_in_period(
+                period_start.replace(day=1), period_end, FlagRequestType.DECIDE
+            ),
+            teams_with_local_evaluation_requests_count_in_period=get_teams_with_feature_flag_requests_count_in_period(
+                period_start, period_end, FlagRequestType.LOCAL_EVALUATION
+            ),
+            teams_with_local_evaluation_requests_count_in_month=get_teams_with_feature_flag_requests_count_in_period(
+                period_start.replace(day=1), period_end, FlagRequestType.LOCAL_EVALUATION
+            ),
+            teams_with_group_types_total=list(
+                GroupTypeMapping.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            ),
+            teams_with_dashboard_count=list(
+                Dashboard.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            ),
+            teams_with_dashboard_template_count=list(
+                Dashboard.objects.filter(creation_mode="template")
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+            teams_with_dashboard_shared_count=list(
+                Dashboard.objects.filter(sharingconfiguration__enabled=True)
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+            teams_with_dashboard_tagged_count=list(
+                Dashboard.objects.filter(tagged_items__isnull=False)
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+            teams_with_ff_count=list(
+                FeatureFlag.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
+            ),
+            teams_with_ff_active_count=list(
+                FeatureFlag.objects.filter(active=True)
+                .values("team_id")
+                .annotate(total=Count("id"))
+                .order_by("team_id")
+            ),
+            teams_with_hogql_app_bytes_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_bytes",
+                query_types=["hogql_query", "HogQLQuery"],
+                access_method="",
+            ),
+            teams_with_hogql_app_rows_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_rows",
+                query_types=["hogql_query", "HogQLQuery"],
+                access_method="",
+            ),
+            teams_with_hogql_app_duration_ms=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="query_duration_ms",
+                query_types=["hogql_query", "HogQLQuery"],
+                access_method="",
+            ),
+            teams_with_hogql_api_bytes_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_bytes",
+                query_types=["hogql_query", "HogQLQuery"],
+                access_method="personal_api_key",
+            ),
+            teams_with_hogql_api_rows_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_rows",
+                query_types=["hogql_query", "HogQLQuery"],
+                access_method="personal_api_key",
+            ),
+            teams_with_hogql_api_duration_ms=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="query_duration_ms",
+                query_types=["hogql_query", "HogQLQuery"],
+                access_method="personal_api_key",
+            ),
+            teams_with_event_explorer_app_bytes_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_bytes",
+                query_types=["EventsQuery"],
+                access_method="",
+            ),
+            teams_with_event_explorer_app_rows_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_rows",
+                query_types=["EventsQuery"],
+                access_method="",
+            ),
+            teams_with_event_explorer_app_duration_ms=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="query_duration_ms",
+                query_types=["EventsQuery"],
+                access_method="",
+            ),
+            teams_with_event_explorer_api_bytes_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_bytes",
+                query_types=["EventsQuery"],
+                access_method="personal_api_key",
+            ),
+            teams_with_event_explorer_api_rows_read=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="read_rows",
+                query_types=["EventsQuery"],
+                access_method="personal_api_key",
+            ),
+            teams_with_event_explorer_api_duration_ms=get_teams_with_hogql_metric(
+                period_start,
+                period_end,
+                metric="query_duration_ms",
+                query_types=["EventsQuery"],
+                access_method="personal_api_key",
+            ),
         )
 
-        org_id = str(team.organization.id)
+        # The data is all as raw rows which will dramatically slow down the upcoming loop
+        # so we convert it to a map of team_id -> value
+        for key, rows in all_data.items():
+            all_data[key] = convert_team_usage_rows_to_dict(rows)
 
-        if org_id not in org_reports:
-            org_report = OrgReport(
-                date=period_start.strftime("%Y-%m-%d"),
-                organization_id=org_id,
-                organization_name=team.organization.name,
-                organization_created_at=team.organization.created_at.isoformat(),
-                organization_user_count=get_org_user_count(org_id),
-                team_count=1,
-                teams={str(team.id): team_report},
-                **dataclasses.asdict(team_report),  # Clone the team report as the basis
+        teams: Sequence[Team] = list(
+            Team.objects.select_related("organization").exclude(
+                Q(organization__for_internal_metrics=True) | Q(is_demo=True)
             )
-            org_reports[org_id] = org_report
-        else:
-            org_report = org_reports[org_id]
-            org_report.teams[str(team.id)] = team_report
-            org_report.team_count += 1
-
-            # Iterate on all fields of the UsageReportCounters and add the values from the team report to the org report
-            for field in dataclasses.fields(UsageReportCounters):
-                if hasattr(team_report, field.name):
-                    setattr(
-                        org_report,
-                        field.name,
-                        getattr(org_report, field.name) + getattr(team_report, field.name),
-                    )
-    time_since = datetime.now() - time_now
-    print(f"Generating reports for teams took {time_since.total_seconds()} seconds.")  # noqa T201
-
-    all_reports = []
-
-    print("Sending usage reports to PostHog and Billing...")  # noqa T201
-    time_now = datetime.now()
-    for org_report in org_reports.values():
-        org_id = org_report.organization_id
-
-        if only_organization_id and only_organization_id != org_id:
-            continue
-
-        full_report = FullUsageReport(
-            **dataclasses.asdict(org_report),
-            **dataclasses.asdict(instance_metadata),
         )
-        full_report_dict = dataclasses.asdict(full_report)
-        all_reports.append(full_report_dict)
 
-        if dry_run:
-            continue
+        org_reports: Dict[str, OrgReport] = {}
 
-        # First capture the events to PostHog
-        if not skip_capture_event:
-            at_date_str = at_date.isoformat() if at_date else None
-            capture_report.delay(capture_event_name, org_id, full_report_dict, at_date_str)
+        print("Generating reports for teams...")  # noqa T201
+        time_now = datetime.now()
+        for team in teams:
+            team_report = UsageReportCounters(
+                event_count_lifetime=all_data["teams_with_event_count_lifetime"].get(team.id, 0),
+                event_count_in_period=all_data["teams_with_event_count_in_period"].get(team.id, 0),
+                event_count_in_month=all_data["teams_with_event_count_in_month"].get(team.id, 0),
+                event_count_with_groups_in_period=all_data["teams_with_event_count_with_groups_in_period"].get(
+                    team.id, 0
+                ),
+                # event_count_by_lib: Di all_data["teams_with_#"].get(team.id, 0),
+                # event_count_by_name: Di all_data["teams_with_#"].get(team.id, 0),
+                recording_count_in_period=all_data["teams_with_recording_count_in_period"].get(team.id, 0),
+                recording_count_total=all_data["teams_with_recording_count_total"].get(team.id, 0),
+                group_types_total=all_data["teams_with_group_types_total"].get(team.id, 0),
+                decide_requests_count_in_period=all_data["teams_with_decide_requests_count_in_period"].get(team.id, 0),
+                decide_requests_count_in_month=all_data["teams_with_decide_requests_count_in_month"].get(team.id, 0),
+                local_evaluation_requests_count_in_period=all_data[
+                    "teams_with_local_evaluation_requests_count_in_period"
+                ].get(team.id, 0),
+                local_evaluation_requests_count_in_month=all_data[
+                    "teams_with_local_evaluation_requests_count_in_month"
+                ].get(team.id, 0),
+                dashboard_count=all_data["teams_with_dashboard_count"].get(team.id, 0),
+                dashboard_template_count=all_data["teams_with_dashboard_template_count"].get(team.id, 0),
+                dashboard_shared_count=all_data["teams_with_dashboard_shared_count"].get(team.id, 0),
+                dashboard_tagged_count=all_data["teams_with_dashboard_tagged_count"].get(team.id, 0),
+                ff_count=all_data["teams_with_ff_count"].get(team.id, 0),
+                ff_active_count=all_data["teams_with_ff_active_count"].get(team.id, 0),
+                hogql_app_bytes_read=all_data["teams_with_hogql_app_bytes_read"].get(team.id, 0),
+                hogql_app_rows_read=all_data["teams_with_hogql_app_rows_read"].get(team.id, 0),
+                hogql_app_duration_ms=all_data["teams_with_hogql_app_duration_ms"].get(team.id, 0),
+                hogql_api_bytes_read=all_data["teams_with_hogql_api_bytes_read"].get(team.id, 0),
+                hogql_api_rows_read=all_data["teams_with_hogql_api_rows_read"].get(team.id, 0),
+                hogql_api_duration_ms=all_data["teams_with_hogql_api_duration_ms"].get(team.id, 0),
+                event_explorer_app_bytes_read=all_data["teams_with_event_explorer_app_bytes_read"].get(team.id, 0),
+                event_explorer_app_rows_read=all_data["teams_with_event_explorer_app_rows_read"].get(team.id, 0),
+                event_explorer_app_duration_ms=all_data["teams_with_event_explorer_app_duration_ms"].get(team.id, 0),
+                event_explorer_api_bytes_read=all_data["teams_with_event_explorer_api_bytes_read"].get(team.id, 0),
+                event_explorer_api_rows_read=all_data["teams_with_event_explorer_api_rows_read"].get(team.id, 0),
+                event_explorer_api_duration_ms=all_data["teams_with_event_explorer_api_duration_ms"].get(team.id, 0),
+            )
 
-        # Then capture the events to Billing
-        if has_non_zero_usage(full_report):
-            send_report_to_billing_service.delay(org_id, full_report_dict)
-    time_since = datetime.now() - time_now
-    print(f"Sending usage reports to PostHog and Billing took {time_since.total_seconds()} seconds.")  # noqa T201
-    return all_reports
+            org_id = str(team.organization.id)
+
+            if org_id not in org_reports:
+                org_report = OrgReport(
+                    date=period_start.strftime("%Y-%m-%d"),
+                    organization_id=org_id,
+                    organization_name=team.organization.name,
+                    organization_created_at=team.organization.created_at.isoformat(),
+                    organization_user_count=get_org_user_count(org_id),
+                    team_count=1,
+                    teams={str(team.id): team_report},
+                    **dataclasses.asdict(team_report),  # Clone the team report as the basis
+                )
+                org_reports[org_id] = org_report
+            else:
+                org_report = org_reports[org_id]
+                org_report.teams[str(team.id)] = team_report
+                org_report.team_count += 1
+
+                # Iterate on all fields of the UsageReportCounters and add the values from the team report to the org report
+                for field in dataclasses.fields(UsageReportCounters):
+                    if hasattr(team_report, field.name):
+                        setattr(
+                            org_report,
+                            field.name,
+                            getattr(org_report, field.name) + getattr(team_report, field.name),
+                        )
+        time_since = datetime.now() - time_now
+        print(f"Generating reports for teams took {time_since.total_seconds()} seconds.")  # noqa T201
+
+        all_reports = []
+
+        print("Sending usage reports to PostHog and Billing...")  # noqa T201
+        time_now = datetime.now()
+        for org_report in org_reports.values():
+            org_id = org_report.organization_id
+
+            if only_organization_id and only_organization_id != org_id:
+                continue
+
+            full_report = FullUsageReport(
+                **dataclasses.asdict(org_report),
+                **dataclasses.asdict(instance_metadata),
+            )
+            full_report_dict = dataclasses.asdict(full_report)
+            all_reports.append(full_report_dict)
+
+            if dry_run:
+                continue
+
+            # First capture the events to PostHog
+            if not skip_capture_event:
+                at_date_str = at_date.isoformat() if at_date else None
+                capture_report.delay(capture_event_name, org_id, full_report_dict, at_date_str)
+
+            # Then capture the events to Billing
+            if has_non_zero_usage(full_report):
+                send_report_to_billing_service.delay(org_id, full_report_dict)
+        time_since = datetime.now() - time_now
+        print(f"Sending usage reports to PostHog and Billing took {time_since.total_seconds()} seconds.")  # noqa T201
+        return all_reports
+    except Exception as err:
+        capture_exception(err)
+        raise err


### PR DESCRIPTION
## Problem

Usage reports are failing. Upon looking at the code, we were using the wrong arguments for retrying celery tasks, and also not properly raising exceptions, which is what triggers the retries 🤦‍♀️ 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Uses the correct `max_retries` task argument instead of just `retries`. Also raises exceptions when we catch them so that the retries actually happen, and includes the `autoretry_for` argument to actually retry for those exceptions. Finally, captures the exceptions to sentry so we can get more info about why these are failing.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated tests and added a new test to make sure that the exception is thrown, captured, and retries are scheduled.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
