### PR TITLE
feat: Size based session flushing

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -134,6 +134,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         // NOTE: 10 minutes
         SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,
         SESSION_RECORDING_BUFFER_AGE_IN_MEMORY_MULTIPLIER: 1.2,
+        SESSION_RECORDING_MAX_BUFFER_SIZE_KB: 1024 * 50, // 50MB
         SESSION_RECORDING_REMOTE_FOLDER: 'session_recordings',
         SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY: '@posthog/replay/partition-high-water-marks',
         POSTHOG_SESSION_RECORDING_REDIS_HOST: undefined,

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -34,10 +34,22 @@ const histogramS3LinesWritten = new Histogram({
     buckets: [0, 50, 100, 150, 200, 300, 400, 500, 750, 1000, 2000, 5000, Infinity],
 })
 
+const histogramS3KbWritten = new Histogram({
+    name: 'recording_blob_ingestion_s3_kb_written',
+    help: 'The uncompressed size of file we send to S3',
+    buckets: [0, 128, 512, 1024, 2048, 5120, 10240, 20480, 51200, Infinity],
+})
+
 const histogramSessionAgeSeconds = new Histogram({
     name: 'recording_blob_ingestion_session_age_seconds',
     help: 'The age of current sessions in seconds',
     buckets: [0, 60, 60 * 2, 60 * 5, 60 * 8, 60 * 10, 60 * 12, 60 * 15, 60 * 20, Infinity],
+})
+
+const histogramSessionSizeKb = new Histogram({
+    name: 'recording_blob_ingestion_session_size_kb',
+    help: 'The size of current sessions in kb',
+    buckets: [0, 128, 512, 1024, 2048, 5120, 10240, 20480, 51200, Infinity],
 })
 
 const histogramSessionSize = new Histogram({
@@ -163,6 +175,7 @@ export class SessionManager {
 
         histogramSessionAgeSeconds.observe(bufferAgeInMemory / 1000)
         histogramSessionSize.observe(this.buffer.count)
+        histogramSessionSizeKb.observe(this.buffer.sizeEstimate / 1024)
 
         if (bufferAgeIsOverThreshold || sessionAgeIsOverThreshold) {
             status.info('🚽', `blob_ingester_session_manager flushing buffer due to age`, {
@@ -238,6 +251,7 @@ export class SessionManager {
 
             counterS3FilesWritten.labels(reason).inc(1)
             histogramS3LinesWritten.observe(this.flushBuffer.count)
+            histogramS3KbWritten.observe(this.flushBuffer.sizeEstimate / 1024)
         } catch (error) {
             if (error.name === 'AbortError' && this.destroying) {
                 // abort of inProgressUpload while destroying is expected

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -201,6 +201,7 @@ export interface PluginsServerConfig {
     // local directory might be a volume mount or a directory on disk (e.g. in local dev)
     SESSION_RECORDING_LOCAL_DIRECTORY: string
     SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: number
+    SESSION_RECORDING_MAX_BUFFER_SIZE_KB: number
     SESSION_RECORDING_BUFFER_AGE_IN_MEMORY_MULTIPLIER: number
     SESSION_RECORDING_REMOTE_FOLDER: string
     SESSION_RECORDING_REDIS_OFFSET_STORAGE_KEY: string

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -99,6 +99,7 @@ describe('session-manager', () => {
 
         expect(sessionManager.buffer).toEqual({
             count: 1,
+            sizeEstimate: 4139,
             oldestKafkaTimestamp: timestamp,
             newestKafkaTimestamp: timestamp,
             file: expect.any(String),


### PR DESCRIPTION
## Problem

We removed our size based flushing due to CPU concerns but we anyways calculate the size of buffer as we write...

## Changes

* Adds this back in
* Doesn't do a compression estimate yet as I want to see it actually do something and see if it fixes an existing issue

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
