### PR TITLE
chore: Added more topic - partition checking

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-blob-consumer.ts
@@ -145,7 +145,7 @@ export class SessionRecordingBlobIngester {
         // lag does not distribute evenly across partitions, so track timestamps per partition
         this.partitionNow[partition] = timestamp
         // If we don't have a last known commit then set it to this offset as we can't commit lower than that
-        this.partitionLastKnownCommit[partition] = this.partitionLastKnownCommit[partition] ?? offset
+        this.partitionLastKnownCommit[partition] = this.partitionLastKnownCommit[partition] ?? offset - 1
         gaugeLagMilliseconds
             .labels({
                 partition: partition.toString(),

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-blob-consumer.test.ts
@@ -35,6 +35,7 @@ jest.mock('../../../../src/kafka/batch-consumer', () => {
                 consumer: {
                     on: jest.fn(),
                     commitSync: mockCommit,
+                    commit: mockCommit,
                 },
             })
         ),


### PR DESCRIPTION
## Problem

Want to swap back to non-sync commits and also add some more checking so that we use the first incoming offset for a partition as the local watermark.

## Changes

* Better removing of partition trackers
* Swap to async commit

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
