### PR TITLE
fix: modify contributing.md to match current processes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ There are many ways to contribute to PostHog. We want to help developers know ex
 
 Just create a new pull request if you want to make an update.
 
-For now, please request Tim (tim@posthog.com) to do the QA.
+We recommend you create an issue if one doesn't already exist, and continue the conversation on the issue to get more info/alignment on what to build.
 
-If you want to speak to us before doing lots of work, just email hey@posthog.com - we're very responsive and friendly!
+For more information on how we review PRs, please refer to our [handbook](https://posthog.com/handbook/engineering/how-we-review).
 
 # Issues
 


### PR DESCRIPTION
## Problem
Issue https://github.com/PostHog/posthog/issues/16568

`CONTRIBUTING.MD` was outdated and referred to previous processes that are no longer applicable.

## Changes

- removed old processes and outdated email 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
N/A