### PR TITLE
Adding note for feature flag conditional variant override

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -970,6 +970,20 @@ function FeatureFlagRollout({ readOnly }: FeatureFlagReadOnlyProps): JSX.Element
                                 ).
                             </p>
                         )}
+                        {featureFlag.filters.groups.filter((group) => group.variant).length > 0 && (
+                            <p className="text-muted">
+                                * Variants rollouts are overriden by release conditions in the following order{' '}
+                                {featureFlag.filters.groups.map((group, index) => {
+                                    if (group.variant) {
+                                        return (
+                                            <span className="simple-tag tag-light-blue font-medium mr-2" key={index}>
+                                                Set {index + 1}
+                                            </span>
+                                        )
+                                    }
+                                })}
+                            </p>
+                        )}
                         <LemonButton
                             type="secondary"
                             onClick={() => {


### PR DESCRIPTION
## Problem
This PR addresses https://github.com/PostHog/posthog/issues/16587

## Changes
Adding foot note when release condition presents and override value is set.

<img width="1164" alt="Screenshot 2023-07-14 at 6 57 58 PM" src="https://github.com/PostHog/posthog/assets/126735714/8b161aac-1dae-4a7c-a03e-51ec854e0e0d">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Manually tested on local machine